### PR TITLE
fix: fix empty wheres in SparkExpressionEval

### DIFF
--- a/flink/src/main/scala/ai/chronon/flink/SparkExpressionEval.scala
+++ b/flink/src/main/scala/ai/chronon/flink/SparkExpressionEval.scala
@@ -215,7 +215,9 @@ object SparkExpressionEval {
       case DataModel.EVENTS   => Seq(s"$timeColumn is NOT NULL")
     }
 
-    val baseFilters = query.getWheres.toScala
+    val baseFilters: Seq[String] = Option(query.getWheres)
+      .map(_.toScala.toSeq)
+      .getOrElse(Seq.empty[String])
 
     val filters: Seq[String] = baseFilters ++ timeFilters
 


### PR DESCRIPTION
## Summary

Full stack trace:
```
                <-----------------------------------------------------------------------------------
                ------------------------------------------------------------------------------------
                                                  DATAPROC LOGS
                ------------------------------------------------------------------------------------
                ------------------------------------------------------------------------------------>
                
INFO:ai.chronon.logger:Running command: gcloud dataproc jobs wait 3b1d9566-1946-497f-a202-2939219d98d7 --region=us-central1 --project=indigo-computer-272415
Waiting for job output...
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/usr/lib/flink/lib/log4j-slf4j-impl-2.17.2.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/usr/lib/hadoop/lib/slf4j-reload4j-1.7.36.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.apache.logging.slf4j.Log4jLoggerFactory]
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.apache.spark.unsafe.Platform (file:/tmp/3b1d9566-1946-497f-a202-2939219d98d7/flink_assembly_deploy.jar) to constructor java.nio.DirectByteBuffer(long,int)
WARNING: Please consider reporting this to the maintainers of org.apache.spark.unsafe.Platform
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release

------------------------------------------------------------
 The program finished with the following exception:

org.apache.flink.client.program.ProgramInvocationException: The main method caused an error: Unable to lookup serving info for GroupBy: 'crn.txns.per_payment_method_global'
	at org.apache.flink.client.program.PackagedProgram.callMainMethod(PackagedProgram.java:372)
	at org.apache.flink.client.program.PackagedProgram.invokeInteractiveModeForExecution(PackagedProgram.java:222)
	at org.apache.flink.client.ClientUtils.executeProgram(ClientUtils.java:105)
	at org.apache.flink.client.cli.CliFrontend.executeProgram(CliFrontend.java:851)
	at org.apache.flink.client.cli.CliFrontend.run(CliFrontend.java:245)
	at org.apache.flink.client.cli.CliFrontend.parseAndRun(CliFrontend.java:1095)
	at org.apache.flink.client.cli.CliFrontend.lambda$mainInternal$9(CliFrontend.java:1189)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/javax.security.auth.Subject.doAs(Subject.java:423)
	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1899)
	at org.apache.flink.runtime.security.contexts.HadoopSecurityContext.runSecured(HadoopSecurityContext.java:41)
	at org.apache.flink.client.cli.CliFrontend.mainInternal(CliFrontend.java:1189)
	at org.apache.flink.client.cli.CliFrontend.main(CliFrontend.java:1157)
Caused by: java.lang.IllegalArgumentException: Unable to lookup serving info for GroupBy: 'crn.txns.per_payment_method_global'
	at ai.chronon.flink.FlinkJob$$anonfun$1.applyOrElse(FlinkJob.scala:348)
	at ai.chronon.flink.FlinkJob$$anonfun$1.applyOrElse(FlinkJob.scala:347)
	at scala.runtime.AbstractPartialFunction.apply(AbstractPartialFunction.scala:38)
	at scala.util.Failure.recover(Try.scala:234)
	at ai.chronon.flink.FlinkJob$.main(FlinkJob.scala:347)
	at ai.chronon.flink.FlinkJob.main(FlinkJob.scala)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.apache.flink.client.program.PackagedProgram.callMainMethod(PackagedProgram.java:355)
	... 12 more
Caused by: java.lang.NullPointerException
	at ai.chronon.flink.SparkExpressionEval$.ai$chronon$flink$SparkExpressionEval$$buildQueryTransformsAndFilters(SparkExpressionEval.scala:220)
	at ai.chronon.flink.SparkExpressionEval.<init>(SparkExpressionEval.scala:39)
	at ai.chronon.flink.deser.SourceProjectionDeserializationSchema.projectedSchema(DeserializationSchema.scala:103)
	at ai.chronon.flink.FlinkJob$.buildFlinkJob(FlinkJob.scala:407)
	at ai.chronon.flink.FlinkJob$.$anonfun$main$7(FlinkJob.scala:345)
	at scala.util.Success.$anonfun$map$1(Try.scala:255)
	at scala.util.Success.map(Try.scala:213)
	at ai.chronon.flink.FlinkJob$.main(FlinkJob.scala:344)
	... 18 more
ERROR: (gcloud.dataproc.jobs.wait) Job [3b1d9566-1946-497f-a202-2939219d98d7] failed with error:
Job failed with message [org.apache.flink.client.program.ProgramInvocationException: The main method caused an error: Unable to lookup serving info for GroupBy: 'crn.txns.per_payment_method_global']. Additional details can be found at:
https://console.cloud.google.com/dataproc/jobs/3b1d9566-1946-497f-a202-2939219d98d7?project=indigo-computer-272415&region=us-central1
gcloud dataproc jobs wait '3b1d9566-1946-497f-a202-2939219d98d7' --region 'us-central1' --project 'indigo-computer-272415'
https://console.cloud.google.com/storage/browser/dataproc-staging-us-central1-937479888-g2bbipll/google-cloud-dataproc-metainfo/ea133f4f-afff-47b6-bc9e-43b423e1ed9f/jobs/3b1d9566-1946-497f-a202-2939219d98d7/
gs://dataproc-staging-us-central1-937479888-g2bbipll/google-cloud-dataproc-metainfo/ea133f4f-afff-47b6-bc9e-43b423e1ed9f/jobs/3b1d9566-1946-497f-a202-2939219d98d7/driveroutput.*
Traceback (most recent call last):
  File "/Users/feltorr/miniconda3/envs/zipline-chronon-test/bin/zipline", line 8, in <module>
    sys.exit(zipline())
             ^^^^^^^^^
  File "/Users/feltorr/miniconda3/envs/zipline-chronon-test/lib/python3.11/site-packages/click/core.py", line 1442, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/feltorr/miniconda3/envs/zipline-chronon-test/lib/python3.11/site-packages/click/core.py", line 1363, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/feltorr/miniconda3/envs/zipline-chronon-test/lib/python3.11/site-packages/click/core.py", line 1830, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/feltorr/miniconda3/envs/zipline-chronon-test/lib/python3.11/site-packages/click/core.py", line 1226, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/feltorr/miniconda3/envs/zipline-chronon-test/lib/python3.11/site-packages/click/core.py", line 794, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/feltorr/miniconda3/envs/zipline-chronon-test/lib/python3.11/site-packages/click/decorators.py", line 34, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/feltorr/miniconda3/envs/zipline-chronon-test/lib/python3.11/site-packages/ai/chronon/repo/run.py", line 271, in main
    GcpRunner(ctx.params).run()
  File "/Users/feltorr/miniconda3/envs/zipline-chronon-test/lib/python3.11/site-packages/ai/chronon/repo/gcp.py", line 522, in run
    check_call(
  File "/Users/feltorr/miniconda3/envs/zipline-chronon-test/lib/python3.11/site-packages/ai/chronon/repo/utils.py", line 68, in check_call
    return subprocess.check_call(cmd.split(), bufsize=0)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/feltorr/miniconda3/envs/zipline-chronon-test/lib/python3.11/subprocess.py", line 413, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['gcloud', 'dataproc', 'jobs', 'wait', '3b1d9566-1946-497f-a202-2939219d98d7', '--region=us-central1', '--project=indigo-computer-272415']' returned non-zero exit status 1.
```

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update

