### PR TITLE
Enable more modules in our CI + fix missing triggers

### DIFF
--- a/.github/image/Dockerfile
+++ b/.github/image/Dockerfile
@@ -5,10 +5,10 @@ FROM alpine:latest
 # Install necessary tools and Python
 RUN apk add --no-cache wget curl bash python3 py3-pip
 
-RUN apk add --no-cache openjdk-17-jdk
+RUN apk add --no-cache openjdk17-jdk
 
 # java
-ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk
 ENV PATH=$PATH:$JAVA_HOME/bin
 
 # sbt for scala

--- a/.github/image/Dockerfile
+++ b/.github/image/Dockerfile
@@ -5,14 +5,10 @@ FROM alpine:latest
 # Install necessary tools and Python
 RUN apk add --no-cache wget curl bash python3 py3-pip
 
-# Add Amazon Corretto repository
-RUN wget -O /etc/apk/keys/amazoncorretto.rsa.pub https://apk.corretto.aws/amazoncorretto.rsa.pub && \
-    echo "https://apk.corretto.aws/" >> /etc/apk/repositories && \
-    apk update
-RUN apk add --no-cache amazon-corretto-17
+RUN apk add --no-cache openjdk-17-jdk
 
 # java
-ENV JAVA_HOME=/usr/lib/jvm/default-jvm
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
 ENV PATH=$PATH:$JAVA_HOME/bin
 
 # sbt for scala

--- a/.github/image/Dockerfile
+++ b/.github/image/Dockerfile
@@ -5,10 +5,14 @@ FROM alpine:latest
 # Install necessary tools and Python
 RUN apk add --no-cache wget curl bash python3 py3-pip
 
-RUN apk add --no-cache openjdk17-jdk
+# Add Amazon Corretto repository
+RUN wget -O /etc/apk/keys/amazoncorretto.rsa.pub https://apk.corretto.aws/amazoncorretto.rsa.pub && \
+    echo "https://apk.corretto.aws/" >> /etc/apk/repositories && \
+    apk update
+RUN apk add --no-cache amazon-corretto-17
 
 # java
-ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk
+ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:$JAVA_HOME/bin
 
 # sbt for scala
@@ -28,6 +32,8 @@ RUN apk add --no-cache \
         autoconf \
         automake \
         libtool \
+        libc6-compat \
+        gcompat \
         curl && \
     curl -LSs https://archive.apache.org/dist/thrift/${THRIFT_VERSION}/thrift-${THRIFT_VERSION}.tar.gz -o thrift-${THRIFT_VERSION}.tar.gz && \
     tar -xzf thrift-${THRIFT_VERSION}.tar.gz && \

--- a/.github/workflows/test_python.yaml
+++ b/.github/workflows/test_python.yaml
@@ -4,15 +4,9 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'api/py/**'
-      - '.github/workflows/test_python.yaml'
   pull_request:
     branches:
       - main
-    paths:
-      - 'api/py/**'
-      - '.github/workflows/test_python.yaml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test_scala_no_spark.yaml
+++ b/.github/workflows/test_scala_no_spark.yaml
@@ -1,4 +1,4 @@
-name: Test non-spark Scala modules
+name: Test non-spark Scala modules - 1
 
 on:
   push:
@@ -55,33 +55,3 @@ jobs:
       - name: Run api tests
         run: |
           sbt "++ 2.12.18 api/test"
-
-      - name: Run hub tests
-        run: |
-          export SBT_OPTS="-Xmx8G -Xms2G"
-          sbt "++ 2.12.18 hub/test"
-
-      - name: Run service tests
-        run: |
-          export SBT_OPTS="-Xmx8G -Xms2G"
-          sbt "++ 2.12.18 service/test"
-
-      - name: Run service commons tests
-        run: |
-          export SBT_OPTS="-Xmx8G -Xms2G"
-          sbt "++ 2.12.18 service_commons/test"
-
-      - name: Run orchestrator tests
-        run: |
-          export SBT_OPTS="-Xmx8G -Xms2G"
-          sbt "++ 2.12.18 orchestration/test"
-
-      - name: Run cloud gcp tests
-        run: |
-          export SBT_OPTS="-Xmx8G -Xms2G"
-          sbt "++ 2.12.18 cloud_gcp/test"    
-
-      - name: Run cloud aws tests
-        run: |
-          export SBT_OPTS="-Xmx8G -Xms2G"
-          sbt "++ 2.12.18 cloud_aws/test"    

