### PR TITLE
Add label join tests using fixtures

### DIFF
--- a/spark/BUILD.bazel
+++ b/spark/BUILD.bazel
@@ -144,6 +144,7 @@ scala_test_suite(
     srcs = glob([
         "src/test/scala/ai/chronon/spark/test/batch/*.scala",
     ]),
+    data = ["//spark/src/test/resources:test-resources"],
     jvm_flags = _JVM_FLAGS_FOR_ACCESSING_BASE_JAVA_CLASSES,
     tags = ["medium"],
     visibility = ["//visibility:public"],

--- a/spark/src/test/resources/local_data_csv/sample_join.csv
+++ b/spark/src/test/resources/local_data_csv/sample_join.csv
@@ -1,0 +1,4 @@
+request_id,listing_id,ts,ds
+request_1,listing_1,2025-05-03 10:00:00,2025-05-03
+request_2,listing_2,2025-05-09 10:00:00,2025-05-09
+request_3,listing_3,2025-05-10 10:00:00,2025-05-10

--- a/spark/src/test/resources/local_data_csv/sample_label_loose_source.csv
+++ b/spark/src/test/resources/local_data_csv/sample_label_loose_source.csv
@@ -1,0 +1,2 @@
+request_id,listing_id,attribution,ts,ds
+request_1,listing_1,[view|click|cart|purchase],2025-05-10 00:00:00,2025-05-10

--- a/spark/src/test/resources/local_data_csv/sample_label_tight_source.csv
+++ b/spark/src/test/resources/local_data_csv/sample_label_tight_source.csv
@@ -1,0 +1,5 @@
+request_id,listing_id,attribution,ts,ds
+request_1,listing_1,[view|click],2025-05-03 11:00:01,2025-05-03
+request_2,listing_2,[view|click],2025-05-09 10:10:10,2025-05-09
+request_2,listing_2,[view|click|cart],2025-05-09 15:10:10,2025-05-09
+request_3,listing_3,[view],2025-05-10 10:10:10,2025-05-10

--- a/spark/src/test/scala/ai/chronon/spark/test/batch/LabelJoinV2Test.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/batch/LabelJoinV2Test.scala
@@ -784,13 +784,8 @@ class LabelJoinV2Test extends AnyFlatSpec {
     val labelComputedMay4 = labelJoinMay4.compute()
     labelComputedMay4.show(truncate = false)
     val expectedMay4Df = Seq(
-      ("request_1",
-       "listing_1",
-       "1746266400000",
-       null,
-       "[view|click]",
-       // we expect only tight for request_1 + listing_1 to be filled. loose will be filled in the future May 10 run
-       "2025-05-03")
+      ("request_1", "listing_1", "1746266400000", null, "[view|click]", "2025-05-03")
+      // we expect only tight for request_1 + listing_1 to be filled. loose will be filled in the future May 10 run
     ).toDF(
       "request_id",
       "listing_id",

--- a/spark/src/test/scala/ai/chronon/spark/test/batch/LabelJoinV2Test.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/batch/LabelJoinV2Test.scala
@@ -22,8 +22,6 @@ class LabelJoinV2Test extends AnyFlatSpec {
   @transient private lazy val logger = LoggerFactory.getLogger(getClass)
 
   val spark: SparkSession = submission.SparkSessionBuilder.build("LabelJoinV2Test", local = true)
-  import spark.implicits._
-
   private val tableUtils = TableTestUtils(spark)
   private val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
   private val twentyNineDaysAgo = tableUtils.partitionSpec.minus(today, new Window(29, TimeUnit.DAYS))
@@ -771,6 +769,8 @@ class LabelJoinV2Test extends AnyFlatSpec {
       "LabelJoinV2TestWithoutRoundDown",
       additionalConfig = Option(Map("spark.chronon.join.label_join.round_down_sub_day_windows" -> "false")),
       local = true)
+    import sparkNoRoundDownWithFixture.implicits._
+
     val namespace = "label_joinv2_temporal_with_fixtures_without_round_down"
 
     val tableUtils = TableTestUtils(sparkNoRoundDownWithFixture)
@@ -831,6 +831,8 @@ class LabelJoinV2Test extends AnyFlatSpec {
       "LabelJoinV2TestWithRoundDown",
       additionalConfig = Option(Map("spark.chronon.join.label_join.round_down_sub_day_windows" -> "true")),
       local = true)
+    import sparkRoundDownWithFixture.implicits._
+
     val namespace = "label_joinv2_temporal_with_fixtures_round_down"
 
     val tableUtils = TableTestUtils(sparkRoundDownWithFixture)


### PR DESCRIPTION
## Summary

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced utilities for loading CSV data into Spark tables with automatic timestamp parsing.
- **Tests**
	- Added new test cases to validate label join behavior using external CSV fixtures, covering scenarios with and without sub-day window rounding.
- **Chores**
	- Made test resources explicitly available to the batch test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->