### PR TITLE
Implement stubbed backend APIs for model list, search and time series

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,6 +27,7 @@ lazy val spark_3_5 = "3.5.1"
 lazy val flink_1_17 = "1.17.0"
 lazy val jackson_2_15 = "2.15.2"
 lazy val avro_1_11 = "1.11.2"
+lazy val circeVersion = "0.14.9"
 
 // skip tests on assembly - uncomment if builds become slow
 // ThisBuild / assembly / test := {}
@@ -218,7 +219,10 @@ lazy val hub = (project in file("hub"))
     scalaVersion := scala_2_13,
     libraryDependencies ++= Seq(
       guice,
-      "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test
+      "org.scalatestplus.play" %% "scalatestplus-play" % "7.0.0" % Test,
+      "io.circe" %% "circe-core" % circeVersion,
+      "io.circe" %% "circe-generic" % circeVersion,
+      "io.circe" %% "circe-parser" % circeVersion
     ),
     // Ensure hub depends on frontend build
     Compile / run := ((Compile / run) dependsOn (frontend / buildFrontend)).evaluated,

--- a/hub/app/controllers/ApplicationController.scala
+++ b/hub/app/controllers/ApplicationController.scala
@@ -1,0 +1,15 @@
+package controllers
+
+import play.api.mvc._
+
+import javax.inject._
+
+/**
+  * Controller to serve up any backend application related items
+  */
+class ApplicationController @Inject() (val controllerComponents: ControllerComponents) extends BaseController {
+  def ping(): Action[AnyContent] =
+    Action { implicit request: Request[AnyContent] =>
+      Ok("pong!")
+    }
+}

--- a/hub/app/controllers/ModelController.scala
+++ b/hub/app/controllers/ModelController.scala
@@ -1,0 +1,52 @@
+package controllers
+
+import model.{ListModelResponse, Model}
+import play.api.mvc._
+
+import javax.inject._
+import io.circe.generic.auto._
+import io.circe.syntax._
+
+/**
+  * Controller for the Zipline models entities
+  */
+@Singleton
+class ModelController @Inject() (val controllerComponents: ControllerComponents) extends BaseController {
+
+  // temporarily serve up mock data while we wait on hooking up our KV store layer
+  private[this] def generateMockModel(id: String): Model =
+    Model(s"my test model - $id",
+          id,
+          online = true,
+          production = true,
+          "my team",
+          "XGBoost",
+          1719262147000L,
+          1727210947000L)
+  private[this] val mockModelRegistry: Seq[Model] = (0 until 100).map(i => generateMockModel(i.toString))
+
+  val defaultOffset = 0
+  val defaultLimit = 10
+
+  /**
+    * Powers the /api/v1/models endpoint. Returns a list of models
+    * @param offset - For pagination. We skip over offset entries before returning results
+    * @param limit - Number of elements to return
+    */
+  def list(offset: Option[Int], limit: Option[Int]): Action[AnyContent] =
+    Action { implicit request: Request[AnyContent] =>
+      // Default values if the parameters are not provided
+      val offsetValue = offset.getOrElse(defaultOffset)
+      val limitValue = limit.getOrElse(defaultLimit)
+
+      if (offsetValue < 0) {
+        BadRequest("Invalid offset - expect a positive number")
+      } else if (limitValue < 0) {
+        BadRequest("Invalid limit - expect a positive number")
+      } else {
+        val paginatedResults = mockModelRegistry.slice(offsetValue, offsetValue + limitValue)
+        val json = ListModelResponse(offsetValue, paginatedResults).asJson.noSpaces
+        Ok(json)
+      }
+    }
+}

