### PR TITLE
Return clearer exception message for .latest when an empty list of values is processed in GetResponse

### DIFF
--- a/online/src/main/scala/ai/chronon/online/Api.scala
+++ b/online/src/main/scala/ai/chronon/online/Api.scala
@@ -46,7 +46,8 @@ object KVStore {
     def latest: Try[TimedValue] = {
       values.flatMap { seq =>
         if (seq.isEmpty) {
-          Failure(new RuntimeException("Values from KvStore were empty."))
+          // Could create a custom exception here, but using NoSuchElementException as upstream code rescues on it
+          Failure(new NoSuchElementException("Values from KvStore were empty."))
         } else {
           Success(seq.maxBy(_.millis))
         }

--- a/online/src/main/scala/ai/chronon/online/fetcher/MetadataStore.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/MetadataStore.scala
@@ -76,7 +76,6 @@ class MetadataStore(fetchContext: FetchContext) {
     val confKey = confPathOrName.computeConfKey(confTypeKeyword)
     fetchContext.kvStore
       .getString(confKey, fetchContext.metadataDataset, fetchContext.timeoutMillis)
-      .map(conf => ThriftJsonCodec.fromJsonStr[T](conf, false, clazz))
       .recoverWith { case th: Throwable =>
         Failure(
           new RuntimeException(
@@ -84,6 +83,7 @@ class MetadataStore(fetchContext: FetchContext) {
             th
           ))
       }
+      .map(conf => ThriftJsonCodec.fromJsonStr[T](conf, false, clazz))
   }
 
   private def getEntityListByTeam[T <: TBase[_, _]: Manifest](team: String): Try[Seq[String]] = {

--- a/spark/src/test/scala/ai/chronon/spark/test/fetcher/FetcherMetadataTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/fetcher/FetcherMetadataTest.scala
@@ -34,7 +34,7 @@ class FetcherMetadataTest extends AnyFlatSpec {
     )
     val actual = testResponse.latest
     assertTrue(actual.isFailure)
-    assertTrue(actual.failed.get.isInstanceOf[RuntimeException])
+    assertTrue(actual.failed.get.isInstanceOf[NoSuchElementException])
     assertTrue(actual.failed.get.getMessage.contains("Values from KvStore were empty."))
   }
 

--- a/spark/src/test/scala/ai/chronon/spark/test/fetcher/FetcherMetadataTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/fetcher/FetcherMetadataTest.scala
@@ -3,7 +3,7 @@ package ai.chronon.spark.test.fetcher
 import ai.chronon.api.Constants.MetadataDataset
 import ai.chronon.api.Extensions.{JoinOps, MetadataOps}
 import ai.chronon.api.ScalaJavaConversions.IterableOps
-import ai.chronon.online.KVStore.GetRequest
+import ai.chronon.online.KVStore.{GetRequest, GetResponse}
 import ai.chronon.online.fetcher.FetchContext
 import ai.chronon.online.{MetadataDirWalker, MetadataEndPoint, fetcher}
 import ai.chronon.spark.catalog.TableUtils
@@ -14,15 +14,28 @@ import org.apache.spark.sql.SparkSession
 import org.junit.Assert.{assertEquals, assertFalse, assertTrue}
 import org.scalatest.flatspec.AnyFlatSpec
 import ai.chronon.spark.Extensions._
+
 import java.util.concurrent.Executors
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.io.Source
+import scala.util.Success
 
 class FetcherMetadataTest extends AnyFlatSpec {
 
   val sessionName = "FetcherMetadataTest"
   val spark: SparkSession = submission.SparkSessionBuilder.build(sessionName, local = true)
+
+  it should "test empty values for GetResponse" in {
+
+    val testResponse = GetResponse(
+      request = GetRequest("testKey".getBytes(), "testDataSet"),
+      values = Success(Seq.empty) // .latest failes when an empty sequence is passed. .maxBy on an empty seq.
+    )
+    val actual = testResponse.latest
+    assertTrue(actual.isFailure)
+    assertTrue(actual.failed.get.isInstanceOf[UnsupportedOperationException])
+  }
 
   it should "test metadata store" in {
     implicit val executionContext: ExecutionContext = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(1))

--- a/spark/src/test/scala/ai/chronon/spark/test/fetcher/FetcherMetadataTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/fetcher/FetcherMetadataTest.scala
@@ -30,11 +30,12 @@ class FetcherMetadataTest extends AnyFlatSpec {
 
     val testResponse = GetResponse(
       request = GetRequest("testKey".getBytes(), "testDataSet"),
-      values = Success(Seq.empty) // .latest failes when an empty sequence is passed. .maxBy on an empty seq.
+      values = Success(Seq.empty)
     )
     val actual = testResponse.latest
     assertTrue(actual.isFailure)
-    assertTrue(actual.failed.get.isInstanceOf[UnsupportedOperationException])
+    assertTrue(actual.failed.get.isInstanceOf[RuntimeException])
+    assertTrue(actual.failed.get.getMessage.contains("Values from KvStore were empty."))
   }
 
   it should "test metadata store" in {


### PR DESCRIPTION
## Summary

## Checklist
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling when retrieving the latest value from an empty data sequence, preventing unexpected crashes.  
  - Enhanced error recovery order during configuration fetching to ensure robust exception handling.  
- **Tests**
  - Added a test to verify error handling when retrieving the latest value from an empty response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->