### PR TITLE
fix: fix empty wheres attribute in SparkExpressionEvalFnTest.scala

### DIFF
--- a/flink/src/main/scala/ai/chronon/flink/SparkExpressionEval.scala
+++ b/flink/src/main/scala/ai/chronon/flink/SparkExpressionEval.scala
@@ -215,7 +215,9 @@ object SparkExpressionEval {
       case DataModel.EVENTS   => Seq(s"$timeColumn is NOT NULL")
     }
 
-    val baseFilters = query.getWheres.toScala
+    val baseFilters: Seq[String] = Option(query.getWheres)
+      .map(_.toScala.toSeq)
+      .getOrElse(Seq.empty[String])
 
     val filters: Seq[String] = baseFilters ++ timeFilters
 

--- a/flink/src/test/scala/ai/chronon/flink/test/SparkExpressionEvalFnTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/SparkExpressionEvalFnTest.scala
@@ -46,7 +46,7 @@ class SparkExpressionEvalFnTest extends AnyFlatSpec {
       E2ETestEvent("test3", 14, 1.7, 1699366993125L)
     )
 
-    val groupBy = FlinkTestUtils.makeGroupBy(Seq("id"), filters=null)
+    val groupBy = FlinkTestUtils.makeGroupBy(Seq("id"), filters = null)
 
     val encoder = Encoders.product[E2ETestEvent]
 


### PR DESCRIPTION
## Summary

Error stack trace:

```
                <-----------------------------------------------------------------------------------
                ------------------------------------------------------------------------------------
                                                  DATAPROC LOGS
                ------------------------------------------------------------------------------------
                ------------------------------------------------------------------------------------>
                
INFO:ai.chronon.logger:Running command: gcloud dataproc jobs wait 3b1d9566-1946-497f-a202-2939219d98d7 --region=us-central1 --project=indigo-computer-272415
Waiting for job output...
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/usr/lib/flink/lib/log4j-slf4j-impl-2.17.2.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/usr/lib/hadoop/lib/slf4j-reload4j-1.7.36.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.apache.logging.slf4j.Log4jLoggerFactory]
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.apache.spark.unsafe.Platform (file:/tmp/3b1d9566-1946-497f-a202-2939219d98d7/flink_assembly_deploy.jar) to constructor java.nio.DirectByteBuffer(long,int)
WARNING: Please consider reporting this to the maintainers of org.apache.spark.unsafe.Platform
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release

------------------------------------------------------------
 The program finished with the following exception:

org.apache.flink.client.program.ProgramInvocationException: The main method caused an error: Unable to lookup serving info for GroupBy: 'crn.txns.per_payment_method_global'
	at org.apache.flink.client.program.PackagedProgram.callMainMethod(PackagedProgram.java:372)
	at org.apache.flink.client.program.PackagedProgram.invokeInteractiveModeForExecution(PackagedProgram.java:222)
	at org.apache.flink.client.ClientUtils.executeProgram(ClientUtils.java:105)
	at org.apache.flink.client.cli.CliFrontend.executeProgram(CliFrontend.java:851)
	at org.apache.flink.client.cli.CliFrontend.run(CliFrontend.java:245)
	at org.apache.flink.client.cli.CliFrontend.parseAndRun(CliFrontend.java:1095)
	at org.apache.flink.client.cli.CliFrontend.lambda$mainInternal$9(CliFrontend.java:1189)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/javax.security.auth.Subject.doAs(Subject.java:423)
	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1899)
	at org.apache.flink.runtime.security.contexts.HadoopSecurityContext.runSecured(HadoopSecurityContext.java:41)
	at org.apache.flink.client.cli.CliFrontend.mainInternal(CliFrontend.java:1189)
	at org.apache.flink.client.cli.CliFrontend.main(CliFrontend.java:1157)
Caused by: java.lang.IllegalArgumentException: Unable to lookup serving info for GroupBy: 'crn.txns.per_payment_method_global'
	at ai.chronon.flink.FlinkJob$$anonfun$1.applyOrElse(FlinkJob.scala:348)
	at ai.chronon.flink.FlinkJob$$anonfun$1.applyOrElse(FlinkJob.scala:347)
	at scala.runtime.AbstractPartialFunction.apply(AbstractPartialFunction.scala:38)
	at scala.util.Failure.recover(Try.scala:234)
	at ai.chronon.flink.FlinkJob$.main(FlinkJob.scala:347)
	at ai.chronon.flink.FlinkJob.main(FlinkJob.scala)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.apache.flink.client.program.PackagedProgram.callMainMethod(PackagedProgram.java:355)
	... 12 more
Caused by: java.lang.NullPointerException
	at ai.chronon.flink.SparkExpressionEval$.ai$chronon$flink$SparkExpressionEval$$buildQueryTransformsAndFilters(SparkExpressionEval.scala:220)
	at ai.chronon.flink.SparkExpressionEval.<init>(SparkExpressionEval.scala:39)
	at ai.chronon.flink.deser.SourceProjectionDeserializationSchema.projectedSchema(DeserializationSchema.scala:103)
	at ai.chronon.flink.FlinkJob$.buildFlinkJob(FlinkJob.scala:407)
	at ai.chronon.flink.FlinkJob$.$anonfun$main$7(FlinkJob.scala:345)
	at scala.util.Success.$anonfun$map$1(Try.scala:255)
	at scala.util.Success.map(Try.scala:213)
	at ai.chronon.flink.FlinkJob$.main(FlinkJob.scala:344)
	... 18 more
```

