### PR TITLE
feat enable cloud profiler

### DIFF
--- a/api/python/test/canary/teams.py
+++ b/api/python/test/canary/teams.py
@@ -72,6 +72,8 @@ gcp = Team(
     ),
     conf=ConfigProperties(
         common={
+            "cloud.profiler.enable": "true",
+            "cloud.profiler.name": "zipline-canary",
             "spark.chronon.cloud_provider": "gcp",  # dummy test config
             "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
             "spark.chronon.partition.format": "yyyy-MM-dd",


### PR DESCRIPTION
## Summary

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled cloud profiler for the GCP team with a specific profiler name in the configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->