### PR TITLE
Throw specific exception for when cluster is not in healthy state.

### DIFF
--- a/cloud_gcp/src/main/scala/ai/chronon/integrations/cloud_gcp/DataprocSubmitter.scala
+++ b/cloud_gcp/src/main/scala/ai/chronon/integrations/cloud_gcp/DataprocSubmitter.scala
@@ -525,7 +525,6 @@ object DataprocSubmitter {
     if (clusterName != "") {
       try {
         val cluster = dataprocClient.getCluster(projectId, region, clusterName)
-
         if (cluster != null) {
           if (
             Set(ClusterStatus.State.RUNNING, ClusterStatus.State.UPDATING, ClusterStatus.State.CREATING).contains(
@@ -535,8 +534,7 @@ object DataprocSubmitter {
             clusterName
           } else {
             throw new Exception(
-              s"Dataproc cluster $clusterName exists but is not in a healthy state: ${cluster.getStatus.getState}. " +
-                s"Attempting to create a new cluster with the provided config.")
+              s"Dataproc cluster $clusterName exists but is not in a healthy state: ${cluster.getStatus.getState}.")
           }
         } else if (maybeClusterConfig.isDefined && maybeClusterConfig.get.contains("dataproc.config")) {
           // Print to stderr so that it flushes immediately
@@ -548,7 +546,7 @@ object DataprocSubmitter {
                                 dataprocClient,
                                 maybeClusterConfig.get.getOrElse("dataproc.config", ""))
         } else {
-          throw new Exception(s"Dataproc cluster $clusterName does not exist and no cluster config provided.")
+          throw new Exception(s"Cluster $clusterName does not exist and no cluster config provided.")
         }
       } catch {
         case _: ApiException if maybeClusterConfig.isDefined && maybeClusterConfig.get.contains("dataproc.config") =>
@@ -559,8 +557,6 @@ object DataprocSubmitter {
                                 region,
                                 dataprocClient,
                                 maybeClusterConfig.get.getOrElse("dataproc.config", ""))
-        case _: ApiException =>
-          throw new Exception(s"Dataproc cluster $clusterName does not exist and no cluster config provided.")
       }
     } else if (maybeClusterConfig.isDefined && maybeClusterConfig.get.contains("dataproc.config")) {
       // Print to stderr so that it flushes immediately

--- a/cloud_gcp/src/main/scala/ai/chronon/integrations/cloud_gcp/DataprocSubmitter.scala
+++ b/cloud_gcp/src/main/scala/ai/chronon/integrations/cloud_gcp/DataprocSubmitter.scala
@@ -9,6 +9,7 @@ import org.apache.hadoop.fs.Path
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
 
+import scala.collection.immutable.Set
 import scala.jdk.CollectionConverters._
 
 case class SubmitterConf(
@@ -524,13 +525,19 @@ object DataprocSubmitter {
     if (clusterName != "") {
       try {
         val cluster = dataprocClient.getCluster(projectId, region, clusterName)
-        if (
-          cluster != null && Set(ClusterStatus.State.RUNNING,
-                                 ClusterStatus.State.UPDATING,
-                                 ClusterStatus.State.CREATING).contains(cluster.getStatus.getState)
-        ) {
-          println(s"Dataproc cluster $clusterName already exists and is healthy.")
-          clusterName
+
+        if (cluster != null) {
+          if (
+            Set(ClusterStatus.State.RUNNING, ClusterStatus.State.UPDATING, ClusterStatus.State.CREATING).contains(
+              cluster.getStatus.getState)
+          ) {
+            println(s"Dataproc cluster $clusterName already exists and is healthy.")
+            clusterName
+          } else {
+            throw new Exception(
+              s"Dataproc cluster $clusterName exists but is not in a healthy state: ${cluster.getStatus.getState}. " +
+                s"Attempting to create a new cluster with the provided config.")
+          }
         } else if (maybeClusterConfig.isDefined && maybeClusterConfig.get.contains("dataproc.config")) {
           // Print to stderr so that it flushes immediately
           System.err.println(

--- a/cloud_gcp/src/test/scala/ai/chronon/integrations/cloud_gcp/DataprocSubmitterTest.scala
+++ b/cloud_gcp/src/test/scala/ai/chronon/integrations/cloud_gcp/DataprocSubmitterTest.scala
@@ -797,6 +797,42 @@ class DataprocSubmitterTest extends AnyFlatSpec with MockitoSugar {
 
   }
 
+  it should "fail to create a Dataproc cluster if already exist in an unhealthy state" in {
+    val mockDataprocClient = mock[ClusterControllerClient]
+
+    val mockCluster = Cluster
+      .newBuilder()
+      .setStatus(ClusterStatus.newBuilder().setState(ClusterStatus.State.UNKNOWN))
+      .build()
+
+    when(mockDataprocClient.getCluster(any[String], any[String], any[String])).thenReturn(mockCluster)
+
+    val region = "test-region"
+    val projectId = "test-project"
+
+    val clusterConfigStr = """{
+      "masterConfig": {
+        "numInstances": 1,
+        "machineTypeUri": "n1-standard-4"
+      },
+      "workerConfig": {
+        "numInstances": 2,
+        "machineTypeUri": "n1-standard-4"
+      }
+    }"""
+
+    assertThrows[Exception] {
+      DataprocSubmitter.getOrCreateCluster("some-cluster",
+                                           Option(Map("dataproc.config" -> clusterConfigStr)),
+                                           projectId,
+                                           region,
+                                           mockDataprocClient)
+    }
+
+    // Expect no calls to create cluster when existing cluster is in unhealthy state
+    verify(mockDataprocClient, never()).createClusterAsync(any())
+  }
+
   it should "create a Dataproc cluster successfully with a given config" in {
     val mockDataprocClient = mock[ClusterControllerClient]
 


### PR DESCRIPTION
## Summary

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unhealthy Dataproc clusters by explicitly notifying users when an existing cluster is not in a healthy state before attempting to create a new one.  
  * Added validation to prevent creation attempts when an existing cluster is detected as unhealthy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->