### PR TITLE
Aligning joinPart output to always be in line with join left

### DIFF
--- a/api/src/main/scala/ai/chronon/api/planner/RelevantLeftForJoinPart.scala
+++ b/api/src/main/scala/ai/chronon/api/planner/RelevantLeftForJoinPart.scala
@@ -34,6 +34,7 @@ object RelevantLeftForJoinPart {
   }
 
   def partTableName(join: Join, joinPart: ai.chronon.api.JoinPart): String = {
+
     val relevantLeft = relevantLeftCompute(join.left, joinPart)
     val rightMetadata = joinPart.groupBy.metaData
     val prefix = Option(joinPart.prefix).map(_.sanitize + "__").getOrElse("")
@@ -50,6 +51,7 @@ object RelevantLeftForJoinPart {
     // removing ns to keep the table name short, hash is enough to differentiate
     val leftTable = removeNamespace(relevantLeft.leftTable)
 
+    // We don't strictly need leftTable here (handled by the hash), but including it for transparency
     s"${groupByName}__${leftTable}__$combinedHash"
   }
 

--- a/api/src/main/scala/ai/chronon/api/planner/RelevantLeftForJoinPart.scala
+++ b/api/src/main/scala/ai/chronon/api/planner/RelevantLeftForJoinPart.scala
@@ -34,7 +34,6 @@ object RelevantLeftForJoinPart {
   }
 
   def partTableName(join: Join, joinPart: ai.chronon.api.JoinPart): String = {
-
     val relevantLeft = relevantLeftCompute(join.left, joinPart)
     val rightMetadata = joinPart.groupBy.metaData
     val prefix = Option(joinPart.prefix).map(_.sanitize + "__").getOrElse("")

--- a/spark/src/main/scala/ai/chronon/spark/Extensions.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Extensions.scala
@@ -115,8 +115,11 @@ object Extensions {
       df.filter(pruneFilter)
     }
 
-    def shiftPartition(numDays: Int, partitionColumn: String = tableUtils.partitionColumn): DataFrame = {
-      df.withColumn(partitionColumn, date_add(df.col(partitionColumn), numDays))
+    def shiftPartition(numDays: Int): DataFrame = {
+      val partitionColumn = tableUtils.partitionColumn
+      df.withColumn(partitionColumn,
+                    date_format(date_add(to_date(col(partitionColumn), tableUtils.partitionSpec.format), numDays),
+                                tableUtils.partitionSpec.format))
     }
 
     def partitionRange: PartitionRange = {

--- a/spark/src/main/scala/ai/chronon/spark/Extensions.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Extensions.scala
@@ -115,6 +115,10 @@ object Extensions {
       df.filter(pruneFilter)
     }
 
+    def shiftPartition(numDays: Int, partitionColumn: String = tableUtils.partitionColumn): DataFrame = {
+      df.withColumn(partitionColumn, date_add(df.col(partitionColumn), numDays))
+    }
+
     def partitionRange: PartitionRange = {
       val (start, end) = df.range[String](tableUtils.partitionColumn)
       PartitionRange(start, end)

--- a/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
@@ -699,9 +699,6 @@ object GroupBy {
                       stepDays: Option[Int] = None,
                       overrideStartPartition: Option[String] = None,
                       skipFirstHole: Boolean = true): Unit = {
-    assert(
-      groupByConf.backfillStartDate != null,
-      s"GroupBy:${groupByConf.metaData.name} has null backfillStartDate. This needs to be set for offline backfilling.")
     Option(groupByConf.setups).foreach(_.foreach(tableUtils.sql))
     val overrideStart = overrideStartPartition.getOrElse(groupByConf.backfillStartDate)
     val outputTable = groupByConf.metaData.outputTable

--- a/spark/src/main/scala/ai/chronon/spark/Join.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Join.scala
@@ -198,13 +198,7 @@ class Join(joinConf: api.Join,
   private def getRightPartsData(leftRange: PartitionRange): Seq[(JoinPart, DataFrame)] = {
     joinConfCloned.joinParts.asScala.map { joinPart =>
       val partTable = joinConfCloned.partOutputTable(joinPart)
-      val effectiveRange =
-        if (joinConfCloned.left.dataModel != ENTITIES && joinPart.groupBy.inferredAccuracy == Accuracy.SNAPSHOT) {
-          leftRange.shift(-1)
-        } else {
-          leftRange
-        }
-      val wheres = effectiveRange.whereClauses("ds")
+      val wheres = leftRange.whereClauses("ds")
       val sql = QueryUtils.build(null, partTable, wheres)
       logger.info(s"Pulling data from joinPart table with: $sql")
       (joinPart, tableUtils.scanDfBase(null, partTable, List.empty, wheres, None))

--- a/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
@@ -100,13 +100,17 @@ abstract class JoinBase(val joinConfCloned: api.Join,
       keyRenamedRightDf
         .withColumn(
           Constants.TimePartitionColumn,
-          date_format(date_add(to_date(col(tableUtils.partitionColumn), tableUtils.partitionSpec.format), 1),
-                      tableUtils.partitionSpec.format)
+          col(tableUtils.partitionColumn)
         )
         .drop(tableUtils.partitionColumn)
     } else {
       keyRenamedRightDf
     }
+
+    leftDf.selectExpr("min(ts_ds) as min_ds", "max(ts_ds) as max_ds").show()
+    joinableRightDf.selectExpr("min(ts_ds) as min_ds", "max(ts_ds) as max_ds").show()
+    //renamedLeftDf.selectExpr("min(ds) as min_ds", "max(ds) as max_ds").show()
+    //    rightDf.selectExpr("min(ds) as min_ds", "max(ds) as max_ds").show()
 
     logger.info(s"""
                |Join keys for ${joinPart.groupBy.metaData.name}: ${keys.mkString(", ")}
@@ -119,6 +123,7 @@ abstract class JoinBase(val joinConfCloned: api.Join,
                |${joinedDf.schema.pretty}
                |""".stripMargin)
 
+    joinedDf.show()
     joinedDf
   }
 

--- a/spark/src/main/scala/ai/chronon/spark/batch/JoinPartJob.scala
+++ b/spark/src/main/scala/ai/chronon/spark/batch/JoinPartJob.scala
@@ -216,7 +216,7 @@ class JoinPartJob(node: JoinPartNode, range: DateRange, showDf: Boolean = false)
 
       case (EVENTS, ENTITIES, Accuracy.TEMPORAL) =>
         // Snapshots and mutations are partitioned with ds holding data between <ds 00:00> and ds <23:59>.
-        genGroupBy(shiftedPartitionRange).temporalEntities(renamedLeftDf).shiftPartition(1)
+        genGroupBy(shiftedPartitionRange).temporalEntities(renamedLeftDf)
     }
     val rightDfWithDerivations = if (joinPart.groupBy.hasDerivations) {
       val finalOutputColumns = joinPart.groupBy.derivationsScala.finalOutputColumn(rightDf.columns).toSeq
@@ -225,10 +225,12 @@ class JoinPartJob(node: JoinPartNode, range: DateRange, showDf: Boolean = false)
     } else {
       rightDf
     }
+
     if (showDf) {
       logger.info(s"printing results for joinPart: ${joinPart.groupBy.metaData.name}")
       rightDfWithDerivations.prettyPrint()
     }
+
     Some(rightDfWithDerivations)
   }
 }

--- a/spark/src/main/scala/ai/chronon/spark/batch/JoinPartJob.scala
+++ b/spark/src/main/scala/ai/chronon/spark/batch/JoinPartJob.scala
@@ -10,9 +10,11 @@ import ai.chronon.spark.Extensions._
 import ai.chronon.spark.catalog.TableUtils
 import ai.chronon.spark.{GroupBy, JoinUtils}
 import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.catalyst.dsl.expressions.StringToAttributeConversionHelper
 import org.apache.spark.sql.functions.{col, date_format}
 import org.apache.spark.util.sketch.BloomFilter
 import org.slf4j.{Logger, LoggerFactory}
+import org.apache.spark.sql.functions._
 
 import java.util
 import scala.collection.{Map, Seq}
@@ -225,6 +227,9 @@ class JoinPartJob(node: JoinPartNode, range: DateRange, showDf: Boolean = false)
     } else {
       rightDf
     }
+
+    renamedLeftDf.selectExpr("min(ds) as min_ds", "max(ds) as max_ds").show()
+    rightDf.selectExpr("min(ds) as min_ds", "max(ds) as max_ds").show()
 
     if (showDf) {
       logger.info(s"printing results for joinPart: ${joinPart.groupBy.metaData.name}")

--- a/spark/src/main/scala/ai/chronon/spark/batch/JoinPartJob.scala
+++ b/spark/src/main/scala/ai/chronon/spark/batch/JoinPartJob.scala
@@ -208,15 +208,15 @@ class JoinPartJob(node: JoinPartNode, range: DateRange, showDf: Boolean = false)
       case (ENTITIES, EVENTS, _)   => partitionRangeGroupBy.snapshotEvents(dateRange)
       case (ENTITIES, ENTITIES, _) => partitionRangeGroupBy.snapshotEntities
       case (EVENTS, EVENTS, Accuracy.SNAPSHOT) =>
-        genGroupBy(shiftedPartitionRange).snapshotEvents(shiftedPartitionRange)
+        genGroupBy(shiftedPartitionRange).snapshotEvents(shiftedPartitionRange).shiftPartition(1)
       case (EVENTS, EVENTS, Accuracy.TEMPORAL) =>
         genGroupBy(unfilledPartitionRange).temporalEvents(renamedLeftDf, Some(toTimeRange(unfilledPartitionRange)))
 
-      case (EVENTS, ENTITIES, Accuracy.SNAPSHOT) => genGroupBy(shiftedPartitionRange).snapshotEntities
+      case (EVENTS, ENTITIES, Accuracy.SNAPSHOT) => genGroupBy(shiftedPartitionRange).snapshotEntities.shiftPartition(1)
 
       case (EVENTS, ENTITIES, Accuracy.TEMPORAL) =>
         // Snapshots and mutations are partitioned with ds holding data between <ds 00:00> and ds <23:59>.
-        genGroupBy(shiftedPartitionRange).temporalEntities(renamedLeftDf)
+        genGroupBy(shiftedPartitionRange).temporalEntities(renamedLeftDf).shiftPartition(1)
     }
     val rightDfWithDerivations = if (joinPart.groupBy.hasDerivations) {
       val finalOutputColumns = joinPart.groupBy.derivationsScala.finalOutputColumn(rightDf.columns).toSeq

--- a/spark/src/main/scala/ai/chronon/spark/batch/MergeJob.scala
+++ b/spark/src/main/scala/ai/chronon/spark/batch/MergeJob.scala
@@ -120,8 +120,7 @@ class MergeJob(node: JoinMergeNode, range: DateRange, joinParts: Seq[JoinPart])(
       keyRenamedRightDf
         .withColumn(
           Constants.TimePartitionColumn,
-          date_format(date_add(to_date(col(tableUtils.partitionColumn), tableUtils.partitionSpec.format), 1),
-                      tableUtils.partitionSpec.format)
+          col(tableUtils.partitionColumn)
         )
         .drop(tableUtils.partitionColumn)
     } else {

--- a/spark/src/main/scala/ai/chronon/spark/batch/MergeJob.scala
+++ b/spark/src/main/scala/ai/chronon/spark/batch/MergeJob.scala
@@ -133,6 +133,10 @@ class MergeJob(node: JoinMergeNode, range: DateRange, joinParts: Seq[JoinPart])(
                    |${leftDf.schema.pretty}
                    |Right Schema:
                    |${joinableRightDf.schema.pretty}""".stripMargin)
+
+    leftDf.show()
+    joinableRightDf.show()
+
     val joinedDf = coalescedJoin(leftDf, joinableRightDf, keys)
     logger.info(s"""Final Schema:
                    |${joinedDf.schema.pretty}


### PR DESCRIPTION
## Summary

Previously, snapshot accuracy would shift the joinPart output to align with the offset. This makes it align to the original left ds.

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to shift date-based partitions on DataFrames by a specified number of days.

- **Bug Fixes**
  - Adjusted logic for time partition alignment during joins to prevent unnecessary date shifting.

- **Refactor**
  - Applied partition shifting to specific DataFrames in batch join operations for improved processing.
  - Removed an assertion related to backfill start dates to streamline backfill logic.
  - Simplified join filtering logic by removing conditional date adjustments.
  - Removed redundant date incrementing in join and merge operations for cleaner partition handling.

- **Documentation**
  - Added a clarifying comment about table name construction for improved code transparency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->