### PR TITLE
feat: change sawtooth window tail logs to debug

### DIFF
--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/SawtoothOnlineAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/SawtoothOnlineAggregator.scala
@@ -54,10 +54,10 @@ class SawtoothOnlineAggregator(val batchEndTs: Long,
 
   val batchTailTs: Array[Option[Long]] = tailTs(batchEndTs)
 
-  logger.info(s"Batch End: ${TsUtils.toStr(batchEndTs)}")
-  logger.info("Window Tails: ")
+  logger.debug(s"Batch End: ${TsUtils.toStr(batchEndTs)}")
+  logger.debug("Window Tails: ")
   for (i <- windowMappings.indices) {
-    logger.info(s"  ${windowMappings(i).aggregationPart.outputColumnName} -> ${batchTailTs(i).map(TsUtils.toStr)}")
+    logger.debug(s"  ${windowMappings(i).aggregationPart.outputColumnName} -> ${batchTailTs(i).map(TsUtils.toStr)}")
   }
 
   def update(batchIr: BatchIr, row: Row): BatchIr = update(batchEndTs, batchIr, row, batchTailTs)


### PR DESCRIPTION
## Summary

Change the log level of the sawtooth window tail logs to debug.

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.
- Chores
  - Adjusted log levels from info to debug for batch end timestamps and window tail details, reducing log noise in standard output while retaining details at debug level. This results in cleaner logs in production/default configurations. Expect less clutter in monitoring dashboards and potentially lower log storage usage. For troubleshooting, enable debug logging to view these details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->