--- a/.github/workflows/test_scala_no_spark.yaml
+++ b/.github/workflows/test_scala_no_spark.yaml
@@ -4,36 +4,9 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'flink/**'
-      - 'aggregator/**'
-      - 'online/**'
-      - 'api/**'
-      - 'hub/**'
-      - 'service/**'
-      - 'service_commons/**'
-      - 'orchestration/**'
-      - 'cloud_gcp/**'
-      - 'cloud_aws/**'
-      - '.github/workflows/test_scala_no_spark.yaml'
-      - 'build.sbt'
   pull_request:
     branches:
       - main
-    paths:
-      - 'flink/**'
-      - 'aggregator/**'
-      - 'online/**'
-      - 'api/**'
-      - 'hub/**'
-      - 'service/**'
-      - 'service_commons/**'
-      - 'orchestration/**'
-      - 'cloud_gcp/**'
-      - 'cloud_aws/**'
-      - '.github/workflows/test_scala_no_spark.yaml'
-      - 'build.sbt'
-
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test_scala_no_spark.yaml
+++ b/.github/workflows/test_scala_no_spark.yaml
@@ -9,6 +9,12 @@ on:
       - 'aggregator/**'
       - 'online/**'
       - 'api/**'
+      - 'hub/**'
+      - 'service/**'
+      - 'service_commons/**'
+      - 'orchestration/**'
+      - 'cloud_gcp/**'
+      - 'cloud_aws/**'
       - '.github/workflows/test_scala_no_spark.yaml'
       - 'build.sbt'
   pull_request:
@@ -19,6 +25,12 @@ on:
       - 'aggregator/**'
       - 'online/**'
       - 'api/**'
+      - 'hub/**'
+      - 'service/**'
+      - 'service_commons/**'
+      - 'orchestration/**'
+      - 'cloud_gcp/**'
+      - 'cloud_aws/**'
       - '.github/workflows/test_scala_no_spark.yaml'
       - 'build.sbt'
 
@@ -81,9 +93,22 @@ jobs:
           export SBT_OPTS="-Xmx8G -Xms2G"
           sbt "++ 2.12.18 service/test"
 
+      - name: Run service commons tests
+        run: |
+          export SBT_OPTS="-Xmx8G -Xms2G"
+          sbt "++ 2.12.18 service_commons/test"
+
       - name: Run orchestrator tests
         run: |
           export SBT_OPTS="-Xmx8G -Xms2G"
           sbt "++ 2.12.18 orchestration/test"
-          
-    
+
+      - name: Run cloud gcp tests
+        run: |
+          export SBT_OPTS="-Xmx8G -Xms2G"
+          sbt "++ 2.12.18 cloud_gcp/test"    
+
+      - name: Run cloud aws tests
+        run: |
+          export SBT_OPTS="-Xmx8G -Xms2G"
+          sbt "++ 2.12.18 cloud_aws/test"    

