### PR TITLE
Adding ability to set additional partitions in table deps

### DIFF
--- a/api/python/ai/chronon/airflow_helpers.py
+++ b/api/python/ai/chronon/airflow_helpers.py
@@ -5,7 +5,7 @@ import ai.chronon.utils as utils
 from ai.chronon.api.ttypes import GroupBy, Join
 
 
-def create_airflow_dependency(table, partition_column):
+def create_airflow_dependency(table, partition_column, additional_partitions=None):
     """
     Create an Airflow dependency object for a table.
 
@@ -30,9 +30,14 @@ def create_airflow_dependency(table, partition_column):
         )
         ```
         """
+
+    additional_partitions_str = ""
+    if additional_partitions:
+        additional_partitions_str = "/" + "/".join(additional_partitions)
+
     return {
         "name": f"wf_{utils.sanitize(table)}",
-        "spec": f"{table}/{partition_column}={{{{ ds }}}}",
+        "spec": f"{table}/{partition_column}={{{{ ds }}}}{additional_partitions_str}",
     }
 
 

--- a/api/python/ai/chronon/staging_query.py
+++ b/api/python/ai/chronon/staging_query.py
@@ -18,6 +18,7 @@ class EngineType:
 class TableDependency:
     table: str
     partition_column: Optional[str] = None
+    additional_partitions: Optional[List[str]] = None
 
 def StagingQuery(
     name: str,
@@ -96,7 +97,7 @@ def StagingQuery(
         stepDays=step_days,
     )
 
-    airflow_dependencies = [airflow_helpers.create_airflow_dependency(t.table, t.partition_column) for t in dependencies] if dependencies else []
+    airflow_dependencies = [airflow_helpers.create_airflow_dependency(t.table, t.partition_column, t.additional_partitions) for t in dependencies] if dependencies else []
     custom_json = json.dumps({"airflow_dependencies": airflow_dependencies})
 
     # Create metadata

--- a/api/python/test/sample/staging_queries/sample_team/sample_staging_query.py
+++ b/api/python/test/sample/staging_queries/sample_team/sample_staging_query.py
@@ -36,6 +36,6 @@ v1 = StagingQuery(
     output_namespace="sample_namespace",
     table_properties={"sample_config_json": """{"sample_key": "sample value}"""},
     dependencies=[
-        TableDependency(table="sample_namespace.sample_table", partition_column="ds")
+        TableDependency(table="sample_namespace.sample_table", partition_column="ds", additional_partitions=["_HR=23:00"]),
     ],
     )


### PR DESCRIPTION
## Summary

Adding an additional partitions argument to table deps

Produces dependency that looks like this: `"customJson": "{\"airflow_dependencies\": [{\"name\": \"wf_sample_namespace_sample_table\", \"spec\": \"sample_namespace.sample_table/ds={{ ds }}/_HR=23:00\"}]}",`

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for specifying additional partition information when defining table dependencies, allowing for more flexible and detailed dependency configurations.

- **Tests**
	- Updated test cases to include examples with additional partition specifications in table dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->