### PR TITLE
Revive push_to_canary

### DIFF
--- a/.github/workflows/push_to_canary.yaml
+++ b/.github/workflows/push_to_canary.yaml
@@ -1,0 +1,523 @@
+name: Push To Canary
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+env:
+  AWS_ACCOUNT_ID: ${{secrets.AWS_ACCOUNT_ID}}
+  AWS_REGION: ${{secrets.AWS_REGION}}
+  GCP_PROJECT_ID: ${{secrets.GCP_PROJECT_ID}}
+  GCP_REGION: ${{secrets.GCP_REGION}}
+
+jobs:
+  build_artifacts:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: corretto
+          java-version: 17
+
+      - name: Setup Bazel cache credentials
+        run: |
+          echo "${{ secrets.BAZEL_CACHE_CREDENTIALS }}" | base64 -d > bazel-cache-key.json
+
+      - name: Install Thrift
+        env:
+          THRIFT_VERSION: 0.21.0
+        run: |
+          sudo apt-get install automake bison flex g++ git libboost-all-dev libevent-dev libssl-dev libtool make pkg-config && \
+          curl -LSs https://archive.apache.org/dist/thrift/${{env.THRIFT_VERSION}}/thrift-${{env.THRIFT_VERSION}}.tar.gz -o thrift-${{env.THRIFT_VERSION}}.tar.gz && \
+          tar -xzf thrift-${{env.THRIFT_VERSION}}.tar.gz && \
+          cd thrift-${{env.THRIFT_VERSION}} && \
+          sudo ./configure --without-python --without-cpp --without-nodejs --without-java --disable-debug --disable-tests --disable-libs && \
+          sudo make && \
+          sudo make install && \
+          cd .. && \
+          sudo rm -rf thrift-${{env.THRIFT_VERSION}} thrift-${{env.THRIFT_VERSION}}.tar.gz
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11' # This should match the version used in [chronon]/.toolversions
+
+      - name: Get the latest release tag
+        id: get_tag
+        run: |
+          git fetch --tags
+          TAG=$(git tag --sort=-creatordate | head -n 1)
+          TAG="${TAG#v}"
+          if [ -z "$TAG" ]; then
+            TAG="0.0.0"
+          fi
+          echo "Latest release tag: $TAG"
+
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Build Python Wheel
+        id: build-wheel
+        shell: bash
+        env:
+          VERSION: "${{ steps.get_tag.outputs.tag }}+${{ github.sha }}"
+        run: |
+          set -eo pipefail
+          echo "Building wheel"
+          python3 -m pip install --upgrade pip
+          python3 -m pip install --upgrade setuptools wheel
+          
+          ./scripts/distribution/build_wheel.sh ${{ env.VERSION }}
+          
+          EXPECTED_ZIPLINE_WHEEL="zipline_ai-${{ env.VERSION }}-py3-none-any.whl"
+          if [ ! -f "$EXPECTED_ZIPLINE_WHEEL" ]; then
+            echo "$EXPECTED_ZIPLINE_WHEEL not found"
+            exit 1
+          fi
+          echo "wheel_file=$EXPECTED_ZIPLINE_WHEEL" >> $GITHUB_OUTPUT
+          echo "version=${{ env.VERSION }}" >> $GITHUB_OUTPUT
+
+      - name: Upload Wheel
+        uses: actions/upload-artifact@v4
+        with:
+          name: zipline-ai-wheel
+          path: ${{ steps.build-wheel.outputs.wheel_file }}
+
+      - name: Build Bazel Project
+        id: bazel-build
+        run: |
+          bazel clean
+          bazel build //flink:flink_assembly_deploy.jar \
+            --remote_cache=https://storage.googleapis.com/zipline-bazel-cache \
+            --google_credentials=bazel-cache-key.json 
+          bazel build //cloud_gcp:cloud_gcp_lib_deploy.jar \
+            --remote_cache=https://storage.googleapis.com/zipline-bazel-cache \
+            --google_credentials=bazel-cache-key.json 
+          bazel build //cloud_aws:cloud_aws_lib_deploy.jar \
+            --remote_cache=https://storage.googleapis.com/zipline-bazel-cache \
+            --google_credentials=bazel-cache-key.json 
+          bazel build //service:service_assembly_deploy.jar \
+            --remote_cache=https://storage.googleapis.com/zipline-bazel-cache \
+            --google_credentials=bazel-cache-key.json
+
+
+      - name: Upload Flink Assembly Jar
+        uses: actions/upload-artifact@v4
+        with:
+          name: flink-assembly-jar
+          path: bazel-bin/flink/flink_assembly_deploy.jar
+
+      - name: Upload Cloud AWS Jar
+        uses: actions/upload-artifact@v4
+        with:
+          name: cloud-aws-jar
+          path: bazel-bin/cloud_aws/cloud_aws_lib_deploy.jar
+
+      - name: Upload Cloud GCP Jar
+        uses: actions/upload-artifact@v4
+        with:
+          name: cloud-gcp-jar
+          path: bazel-bin/cloud_gcp/cloud_gcp_lib_deploy.jar
+
+      - name: Upload Service Assembly Jar
+        uses: actions/upload-artifact@v4
+        with:
+          name: service-assembly-jar
+          path: bazel-bin/service/service_assembly_deploy.jar
+    outputs:
+      wheel_file: ${{ steps.build-wheel.outputs.wheel_file }}
+      version: ${{ steps.build-wheel.outputs.version }}
+
+
+  push_to_aws:
+    needs: build_artifacts
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+
+    steps:
+
+      - name: Download Python Wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: zipline-ai-wheel
+
+      - name: Download Flink Assembly Jar
+        uses: actions/download-artifact@v4
+        with:
+          name: flink-assembly-jar
+
+      - name: Download Cloud AWS Lib Jar
+        uses: actions/download-artifact@v4
+        with:
+          name: cloud-aws-jar
+
+      - name: Download Service Assembly Jar
+        uses: actions/download-artifact@v4
+        with:
+          name: service-assembly-jar
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{env.AWS_ACCOUNT_ID}}:role/github_actions
+          aws-region: ${{env.AWS_REGION}}
+
+      - name: Push Jars to s3 Bucket
+        shell: bash
+        run: |
+          set -eo pipefail
+          aws s3 cp ${{ needs.build_artifacts.outputs.wheel_file }} s3://zipline-artifacts-canary/release/${{ needs.build_artifacts.outputs.version }}/wheels/ --metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
+          aws s3 cp flink_assembly_deploy.jar s3://zipline-artifacts-canary/release/${{ needs.build_artifacts.outputs.version }}/jars/flink_assembly_deploy.jar --metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
+          aws s3 cp cloud_aws_lib_deploy.jar s3://zipline-artifacts-canary/release/${{ needs.build_artifacts.outputs.version }}/jars/cloud_aws_lib_deploy.jar --metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
+          aws s3 cp service_assembly_deploy.jar s3://zipline-artifacts-canary/release/${{ needs.build_artifacts.outputs.version }}/jars/service_assembly_deploy.jar --metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
+
+
+  push_to_gcp:
+    needs: build_artifacts
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download Python Wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: zipline-ai-wheel
+
+      - name: Download Flink Assembly Jar
+        uses: actions/download-artifact@v4
+        with:
+          name: flink-assembly-jar
+
+      - name: Download Cloud GCP Lib Jar
+        uses: actions/download-artifact@v4
+        with:
+          name: cloud-gcp-jar
+
+      - name: Download Service Assembly Jar
+        uses: actions/download-artifact@v4
+        with:
+          name: service-assembly-jar
+
+
+      - name: Configure GCP Credentials
+        uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{env.GCP_PROJECT_ID}}
+          workload_identity_provider: projects/${{secrets.GCP_CANARY_PROJECT_NUMBER}}/locations/global/workloadIdentityPools/github-actions/providers/github
+          service_account: github-actions@${{secrets.GCP_CANARY_PROJECT_ID}}.iam.gserviceaccount.com
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Push Jars to GCS Bucket
+        shell: bash
+        env:
+          GAR_QUICKSTART_REPOSITORY: ${{env.GCP_REGION}}-docker.pkg.dev/${{env.GCP_PROJECT_ID}}/canary-images/quickstart
+          IMAGE_TAG: main
+        run: |
+          set -eo pipefail
+          gcloud storage cp ${{ needs.build_artifacts.outputs.wheel_file }} gs://zipline-artifacts-canary/release/${{ needs.build_artifacts.outputs.version }}/wheels/
+          gcloud storage objects update gs://zipline-artifacts-canary/release/${{ needs.build_artifacts.outputs.version }}/wheels/${{ needs.build_artifacts.outputs.wheel_file }} --custom-metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
+          gcloud storage cp flink_assembly_deploy.jar gs://zipline-artifacts-canary/release/${{ needs.build_artifacts.outputs.version }}/jars/flink_assembly_deploy.jar
+          gcloud storage objects update gs://zipline-artifacts-canary/release/${{ needs.build_artifacts.outputs.version }}/jars/flink_assembly_deploy.jar --custom-metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
+          gcloud storage cp cloud_gcp_lib_deploy.jar gs://zipline-artifacts-canary/release/${{ needs.build_artifacts.outputs.version }}/jars/cloud_gcp_lib_deploy.jar
+          gcloud storage objects update gs://zipline-artifacts-canary/release/${{ needs.build_artifacts.outputs.version }}/jars/cloud_gcp_lib_deploy.jar --custom-metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
+          gcloud storage cp service_assembly_deploy.jar gs://zipline-artifacts-canary/release/${{ needs.build_artifacts.outputs.version }}/jars/service_assembly_deploy.jar
+          gcloud storage objects update gs://zipline-artifacts-canary/release/${{ needs.build_artifacts.outputs.version }}/jars/service_assembly_deploy.jar --custom-metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
+
+
+  run_aws_integration_tests:
+    runs-on: ubuntu-latest
+    needs: [ build_artifacts, push_to_aws ]
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials for Canary Project
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{secrets.AWS_ACCOUNT_ID}}:role/github_actions
+          aws-region: ${{secrets.AWS_REGION}}
+
+      - name: Run Quickstart Integration Tests
+        id: aws_integration_tests
+        shell: bash
+        run: |
+          set -xo pipefail
+          ./scripts/distribution/run_aws_quickstart.sh --canary --version ${{ needs.build_artifacts.outputs.version }}
+
+      - name:  On Fail Notify Slack
+        id: notify_slack
+        if: failure()
+        uses: slackapi/slack-github-action@v1
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_AWS_WEBHOOK_URL }}
+        with:
+          payload: |
+            {
+              "text": "Zipline AWS CI Tests Failed\n\n The integration tests failed for commit <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.sha }}> on branch ${{ github.ref }}. Please check the logs for more details.",
+              "attachments": [
+                {
+                  "text": "",
+                  "color": "#ff0000"
+                }
+              ]
+            }
+
+
+  run_gcp_integration_tests:
+    runs-on: ubuntu-latest
+    needs: [build_artifacts, push_to_gcp]
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      # Checkout the canary-confs repo with the branch with Zipline specific team.json
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Configure GCP Credentials for Canary Project
+        uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{secrets.GCP_CANARY_PROJECT_ID}}
+          workload_identity_provider: projects/${{secrets.GCP_CANARY_PROJECT_NUMBER}}/locations/global/workloadIdentityPools/github-actions/providers/github
+          service_account: github-actions@${{secrets.GCP_CANARY_PROJECT_ID}}.iam.gserviceaccount.com
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Run Quickstart Integration Tests
+        shell: bash
+        id: gcp_integration_tests
+        run: |
+          set -xo pipefail
+          ./scripts/distribution/run_gcp_quickstart.sh --canary --version ${{ needs.build_artifacts.outputs.version }}
+
+      - name:  On Fail Notify Slack
+        id: notify_slack
+        if: failure()
+        uses: slackapi/slack-github-action@v1
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_GCP_WEBHOOK_URL }}
+        with:
+          payload: |
+            {
+              "text": "Zipline GCP CI Tests Failed\n\n The integration tests failed for commit <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.sha }}> on branch ${{ github.ref }}. Please check the logs for more details.",
+              "attachments": [
+                {
+                  "text": "",
+                  "color": "#ff0000"
+                }
+              ]
+            }
+
+  push_to_aws_passing:
+    needs: [ build_artifacts, run_gcp_integration_tests, run_aws_integration_tests ]
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+
+    steps:
+
+      - name: Download Python Wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: zipline-ai-wheel
+
+      - name: Download Flink Assembly Jar
+        uses: actions/download-artifact@v4
+        with:
+          name: flink-assembly-jar
+
+      - name: Download Cloud AWS Lib Jar
+        uses: actions/download-artifact@v4
+        with:
+          name: cloud-aws-jar
+
+      - name: Download Service Assembly Jar
+        uses: actions/download-artifact@v4
+        with:
+          name: service-assembly-jar
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{env.AWS_ACCOUNT_ID}}:role/github_actions
+          aws-region: ${{env.AWS_REGION}}
+
+      - name: Push Jars to s3 Bucket
+        shell: bash
+        run: |
+          set -eo pipefail
+          aws s3 cp ${{ needs.build_artifacts.outputs.wheel_file }} s3://zipline-artifacts-canary/release/platform-passing-candidate/wheels/ --metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
+          aws s3 cp flink_assembly_deploy.jar s3://zipline-artifacts-canary/release/platform-passing-candidate/jars/flink_assembly_deploy.jar --metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
+          aws s3 cp cloud_aws_lib_deploy.jar s3://zipline-artifacts-canary/release/platform-passing-candidate/jars/cloud_aws_lib_deploy.jar --metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
+          aws s3 cp service_assembly_deploy.jar s3://zipline-artifacts-canary/release/platform-passing-candidate/jars/service_assembly_deploy.jar --metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
+
+
+  push_to_gcp_passing:
+    needs: [build_artifacts, run_gcp_integration_tests, run_aws_integration_tests]
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download Python Wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: zipline-ai-wheel
+
+      - name: Download Flink Assembly Jar
+        uses: actions/download-artifact@v4
+        with:
+          name: flink-assembly-jar
+
+      - name: Download Cloud GCP Lib Jar
+        uses: actions/download-artifact@v4
+        with:
+          name: cloud-gcp-jar
+
+      - name: Download Service Assembly Jar
+        uses: actions/download-artifact@v4
+        with:
+          name: service-assembly-jar
+
+
+      - name: Configure GCP Credentials
+        uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{env.GCP_PROJECT_ID}}
+          workload_identity_provider: projects/${{secrets.GCP_CANARY_PROJECT_NUMBER}}/locations/global/workloadIdentityPools/github-actions/providers/github
+          service_account: github-actions@${{secrets.GCP_CANARY_PROJECT_ID}}.iam.gserviceaccount.com
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Push Jars to GCS Bucket
+        shell: bash
+        env:
+          GAR_QUICKSTART_REPOSITORY: ${{env.GCP_REGION}}-docker.pkg.dev/${{env.GCP_PROJECT_ID}}/canary-images/quickstart
+          IMAGE_TAG: main
+        run: |
+          set -eo pipefail
+          gcloud storage cp ${{ needs.build_artifacts.outputs.wheel_file }} gs://zipline-artifacts-canary/release/platform-passing-candidate/wheels/
+          gcloud storage objects update gs://zipline-artifacts-canary/release/platform-passing-candidate/wheels/${{ needs.build_artifacts.outputs.wheel_file }} --custom-metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
+          gcloud storage cp flink_assembly_deploy.jar gs://zipline-artifacts-canary/release/platform-passing-candidate/jars/flink_assembly_deploy.jar
+          gcloud storage objects update gs://zipline-artifacts-canary/release/platform-passing-candidate/jars/flink_assembly_deploy.jar --custom-metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
+          gcloud storage cp cloud_gcp_lib_deploy.jar gs://zipline-artifacts-canary/release/platform-passing-candidate/jars/cloud_gcp_lib_deploy.jar
+          gcloud storage objects update gs://zipline-artifacts-canary/release/platform-passing-candidate/jars/cloud_gcp_lib_deploy.jar --custom-metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
+          gcloud storage cp service_assembly_deploy.jar gs://zipline-artifacts-canary/release/platform-passing-candidate/jars/service_assembly_deploy.jar
+          gcloud storage objects update gs://zipline-artifacts-canary/release/platform-passing-candidate/jars/service_assembly_deploy.jar --custom-metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
+
+
+  clean_up_artifacts:
+    permissions:
+      contents: read
+
+    runs-on: ubuntu-latest
+
+    needs: [ push_to_gcp_passing, push_to_aws_passing ]
+
+    steps:
+      - name: Delete Artifacts
+        uses: geekyeggo/delete-artifact@v5
+        with:
+          name: |
+            zipline-ai-wheel
+            flink-assembly-jar
+            cloud-aws-jar
+            cloud-gcp-jar
+            service-assembly-jar
+
+
+  merge_to_main-passing-tests:
+    needs: [run_aws_integration_tests, run_gcp_integration_tests]
+    if: ${{ needs.run_aws_integration_tests.result == 'success' && needs.run_gcp_integration_tests.result == 'success' }}
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout Main Branch
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+      - name: Update Stable Branch
+        env:
+          TARGET_BRANCH: main-passing-tests
+        run: |
+          echo "Merging to main branch after successful push to canary"
+          if git show-ref --quiet refs/heads/$TARGET_BRANCH; then
+            echo "Target branch $TARGET_BRANCH exists. Merging main into it..."
+            git checkout $TARGET_BRANCH
+            git merge main --no-ff -m "Merge main into $TARGET_BRANCH"
+          else
+            echo "Target branch $TARGET_BRANCH does not exist. Creating it..."
+            git checkout -b $TARGET_BRANCH main
+          fi
+          git push origin $TARGET_BRANCH
+
+      - name: Create CI Status File
+        run: |
+          echo ${{ github.sha }} > ci_success.txt
+
+      - name: Update CI Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci_success
+          path: ci_success.txt
+
+
+  on_fail_notify_slack:
+    needs: [run_aws_integration_tests, run_gcp_integration_tests]
+    if: failure()
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Send Failure Notification
+        uses: slackapi/slack-github-action@v1
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TESTS_WEBHOOK_URL }}
+        with:
+          payload: |
+            {
+              "text": "Zipline CI Tests Failed\n\n The integration tests failed for commit <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.sha }}> on branch ${{ github.ref }}. Please check the logs for more details.",
+              "attachments": [
+                {
+                  "text": "",
+                  "color": "#ff0000"
+                }
+              ]
+            }


### PR DESCRIPTION
## Summary

As we will be releasing from chronon, this change brings back the canary build and testing.

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Introduced a new automated workflow for continuous integration and deployment to canary environments on AWS and GCP.
	- Added integration tests and artifact uploads for both platforms, with Slack notifications for build or test failures.
	- Enhanced artifact tracking with detailed metadata and automated cleanup after deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->