### PR TITLE
Set some defaults based on initial customer engagements

### DIFF
--- a/api/python/ai/chronon/resources/gcp/teams.py
+++ b/api/python/ai/chronon/resources/gcp/teams.py
@@ -20,9 +20,9 @@ default = Team(
             "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
             "spark.kryo.registrator": "ai.chronon.integrations.cloud_gcp.ChrononIcebergKryoRegistrator",
 
-            "spark.chronon.coalesce.factor": "10",
-            "spark.default.parallelism": "10",
-            "spark.sql.shuffle.partitions": "10",
+            "spark.chronon.coalesce.factor": "2",
+            "spark.default.parallelism": "10000",
+            "spark.sql.shuffle.partitions": "10000",
 
             # TODO: Please fill in the following values
             "spark.sql.catalog.bigquery_catalog.warehouse": "gs://zipline-warehouse-<customer_id>/data/tables/",

--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -482,6 +482,11 @@ object Driver {
                      descr = "Auto expand hive table if new columns added in staging query",
                      default = Option(true))
 
+      override val stepDays: ScallopOption[Int] =
+        opt[Int](required = false,
+                 descr = "Runs offline stagingquery backfill in steps, step-days at a time. Default is 1 day",
+                 default = Option(1))
+
       lazy val stagingQueryConf: api.StagingQuery = parseConf[api.StagingQuery](confPath())
       override def subcommandName(): String = s"staging_query_${stagingQueryConf.metaData.name}_backfill"
     }


### PR DESCRIPTION
## Summary

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new command-line option to control the number of days for offline staging query backfill, with a default of 1 day.

- **Bug Fixes**
  - Improved handling of table properties during staging query saves to ensure consistent application of write distribution settings.

- **Chores**
  - Updated default Spark configuration values for improved performance and resource utilization.
  - Centralized Spark configuration retrieval for parallelism and coalesce factor to standardize behavior across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
