### PR TITLE
build and push dockerfile to ghcr on every change

### DIFF
--- a/.github/workflows/build_and_push_docker.yaml
+++ b/.github/workflows/build_and_push_docker.yaml
@@ -1,0 +1,35 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    paths:
+      - '.github/image/Dockerfile'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .github/image
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest


### PR DESCRIPTION
## Summary
same as title, we will be using this for CI

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Introduced a GitHub Actions workflow to automate the building and pushing of Docker images to a container registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->