### PR TITLE
Cache and log number of rows only if not benchmark mode

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
@@ -260,6 +260,8 @@ class TableUtils(@transient val sparkSession: SparkSession) extends Serializable
 
     TableCache.remove(tableName)
 
+    finalizedDf.cache()
+
     logger.info(s"Writing to $tableName ...")
 
     finalizedDf.write
@@ -271,6 +273,8 @@ class TableUtils(@transient val sparkSession: SparkSession) extends Serializable
       .insertInto(tableName)
 
     logger.info(s"Finished writing to $tableName")
+
+    logger.info(s"Table $tableName has been written with ${finalizedDf.count()} rows.")
   }
 
   // retains only the invocations from chronon code.


### PR DESCRIPTION
## Summary

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configuration option to control caching and row count logging during data partition insertion.

- **Chores**
  - Enhanced logging behavior with a new benchmark mode setting to optimize performance monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->