### PR TITLE
feat: support force overwrite for stagingquery

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -509,6 +509,10 @@ object Driver {
 
       lazy val stagingQueryConf: api.StagingQuery = parseConf[api.StagingQuery](confPath())
       override def subcommandName(): String = s"staging_query_${stagingQueryConf.metaData.name}_backfill"
+
+      val forceOverwrite =
+        opt[Boolean]("key", descr = "Setting to true overwrites any existing partitions.", default = Some(false))
+
     }
 
     def run(args: Args): Unit = {
@@ -521,7 +525,8 @@ object Driver {
       stagingQueryJob.computeStagingQuery(args.stepDays.toOption,
                                           args.enableAutoExpand.toOption,
                                           args.startPartitionOverride.toOption,
-                                          !args.runFirstHole())
+                                          !args.runFirstHole(),
+                                          args.forceOverwrite())
 
       if (args.shouldExport()) {
         args.exportTableToLocal(args.stagingQueryConf.metaData.outputTable, tableUtils)


### PR DESCRIPTION
## Summary

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new command-line option to allow overwriting existing partitions during staging query backfill jobs.
  - Enhanced processing logic to support forced overwriting of partitions when enabled.
  - Added logging to indicate when the overwrite option is enabled and which partition ranges will be processed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