--- a/hub/app/controllers/ModelController.scala
+++ b/hub/app/controllers/ModelController.scala
@@ -14,17 +14,7 @@ import javax.inject._
 @Singleton
 class ModelController @Inject() (val controllerComponents: ControllerComponents) extends BaseController with Paginate {
 
-  // temporarily serve up mock data while we wait on hooking up our KV store layer
-  private[this] def generateMockModel(id: String): Model =
-    Model(s"my test model - $id",
-          id,
-          online = true,
-          production = true,
-          "my team",
-          "XGBoost",
-          1719262147000L,
-          1727210947000L)
-  private[this] val mockModelRegistry: Seq[Model] = (0 until 100).map(i => generateMockModel(i.toString))
+  import MockDataService._
 
   /**
     * Powers the /api/v1/models endpoint. Returns a list of models
@@ -47,4 +37,19 @@ class ModelController @Inject() (val controllerComponents: ControllerComponents)
         Ok(json)
       }
     }
+}
+
+object MockDataService {
+  // temporarily serve up mock data while we wait on hooking up our KV store layer
+  def generateMockModel(id: String): Model =
+    Model(s"my test model - $id",
+          id,
+          online = true,
+          production = true,
+          "my team",
+          "XGBoost",
+          1719262147000L,
+          1727210947000L)
+
+  val mockModelRegistry: Seq[Model] = (0 until 100).map(i => generateMockModel(i.toString))
 }

--- a/hub/app/controllers/ModelController.scala
+++ b/hub/app/controllers/ModelController.scala
@@ -1,11 +1,12 @@
 package controllers
 
-import model.{ListModelResponse, Model}
+import io.circe.generic.auto._
+import io.circe.syntax._
+import model.ListModelResponse
+import model.Model
 import play.api.mvc._
 
 import javax.inject._
-import io.circe.generic.auto._
-import io.circe.syntax._
 
 /**
   * Controller for the Zipline models entities

--- a/hub/app/controllers/Paginate.scala
+++ b/hub/app/controllers/Paginate.scala
@@ -1,0 +1,13 @@
+package controllers
+
+import model.Model
+
+trait Paginate {
+  val defaultOffset = 0
+  val defaultLimit = 10
+  val maxLimit = 100
+
+  def paginateResults(results: Seq[Model], offset: Int, limit: Int): Seq[Model] = {
+    results.slice(offset, offset + limit)
+  }
+}

--- a/hub/app/controllers/SearchController.scala
+++ b/hub/app/controllers/SearchController.scala
@@ -1,0 +1,58 @@
+package controllers
+
+import model.{Model, SearchModelResponse}
+import play.api.mvc._
+
+import javax.inject._
+import io.circe.generic.auto._
+import io.circe.syntax._
+
+/**
+  * Controller to power search related APIs
+  */
+class SearchController @Inject() (val controllerComponents: ControllerComponents) extends BaseController {
+
+  // temporarily serve up mock data while we wait on hooking up our KV store layer
+  private[this] def generateMockModel(id: String): Model =
+    Model(s"my test model - $id",
+          id,
+          online = true,
+          production = true,
+          "my team",
+          "XGBoost",
+          1719262147000L,
+          1727210947000L)
+  private[this] val mockModelRegistry: Seq[Model] = (0 until 100).map(i => generateMockModel(i.toString))
+
+  val defaultOffset = 0
+  val defaultLimit = 10
+
+  /**
+    * Powers the /api/v1/search endpoint. Returns a list of models
+    * @param term - Search term to search for (currently we only support searching model names)
+    * @param offset - For pagination. We skip over offset entries before returning results
+    * @param limit - Number of elements to return
+    */
+  def search(term: String, offset: Option[Int], limit: Option[Int]): Action[AnyContent] =
+    Action { implicit request: Request[AnyContent] =>
+      // Default values if the parameters are not provided
+      val offsetValue = offset.getOrElse(defaultOffset)
+      val limitValue = limit.getOrElse(defaultLimit)
+
+      if (offsetValue < 0) {
+        BadRequest("Invalid offset - expect a positive number")
+      } else if (limitValue < 0) {
+        BadRequest("Invalid limit - expect a positive number")
+      } else {
+        val searchResults = searchRegistry(term)
+        val paginatedResults = searchResults.slice(offsetValue, offsetValue + limitValue)
+        val json = SearchModelResponse(offsetValue, paginatedResults).asJson.noSpaces
+        Ok(json)
+      }
+    }
+
+  // a trivial search where we check the model name for similarity with the search term
+  private def searchRegistry(term: String): Seq[Model] = {
+    mockModelRegistry.filter(m => m.name.contains(term))
+  }
+}

--- a/hub/app/controllers/SearchController.scala
+++ b/hub/app/controllers/SearchController.scala
@@ -13,20 +13,7 @@ import javax.inject._
   */
 class SearchController @Inject() (val controllerComponents: ControllerComponents) extends BaseController with Paginate {
 
-  // temporarily serve up mock data while we wait on hooking up our KV store layer
-  private[this] def generateMockModel(id: String): Model =
-    Model(s"my test model - $id",
-          id,
-          online = true,
-          production = true,
-          "my team",
-          "XGBoost",
-          1719262147000L,
-          1727210947000L)
-  private[this] val mockModelRegistry: Seq[Model] = (0 until 100).map(i => generateMockModel(i.toString))
-
-  val defaultOffset = 0
-  val defaultLimit = 10
+  import MockDataService._
 
   /**
     * Powers the /api/v1/search endpoint. Returns a list of models

--- a/hub/app/controllers/SearchController.scala
+++ b/hub/app/controllers/SearchController.scala
@@ -1,11 +1,12 @@
 package controllers
 
-import model.{Model, SearchModelResponse}
+import io.circe.generic.auto._
+import io.circe.syntax._
+import model.Model
+import model.SearchModelResponse
 import play.api.mvc._
 
 import javax.inject._
-import io.circe.generic.auto._
-import io.circe.syntax._
 
 /**
   * Controller to power search related APIs

--- a/hub/app/controllers/TimeSeriesController.scala
+++ b/hub/app/controllers/TimeSeriesController.scala
@@ -139,30 +139,23 @@ class TimeSeriesController @Inject() (val controllerComponents: ControllerCompon
                                sliceId: Option[String],
                                offset: Option[String],
                                algorithm: Option[String]): Result = {
-    val maybeOffset = parseOffset(offset)
-    val maybeAlgorithm = parseAlgorithm(algorithm)
 
-    if (maybeOffset.isEmpty) {
-      BadRequest(s"Unable to parse offset - $offset")
-    } else if (maybeAlgorithm.isEmpty) {
-      BadRequest("Invalid drift algorithm. Expect PSI or KL")
-    } else {
-      // TODO uncomment when we're ready to use these
-      //val offset = maybeOffset.get
-      //val algorithm = maybeAlgorithm.get
-
-      val mockGroupBys = generateMockGroupBys(3)
-      val groupByTimeSeries = mockGroupBys.map { g =>
-        val mockFeatures = generateMockFeatures(g, 10)
-        val featureTS = mockFeatures.map {
-          FeatureTimeSeries(_, generateMockTimeSeriesPoints(startTs, endTs))
+    (parseOffset(offset), parseAlgorithm(algorithm)) match {
+      case (None, _)                                   => BadRequest(s"Unable to parse offset - $offset")
+      case (_, None)                                   => BadRequest("Invalid drift algorithm. Expect PSI or KL")
+      case (Some(parsedOffset), Some(parsedAlgorithm)) =>
+        // TODO: Use parsedOffset and parsedAlgorithm when ready
+        val mockGroupBys = generateMockGroupBys(3)
+        val groupByTimeSeries = mockGroupBys.map { g =>
+          val mockFeatures = generateMockFeatures(g, 10)
+          val featureTS = mockFeatures.map {
+            FeatureTimeSeries(_, generateMockTimeSeriesPoints(startTs, endTs))
+          }
+          GroupByTimeSeries(g, featureTS)
         }
-        GroupByTimeSeries(g, featureTS)
-      }
 
-      val mockTSData = JoinTimeSeriesResponse(name, groupByTimeSeries)
-      val json = mockTSData.asJson.noSpaces
-      Ok(json)
+        val mockTSData = JoinTimeSeriesResponse(name, groupByTimeSeries)
+        Ok(mockTSData.asJson.noSpaces)
     }
   }
 

--- a/hub/app/controllers/TimeSeriesController.scala
+++ b/hub/app/controllers/TimeSeriesController.scala
@@ -1,11 +1,10 @@
 package controllers
-import play.api.mvc._
-
-import javax.inject._
 import io.circe.generic.auto._
 import io.circe.syntax._
 import model._
+import play.api.mvc._
 
+import javax.inject._
 import scala.concurrent.duration._
 import scala.util.Random
 
@@ -134,8 +133,8 @@ class TimeSeriesController @Inject() (val controllerComponents: ControllerCompon
       val metricRollup = parseMetricRollup(Some(metrics))
 
       (metricChoice, metricRollup) match {
-        case (None, _)                   => BadRequest(s"Invalid metric choice. Expect drift / skew")
-        case (_, None)                   => BadRequest(s"Invalid metric rollup. Expect max / null / value")
+        case (None, _)                   => BadRequest("Invalid metric choice. Expect drift / skew")
+        case (_, None)                   => BadRequest("Invalid metric rollup. Expect max / null / value")
         case (Some(Drift), Some(rollup)) => doFetchJoinDrift(name, startTs, endTs, rollup, slice, offset, algorithm)
         case (Some(Skew), Some(rollup))  => doFetchJoinSkew(name, startTs, endTs, rollup, slice)
       }
@@ -209,9 +208,9 @@ class TimeSeriesController @Inject() (val controllerComponents: ControllerCompon
       val granularityType = parseGranularity(granularity)
 
       (metricChoice, metricRollup, granularityType) match {
-        case (None, _, _) => BadRequest(s"Invalid metric choice. Expect drift / skew")
-        case (_, None, _) => BadRequest(s"Invalid metric rollup. Expect max / null / value")
-        case (_, _, None) => BadRequest(s"Invalid granularity. Expect raw / percentile / aggregates")
+        case (None, _, _) => BadRequest("Invalid metric choice. Expect drift / skew")
+        case (_, None, _) => BadRequest("Invalid metric rollup. Expect max / null / value")
+        case (_, _, None) => BadRequest("Invalid granularity. Expect raw / percentile / aggregates")
         case (Some(Drift), Some(rollup), Some(g)) =>
           doFetchFeatureDrift(name, startTs, endTs, rollup, slice, g, offset, algorithm)
         case (Some(Skew), Some(rollup), Some(g)) => doFetchFeatureSkew(name, startTs, endTs, rollup, slice, g)

--- a/hub/app/controllers/TimeSeriesController.scala
+++ b/hub/app/controllers/TimeSeriesController.scala
@@ -1,0 +1,351 @@
+package controllers
+import play.api.mvc._
+
+import javax.inject._
+import io.circe.generic.auto._
+import io.circe.syntax._
+import model._
+
+import scala.concurrent.duration._
+import scala.util.Random
+
+/**
+  * Controller that serves various time series endpoints at the model, join and feature level
+  */
+@Singleton
+class TimeSeriesController @Inject() (val controllerComponents: ControllerComponents) extends BaseController {
+
+  import TimeSeriesController._
+
+  /**
+    * Helps retrieve a model performance drift time series. Time series is retrieved between the start and end ts.
+    * The offset is used to compute the distribution to compare against (we compare current time range with the same
+    * sized time range starting offset time period prior).
+    */
+  def fetchModel(id: String, startTs: Long, endTs: Long, offset: String, algorithm: String): Action[AnyContent] =
+    doFetchModel(id, startTs, endTs, offset, algorithm)
+
+  /**
+    * Helps retrieve a model time series with the data sliced based on the relevant slice (identified by sliceId)
+    */
+  def fetchModelSlice(id: String,
+                      sliceId: String,
+                      startTs: Long,
+                      endTs: Long,
+                      offset: String,
+                      algorithm: String): Action[AnyContent] =
+    doFetchModel(id, startTs, endTs, offset, algorithm, Some(sliceId))
+
+  /**
+    * Helps retrieve a time series (drift or skew) for each of the features that are part of a join. Time series is
+    * retrieved between the start and end ts. If the metric type is for drift, the offset is used to compute the
+    * distribution to compare against (we compare current time range with the same sized time range starting offset time
+    * period prior). We compute either the max (drift or skew), null drift / skew or value's drift or skew based on the
+    * metric choice.
+    */
+  def fetchJoin(name: String,
+                startTs: Long,
+                endTs: Long,
+                metricType: String,
+                metrics: String,
+                offset: Option[String],
+                algorithm: Option[String]): Action[AnyContent] =
+    doFetchJoin(name, startTs, endTs, metricType, metrics, None, offset, algorithm)
+
+  /**
+    * Helps retrieve a time series (drift or skew) for each of the features that are part of a join. The data is sliced
+    * based on the configured slice (looked up by sliceId)
+    */
+  def fetchJoinSlice(name: String,
+                     sliceId: String,
+                     startTs: Long,
+                     endTs: Long,
+                     metricType: String,
+                     metrics: String,
+                     offset: Option[String],
+                     algorithm: Option[String]): Action[AnyContent] =
+    doFetchJoin(name, startTs, endTs, metricType, metrics, Some(sliceId), offset, algorithm)
+
+  /**
+    * Helps retrieve a time series (drift or skew) for a given feature. Time series is
+    * retrieved between the start and end ts. Choice of granularity (raw, aggregate, percentiles) along with the
+    * metric type (drift / skew) dictates the shape of the returned time series.
+    */
+  def fetchFeature(name: String,
+                   startTs: Long,
+                   endTs: Long,
+                   metricType: String,
+                   metrics: String,
+                   granularity: String,
+                   offset: Option[String],
+                   algorithm: Option[String]): Action[AnyContent] =
+    doFetchFeature(name, startTs, endTs, metricType, metrics, None, granularity, offset, algorithm)
+
+  /**
+    * Helps retrieve a time series (drift or skew) for a given feature. The data is sliced based on the configured slice
+    * (looked up by sliceId)
+    */
+  def fetchFeatureSlice(name: String,
+                        sliceId: String,
+                        startTs: Long,
+                        endTs: Long,
+                        metricType: String,
+                        metrics: String,
+                        granularity: String,
+                        offset: Option[String],
+                        algorithm: Option[String]): Action[AnyContent] =
+    doFetchFeature(name, startTs, endTs, metricType, metrics, Some(sliceId), granularity, offset, algorithm)
+
+  private def doFetchModel(id: String,
+                           startTs: Long,
+                           endTs: Long,
+                           offset: String,
+                           algorithm: String,
+                           sliceId: Option[String] = None): Action[AnyContent] =
+    Action { implicit request: Request[AnyContent] =>
+      val maybeOffset = parseOffset(Some(offset))
+      val maybeAlgorithm = parseAlgorithm(Some(algorithm))
+
+      if (maybeOffset.isEmpty) {
+        BadRequest(s"Unable to parse offset - $offset")
+      } else if (maybeAlgorithm.isEmpty) {
+        BadRequest("Invalid drift algorithm. Expect PSI or KL")
+      } else {
+        // TODO uncomment when we're ready to use these
+        //val offset = maybeOffset.get
+        //val algorithm = maybeAlgorithm.get
+
+        val mockTSData = ModelTimeSeriesResponse(id, generateMockTimeSeriesPoints(startTs, endTs))
+        val json = mockTSData.asJson.noSpaces
+        Ok(json)
+      }
+    }
+
+  private def doFetchJoin(name: String,
+                          startTs: Long,
+                          endTs: Long,
+                          metricType: String,
+                          metrics: String,
+                          slice: Option[String],
+                          offset: Option[String],
+                          algorithm: Option[String]): Action[AnyContent] =
+    Action { implicit request: Request[AnyContent] =>
+      val metricChoice = parseMetricChoice(Some(metricType))
+      val metricRollup = parseMetricRollup(Some(metrics))
+
+      (metricChoice, metricRollup) match {
+        case (None, _)                   => BadRequest(s"Invalid metric choice. Expect drift / skew")
+        case (_, None)                   => BadRequest(s"Invalid metric rollup. Expect max / null / value")
+        case (Some(Drift), Some(rollup)) => doFetchJoinDrift(name, startTs, endTs, rollup, slice, offset, algorithm)
+        case (Some(Skew), Some(rollup))  => doFetchJoinSkew(name, startTs, endTs, rollup, slice)
+      }
+    }
+
+  private def doFetchJoinDrift(name: String,
+                               startTs: Long,
+                               endTs: Long,
+                               metric: Metric,
+                               sliceId: Option[String],
+                               offset: Option[String],
+                               algorithm: Option[String]): Result = {
+    val maybeOffset = parseOffset(offset)
+    val maybeAlgorithm = parseAlgorithm(algorithm)
+
+    if (maybeOffset.isEmpty) {
+      BadRequest(s"Unable to parse offset - $offset")
+    } else if (maybeAlgorithm.isEmpty) {
+      BadRequest("Invalid drift algorithm. Expect PSI or KL")
+    } else {
+      // TODO uncomment when we're ready to use these
+      //val offset = maybeOffset.get
+      //val algorithm = maybeAlgorithm.get
+
+      val mockGroupBys = generateMockGroupBys(3)
+      val groupByTimeSeries = mockGroupBys.map { g =>
+        val mockFeatures = generateMockFeatures(g, 10)
+        val featureTS = mockFeatures.map {
+          FeatureTimeSeries(_, generateMockTimeSeriesPoints(startTs, endTs))
+        }
+        GroupByTimeSeries(g, featureTS)
+      }
+
+      val mockTSData = JoinTimeSeriesResponse(name, groupByTimeSeries)
+      val json = mockTSData.asJson.noSpaces
+      Ok(json)
+    }
+  }
+
+  private def doFetchJoinSkew(name: String,
+                              startTs: Long,
+                              endTs: Long,
+                              metric: Metric,
+                              sliceId: Option[String]): Result = {
+    val mockGroupBys = generateMockGroupBys(3)
+    val groupByTimeSeries = mockGroupBys.map { g =>
+      val mockFeatures = generateMockFeatures(g, 10)
+      val featureTS = mockFeatures.map {
+        FeatureTimeSeries(_, generateMockTimeSeriesPoints(startTs, endTs))
+      }
+      GroupByTimeSeries(g, featureTS)
+    }
+
+    val mockTSData = JoinTimeSeriesResponse(name, groupByTimeSeries)
+    val json = mockTSData.asJson.noSpaces
+    Ok(json)
+  }
+
+  private def doFetchFeature(name: String,
+                             startTs: Long,
+                             endTs: Long,
+                             metricType: String,
+                             metrics: String,
+                             slice: Option[String],
+                             granularity: String,
+                             offset: Option[String],
+                             algorithm: Option[String]): Action[AnyContent] =
+    Action { implicit request: Request[AnyContent] =>
+      val metricChoice = parseMetricChoice(Some(metricType))
+      val metricRollup = parseMetricRollup(Some(metrics))
+      val granularityType = parseGranularity(granularity)
+
+      (metricChoice, metricRollup, granularityType) match {
+        case (None, _, _) => BadRequest(s"Invalid metric choice. Expect drift / skew")
+        case (_, None, _) => BadRequest(s"Invalid metric rollup. Expect max / null / value")
+        case (_, _, None) => BadRequest(s"Invalid granularity. Expect raw / percentile / aggregates")
+        case (Some(Drift), Some(rollup), Some(g)) =>
+          doFetchFeatureDrift(name, startTs, endTs, rollup, slice, g, offset, algorithm)
+        case (Some(Skew), Some(rollup), Some(g)) => doFetchFeatureSkew(name, startTs, endTs, rollup, slice, g)
+      }
+    }
+
+  private def doFetchFeatureDrift(name: String,
+                                  startTs: Long,
+                                  endTs: Long,
+                                  metric: Metric,
+                                  sliceId: Option[String],
+                                  granularity: Granularity,
+                                  offset: Option[String],
+                                  algorithm: Option[String]): Result = {
+    val maybeOffset = parseOffset(offset)
+    val maybeAlgorithm = parseAlgorithm(algorithm)
+
+    if (maybeOffset.isEmpty) {
+      BadRequest(s"Unable to parse offset - $offset")
+    } else if (maybeAlgorithm.isEmpty) {
+      BadRequest("Invalid drift algorithm. Expect PSI or KL")
+    } else if (granularity == Raw) {
+      BadRequest("We don't support Raw granularity for drift metric types")
+    } else {
+      // TODO uncomment when we're ready to use these
+      //val offset = maybeOffset.get
+      //val algorithm = maybeAlgorithm.get
+      val featureTs = if (granularity == Aggregates) {
+        FeatureTimeSeries(name, generateMockTimeSeriesPoints(startTs, endTs))
+      } else {
+        FeatureTimeSeries(name, generateMockTimeSeriesPercentilePoints(startTs, endTs))
+      }
+      val json = featureTs.asJson.noSpaces
+      Ok(json)
+    }
+  }
+
+  private def doFetchFeatureSkew(name: String,
+                                 startTs: Long,
+                                 endTs: Long,
+                                 metric: Metric,
+                                 sliceId: Option[String],
+                                 granularity: Granularity): Result = {
+    if (granularity == Aggregates) {
+      BadRequest("We don't support Aggregates granularity for skew metric types")
+    } else {
+      val featureTsJson = if (granularity == Raw) {
+        val featureTs = RawComparedFeatureTimeSeries(name,
+                                                     generateMockRawTimeSeriesPoints(startTs, 100),
+                                                     generateMockRawTimeSeriesPoints(startTs, 100))
+        featureTs.asJson.noSpaces
+      } else {
+        val featuresTs = FeatureTimeSeries(name, generateMockTimeSeriesPercentilePoints(startTs, endTs))
+        featuresTs.asJson.noSpaces
+      }
+      Ok(featureTsJson)
+    }
+  }
+}
+
+object TimeSeriesController {
+
+  def parseOffset(offset: Option[String]): Option[Duration] = {
+    offset.map(_.toLowerCase) match {
+      case Some(s"${num}h") if num.forall(_.isDigit) => Some(num.toInt.hours)
+      case Some(s"${num}d") if num.forall(_.isDigit) => Some(num.toInt.days)
+      case _                                         => None
+    }
+  }
+
+  def parseAlgorithm(algorithm: Option[String]): Option[DriftAlgorithm] = {
+    algorithm.map(_.toLowerCase) match {
+      case Some("psi") => Some(PSI)
+      case Some("kl")  => Some(KL)
+      case _           => None
+    }
+  }
+
+  def parseMetricChoice(metricType: Option[String]): Option[MetricType] = {
+    metricType.map(_.toLowerCase) match {
+      case Some("drift") => Some(Drift)
+      case Some("skew")  => Some(Skew)
+      case Some("ooc")   => Some(Skew)
+      case _             => None
+    }
+  }
+
+  def parseMetricRollup(metrics: Option[String]): Option[Metric] = {
+    metrics.map(_.toLowerCase) match {
+      case Some("max")   => Some(MaxMetric)
+      case Some("null")  => Some(NullMetric)
+      case Some("value") => Some(ValuesMetric)
+      case _             => None
+    }
+  }
+
+  def parseGranularity(granularity: String): Option[Granularity] = {
+    granularity.toLowerCase match {
+      case "raw"        => Some(Raw)
+      case "percentile" => Some(Percentile)
+      case "aggregates" => Some(Aggregates)
+      case _            => None
+    }
+  }
+
+  // !!!!! Mock generation code !!!!! //
+
+  val mockGeneratedPercentiles: Seq[String] =
+    Seq("p0", "p10", "p20", "p30", "p40", "p50", "p60", "p70", "p75", "p80", "p90", "p95", "p99", "p100")
+
+  // temporarily serve up mock data while we wait on hooking up our KV store layer + drift calculation
+  private def generateMockTimeSeriesPoints(startTs: Long, endTs: Long): Seq[TimeSeriesPoint] = {
+    val random = new Random(1000)
+    (startTs until endTs by (1.hours.toMillis)).map(ts => TimeSeriesPoint(random.between(0, 0.5), ts))
+  }
+
+  private def generateMockRawTimeSeriesPoints(timestamp: Long, count: Int): Seq[TimeSeriesPoint] = {
+    val random = new Random(1000)
+    (0 until count).map(_ => TimeSeriesPoint(random.between(0, 0.5), timestamp))
+  }
+
+  private def generateMockTimeSeriesPercentilePoints(startTs: Long, endTs: Long): Seq[TimeSeriesPoint] = {
+    val random = new Random(1000)
+    (startTs until endTs by (1.hours.toMillis)).flatMap { ts =>
+      mockGeneratedPercentiles.zipWithIndex.map {
+        case (p, i) => TimeSeriesPoint(random.between(0, 0.05 * (i + 1)), ts, Some(p))
+      }
+    }
+  }
+
+  private def generateMockGroupBys(numGroupBys: Int): Seq[String] =
+    (1 to numGroupBys).map(i => s"my_groupby_$i")
+
+  private def generateMockFeatures(groupBy: String, featuresPerGroupBy: Int): Seq[String] =
+    (1 to featuresPerGroupBy).map(i => s"$groupBy.my_feature_$i")
+
+}

--- a/hub/app/controllers/TimeSeriesController.scala
+++ b/hub/app/controllers/TimeSeriesController.scala
@@ -274,10 +274,12 @@ class TimeSeriesController @Inject() (val controllerComponents: ControllerCompon
 object TimeSeriesController {
 
   def parseOffset(offset: Option[String]): Option[Duration] = {
+    val hourPattern = """(\d+)h""".r
+    val dayPattern = """(\d+)d""".r
     offset.map(_.toLowerCase) match {
-      case Some(s"${num}h") if num.forall(_.isDigit) => Some(num.toInt.hours)
-      case Some(s"${num}d") if num.forall(_.isDigit) => Some(num.toInt.days)
-      case _                                         => None
+      case Some(hourPattern(num)) => Some(num.toInt.hours)
+      case Some(dayPattern(num))  => Some(num.toInt.days)
+      case _                      => None
     }
   }
 

--- a/hub/app/controllers/TimeSeriesController.scala
+++ b/hub/app/controllers/TimeSeriesController.scala
@@ -103,8 +103,8 @@ class TimeSeriesController @Inject() (val controllerComponents: ControllerCompon
                            sliceId: Option[String] = None): Action[AnyContent] =
     Action { implicit request: Request[AnyContent] =>
       (parseOffset(Some(offset)), parseAlgorithm(Some(algorithm))) match {
-        case (None, _)                                   => BadRequest(s"Unable to parse offset - $offset")
-        case (_, None)                                   => BadRequest("Invalid drift algorithm. Expect PSI or KL")
+        case (None, _)          => BadRequest(s"Unable to parse offset - $offset")
+        case (_, None)          => BadRequest("Invalid drift algorithm. Expect PSI or KL")
         case (Some(_), Some(_)) =>
           // TODO: Use parsedOffset and parsedAlgorithm when ready
           val mockTSData = ModelTimeSeriesResponse(id, generateMockTimeSeriesPoints(startTs, endTs))
@@ -141,8 +141,8 @@ class TimeSeriesController @Inject() (val controllerComponents: ControllerCompon
                                algorithm: Option[String]): Result = {
 
     (parseOffset(offset), parseAlgorithm(algorithm)) match {
-      case (None, _)                                   => BadRequest(s"Unable to parse offset - $offset")
-      case (_, None)                                   => BadRequest("Invalid drift algorithm. Expect PSI or KL")
+      case (None, _)          => BadRequest(s"Unable to parse offset - $offset")
+      case (_, None)          => BadRequest("Invalid drift algorithm. Expect PSI or KL")
       case (Some(_), Some(_)) =>
         // TODO: Use parsedOffset and parsedAlgorithm when ready
         val mockGroupBys = generateMockGroupBys(3)
@@ -214,8 +214,8 @@ class TimeSeriesController @Inject() (val controllerComponents: ControllerCompon
       BadRequest("We don't support Raw granularity for drift metric types")
     } else {
       (parseOffset(offset), parseAlgorithm(algorithm)) match {
-        case (None, _)                                   => BadRequest(s"Unable to parse offset - $offset")
-        case (_, None)                                   => BadRequest("Invalid drift algorithm. Expect PSI or KL")
+        case (None, _)          => BadRequest(s"Unable to parse offset - $offset")
+        case (_, None)          => BadRequest("Invalid drift algorithm. Expect PSI or KL")
         case (Some(_), Some(_)) =>
           // TODO: Use parsedOffset and parsedAlgorithm when ready
           val featureTs = if (granularity == Aggregates) {

--- a/hub/app/controllers/TimeSeriesController.scala
+++ b/hub/app/controllers/TimeSeriesController.scala
@@ -39,7 +39,7 @@ class TimeSeriesController @Inject() (val controllerComponents: ControllerCompon
     * Helps retrieve a time series (drift or skew) for each of the features that are part of a join. Time series is
     * retrieved between the start and end ts. If the metric type is for drift, the offset is used to compute the
     * distribution to compare against (we compare current time range with the same sized time range starting offset time
-    * period prior). We compute either the max (drift or skew), null drift / skew or value's drift or skew based on the
+    * period prior). We compute either the null drift / skew or value's drift or skew based on the
     * metric choice.
     */
   def fetchJoin(name: String,
@@ -134,7 +134,7 @@ class TimeSeriesController @Inject() (val controllerComponents: ControllerCompon
 
       (metricChoice, metricRollup) match {
         case (None, _)                   => BadRequest("Invalid metric choice. Expect drift / skew")
-        case (_, None)                   => BadRequest("Invalid metric rollup. Expect max / null / value")
+        case (_, None)                   => BadRequest("Invalid metric rollup. Expect null / value")
         case (Some(Drift), Some(rollup)) => doFetchJoinDrift(name, startTs, endTs, rollup, slice, offset, algorithm)
         case (Some(Skew), Some(rollup))  => doFetchJoinSkew(name, startTs, endTs, rollup, slice)
       }
@@ -209,7 +209,7 @@ class TimeSeriesController @Inject() (val controllerComponents: ControllerCompon
 
       (metricChoice, metricRollup, granularityType) match {
         case (None, _, _) => BadRequest("Invalid metric choice. Expect drift / skew")
-        case (_, None, _) => BadRequest("Invalid metric rollup. Expect max / null / value")
+        case (_, None, _) => BadRequest("Invalid metric rollup. Expect null / value")
         case (_, _, None) => BadRequest("Invalid granularity. Expect raw / percentile / aggregates")
         case (Some(Drift), Some(rollup), Some(g)) =>
           doFetchFeatureDrift(name, startTs, endTs, rollup, slice, g, offset, algorithm)
@@ -300,7 +300,6 @@ object TimeSeriesController {
 
   def parseMetricRollup(metrics: Option[String]): Option[Metric] = {
     metrics.map(_.toLowerCase) match {
-      case Some("max")   => Some(MaxMetric)
       case Some("null")  => Some(NullMetric)
       case Some("value") => Some(ValuesMetric)
       case _             => None

--- a/hub/app/controllers/TimeSeriesController.scala
+++ b/hub/app/controllers/TimeSeriesController.scala
@@ -102,21 +102,13 @@ class TimeSeriesController @Inject() (val controllerComponents: ControllerCompon
                            algorithm: String,
                            sliceId: Option[String] = None): Action[AnyContent] =
     Action { implicit request: Request[AnyContent] =>
-      val maybeOffset = parseOffset(Some(offset))
-      val maybeAlgorithm = parseAlgorithm(Some(algorithm))
-
-      if (maybeOffset.isEmpty) {
-        BadRequest(s"Unable to parse offset - $offset")
-      } else if (maybeAlgorithm.isEmpty) {
-        BadRequest("Invalid drift algorithm. Expect PSI or KL")
-      } else {
-        // TODO uncomment when we're ready to use these
-        //val offset = maybeOffset.get
-        //val algorithm = maybeAlgorithm.get
-
-        val mockTSData = ModelTimeSeriesResponse(id, generateMockTimeSeriesPoints(startTs, endTs))
-        val json = mockTSData.asJson.noSpaces
-        Ok(json)
+      (parseOffset(Some(offset)), parseAlgorithm(Some(algorithm))) match {
+        case (None, _)                                   => BadRequest(s"Unable to parse offset - $offset")
+        case (_, None)                                   => BadRequest("Invalid drift algorithm. Expect PSI or KL")
+        case (Some(parsedOffset), Some(parsedAlgorithm)) =>
+          // TODO: Use parsedOffset and parsedAlgorithm when ready
+          val mockTSData = ModelTimeSeriesResponse(id, generateMockTimeSeriesPoints(startTs, endTs))
+          Ok(mockTSData.asJson.noSpaces)
       }
     }
 

--- a/hub/app/controllers/TimeSeriesController.scala
+++ b/hub/app/controllers/TimeSeriesController.scala
@@ -105,7 +105,7 @@ class TimeSeriesController @Inject() (val controllerComponents: ControllerCompon
       (parseOffset(Some(offset)), parseAlgorithm(Some(algorithm))) match {
         case (None, _)                                   => BadRequest(s"Unable to parse offset - $offset")
         case (_, None)                                   => BadRequest("Invalid drift algorithm. Expect PSI or KL")
-        case (Some(parsedOffset), Some(parsedAlgorithm)) =>
+        case (Some(_), Some(_)) =>
           // TODO: Use parsedOffset and parsedAlgorithm when ready
           val mockTSData = ModelTimeSeriesResponse(id, generateMockTimeSeriesPoints(startTs, endTs))
           Ok(mockTSData.asJson.noSpaces)
@@ -143,7 +143,7 @@ class TimeSeriesController @Inject() (val controllerComponents: ControllerCompon
     (parseOffset(offset), parseAlgorithm(algorithm)) match {
       case (None, _)                                   => BadRequest(s"Unable to parse offset - $offset")
       case (_, None)                                   => BadRequest("Invalid drift algorithm. Expect PSI or KL")
-      case (Some(parsedOffset), Some(parsedAlgorithm)) =>
+      case (Some(_), Some(_)) =>
         // TODO: Use parsedOffset and parsedAlgorithm when ready
         val mockGroupBys = generateMockGroupBys(3)
         val groupByTimeSeries = mockGroupBys.map { g =>
@@ -216,7 +216,7 @@ class TimeSeriesController @Inject() (val controllerComponents: ControllerCompon
       (parseOffset(offset), parseAlgorithm(algorithm)) match {
         case (None, _)                                   => BadRequest(s"Unable to parse offset - $offset")
         case (_, None)                                   => BadRequest("Invalid drift algorithm. Expect PSI or KL")
-        case (Some(parsedOffset), Some(parsedAlgorithm)) =>
+        case (Some(_), Some(_)) =>
           // TODO: Use parsedOffset and parsedAlgorithm when ready
           val featureTs = if (granularity == Aggregates) {
             FeatureTimeSeries(name, generateMockTimeSeriesPoints(startTs, endTs))

--- a/hub/app/model/Model.scala
+++ b/hub/app/model/Model.scala
@@ -1,0 +1,65 @@
+package model
+
+/** Captures some details related to ML models registered with Zipline to surface in the Hub UI */
+case class Model(name: String,
+                 id: String,
+                 online: Boolean,
+                 production: Boolean,
+                 team: String,
+                 modelType: String,
+                 createTime: Long,
+                 lastUpdated: Long)
+
+/** Supported Metric types */
+sealed trait MetricType
+
+/** Drift between two distributions */
+case object Drift extends MetricType
+
+/** Training / serving or online/offline consistency */
+case object Skew extends MetricType
+
+/** Supported drift algorithms */
+sealed trait DriftAlgorithm
+
+/** Population Stability Index */
+case object PSI extends DriftAlgorithm
+
+/** Kullback-Leibler (KL) divergence */
+case object KL extends DriftAlgorithm
+
+/** Supported metric rollups */
+sealed trait Metric
+
+/** Roll up by computing max */
+case object MaxMetric extends Metric
+
+/** Roll up over null counts */
+case object NullMetric extends Metric
+
+/** Roll up over raw values */
+case object ValuesMetric extends Metric
+
+/** Supported granularity types */
+sealed trait Granularity
+
+/** Raw - return raw distribution values */
+case object Raw extends Granularity
+
+/** Percentile - return percentile distribution values */
+case object Percentile extends Granularity
+
+/** Aggregates - compute aggregated metrics (e.g. drift) */
+case object Aggregates extends Granularity
+
+case class TimeSeriesPoint(value: Double, ts: Long, label: Option[String] = None)
+case class FeatureTimeSeries(feature: String, points: Seq[TimeSeriesPoint])
+case class RawComparedFeatureTimeSeries(feature: String, baseline: Seq[TimeSeriesPoint], current: Seq[TimeSeriesPoint])
+case class GroupByTimeSeries(name: String, items: Seq[FeatureTimeSeries])
+
+// Currently search only covers models
+case class SearchModelResponse(offset: Int, items: Seq[Model])
+case class ListModelResponse(offset: Int, items: Seq[Model])
+
+case class ModelTimeSeriesResponse(id: String, items: Seq[TimeSeriesPoint])
+case class JoinTimeSeriesResponse(name: String, items: Seq[GroupByTimeSeries])

--- a/hub/app/model/Model.scala
+++ b/hub/app/model/Model.scala
@@ -31,9 +31,6 @@ case object KL extends DriftAlgorithm
 /** Supported metric rollups */
 sealed trait Metric
 
-/** Roll up by computing max */
-case object MaxMetric extends Metric
-
 /** Roll up over null counts */
 case object NullMetric extends Metric
 

--- a/hub/conf/application.test.conf
+++ b/hub/conf/application.test.conf
@@ -1,0 +1,21 @@
+# This is the main configuration file for the application.
+# https://www.playframework.com/documentation/latest/ConfigFile
+
+play.http.secret.key = ${?PLAY_HTTP_SECRET_KEY}
+play.i18n.langs = ["en"]
+
+# Database configuration
+# ~~~~~
+# You can declare as many datasources as you want.
+# By convention, the default datasource is named `default`
+#
+# db.default.driver=org.h2.Driver
+# db.default.url="jdbc:h2:mem:play"
+
+# Evolutions
+# ~~~~~
+# You can disable evolutions if needed
+# play.evolutions.enabled=false
+
+# You can disable evolutions for a specific datasource if necessary
+# play.evolutions.db.default.enabled=false

--- a/hub/conf/routes
+++ b/hub/conf/routes
@@ -1,6 +1,3 @@
-# Serve SvelteKit static assets
-GET    /          controllers.Assets.at(path="/public", file="index.html")
-GET    /*file      controllers.Assets.at(path="/public", file)
 # Backend APIs
 GET     /api/v1/ping                                     controllers.ApplicationController.ping()
 GET     /api/v1/models                                   controllers.ModelController.list(offset: Option[Int], limit: Option[Int])
@@ -11,3 +8,6 @@ GET     /api/v1/join/:name/timeseries                    controllers.TimeSeriesC
 GET     /api/v1/join/:name/timeseries/slice/:sliceId     controllers.TimeSeriesController.fetchJoinSlice(name: String, sliceId: String, startTs: Long, endTs: Long, metricType: String, metrics: String, offset: Option[String], algorithm: Option[String])
 GET     /api/v1/feature/:name/timeseries                 controllers.TimeSeriesController.fetchFeature(name: String, startTs: Long, endTs: Long, metricType: String, metrics: String, granularity: String, offset: Option[String], algorithm: Option[String])
 GET     /api/v1/feature/:name/timeseries/slice/:sliceId  controllers.TimeSeriesController.fetchFeatureSlice(name: String, sliceId: String, startTs: Long, endTs: Long, metricType: String, metrics: String, granularity: String, offset: Option[String], algorithm: Option[String])
+# Serve SvelteKit static assets
+GET    /          controllers.Assets.at(path="/public", file="index.html")
+GET    /*file      controllers.Assets.at(path="/public", file)

--- a/hub/conf/routes
+++ b/hub/conf/routes
@@ -1,3 +1,13 @@
 # Serve SvelteKit static assets
 GET    /          controllers.Assets.at(path="/public", file="index.html")
 GET    /*file      controllers.Assets.at(path="/public", file)
+# Backend APIs
+GET     /api/v1/ping                                     controllers.ApplicationController.ping()
+GET     /api/v1/models                                   controllers.ModelController.list(offset: Option[Int], limit: Option[Int])
+GET     /api/v1/search                                   controllers.SearchController.search(term: String, offset: Option[Int], limit: Option[Int])
+GET     /api/v1/model/:id/timeseries                     controllers.TimeSeriesController.fetchModel(id: String, startTs: Long, endTs: Long, offset: String, algorithm: String)
+GET     /api/v1/model/:id/timeseries/slice/:sliceId      controllers.TimeSeriesController.fetchModelSlice(id: String, sliceId: String, startTs: Long, endTs: Long, offset: String, algorithm: String)
+GET     /api/v1/join/:name/timeseries                    controllers.TimeSeriesController.fetchJoin(name: String, startTs: Long, endTs: Long, metricType: String, metrics: String, offset: Option[String], algorithm: Option[String])
+GET     /api/v1/join/:name/timeseries/slice/:sliceId     controllers.TimeSeriesController.fetchJoinSlice(name: String, sliceId: String, startTs: Long, endTs: Long, metricType: String, metrics: String, offset: Option[String], algorithm: Option[String])
+GET     /api/v1/feature/:name/timeseries                 controllers.TimeSeriesController.fetchFeature(name: String, startTs: Long, endTs: Long, metricType: String, metrics: String, granularity: String, offset: Option[String], algorithm: Option[String])
+GET     /api/v1/feature/:name/timeseries/slice/:sliceId  controllers.TimeSeriesController.fetchFeatureSlice(name: String, sliceId: String, startTs: Long, endTs: Long, metricType: String, metrics: String, granularity: String, offset: Option[String], algorithm: Option[String])

--- a/hub/test/controllers/ModelControllerSpec.scala
+++ b/hub/test/controllers/ModelControllerSpec.scala
@@ -1,21 +1,21 @@
 package controllers
 
-import org.scalatestplus.play._
-import play.api.http.Status.{BAD_REQUEST, OK}
-import play.api.mvc._
-import play.api.test.Helpers._
-import play.api.test._
-
 import io.circe._
 import io.circe.generic.auto._
 import io.circe.parser._
 import model.ListModelResponse
 import org.scalatest.EitherValues
+import org.scalatestplus.play._
+import play.api.http.Status.BAD_REQUEST
+import play.api.http.Status.OK
+import play.api.mvc._
+import play.api.test.Helpers._
+import play.api.test._
 
 class ModelControllerSpec extends PlaySpec with Results with EitherValues {
 
   // Create a stub ControllerComponents
-  val stubCC = stubControllerComponents()
+  val stubCC: ControllerComponents = stubControllerComponents()
 
   val controller = new ModelController(stubCC)
 

--- a/hub/test/controllers/ModelControllerSpec.scala
+++ b/hub/test/controllers/ModelControllerSpec.scala
@@ -1,0 +1,56 @@
+package controllers
+
+import org.scalatestplus.play._
+import play.api.http.Status.{BAD_REQUEST, OK}
+import play.api.mvc._
+import play.api.test.Helpers._
+import play.api.test._
+
+import io.circe._
+import io.circe.generic.auto._
+import io.circe.parser._
+import model.ListModelResponse
+import org.scalatest.EitherValues
+
+class ModelControllerSpec extends PlaySpec with Results with EitherValues {
+
+  // Create a stub ControllerComponents
+  val stubCC = stubControllerComponents()
+
+  val controller = new ModelController(stubCC)
+
+  "ModelController" should {
+
+    "send 400 on a bad offset" in {
+      val result = controller.list(Some(-1), Some(10)).apply(FakeRequest())
+      status(result) mustBe BAD_REQUEST
+    }
+
+    "send 400 on a bad limit" in {
+      val result = controller.list(Some(10), Some(-2)).apply(FakeRequest())
+      status(result) mustBe BAD_REQUEST
+    }
+
+    "send valid results on a correctly formed request" in {
+      val result = controller.list(None, None).apply(FakeRequest())
+      status(result) mustBe OK
+      val bodyText = contentAsString(result)
+      val listModelResponse: Either[Error, ListModelResponse] = decode[ListModelResponse](bodyText)
+      val items = listModelResponse.value.items
+      items.length mustBe controller.defaultLimit
+      items.map(_.id.toInt).toSet mustBe (0 until 10).toSet
+    }
+
+    "send results in a paginated fashion correctly" in {
+      val startOffset = 25
+      val number = 20
+      val result = controller.list(Some(startOffset), Some(number)).apply(FakeRequest())
+      status(result) mustBe OK
+      val bodyText = contentAsString(result)
+      val listModelResponse: Either[Error, ListModelResponse] = decode[ListModelResponse](bodyText)
+      val items = listModelResponse.value.items
+      items.length mustBe number
+      items.map(_.id.toInt).toSet mustBe (startOffset until startOffset + number).toSet
+    }
+  }
+}

--- a/hub/test/controllers/SearchControllerSpec.scala
+++ b/hub/test/controllers/SearchControllerSpec.scala
@@ -1,0 +1,55 @@
+package controllers
+
+import io.circe._
+import io.circe.generic.auto._
+import io.circe.parser._
+import model.ListModelResponse
+import org.scalatest.EitherValues
+import org.scalatestplus.play._
+import play.api.http.Status.{BAD_REQUEST, OK}
+import play.api.mvc._
+import play.api.test.Helpers._
+import play.api.test._
+
+class SearchControllerSpec extends PlaySpec with Results with EitherValues {
+
+  // Create a stub ControllerComponents
+  val stubCC = stubControllerComponents()
+
+  val controller = new SearchController(stubCC)
+
+  "SearchController" should {
+
+    "send 400 on a bad offset" in {
+      val result = controller.search("foo", Some(-1), Some(10)).apply(FakeRequest())
+      status(result) mustBe BAD_REQUEST
+    }
+
+    "send 400 on a bad limit" in {
+      val result = controller.search("foo", Some(10), Some(-2)).apply(FakeRequest())
+      status(result) mustBe BAD_REQUEST
+    }
+
+    "send valid results on a correctly formed request" in {
+      val result = controller.search("1", None, None).apply(FakeRequest())
+      status(result) mustBe OK
+      val bodyText = contentAsString(result)
+      val listModelResponse: Either[Error, ListModelResponse] = decode[ListModelResponse](bodyText)
+      val items = listModelResponse.value.items
+      items.length mustBe controller.defaultLimit
+      items.map(_.id.toInt).toSet mustBe Set(1, 10, 11, 12, 13, 14, 15, 16, 17, 18)
+    }
+
+    "send results in a paginated fashion correctly" in {
+      val startOffset = 25
+      val number = 20
+      val result = controller.search("test", Some(startOffset), Some(number)).apply(FakeRequest())
+      status(result) mustBe OK
+      val bodyText = contentAsString(result)
+      val listModelResponse: Either[Error, ListModelResponse] = decode[ListModelResponse](bodyText)
+      val items = listModelResponse.value.items
+      items.length mustBe number
+      items.map(_.id.toInt).toSet mustBe (startOffset until startOffset + number).toSet
+    }
+  }
+}

--- a/hub/test/controllers/SearchControllerSpec.scala
+++ b/hub/test/controllers/SearchControllerSpec.scala
@@ -6,7 +6,8 @@ import io.circe.parser._
 import model.ListModelResponse
 import org.scalatest.EitherValues
 import org.scalatestplus.play._
-import play.api.http.Status.{BAD_REQUEST, OK}
+import play.api.http.Status.BAD_REQUEST
+import play.api.http.Status.OK
 import play.api.mvc._
 import play.api.test.Helpers._
 import play.api.test._
@@ -14,7 +15,7 @@ import play.api.test._
 class SearchControllerSpec extends PlaySpec with Results with EitherValues {
 
   // Create a stub ControllerComponents
-  val stubCC = stubControllerComponents()
+  val stubCC: ControllerComponents = stubControllerComponents()
 
   val controller = new SearchController(stubCC)
 

--- a/hub/test/controllers/TimeSeriesControllerSpec.scala
+++ b/hub/test/controllers/TimeSeriesControllerSpec.scala
@@ -89,7 +89,7 @@ class TimeSeriesControllerSpec extends PlaySpec with Results with EitherValues {
       response.name mustBe "my_join"
       response.items.nonEmpty mustBe true
 
-      val expectedLength = (Duration(endTs, TimeUnit.MILLISECONDS) - Duration(startTs, TimeUnit.MILLISECONDS)).toHours
+      val expectedLength = expectedHours(startTs, endTs)
       response.items.foreach { grpByTs =>
         grpByTs.items.isEmpty mustBe false
         grpByTs.items.foreach(featureTs => featureTs.points.length mustBe expectedLength)
@@ -108,7 +108,7 @@ class TimeSeriesControllerSpec extends PlaySpec with Results with EitherValues {
       response.name mustBe "my_join"
       response.items.nonEmpty mustBe true
 
-      val expectedLength = (Duration(endTs, TimeUnit.MILLISECONDS) - Duration(startTs, TimeUnit.MILLISECONDS)).toHours
+      val expectedLength = expectedHours(startTs, endTs)
       response.items.foreach { grpByTs =>
         grpByTs.items.isEmpty mustBe false
         grpByTs.items.foreach(featureTs => featureTs.points.length mustBe expectedLength)
@@ -188,7 +188,7 @@ class TimeSeriesControllerSpec extends PlaySpec with Results with EitherValues {
       response.feature mustBe "my_feature"
       response.points.nonEmpty mustBe true
 
-      val expectedLength = (Duration(endTs, TimeUnit.MILLISECONDS) - Duration(startTs, TimeUnit.MILLISECONDS)).toHours
+      val expectedLength = expectedHours(startTs, endTs)
       response.points.length mustBe expectedLength
     }
 
@@ -207,9 +207,7 @@ class TimeSeriesControllerSpec extends PlaySpec with Results with EitherValues {
       response.points.nonEmpty mustBe true
 
       // expect one entry per percentile for each time series point
-      val expectedLength = TimeSeriesController.mockGeneratedPercentiles.length * (Duration(
-        endTs,
-        TimeUnit.MILLISECONDS) - Duration(startTs, TimeUnit.MILLISECONDS)).toHours
+      val expectedLength = TimeSeriesController.mockGeneratedPercentiles.length * expectedHours(startTs, endTs)
       response.points.length mustBe expectedLength
     }
 
@@ -246,10 +244,12 @@ class TimeSeriesControllerSpec extends PlaySpec with Results with EitherValues {
       response.points.nonEmpty mustBe true
 
       // expect one entry per percentile for each time series point
-      val expectedLength = TimeSeriesController.mockGeneratedPercentiles.length * (Duration(
-        endTs,
-        TimeUnit.MILLISECONDS) - Duration(startTs, TimeUnit.MILLISECONDS)).toHours
+      val expectedLength = TimeSeriesController.mockGeneratedPercentiles.length * expectedHours(startTs, endTs)
       response.points.length mustBe expectedLength
     }
+  }
+
+  private def expectedHours(startTs: Long, endTs: Long): Long = {
+    Duration(endTs - startTs, TimeUnit.MILLISECONDS).toHours
   }
 }

--- a/hub/test/controllers/TimeSeriesControllerSpec.scala
+++ b/hub/test/controllers/TimeSeriesControllerSpec.scala
@@ -52,7 +52,7 @@ class TimeSeriesControllerSpec extends PlaySpec with Results with EitherValues {
   "TimeSeriesController's join ts lookup" should {
 
     "send 400 on an invalid metric choice" in {
-      val invalid = controller.fetchJoin("my_join", 123L, 456L, "meow", "max", None, None).apply(FakeRequest())
+      val invalid = controller.fetchJoin("my_join", 123L, 456L, "meow", "null", None, None).apply(FakeRequest())
       status(invalid) mustBe BAD_REQUEST
     }
 
@@ -63,17 +63,17 @@ class TimeSeriesControllerSpec extends PlaySpec with Results with EitherValues {
 
     "send 400 on an invalid time offset for drift metric" in {
       val invalid1 =
-        controller.fetchJoin("my_join", 123L, 456L, "drift", "max", Some("Xh"), Some("psi")).apply(FakeRequest())
+        controller.fetchJoin("my_join", 123L, 456L, "drift", "null", Some("Xh"), Some("psi")).apply(FakeRequest())
       status(invalid1) mustBe BAD_REQUEST
 
       val invalid2 =
-        controller.fetchJoin("my_join", 123L, 456L, "drift", "max", Some("-1h"), Some("psi")).apply(FakeRequest())
+        controller.fetchJoin("my_join", 123L, 456L, "drift", "null", Some("-1h"), Some("psi")).apply(FakeRequest())
       status(invalid2) mustBe BAD_REQUEST
     }
 
     "send 400 on an invalid algorithm for drift metric" in {
       val invalid1 =
-        controller.fetchJoin("my_join", 123L, 456L, "drift", "max", Some("10h"), Some("meow")).apply(FakeRequest())
+        controller.fetchJoin("my_join", 123L, 456L, "drift", "null", Some("10h"), Some("meow")).apply(FakeRequest())
       status(invalid1) mustBe BAD_REQUEST
     }
 
@@ -81,7 +81,7 @@ class TimeSeriesControllerSpec extends PlaySpec with Results with EitherValues {
       val startTs = 1725926400000L // 09/10/2024 00:00 UTC
       val endTs = 1726106400000L // 09/12/2024 02:00 UTC
       val result =
-        controller.fetchJoin("my_join", startTs, endTs, "drift", "max", Some("10h"), Some("psi")).apply(FakeRequest())
+        controller.fetchJoin("my_join", startTs, endTs, "drift", "null", Some("10h"), Some("psi")).apply(FakeRequest())
       status(result) mustBe OK
       val bodyText = contentAsString(result)
       val modelTSResponse: Either[Error, JoinTimeSeriesResponse] = decode[JoinTimeSeriesResponse](bodyText)
@@ -100,7 +100,7 @@ class TimeSeriesControllerSpec extends PlaySpec with Results with EitherValues {
       val startTs = 1725926400000L // 09/10/2024 00:00 UTC
       val endTs = 1726106400000L // 09/12/2024 02:00 UTC
       val result =
-        controller.fetchJoin("my_join", startTs, endTs, "skew", "max", None, None).apply(FakeRequest())
+        controller.fetchJoin("my_join", startTs, endTs, "skew", "null", None, None).apply(FakeRequest())
       status(result) mustBe OK
       val bodyText = contentAsString(result)
       val modelTSResponse: Either[Error, JoinTimeSeriesResponse] = decode[JoinTimeSeriesResponse](bodyText)
@@ -120,7 +120,7 @@ class TimeSeriesControllerSpec extends PlaySpec with Results with EitherValues {
 
     "send 400 on an invalid metric choice" in {
       val invalid =
-        controller.fetchFeature("my_feature", 123L, 456L, "meow", "max", "raw", None, None).apply(FakeRequest())
+        controller.fetchFeature("my_feature", 123L, 456L, "meow", "null", "raw", None, None).apply(FakeRequest())
       status(invalid) mustBe BAD_REQUEST
     }
 
@@ -132,20 +132,20 @@ class TimeSeriesControllerSpec extends PlaySpec with Results with EitherValues {
 
     "send 400 on an invalid granularity" in {
       val invalid =
-        controller.fetchFeature("my_feature", 123L, 456L, "drift", "max", "woof", None, None).apply(FakeRequest())
+        controller.fetchFeature("my_feature", 123L, 456L, "drift", "null", "woof", None, None).apply(FakeRequest())
       status(invalid) mustBe BAD_REQUEST
     }
 
     "send 400 on an invalid time offset for drift metric" in {
       val invalid1 =
         controller
-          .fetchFeature("my_feature", 123L, 456L, "drift", "max", "aggregates", Some("Xh"), Some("psi"))
+          .fetchFeature("my_feature", 123L, 456L, "drift", "null", "aggregates", Some("Xh"), Some("psi"))
           .apply(FakeRequest())
       status(invalid1) mustBe BAD_REQUEST
 
       val invalid2 =
         controller
-          .fetchFeature("my_feature", 123L, 456L, "drift", "max", "aggregates", Some("-1h"), Some("psi"))
+          .fetchFeature("my_feature", 123L, 456L, "drift", "null", "aggregates", Some("-1h"), Some("psi"))
           .apply(FakeRequest())
       status(invalid2) mustBe BAD_REQUEST
     }
@@ -153,7 +153,7 @@ class TimeSeriesControllerSpec extends PlaySpec with Results with EitherValues {
     "send 400 on an invalid algorithm for drift metric" in {
       val invalid1 =
         controller
-          .fetchFeature("my_feature", 123L, 456L, "drift", "max", "aggregates", Some("10h"), Some("meow"))
+          .fetchFeature("my_feature", 123L, 456L, "drift", "null", "aggregates", Some("10h"), Some("meow"))
           .apply(FakeRequest())
       status(invalid1) mustBe BAD_REQUEST
     }
@@ -161,7 +161,7 @@ class TimeSeriesControllerSpec extends PlaySpec with Results with EitherValues {
     "send 400 on an invalid granularity for drift metric" in {
       val invalid1 =
         controller
-          .fetchFeature("my_feature", 123L, 456L, "drift", "max", "raw", Some("10h"), Some("psi"))
+          .fetchFeature("my_feature", 123L, 456L, "drift", "null", "raw", Some("10h"), Some("psi"))
           .apply(FakeRequest())
       status(invalid1) mustBe BAD_REQUEST
     }
@@ -169,7 +169,7 @@ class TimeSeriesControllerSpec extends PlaySpec with Results with EitherValues {
     "send 400 on an invalid granularity for skew metric" in {
       val invalid1 =
         controller
-          .fetchFeature("my_feature", 123L, 456L, "skew", "max", "aggregates", Some("10h"), Some("psi"))
+          .fetchFeature("my_feature", 123L, 456L, "skew", "null", "aggregates", Some("10h"), Some("psi"))
           .apply(FakeRequest())
       status(invalid1) mustBe BAD_REQUEST
     }
@@ -179,7 +179,7 @@ class TimeSeriesControllerSpec extends PlaySpec with Results with EitherValues {
       val endTs = 1726106400000L // 09/12/2024 02:00 UTC
       val result =
         controller
-          .fetchFeature("my_feature", startTs, endTs, "drift", "max", "aggregates", Some("10h"), Some("psi"))
+          .fetchFeature("my_feature", startTs, endTs, "drift", "null", "aggregates", Some("10h"), Some("psi"))
           .apply(FakeRequest())
       status(result) mustBe OK
       val bodyText = contentAsString(result)
@@ -197,7 +197,7 @@ class TimeSeriesControllerSpec extends PlaySpec with Results with EitherValues {
       val endTs = 1726106400000L // 09/12/2024 02:00 UTC
       val result =
         controller
-          .fetchFeature("my_feature", startTs, endTs, "drift", "max", "percentile", Some("10h"), Some("psi"))
+          .fetchFeature("my_feature", startTs, endTs, "drift", "null", "percentile", Some("10h"), Some("psi"))
           .apply(FakeRequest())
       status(result) mustBe OK
       val bodyText = contentAsString(result)
@@ -217,7 +217,7 @@ class TimeSeriesControllerSpec extends PlaySpec with Results with EitherValues {
       val startTs = 1725926400000L // 09/10/2024 00:00 UTC
       val endTs = 1726106400000L // 09/12/2024 02:00 UTC
       val result =
-        controller.fetchFeature("my_feature", startTs, endTs, "skew", "max", "raw", None, None).apply(FakeRequest())
+        controller.fetchFeature("my_feature", startTs, endTs, "skew", "null", "raw", None, None).apply(FakeRequest())
       status(result) mustBe OK
       val bodyText = contentAsString(result)
       val featureTSResponse: Either[Error, RawComparedFeatureTimeSeries] =
@@ -236,7 +236,7 @@ class TimeSeriesControllerSpec extends PlaySpec with Results with EitherValues {
       val endTs = 1726106400000L // 09/12/2024 02:00 UTC
       val result =
         controller
-          .fetchFeature("my_feature", startTs, endTs, "skew", "max", "percentile", None, None)
+          .fetchFeature("my_feature", startTs, endTs, "skew", "null", "percentile", None, None)
           .apply(FakeRequest())
       status(result) mustBe OK
       val bodyText = contentAsString(result)

--- a/hub/test/controllers/TimeSeriesControllerSpec.scala
+++ b/hub/test/controllers/TimeSeriesControllerSpec.scala
@@ -1,0 +1,254 @@
+package controllers
+
+import io.circe._
+import io.circe.generic.auto._
+import io.circe.parser._
+import model._
+import org.scalatest.EitherValues
+import org.scalatestplus.play._
+import play.api.http.Status.{BAD_REQUEST, OK}
+import play.api.mvc._
+import play.api.test.Helpers._
+import play.api.test._
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.Duration
+
+class TimeSeriesControllerSpec extends PlaySpec with Results with EitherValues {
+
+  // Create a stub ControllerComponents
+  val stubCC = stubControllerComponents()
+
+  val controller = new TimeSeriesController(stubCC)
+
+  "TimeSeriesController's model ts lookup" should {
+
+    "send 400 on an invalid time offset" in {
+      val invalid1 = controller.fetchModel("id-123", 123L, 456L, "Xh", "psi").apply(FakeRequest())
+      status(invalid1) mustBe BAD_REQUEST
+
+      val invalid2 = controller.fetchModel("id-123", 123L, 456L, "-10h", "psi").apply(FakeRequest())
+      status(invalid2) mustBe BAD_REQUEST
+    }
+
+    "send 400 on an invalid algorithm" in {
+      val invalid1 = controller.fetchModel("id-123", 123L, 456L, "10h", "meow").apply(FakeRequest())
+      status(invalid1) mustBe BAD_REQUEST
+    }
+
+    "send valid results on a correctly formed model ts request" in {
+      val startTs = 1725926400000L // 09/10/2024 00:00 UTC
+      val endTs = 1726106400000L // 09/12/2024 02:00 UTC
+      val result = controller.fetchModel("id-123", startTs, endTs, "10h", "psi").apply(FakeRequest())
+      status(result) mustBe OK
+      val bodyText = contentAsString(result)
+      val modelTSResponse: Either[Error, ModelTimeSeriesResponse] = decode[ModelTimeSeriesResponse](bodyText)
+      val items = modelTSResponse.value.items
+      items.length mustBe (Duration(endTs, TimeUnit.MILLISECONDS) - Duration(startTs, TimeUnit.MILLISECONDS)).toHours
+    }
+  }
+
+  "TimeSeriesController's join ts lookup" should {
+
+    "send 400 on an invalid metric choice" in {
+      val invalid = controller.fetchJoin("my_join", 123L, 456L, "meow", "max", None, None).apply(FakeRequest())
+      status(invalid) mustBe BAD_REQUEST
+    }
+
+    "send 400 on an invalid metric rollup" in {
+      val invalid = controller.fetchJoin("my_join", 123L, 456L, "drift", "woof", None, None).apply(FakeRequest())
+      status(invalid) mustBe BAD_REQUEST
+    }
+
+    "send 400 on an invalid time offset for drift metric" in {
+      val invalid1 =
+        controller.fetchJoin("my_join", 123L, 456L, "drift", "max", Some("Xh"), Some("psi")).apply(FakeRequest())
+      status(invalid1) mustBe BAD_REQUEST
+
+      val invalid2 =
+        controller.fetchJoin("my_join", 123L, 456L, "drift", "max", Some("-1h"), Some("psi")).apply(FakeRequest())
+      status(invalid2) mustBe BAD_REQUEST
+    }
+
+    "send 400 on an invalid algorithm for drift metric" in {
+      val invalid1 =
+        controller.fetchJoin("my_join", 123L, 456L, "drift", "max", Some("10h"), Some("meow")).apply(FakeRequest())
+      status(invalid1) mustBe BAD_REQUEST
+    }
+
+    "send valid results on a correctly formed model ts drift lookup request" in {
+      val startTs = 1725926400000L // 09/10/2024 00:00 UTC
+      val endTs = 1726106400000L // 09/12/2024 02:00 UTC
+      val result =
+        controller.fetchJoin("my_join", startTs, endTs, "drift", "max", Some("10h"), Some("psi")).apply(FakeRequest())
+      status(result) mustBe OK
+      val bodyText = contentAsString(result)
+      val modelTSResponse: Either[Error, JoinTimeSeriesResponse] = decode[JoinTimeSeriesResponse](bodyText)
+      val response = modelTSResponse.value
+      response.name mustBe "my_join"
+      response.items.nonEmpty mustBe true
+
+      val expectedLength = (Duration(endTs, TimeUnit.MILLISECONDS) - Duration(startTs, TimeUnit.MILLISECONDS)).toHours
+      response.items.foreach { grpByTs =>
+        grpByTs.items.isEmpty mustBe false
+        grpByTs.items.foreach(featureTs => featureTs.points.length mustBe expectedLength)
+      }
+    }
+
+    "send valid results on a correctly formed model ts skew lookup request" in {
+      val startTs = 1725926400000L // 09/10/2024 00:00 UTC
+      val endTs = 1726106400000L // 09/12/2024 02:00 UTC
+      val result =
+        controller.fetchJoin("my_join", startTs, endTs, "skew", "max", None, None).apply(FakeRequest())
+      status(result) mustBe OK
+      val bodyText = contentAsString(result)
+      val modelTSResponse: Either[Error, JoinTimeSeriesResponse] = decode[JoinTimeSeriesResponse](bodyText)
+      val response = modelTSResponse.value
+      response.name mustBe "my_join"
+      response.items.nonEmpty mustBe true
+
+      val expectedLength = (Duration(endTs, TimeUnit.MILLISECONDS) - Duration(startTs, TimeUnit.MILLISECONDS)).toHours
+      response.items.foreach { grpByTs =>
+        grpByTs.items.isEmpty mustBe false
+        grpByTs.items.foreach(featureTs => featureTs.points.length mustBe expectedLength)
+      }
+    }
+  }
+
+  "TimeSeriesController's feature ts lookup" should {
+
+    "send 400 on an invalid metric choice" in {
+      val invalid =
+        controller.fetchFeature("my_feature", 123L, 456L, "meow", "max", "raw", None, None).apply(FakeRequest())
+      status(invalid) mustBe BAD_REQUEST
+    }
+
+    "send 400 on an invalid metric rollup" in {
+      val invalid =
+        controller.fetchFeature("my_feature", 123L, 456L, "drift", "woof", "raw", None, None).apply(FakeRequest())
+      status(invalid) mustBe BAD_REQUEST
+    }
+
+    "send 400 on an invalid granularity" in {
+      val invalid =
+        controller.fetchFeature("my_feature", 123L, 456L, "drift", "max", "woof", None, None).apply(FakeRequest())
+      status(invalid) mustBe BAD_REQUEST
+    }
+
+    "send 400 on an invalid time offset for drift metric" in {
+      val invalid1 =
+        controller
+          .fetchFeature("my_feature", 123L, 456L, "drift", "max", "aggregates", Some("Xh"), Some("psi"))
+          .apply(FakeRequest())
+      status(invalid1) mustBe BAD_REQUEST
+
+      val invalid2 =
+        controller
+          .fetchFeature("my_feature", 123L, 456L, "drift", "max", "aggregates", Some("-1h"), Some("psi"))
+          .apply(FakeRequest())
+      status(invalid2) mustBe BAD_REQUEST
+    }
+
+    "send 400 on an invalid algorithm for drift metric" in {
+      val invalid1 =
+        controller
+          .fetchFeature("my_feature", 123L, 456L, "drift", "max", "aggregates", Some("10h"), Some("meow"))
+          .apply(FakeRequest())
+      status(invalid1) mustBe BAD_REQUEST
+    }
+
+    "send 400 on an invalid granularity for drift metric" in {
+      val invalid1 =
+        controller
+          .fetchFeature("my_feature", 123L, 456L, "drift", "max", "raw", Some("10h"), Some("psi"))
+          .apply(FakeRequest())
+      status(invalid1) mustBe BAD_REQUEST
+    }
+
+    "send 400 on an invalid granularity for skew metric" in {
+      val invalid1 =
+        controller
+          .fetchFeature("my_feature", 123L, 456L, "skew", "max", "aggregates", Some("10h"), Some("psi"))
+          .apply(FakeRequest())
+      status(invalid1) mustBe BAD_REQUEST
+    }
+
+    "send valid results on a correctly formed feature ts aggregate drift lookup request" in {
+      val startTs = 1725926400000L // 09/10/2024 00:00 UTC
+      val endTs = 1726106400000L // 09/12/2024 02:00 UTC
+      val result =
+        controller
+          .fetchFeature("my_feature", startTs, endTs, "drift", "max", "aggregates", Some("10h"), Some("psi"))
+          .apply(FakeRequest())
+      status(result) mustBe OK
+      val bodyText = contentAsString(result)
+      val featureTSResponse: Either[Error, FeatureTimeSeries] = decode[FeatureTimeSeries](bodyText)
+      val response = featureTSResponse.value
+      response.feature mustBe "my_feature"
+      response.points.nonEmpty mustBe true
+
+      val expectedLength = (Duration(endTs, TimeUnit.MILLISECONDS) - Duration(startTs, TimeUnit.MILLISECONDS)).toHours
+      response.points.length mustBe expectedLength
+    }
+
+    "send valid results on a correctly formed feature ts percentile drift lookup request" in {
+      val startTs = 1725926400000L // 09/10/2024 00:00 UTC
+      val endTs = 1726106400000L // 09/12/2024 02:00 UTC
+      val result =
+        controller
+          .fetchFeature("my_feature", startTs, endTs, "drift", "max", "percentile", Some("10h"), Some("psi"))
+          .apply(FakeRequest())
+      status(result) mustBe OK
+      val bodyText = contentAsString(result)
+      val featureTSResponse: Either[Error, FeatureTimeSeries] = decode[FeatureTimeSeries](bodyText)
+      val response = featureTSResponse.value
+      response.feature mustBe "my_feature"
+      response.points.nonEmpty mustBe true
+
+      // expect one entry per percentile for each time series point
+      val expectedLength = TimeSeriesController.mockGeneratedPercentiles.length * (Duration(
+        endTs,
+        TimeUnit.MILLISECONDS) - Duration(startTs, TimeUnit.MILLISECONDS)).toHours
+      response.points.length mustBe expectedLength
+    }
+
+    "send valid results on a correctly formed feature ts raw skew lookup request" in {
+      val startTs = 1725926400000L // 09/10/2024 00:00 UTC
+      val endTs = 1726106400000L // 09/12/2024 02:00 UTC
+      val result =
+        controller.fetchFeature("my_feature", startTs, endTs, "skew", "max", "raw", None, None).apply(FakeRequest())
+      status(result) mustBe OK
+      val bodyText = contentAsString(result)
+      val featureTSResponse: Either[Error, RawComparedFeatureTimeSeries] =
+        decode[RawComparedFeatureTimeSeries](bodyText)
+      val response = featureTSResponse.value
+      response.feature mustBe "my_feature"
+      response.baseline.nonEmpty mustBe true
+      response.baseline.length mustBe response.current.length
+      // we expect a skew distribution at a fixed time stamp
+      response.baseline.foreach(p => p.ts mustBe startTs)
+      response.current.foreach(p => p.ts mustBe startTs)
+    }
+
+    "send valid results on a correctly formed feature ts percentile skew lookup request" in {
+      val startTs = 1725926400000L // 09/10/2024 00:00 UTC
+      val endTs = 1726106400000L // 09/12/2024 02:00 UTC
+      val result =
+        controller
+          .fetchFeature("my_feature", startTs, endTs, "skew", "max", "percentile", None, None)
+          .apply(FakeRequest())
+      status(result) mustBe OK
+      val bodyText = contentAsString(result)
+      val featureTSResponse: Either[Error, FeatureTimeSeries] = decode[FeatureTimeSeries](bodyText)
+      val response = featureTSResponse.value
+      response.feature mustBe "my_feature"
+      response.points.nonEmpty mustBe true
+
+      // expect one entry per percentile for each time series point
+      val expectedLength = TimeSeriesController.mockGeneratedPercentiles.length * (Duration(
+        endTs,
+        TimeUnit.MILLISECONDS) - Duration(startTs, TimeUnit.MILLISECONDS)).toHours
+      response.points.length mustBe expectedLength
+    }
+  }
+}

--- a/hub/test/controllers/TimeSeriesControllerSpec.scala
+++ b/hub/test/controllers/TimeSeriesControllerSpec.scala
@@ -6,7 +6,8 @@ import io.circe.parser._
 import model._
 import org.scalatest.EitherValues
 import org.scalatestplus.play._
-import play.api.http.Status.{BAD_REQUEST, OK}
+import play.api.http.Status.BAD_REQUEST
+import play.api.http.Status.OK
 import play.api.mvc._
 import play.api.test.Helpers._
 import play.api.test._
@@ -17,7 +18,7 @@ import scala.concurrent.duration.Duration
 class TimeSeriesControllerSpec extends PlaySpec with Results with EitherValues {
 
   // Create a stub ControllerComponents
-  val stubCC = stubControllerComponents()
+  val stubCC: ControllerComponents = stubControllerComponents()
 
   val controller = new TimeSeriesController(stubCC)
 

--- a/hub/test/controllers/TimeSeriesControllerSpec.scala
+++ b/hub/test/controllers/TimeSeriesControllerSpec.scala
@@ -44,6 +44,7 @@ class TimeSeriesControllerSpec extends PlaySpec with Results with EitherValues {
       status(result) mustBe OK
       val bodyText = contentAsString(result)
       val modelTSResponse: Either[Error, ModelTimeSeriesResponse] = decode[ModelTimeSeriesResponse](bodyText)
+      modelTSResponse.isRight mustBe true
       val items = modelTSResponse.value.items
       items.length mustBe (Duration(endTs, TimeUnit.MILLISECONDS) - Duration(startTs, TimeUnit.MILLISECONDS)).toHours
     }
@@ -85,6 +86,7 @@ class TimeSeriesControllerSpec extends PlaySpec with Results with EitherValues {
       status(result) mustBe OK
       val bodyText = contentAsString(result)
       val modelTSResponse: Either[Error, JoinTimeSeriesResponse] = decode[JoinTimeSeriesResponse](bodyText)
+      modelTSResponse.isRight mustBe true
       val response = modelTSResponse.value
       response.name mustBe "my_join"
       response.items.nonEmpty mustBe true
@@ -104,6 +106,7 @@ class TimeSeriesControllerSpec extends PlaySpec with Results with EitherValues {
       status(result) mustBe OK
       val bodyText = contentAsString(result)
       val modelTSResponse: Either[Error, JoinTimeSeriesResponse] = decode[JoinTimeSeriesResponse](bodyText)
+      modelTSResponse.isRight mustBe true
       val response = modelTSResponse.value
       response.name mustBe "my_join"
       response.items.nonEmpty mustBe true
@@ -184,6 +187,7 @@ class TimeSeriesControllerSpec extends PlaySpec with Results with EitherValues {
       status(result) mustBe OK
       val bodyText = contentAsString(result)
       val featureTSResponse: Either[Error, FeatureTimeSeries] = decode[FeatureTimeSeries](bodyText)
+      featureTSResponse.isRight mustBe true
       val response = featureTSResponse.value
       response.feature mustBe "my_feature"
       response.points.nonEmpty mustBe true
@@ -202,6 +206,7 @@ class TimeSeriesControllerSpec extends PlaySpec with Results with EitherValues {
       status(result) mustBe OK
       val bodyText = contentAsString(result)
       val featureTSResponse: Either[Error, FeatureTimeSeries] = decode[FeatureTimeSeries](bodyText)
+      featureTSResponse.isRight mustBe true
       val response = featureTSResponse.value
       response.feature mustBe "my_feature"
       response.points.nonEmpty mustBe true
@@ -220,6 +225,7 @@ class TimeSeriesControllerSpec extends PlaySpec with Results with EitherValues {
       val bodyText = contentAsString(result)
       val featureTSResponse: Either[Error, RawComparedFeatureTimeSeries] =
         decode[RawComparedFeatureTimeSeries](bodyText)
+      featureTSResponse.isRight mustBe true
       val response = featureTSResponse.value
       response.feature mustBe "my_feature"
       response.baseline.nonEmpty mustBe true
@@ -239,6 +245,7 @@ class TimeSeriesControllerSpec extends PlaySpec with Results with EitherValues {
       status(result) mustBe OK
       val bodyText = contentAsString(result)
       val featureTSResponse: Either[Error, FeatureTimeSeries] = decode[FeatureTimeSeries](bodyText)
+      featureTSResponse.isRight mustBe true
       val response = featureTSResponse.value
       response.feature mustBe "my_feature"
       response.points.nonEmpty mustBe true


### PR DESCRIPTION
## Summary
Add some stubbed APIs based on the outline sketched out in [doc](https://docs.google.com/document/d/1e1GbcnKqWdzZxrhWyWSS1Fu8ynMD3apkZwXgl3_8b2U/edit). As part of this I've added some basic validation of the endpoint params. We'll need to do a more thorough pass there and lock things down so that the backend APIs can only be hit by the frontend in a subsequent PR.

## Checklist
- [X] Added Unit Tests
- [ ] Covered by existing CI
- [X] Integration tested
- [ ] Documentation update

Test by unit tests + manual. For manual testing and to see the output:
```
sbt "project hub" run
```

Then in a browser / via curl, you can pull up some of these endpoints to see the returned responses:
```
http://localhost:9000/api/v1/models
http://localhost:9000/api/v1/search?term=1&limit=20


http://localhost:9000/api/v1/model/1/timeseries?startTs=1725926400000&endTs=1726106400000&offset=10h&algorithm=psi
http://localhost:9000/api/v1/model/1/timeseries/slice/123?startTs=1725926400000&endTs=1726106400000&offset=10h&algorithm=psi

http://localhost:9000/api/v1/join/my_join/timeseries?startTs=1725926400000&endTs=1726106400000&metricType=drift&metrics=null&offset=10h&algorithm=psi
http://localhost:9000/api/v1/join/my_join/timeseries?startTs=1725926400000&endTs=1726106400000&metricType=skew&metrics=null

http://localhost:9000/api/v1/join/my_join/timeseries/slice/123?startTs=1725926400000&endTs=1726106400000&metricType=drift&metrics=null&offset=10h&algorithm=psi
http://localhost:9000/api/v1/join/my_join/timeseries/slice/123?startTs=1725926400000&endTs=1726106400000&metricType=skew&metrics=null

http://localhost:9000/api/v1/feature/my_feat/timeseries?startTs=1725926400000&endTs=1726106400000&metricType=drift&metrics=null&offset=10h&algorithm=psi&granularity=aggregates
http://localhost:9000/api/v1/feature/my_feat/timeseries?startTs=1725926400000&endTs=1726106400000&metricType=drift&metrics=null&offset=10h&algorithm=psi&granularity=percentile

http://localhost:9000/api/v1/feature/my_feat/timeseries?startTs=1725926400000&endTs=1726106400000&metricType=skew&metrics=null&granularity=raw
http://localhost:9000/api/v1/feature/my_feat/timeseries?startTs=1725926400000&endTs=1726106400000&metricType=skew&metrics=null&granularity=percentile
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced `ApplicationController`, `ModelController`, `SearchController`, and `TimeSeriesController` for handling various API requests, including endpoints for listing models, searching, and retrieving time series metrics.
  - Added a health check endpoint at `/api/v1/ping`.

- **Improvements**
  - Updated library dependencies for enhanced JSON handling and testing capabilities, including the addition of the Circe library.

- **Bug Fixes**
  - Implemented error handling for invalid pagination parameters across various endpoints.

- **Tests**
  - Added unit tests for `ModelController`, `SearchController`, and `TimeSeriesController` to ensure proper functionality and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->