--- a/.github/workflows/test_scala_no_spark_2.yaml
+++ b/.github/workflows/test_scala_no_spark_2.yaml
@@ -1,0 +1,62 @@
+name: Test non-spark Scala modules - 2
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  no_spark_scala_tests:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository }}-ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    defaults:
+      run:
+        working-directory: ${{ github.workspace }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set SBT resources
+        run: |
+          echo "SBT_OPTS=-Xmx8G -Xms2G" >> $GITHUB_ENV
+
+      - name: Run hub tests
+        run: |
+          export SBT_OPTS="-Xmx8G -Xms2G"
+          sbt "++ 2.12.18 hub/test"
+
+      - name: Run service tests
+        run: |
+          export SBT_OPTS="-Xmx8G -Xms2G"
+          sbt "++ 2.12.18 service/test"
+
+      - name: Run service commons tests
+        run: |
+          export SBT_OPTS="-Xmx8G -Xms2G"
+          sbt "++ 2.12.18 service_commons/test"
+
+      - name: Run orchestrator tests
+        run: |
+          export SBT_OPTS="-Xmx8G -Xms2G"
+          sbt "++ 2.12.18 orchestration/test"
+
+      - name: Run cloud gcp tests
+        run: |
+          export SBT_OPTS="-Xmx8G -Xms2G"
+          sbt "++ 2.12.18 cloud_gcp/test"    
+
+      - name: Run cloud aws tests
+        run: |
+          export SBT_OPTS="-Xmx8G -Xms2G"
+          sbt "++ 2.12.18 cloud_aws/test"    

--- a/.github/workflows/test_scala_spark.yaml
+++ b/.github/workflows/test_scala_spark.yaml
@@ -4,17 +4,9 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'spark/**'
-      - '.github/workflows/test_scala_spark.yaml'
-      - 'build.sbt'
   pull_request:
     branches:
       - main
-    paths:
-      - 'spark/**'
-      - '.github/workflows/test_scala_spark.yaml'
-      - 'build.sbt'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/cloud_gcp/src/test/scala/ai/chronon/integrations/cloud_gcp/BigTableKVStoreTest.scala
+++ b/cloud_gcp/src/test/scala/ai/chronon/integrations/cloud_gcp/BigTableKVStoreTest.scala
@@ -15,10 +15,7 @@ import com.google.cloud.bigtable.data.v2.BigtableDataSettings
 import com.google.cloud.bigtable.data.v2.models.Query
 import com.google.cloud.bigtable.data.v2.models.Row
 import com.google.cloud.bigtable.data.v2.models.RowMutation
-import com.google.cloud.bigtable.emulator.v2.BigtableEmulatorRule
-import org.junit.Rule
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import com.google.cloud.bigtable.emulator.v2.Emulator
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.mockito.Mockito.withSettings
@@ -33,16 +30,11 @@ import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 import scala.jdk.CollectionConverters._
 
-@RunWith(classOf[JUnit4])
-class BigTableKVStoreTest extends AnyFlatSpec with BeforeAndAfter{
+class BigTableKVStoreTest extends AnyFlatSpec with BeforeAndAfter {
 
   import BigTableKVStore._
 
-  // ugly hacks to wire up the emulator. See: https://stackoverflow.com/questions/32160549/using-junit-rule-with-scalatest-e-g-temporaryfolder
-  val _bigtableEmulator: BigtableEmulatorRule = BigtableEmulatorRule.create()
-  @Rule
-  def bigtableEmulator: BigtableEmulatorRule = _bigtableEmulator
-
+  private var emulator: Emulator = _
   private var dataClient: BigtableDataClient = _
   private var adminClient: BigtableTableAdminClient = _
 
@@ -50,16 +42,18 @@ class BigTableKVStoreTest extends AnyFlatSpec with BeforeAndAfter{
   private val instanceId = "test-instance"
 
   before {
+    emulator = Emulator.createBundled
+    emulator.start()
     // Configure settings to use emulator
     val dataSettings = BigtableDataSettings
-      .newBuilderForEmulator(bigtableEmulator.getPort)
+      .newBuilderForEmulator(emulator.getPort)
       .setProjectId(projectId)
       .setInstanceId(instanceId)
       .setCredentialsProvider(NoCredentialsProvider.create())
       .build()
 
     val adminSettings = BigtableTableAdminSettings
-      .newBuilderForEmulator(bigtableEmulator.getPort)
+      .newBuilderForEmulator(emulator.getPort)
       .setProjectId(projectId)
       .setInstanceId(instanceId)
       .setCredentialsProvider(NoCredentialsProvider.create())


### PR DESCRIPTION
## Summary
Noticed that some of our modules are missing in CI (e.g. gcp and aws). Also some of our path triggers were missing some locations so we might have prs slipping through with bugs.

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflows to trigger on any push or pull request, expanding the scope of test runs.
	- Introduced a new workflow for testing non-Spark Scala modules.
	- Refactored BigTable KV Store test to use ScalaTest conventions and updated emulator setup.
	- Updated Dockerfile to install OpenJDK 17 instead of Amazon Corretto.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->