### PR TITLE
perf: reuse partition formatter

### DIFF
--- a/api/src/main/scala/ai/chronon/api/DataRange.scala
+++ b/api/src/main/scala/ai/chronon/api/DataRange.scala
@@ -16,6 +16,9 @@
 
 package ai.chronon.api
 
+import org.slf4j.LoggerFactory
+import org.slf4j.Logger
+
 sealed trait DataRange {
   def toTimePoints: Array[Long]
 }
@@ -38,6 +41,11 @@ case class TimeRange(start: Long, end: Long)(implicit partitionSpec: PartitionSp
 case class PartitionRange(start: String, end: String)(implicit val partitionSpec: PartitionSpec)
     extends DataRange
     with Ordered[PartitionRange] {
+
+  val logger: Logger = LoggerFactory.getLogger(this.getClass)
+  // enforcing invariant: start and end should be compatible with the format
+  val startMillis: Option[Long] = Option(start).map(partitionSpec.epochMillis)
+  val endMillis: Option[Long] = Option(end).map(partitionSpec.epochMillis)
 
   def valid: Boolean = {
     (Option(start), Option(end)) match {

--- a/api/src/main/scala/ai/chronon/api/Extensions.scala
+++ b/api/src/main/scala/ai/chronon/api/Extensions.scala
@@ -1226,7 +1226,7 @@ object Extensions {
       result
     }
 
-    def partitionSpec(defaultSpec: PartitionSpec): PartitionSpec = {
+    def partitionSpec(implicit defaultSpec: PartitionSpec): PartitionSpec = {
       val column = Option(query).flatMap((q) => Option(q.partitionColumn)).getOrElse(defaultSpec.column)
       val format = Option(query).flatMap((q) => Option(q.partitionFormat)).getOrElse(defaultSpec.format)
       val interval = Option(query).flatMap((q) => Option(q.partitionInterval)).getOrElse(WindowUtils.Day)

--- a/api/src/main/scala/ai/chronon/api/PartitionSpec.scala
+++ b/api/src/main/scala/ai/chronon/api/PartitionSpec.scala
@@ -17,6 +17,8 @@
 package ai.chronon.api
 
 import ai.chronon.api.Extensions._
+import ai.chronon.api.PartitionSpec.getFormatter
+import org.eclipse.collections.impl.map.mutable.ConcurrentHashMap
 
 import java.text.SimpleDateFormat
 import java.time.Instant
@@ -27,19 +29,12 @@ import java.util.TimeZone
 
 case class PartitionSpec(column: String, format: String, spanMillis: Long) {
 
-  private def partitionFormatter =
-    DateTimeFormatter
-      .ofPattern(format, Locale.US)
-      .withZone(ZoneOffset.UTC)
-
-  private def sdf = {
-    val formatter = new SimpleDateFormat(format)
-    formatter.setTimeZone(TimeZone.getTimeZone("UTC"))
-    formatter
-  }
+  private def partitionFormatter = getFormatter(format)
 
   def epochMillis(partition: String): Long = {
-    sdf.parse(partition).getTime
+    val accessor = partitionFormatter.parse(partition)
+    val instant = Instant.from(accessor)
+    instant.toEpochMilli
   }
 
   // what is the date portion of this timestamp
@@ -97,4 +92,14 @@ case class PartitionSpec(column: String, format: String, spanMillis: Long) {
 
 object PartitionSpec {
   val daily: PartitionSpec = PartitionSpec("ds", "yyyy-MM-dd", 24 * 60 * 60 * 1000)
+
+  // re-use formatters - once per format
+  private val formatterMap: ConcurrentHashMap[String, DateTimeFormatter] = new ConcurrentHashMap[String, DateTimeFormatter]()
+
+  private def getFormatter(format: String): DateTimeFormatter = {
+    formatterMap.computeIfAbsent(format, {format: String =>  DateTimeFormatter
+      .ofPattern(format, Locale.US)
+      .withZone(ZoneOffset.UTC)
+    })
+  }
 }

--- a/api/src/main/scala/ai/chronon/api/PartitionSpec.scala
+++ b/api/src/main/scala/ai/chronon/api/PartitionSpec.scala
@@ -21,7 +21,8 @@ import ai.chronon.api.PartitionSpec.getFormatter
 
 import java.time.Instant
 import java.time.ZoneOffset
-import java.time.format.DateTimeFormatter
+import java.time.format.{DateTimeFormatter, DateTimeFormatterBuilder}
+import java.time.temporal.ChronoField
 import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
 
@@ -96,11 +97,17 @@ object PartitionSpec {
     new ConcurrentHashMap[String, DateTimeFormatter]()
 
   private def getFormatter(format: String): DateTimeFormatter = {
-    formatterMap.computeIfAbsent(format,
-                                 { format: String =>
-                                   DateTimeFormatter
-                                     .ofPattern(format, Locale.US)
-                                     .withZone(ZoneOffset.UTC)
-                                 })
+    formatterMap.computeIfAbsent(
+      format,
+      { format: String =>
+        new DateTimeFormatterBuilder()
+          .appendPattern(format)
+          .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
+          .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
+          .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
+          .toFormatter(Locale.US)
+          .withZone(ZoneOffset.UTC)
+      }
+    )
   }
 }

--- a/api/src/main/scala/ai/chronon/api/PartitionSpec.scala
+++ b/api/src/main/scala/ai/chronon/api/PartitionSpec.scala
@@ -18,14 +18,12 @@ package ai.chronon.api
 
 import ai.chronon.api.Extensions._
 import ai.chronon.api.PartitionSpec.getFormatter
-import org.eclipse.collections.impl.map.mutable.ConcurrentHashMap
 
-import java.text.SimpleDateFormat
 import java.time.Instant
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.util.Locale
-import java.util.TimeZone
+import java.util.concurrent.ConcurrentHashMap
 
 case class PartitionSpec(column: String, format: String, spanMillis: Long) {
 
@@ -94,12 +92,15 @@ object PartitionSpec {
   val daily: PartitionSpec = PartitionSpec("ds", "yyyy-MM-dd", 24 * 60 * 60 * 1000)
 
   // re-use formatters - once per format
-  private val formatterMap: ConcurrentHashMap[String, DateTimeFormatter] = new ConcurrentHashMap[String, DateTimeFormatter]()
+  private val formatterMap: ConcurrentHashMap[String, DateTimeFormatter] =
+    new ConcurrentHashMap[String, DateTimeFormatter]()
 
   private def getFormatter(format: String): DateTimeFormatter = {
-    formatterMap.computeIfAbsent(format, {format: String =>  DateTimeFormatter
-      .ofPattern(format, Locale.US)
-      .withZone(ZoneOffset.UTC)
-    })
+    formatterMap.computeIfAbsent(format,
+                                 { format: String =>
+                                   DateTimeFormatter
+                                     .ofPattern(format, Locale.US)
+                                     .withZone(ZoneOffset.UTC)
+                                 })
   }
 }

--- a/api/src/main/scala/ai/chronon/api/PartitionSpec.scala
+++ b/api/src/main/scala/ai/chronon/api/PartitionSpec.scala
@@ -30,10 +30,14 @@ case class PartitionSpec(column: String, format: String, spanMillis: Long) {
 
   private def partitionFormatter = getFormatter(format)
 
-  def epochMillis(partition: String): Long = {
+  def epochMillis(partition: String): Long = try {
     val accessor = partitionFormatter.parse(partition)
     val instant = Instant.from(accessor)
     instant.toEpochMilli
+  } catch {
+    case exception: Exception =>
+      println(s"Failed to parse string $partition using format $format")
+      throw exception
   }
 
   // what is the date portion of this timestamp

--- a/api/src/main/scala/ai/chronon/api/planner/TableDependencies.scala
+++ b/api/src/main/scala/ai/chronon/api/planner/TableDependencies.scala
@@ -17,7 +17,15 @@ object TableDependencies {
   def fromJoin(join: api.Join): Seq[TableDependency] = {
     val joinParts = Option(join.joinParts).map(_.iterator().toScala.toArray).getOrElse(Array.empty)
     val joinPartDeps = joinParts.flatMap((jp) => fromGroupBy(jp.groupBy))
-    val leftDep = scala.Option(join.left).map((src) => fromTable(src.table))
+    val leftDep = scala.Option(join.left).map { src =>
+      val dep = fromTable(src.table)
+      dep.tableInfo
+        .setPartitionColumn(src.query.getPartitionColumn)
+        .setPartitionFormat(src.query.getPartitionFormat)
+        .setPartitionInterval(src.query.getPartitionInterval)
+      dep
+    }
+
     val bootstrap =
       scala.Option(join.bootstrapParts).map(_.toScala.toArray[BootstrapPart]).getOrElse(Array.empty[BootstrapPart])
     val bootstrapDeps = bootstrap.map((bp) => fromTable(bp.table, bp.query))

--- a/spark/src/main/scala/ai/chronon/spark/Extensions.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Extensions.scala
@@ -55,7 +55,6 @@ object Extensions {
     def toAvroSchema(name: String = null): Schema = AvroConversions.fromChrononSchema(toChrononSchema(name))
   }
 
-  case class DfStats(count: Long, partitionRange: PartitionRange)
   // helper class to maintain datafram stats that are necessary for downstream operations
   case class DfWithStats(df: DataFrame, partitionCounts: Map[String, Long])(implicit val partitionSpec: PartitionSpec) {
     private val minPartition: String = partitionCounts.keys.min

--- a/spark/src/main/scala/ai/chronon/spark/Join.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Join.scala
@@ -236,6 +236,9 @@ class Join(joinConf: api.Join,
                             runSmallMode: Boolean = false,
                             usingBootstrappedLeft: Boolean = false): Option[DataFrame] = {
 
+    println("left df results")
+    leftDf.show()
+
     val leftTaggedDf = leftDf.addTimebasedColIfExists()
 
     // compute bootstrap table - a left outer join between left source and various bootstrap source table

--- a/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
@@ -290,19 +290,27 @@ abstract class JoinBase(val joinConfCloned: api.Join,
     logger.info(s"Join range to fill $rangeToFill")
 
     // check if left source doesn't have any partition for the requested range
-    val existingLeftRange = tableUtils.partitions(
+    val existingLeftPartitions: Seq[String] = tableUtils.partitions(
       joinConfCloned.left.table,
       partitionRange = Option(rangeToFill),
       tablePartitionSpec = Option(joinConfCloned.left.query.partitionSpec(tableUtils.partitionSpec))
-    )
+    ).map(p => tableUtils.partitionSpec.translate(p, rangeToFill.partitionSpec))
+
     val requested = rangeToFill.partitions
-    val fillableRanges = requested.filter(existingLeftRange.contains)
+    val fillableRanges = requested.filter(existingLeftPartitions.contains)
 
     if (fillableRanges.isEmpty) {
       logger.info(s"""No relevant input partitions present in join.left table ${joinConfCloned.left.table}
                    | for the requested range ${rangeToFill.start} - ${rangeToFill.end}. Exiting...""".stripMargin)
       return None
     }
+
+    logger.info(
+      s"""
+         |rangeToFill: ${rangeToFill}
+         |rangeToFillSpec: ${rangeToFill.partitionSpec}
+         |""".stripMargin
+    )
 
     val unfilledRanges = tableUtils
       .unfilledRanges(
@@ -330,7 +338,7 @@ abstract class JoinBase(val joinConfCloned: api.Join,
     // build bootstrap info once for the entire job
     val bootstrapInfo = BootstrapInfo.from(joinConfCloned.deepCopy(), rangeToFill, tableUtils, leftSchema)
 
-    val wholeRange = PartitionRange(unfilledRanges.minBy(_.start).start, unfilledRanges.maxBy(_.end).end)
+    val wholeRange = PartitionRange(unfilledRanges.minBy(_.start).start, unfilledRanges.maxBy(_.end).end)(unfilledRanges.head.partitionSpec)
 
     val leftDataOpt = leftDf(joinConfCloned, wholeRange, tableUtils)
     require(leftDataOpt.nonEmpty,

--- a/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
@@ -84,10 +84,17 @@ object JoinUtils {
 
     val partitionColumnOfLeft = effectiveLeftSpec.column
 
+    println(s"printing left table")
+    tableUtils.scanDf(joinConf.left.query,
+      joinConf.left.table,
+      Some((Map(partitionColumnOfLeft -> null) ++ timeProjection).toMap),
+      range = None).limit(5).show()
+
     var df = tableUtils.scanDf(joinConf.left.query,
                                joinConf.left.table,
                                Some((Map(partitionColumnOfLeft -> null) ++ timeProjection).toMap),
                                range = Some(effectiveLeftRange))
+
 
     limit.foreach(l => df = df.limit(l))
 
@@ -131,10 +138,26 @@ object JoinUtils {
 
     implicit val tu: TableUtils = tableUtils
 
-    val firstAvailablePartitionOpt =
+    val firstAvailablePartitionRawOpt =
       tableUtils.firstAvailablePartition(leftSource.table,
                                          leftSpec,
                                          subPartitionFilters = leftSource.subPartitionFilters)
+
+    val firstAvailablePartitionOpt = firstAvailablePartitionRawOpt.map(p =>
+        tableUtils.partitionSpec.translate(p, leftSpec)
+    )
+
+    logger.info(
+      s"""
+         |endPartitionRaw:           $endPartitionRaw
+         |overrideStartPartitionRaw: $overrideStartPartitionRaw
+         |endPartition:              $endPartition
+         |overrideStartPartition:    $overrideStartPartition
+         |tableUtils Spec:           ${tableUtils.partitionSpec}
+         |leftSpec:                  $leftSpec
+         |firstAvailablePartition:   $firstAvailablePartitionOpt
+         |""".stripMargin
+    )
 
     lazy val defaultLeftStart = Option(leftSource.query.startPartition)
       .getOrElse {

--- a/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
@@ -112,9 +112,15 @@ object JoinUtils {
     */
   def getRangeToFill(leftSource: ai.chronon.api.Source,
                      tableUtils: TableUtils,
-                     endPartition: String,
-                     overrideStartPartition: Option[String] = None,
+                     endPartitionRaw: String,
+                     overrideStartPartitionRaw: Option[String] = None,
                      historicalBackfill: Boolean = true): PartitionRange = {
+
+    val leftSpec = leftSource.query.partitionSpec(tableUtils.partitionSpec)
+
+    // translate this range to match left partitionSpec
+    val endPartition = tableUtils.partitionSpec.translate(endPartitionRaw, leftSpec)
+    val overrideStartPartition = overrideStartPartitionRaw.map(p => tableUtils.partitionSpec.translate(p, leftSpec))
 
     val overrideStart = if (historicalBackfill) {
       overrideStartPartition
@@ -124,12 +130,12 @@ object JoinUtils {
     }
 
     implicit val tu: TableUtils = tableUtils
-    val leftSpec = leftSource.query.partitionSpec(tableUtils.partitionSpec)
 
     val firstAvailablePartitionOpt =
       tableUtils.firstAvailablePartition(leftSource.table,
                                          leftSpec,
                                          subPartitionFilters = leftSource.subPartitionFilters)
+
     lazy val defaultLeftStart = Option(leftSource.query.startPartition)
       .getOrElse {
         require(

--- a/spark/src/main/scala/ai/chronon/spark/batch/BatchNodeRunner.scala
+++ b/spark/src/main/scala/ai/chronon/spark/batch/BatchNodeRunner.scala
@@ -126,10 +126,12 @@ class BatchNodeRunner(node: Node, tableUtils: TableUtils) extends NodeRunner {
       val stepDays = for {
         executionInfo <- Option(metadata.executionInfo)
       } yield executionInfo.stepDays
-      val df = join.computeJoin(stepDays = stepDays, overrideStartPartition = Option(range.start))
+      val dfOpt = join.computeJoinOpt(stepDays = stepDays, overrideStartPartition = Option(range.start))
 
-      df.show(numRows = 3, truncate = 0, vertical = true)
-      logger.info(s"\nShowing three rows of output above.\nQuery table '$joinName' for more.\n")
+      dfOpt.foreach {
+        logger.info(s"\nShowing three rows of output above.\nQuery table '$joinName' for more.\n")
+        _.show(numRows = 3, truncate = 0, vertical = true)
+      }
     }
   }
 

--- a/spark/src/main/scala/ai/chronon/spark/batch/JoinBootstrapJob.scala
+++ b/spark/src/main/scala/ai/chronon/spark/batch/JoinBootstrapJob.scala
@@ -27,7 +27,8 @@ class JoinBootstrapJob(node: JoinBootstrapNode, metaData: MetaData, range: DateR
   @transient lazy val logger: Logger = LoggerFactory.getLogger(getClass)
 
   private val join = node.join
-  private val dateRange = range.toPartitionRange
+  private val leftSpec = join.left.query.partitionSpec
+  private val dateRange = range.toPartitionRange(leftSpec)
   private val leftSourceTable = JoinUtils.computeFullLeftSourceTableName(join)
 
   // Use the node's metadata output table
@@ -39,6 +40,9 @@ class JoinBootstrapJob(node: JoinBootstrapNode, metaData: MetaData, range: DateR
     // `f"${source.table}_${ThriftJsonCodec.md5Digest(sourceWithFilter)}"` Logic should  be computed by orchestrator
     // and passed to both jobs
     val leftDf = tableUtils.scanDf(query = null, table = leftSourceTable, range = Some(dateRange))
+
+    println("bootstrap job left df")
+    leftDf.show()
 
     val bootstrapInfo = BootstrapInfo.from(join, dateRange, tableUtils, Option(leftDf.schema))
 
@@ -126,6 +130,16 @@ class JoinBootstrapJob(node: JoinBootstrapNode, metaData: MetaData, range: DateR
     val enrichedDf = padExternalFields(joinedDf, bootstrapInfo)
 
     println(s"EnrichedDF schema: ${enrichedDf.schema}")
+
+    // TODO: remove
+    println(
+      s"""DEBUG_HELPER
+         |date range: $dateRange
+         |date range spec: ${dateRange.partitionSpec}
+         |bootstrap part spec: ${parts.map(bp => s"${bp.query.startPartition}..${bp.query.endPartition}")}
+         |""".stripMargin)
+    leftDf.show()
+    enrichedDf.show()
 
     // set autoExpand = true since log table could be a bootstrap part
     enrichedDf.save(bootstrapTable, tableProps, autoExpand = true)

--- a/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
@@ -122,7 +122,9 @@ class TableUtils(@transient val sparkSession: SparkSession) extends Serializable
   def partitions(tableName: String,
                  subPartitionsFilter: Map[String, String] = Map.empty,
                  partitionRange: Option[PartitionRange] = None,
-                 tablePartitionSpec: Option[PartitionSpec] = None): List[String] = {
+                 tablePartitionSpec: Option[PartitionSpec] = None,
+                 translateToDefault: Boolean = true
+                ): List[String] = {
     if (!tableReachable(tableName)) return List.empty[String]
     val rangeWheres = andPredicates(partitionRange.map(_.whereClauses).getOrElse(Seq.empty))
 
@@ -146,11 +148,13 @@ class TableUtils(@transient val sparkSession: SparkSession) extends Serializable
       })
       .getOrElse(List.empty)
 
-    // if table is yyyyMMdd and global partitionSpec is yyyy-MM-dd, partitions will use yyyyMMdd
-    // downstream range arithmetic requires yyyy-MM-dd - so we need to translate to global
-    tablePartitionSpec
-      .map(ps => partitions.map(date => ps.translate(date, partitionSpec)))
-      .getOrElse(partitions)
+    if(translateToDefault && tablePartitionSpec.nonEmpty) {
+      // if table is yyyyMMdd and global partitionSpec is yyyy-MM-dd, partitions will use yyyyMMdd
+      // downstream range arithmetic requires yyyy-MM-dd - so we need to translate to global
+      partitions.map(date => tablePartitionSpec.get.translate(date, partitionSpec))
+    } else {
+      partitions
+    }
   }
 
   def tableCoversRange(table: String, range: PartitionRange): Boolean = {
@@ -339,13 +343,13 @@ class TableUtils(@transient val sparkSession: SparkSession) extends Serializable
     }
   }
 
-  def chunk(partitions: Set[String]): Seq[PartitionRange] = {
+  def chunk(partitions: Set[String], spec: PartitionSpec = partitionSpec): Seq[PartitionRange] = {
     val sortedDates = partitions.toSeq.sorted
     sortedDates.foldLeft(Seq[PartitionRange]()) { (ranges, nextDate) =>
-      if (ranges.isEmpty || partitionSpec.after(ranges.last.end) != nextDate) {
-        ranges :+ PartitionRange(nextDate, nextDate)(partitionSpec)
+      if (ranges.isEmpty || spec.after(ranges.last.end) != nextDate) {
+        ranges :+ PartitionRange(nextDate, nextDate)(spec)
       } else {
-        val newRange = PartitionRange(ranges.last.start, nextDate)(partitionSpec)
+        val newRange = PartitionRange(ranges.last.start, nextDate)(spec)
         ranges.dropRight(1) :+ newRange
       }
     }
@@ -359,7 +363,6 @@ class TableUtils(@transient val sparkSession: SparkSession) extends Serializable
                      inputToOutputShift: Int = 0,
                      skipFirstHole: Boolean = true,
                      inputPartitionSpecs: Seq[PartitionSpec] = Seq(partitionSpec)
-
                      // ------- TODO: CLEANUP --------
   ): Option[Seq[PartitionRange]] = {
 
@@ -380,9 +383,9 @@ class TableUtils(@transient val sparkSession: SparkSession) extends Serializable
 
       outputPartitionRange.copy(start = partitionSpec.shift(inputStart.get, inputToOutputShift))(partitionSpec)
     } else {
-
       outputPartitionRange
     }
+
     val outputExisting = partitions(outputTable)
     // To avoid recomputing partitions removed by retention mechanisms we will not fill holes in the very beginning of the range
     // If a user fills a new partition in the newer end of the range, then we will never fill any partitions before that range.
@@ -392,6 +395,14 @@ class TableUtils(@transient val sparkSession: SparkSession) extends Serializable
     } else {
       validPartitionRange.start
     }
+
+    logger.info(
+      s"""
+         |outputRange: $outputPartitionRange
+         |outputSpec: ${outputPartitionRange.partitionSpec}
+         |validRange: ${validPartitionRange}
+         |validRangeSpec: ${validPartitionRange.partitionSpec}
+         |""".stripMargin)
 
     val fillablePartitions =
       if (skipFirstHole) {
@@ -413,7 +424,10 @@ class TableUtils(@transient val sparkSession: SparkSession) extends Serializable
                                    Option(outputPartitionRange),
                                    tablePartitionSpec = Some(inputPartitionSpec))
       ) yield {
-        partitionSpec.shift(partitionStr, inputToOutputShift)
+        partitionSpec.translate(
+          partitionSpec.shift(partitionStr, inputToOutputShift),
+          outputPartitionRange.partitionSpec
+        )
       }
 
     val inputMissing = inputTables
@@ -421,7 +435,7 @@ class TableUtils(@transient val sparkSession: SparkSession) extends Serializable
       .getOrElse(Set.empty)
 
     val missingPartitions = outputMissing -- inputMissing
-    val missingChunks = chunk(missingPartitions)
+    val missingChunks = chunk(missingPartitions, outputPartitionRange.partitionSpec)
 
     logger.info(s"""
                |Unfilled range computation:
@@ -429,6 +443,7 @@ class TableUtils(@transient val sparkSession: SparkSession) extends Serializable
                |   Missing output partitions: ${outputMissing.toSeq.sorted.prettyInline}
                |   Input tables: ${inputTables.getOrElse(Seq("None")).mkString(", ")}
                |   Missing input partitions: ${inputMissing.toSeq.sorted.prettyInline}
+               |   Existing Input Partitions: ${existingInputPartitions}
                |   Unfilled Partitions: ${missingPartitions.toSeq.sorted.prettyInline}
                |   Unfilled ranges: ${missingChunks.sorted.mkString("")}
                |""".stripMargin)

--- a/spark/src/test/scala/ai/chronon/spark/test/batch/BatchNodeRunnerTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/batch/BatchNodeRunnerTest.scala
@@ -25,6 +25,7 @@ import ai.chronon.spark.batch.BatchNodeRunner
 import ai.chronon.spark.submission.SparkSessionBuilder
 import ai.chronon.spark.test.{MockKVStore, TableTestUtils}
 import ai.chronon.spark.utils.MockApi
+import com.google.gson.{Gson, GsonBuilder}
 import org.apache.spark.sql.SparkSession
 import org.junit.Assert._
 import org.scalatest.flatspec.AnyFlatSpec
@@ -452,6 +453,7 @@ class BatchNodeRunnerTest extends AnyFlatSpec with BeforeAndAfterAll with Before
         }
 
       case Failure(exception) =>
+        exception.printStackTrace()
         fail(s"runFromArgs should have succeeded but failed with: ${exception.getMessage}")
     }
   }


### PR DESCRIPTION
## Summary
allocate the datetimeformatter only once globally (it is already thread safe) and remove usage of SDF.


## Checklist
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved date and time parsing performance and reliability by optimizing how date formatters are managed internally.
  * Enhanced partition metadata handling to ensure accurate propagation in join operations.
  * Improved partition range calculations by translating partition specifications for consistency.
  * Added safer handling of optional data results during batch join processing.
  * Enhanced logging and debugging outputs for partition ranges, data frames, and join operations to aid troubleshooting.
  * Updated partition listing and chunking methods to support flexible partition spec translations and improved range computations.
* **Tests**
  * Improved test diagnostics by printing exception details on failure for partition range translation tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->