### PR TITLE
Allow for jobs to be submitted when cluster is UPDATING

### DIFF
--- a/cloud_gcp/src/main/scala/ai/chronon/integrations/cloud_gcp/DataprocSubmitter.scala
+++ b/cloud_gcp/src/main/scala/ai/chronon/integrations/cloud_gcp/DataprocSubmitter.scala
@@ -539,7 +539,10 @@ object DataprocSubmitter {
     if (clusterName != "") {
       try {
         val cluster = dataprocClient.getCluster(projectId, region, clusterName)
-        if (cluster != null && cluster.getStatus.getState == ClusterStatus.State.RUNNING) {
+        if (
+          cluster != null && Set(ClusterStatus.State.RUNNING, ClusterStatus.State.UPDATING).contains(
+            cluster.getStatus.getState)
+        ) {
           println(s"Dataproc cluster $clusterName already exists and is running.")
           clusterName
         } else if (maybeClusterConfig.isDefined && maybeClusterConfig.get.contains("dataproc.config")) {


### PR DESCRIPTION
## Summary

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cluster validation logic to allow reuse of Dataproc clusters that are either RUNNING or UPDATING, resulting in more flexible and reliable cluster management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->