### PR TITLE
Thrift newer version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -82,12 +82,11 @@ lazy val api = project
     crossScalaVersions := supportedVersions,
     libraryDependencies ++= spark_sql_provided,
     libraryDependencies ++= Seq(
-      // TODO shade thrift and upgrade to 0.20
-      "org.apache.thrift" % "libthrift" % "0.13.0",
+      "org.apache.thrift" % "libthrift" % "0.20.0",
       "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-      "org.scala-lang.modules" %% "scala-collection-compat" % "2.6.0",
+      "org.scala-lang.modules" %% "scala-collection-compat" % "2.11.0",
       "com.novocode" % "junit-interface" % "0.11" % "test",
-      "org.scalatest" %% "scalatest" % "3.2.15" % "test",
+      "org.scalatest" %% "scalatest" % "3.2.19" % "test",
       "org.scalatestplus" %% "mockito-3-4" % "3.2.10.0" % "test"
     )
   )
@@ -110,8 +109,8 @@ lazy val online = project
       "org.scala-lang.modules" %% "scala-java8-compat" % "1.0.2",
       "com.datadoghq" % "java-dogstatsd-client" % "4.4.1",
       "org.rogach" %% "scallop" % "5.1.0",
-      "net.jodah" % "typetools" % "0.6.3"
-      "com.github.ben-manes.caffeine" % "caffeine" % "2.9.3"
+      "net.jodah" % "typetools" % "0.6.3",
+      "com.github.ben-manes.caffeine" % "caffeine" % "3.1.8"
     ),
     libraryDependencies ++= spark_all,
   )
@@ -128,8 +127,8 @@ lazy val online_unshaded = (project in file("online"))
       "org.scala-lang.modules" %% "scala-java8-compat" % "1.0.2",
       "com.datadoghq" % "java-dogstatsd-client" % "4.4.1",
       "org.rogach" %% "scallop" % "5.1.0",
-      "net.jodah" % "typetools" % "0.6.3"
-      "com.github.ben-manes.caffeine" % "caffeine" % "2.9.3"
+      "net.jodah" % "typetools" % "0.6.3",
+      "com.github.ben-manes.caffeine" % "caffeine" % "3.1.8"
     ),
     libraryDependencies ++= jackson,
     libraryDependencies ++= spark_all.map(_ % "provided"),

--- a/build.sbt
+++ b/build.sbt
@@ -28,6 +28,7 @@ lazy val avro_1_11 = "1.11.2"
 // skip tests on assembly - uncomment if builds become slow
 // ThisBuild / assembly / test := {}
 
+ThisBuild / scalaVersion := scala_2_12
 
 lazy val supportedVersions = List(scala_2_12) // List(scala211, scala212, scala213)
 
@@ -83,6 +84,7 @@ lazy val api = project
     libraryDependencies ++= spark_sql_provided,
     libraryDependencies ++= Seq(
       "org.apache.thrift" % "libthrift" % "0.20.0",
+      "javax.annotation" % "javax.annotation-api" % "1.3.2",
       "org.scala-lang" % "scala-reflect" % scalaVersion.value,
       "org.scala-lang.modules" %% "scala-collection-compat" % "2.11.0",
       "com.novocode" % "junit-interface" % "0.11" % "test",

--- a/project/ThriftGen.scala
+++ b/project/ThriftGen.scala
@@ -1,19 +1,26 @@
 import org.slf4j.LoggerFactory
-import sbt._
+import sbt.*
 
-import sys.process._
+import scala.language.postfixOps
+import sys.process.*
 
 object Thrift {
-  @transient lazy val logger = LoggerFactory.getLogger(getClass)
+
+  def print_and_execute(command: String): Unit = {
+    println(s"+ $command")
+    command !
+  }
+
   def gen(inputPath: String, outputPath: String, language: String, cleanupSuffixPath: String = "", extension: String = null): Seq[File] = {
-    s"""echo "Generating files from thrift file: $outputPath \ninto folder $inputPath" """ !;
-    s"rm -rf $outputPath/$cleanupSuffixPath" !;
+    s"""echo "Generating files from thrift file: $inputPath \ninto folder $outputPath" """ !;
+    print_and_execute(s"rm -rf $outputPath/$cleanupSuffixPath")
     s"mkdir -p $outputPath" !;
-    s"thrift --gen $language -out $outputPath $inputPath" !;
+    print_and_execute(s"thrift -version")
+    print_and_execute(s"thrift --gen $language -out $outputPath $inputPath")
     val files = (PathFinder(new File(outputPath)) ** s"*.${Option(extension).getOrElse(language)}").get()
-    logger.info("Generated files list")
-    files.map(_.getPath).foreach { path => logger.info(s"    $path") }
-    logger.info("\n")
+    println("Generated files list")
+    files.map(_.getPath).foreach { path => println(s"    $path") }
+    println("\n")
     files
   }
 }


### PR DESCRIPTION
## Summary
0.13 -> 0.20

## Why / Goal
old thrift is pretty hard to build or install - 0.20 is the latest stable

## Test Plan
compile passes, will revisit tests later