## Tests

Running the added test without the fix gives:
```bash
//flink:tests_test_suite_src_test_scala_ai_chronon_flink_test_SparkExpressionEvalFnTest.scala FAILED in 22.7s
```

```bash
  Cause: java.lang.NullPointerException:
  at ai.chronon.flink.SparkExpressionEval$.ai$chronon$flink$SparkExpressionEval$$buildQueryTransformsAndFilters(SparkExpressionEval.scala:224)
  at ai.chronon.flink.SparkExpressionEval.<init>(SparkExpressionEval.scala:39)
  at ai.chronon.flink.SparkExpressionEvalFn.open(SparkExpressionEvalFn.scala:34)
  at org.apache.flink.api.common.functions.util.FunctionUtils.openFunction(FunctionUtils.java:34)
  at org.apache.flink.streaming.api.operators.AbstractUdfStreamOperator.open(AbstractUdfStreamOperator.java:101)
  at org.apache.flink.streaming.api.operators.StreamFlatMap.open(StreamFlatMap.java:40)
  at org.apache.flink.streaming.runtime.tasks.RegularOperatorChain.initializeStateAndOpenOperators(RegularOperatorChain.java:107)
  at org.apache.flink.streaming.runtime.tasks.StreamTask.restoreGates(StreamTask.java:734)
  at org.apache.flink.streaming.runtime.tasks.StreamTaskActionExecutor$1.call(StreamTaskActionExecutor.java:55)
  at org.apache.flink.streaming.runtime.tasks.StreamTask.restoreInternal(StreamTask.java:709)
  at org.apache.flink.streaming.runtime.tasks.StreamTask.restore(StreamTask.java:675)
  at org.apache.flink.runtime.taskmanager.Task.runWithSystemExitMonitoring(Task.java:952)
  at org.apache.flink.runtime.taskmanager.Task.restoreAndInvoke(Task.java:921)
  at org.apache.flink.runtime.taskmanager.Task.doRun(Task.java:745)
  at org.apache.flink.runtime.taskmanager.Task.run(Task.java:562)
  at java.base/java.lang.Thread.run(Thread.java:829)
```

All green after the fix:
![Screenshot 2025-06-27 at 15 36 32](https://github.com/user-attachments/assets/c230582e-13f3-469b-a7fb-186e416bf45b)


## Checklist
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of null filter values in group-by operations to prevent potential errors.

* **Tests**
  * Added a test to verify correct processing of group-by operations when filters are set to null.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->