### PR TITLE
feat: set rootLogger.level using env var

### DIFF
--- a/service/src/main/resources/log4j2.properties
+++ b/service/src/main/resources/log4j2.properties
@@ -20,7 +20,7 @@ appender.file.strategy.type = DefaultRolloverStrategy
 appender.file.strategy.max = 30
 
 # Root logger
-rootLogger.level = info
+rootLogger.level = ${env:LOG_LEVEL:-info}
 rootLogger.appenderRef.console.ref = Console
 rootLogger.appenderRef.file.ref = File
 


### PR DESCRIPTION
## Summary

Adds the ability to set the `rootLogger.level` parameter using an environment variable.

Running with `-e LOG_LEVEL=info`:
<img width="1279" height="234" alt="Screenshot 2025-08-13 at 14 00 20" src="https://github.com/user-attachments/assets/af31cc92-6cc1-4f8f-8d5f-028239dd65fa" />

Running with `-e LOG_LEVEL=debug`:
<img width="1358" height="510" alt="Screenshot 2025-08-13 at 14 15 01" src="https://github.com/user-attachments/assets/af5949db-c1b5-444c-8536-cee479594200" />


## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Logging level is now configurable via an environment variable (LOG_LEVEL), allowing you to adjust verbosity without code changes; defaults to “info” if not set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->