### PR TITLE
Fix: Push Wheel To passing-candidate

### DIFF
--- a/.github/workflows/push_to_canary.yaml
+++ b/.github/workflows/push_to_canary.yaml
@@ -2,8 +2,8 @@ name: Push To Canary
 
 on:
   push:
-    branches:
-      - main
+#    branches:
+#      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -72,7 +72,7 @@ jobs:
         run: |
           set -eo pipefail
           echo "Building wheel"
-          ./mill python.wheel ${{ env.VERSION }}
+          ./scripts/distribution/build_wheel.sh ${{ env.VERSION }}
           
           EXPECTED_ZIPLINE_WHEEL="out/python/wheel.dest/dist/zipline_ai-${{ env.VERSION }}-py3-none-any.whl"
           if [ ! -f "$EXPECTED_ZIPLINE_WHEEL" ]; then
@@ -357,135 +357,135 @@ jobs:
               ]
             }
 
-  push_to_aws_passing:
-    needs: [ build_artifacts, run_gcp_integration_tests, run_aws_integration_tests ]
-    runs-on: ubuntu-latest
-
-    permissions:
-      id-token: write
-
-    steps:
-
-      - name: Download Python Wheel
-        uses: actions/download-artifact@v4
-        with:
-          name: zipline-ai-wheel
-
-      - name: Download Flink Assembly Jar
-        uses: actions/download-artifact@v4
-        with:
-          name: flink-assembly-jar
-
-      - name: Download Cloud AWS Lib Jar
-        uses: actions/download-artifact@v4
-        with:
-          name: cloud-aws-jar
-
-      - name: Download Service Assembly Jar
-        uses: actions/download-artifact@v4
-        with:
-          name: service-assembly-jar
-
-      - name: Rename JAR files to expected names
-        run: |
-          # The artifacts are downloaded into directories named after the artifact
-          # We need to move them to the current directory with the expected names
-          mv flink-assembly-jar/out.jar flink_assembly_deploy.jar
-          mv cloud-aws-jar/out.jar cloud_aws_lib_deploy.jar
-          mv service-assembly-jar/out.jar service_assembly_deploy.jar
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::${{env.AWS_ACCOUNT_ID}}:role/github_actions
-          aws-region: ${{env.AWS_REGION}}
-
-      - name: Push Jars to s3 Bucket
-        shell: bash
-        run: |
-          set -eo pipefail
-          aws s3 cp ${{ needs.build_artifacts.outputs.wheel_file }} s3://zipline-artifacts-canary/release/passing-candidate/wheels/ --metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
-          aws s3 cp flink_assembly_deploy.jar s3://zipline-artifacts-canary/release/passing-candidate/jars/flink_assembly_deploy.jar --metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
-          aws s3 cp cloud_aws_lib_deploy.jar s3://zipline-artifacts-canary/release/passing-candidate/jars/cloud_aws_lib_deploy.jar --metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
-          aws s3 cp service_assembly_deploy.jar s3://zipline-artifacts-canary/release/passing-candidate/jars/service_assembly_deploy.jar --metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
-
-
-  push_to_gcp_passing:
-    needs: [build_artifacts, run_gcp_integration_tests, run_aws_integration_tests]
-    runs-on: ubuntu-latest
-
-    permissions:
-      id-token: write
-      contents: read
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Download Python Wheel
-        uses: actions/download-artifact@v4
-        with:
-          name: zipline-ai-wheel
-
-      - name: Download Flink Assembly Jar
-        uses: actions/download-artifact@v4
-        with:
-          name: flink-assembly-jar
-
-      - name: Download Cloud GCP Lib Jar
-        uses: actions/download-artifact@v4
-        with:
-          name: cloud-gcp-jar
-
-      - name: Download Service Assembly Jar
-        uses: actions/download-artifact@v4
-        with:
-          name: service-assembly-jar
-
-      - name: Download PubSub Jar
-        uses: actions/download-artifact@v4
-        with:
-          name: pubsub-jar
-
-      - name: Rename JAR files to expected names
-        run: |
-          # The artifacts are downloaded into directories named after the artifact
-          # We need to move them to the current directory with the expected names
-          mv flink-assembly-jar/out.jar flink_assembly_deploy.jar
-          mv cloud-gcp-jar/out.jar cloud_gcp_lib_deploy.jar
-          mv service-assembly-jar/out.jar service_assembly_deploy.jar
-          mv pubsub-jar/out.jar connectors_pubsub_deploy.jar
-
-      - name: Configure GCP Credentials
-        uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{env.GCP_PROJECT_ID}}
-          workload_identity_provider: projects/${{secrets.GCP_CANARY_PROJECT_NUMBER}}/locations/global/workloadIdentityPools/github-actions/providers/github
-          service_account: github-actions@${{secrets.GCP_CANARY_PROJECT_ID}}.iam.gserviceaccount.com
-
-      - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-
-      - name: Push Jars to GCS Bucket
-        shell: bash
-        env:
-          GAR_QUICKSTART_REPOSITORY: ${{env.GCP_REGION}}-docker.pkg.dev/${{env.GCP_PROJECT_ID}}/canary-images/quickstart
-          IMAGE_TAG: main
-        run: |
-          set -eo pipefail
-          gcloud storage cp ${{ needs.build_artifacts.outputs.wheel_file }} gs://zipline-artifacts-canary/release/passing-candidate/wheels/
-          gcloud storage objects update gs://zipline-artifacts-canary/release/passing-candidate/wheels/${{ needs.build_artifacts.outputs.wheel_file }} --custom-metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
-          
-          gcloud storage cp flink_assembly_deploy.jar gs://zipline-artifacts-canary/release/passing-candidate/jars/flink_assembly_deploy.jar
-          gcloud storage objects update gs://zipline-artifacts-canary/release/passing-candidate/jars/flink_assembly_deploy.jar --custom-metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
-          
-          gcloud storage cp cloud_gcp_lib_deploy.jar gs://zipline-artifacts-canary/release/passing-candidate/jars/cloud_gcp_lib_deploy.jar
-          gcloud storage objects update gs://zipline-artifacts-canary/release/passing-candidate/jars/cloud_gcp_lib_deploy.jar --custom-metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
-          
-          gcloud storage cp service_assembly_deploy.jar gs://zipline-artifacts-canary/release/passing-candidate/jars/service_assembly_deploy.jar
-          gcloud storage objects update gs://zipline-artifacts-canary/release/passing-candidate/jars/service_assembly_deploy.jar --custom-metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
-
-          gcloud storage cp connectors_pubsub_deploy.jar gs://zipline-artifacts-canary/release/passing-candidate/jars/connectors_pubsub_deploy.jar
-          gcloud storage objects update gs://zipline-artifacts-canary/release/passing-candidate/jars/connectors_pubsub_deploy.jar --custom-metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
+#  push_to_aws_passing:
+#    needs: [ build_artifacts, run_gcp_integration_tests, run_aws_integration_tests ]
+#    runs-on: ubuntu-latest
+#
+#    permissions:
+#      id-token: write
+#
+#    steps:
+#
+#      - name: Download Python Wheel
+#        uses: actions/download-artifact@v4
+#        with:
+#          name: zipline-ai-wheel
+#
+#      - name: Download Flink Assembly Jar
+#        uses: actions/download-artifact@v4
+#        with:
+#          name: flink-assembly-jar
+#
+#      - name: Download Cloud AWS Lib Jar
+#        uses: actions/download-artifact@v4
+#        with:
+#          name: cloud-aws-jar
+#
+#      - name: Download Service Assembly Jar
+#        uses: actions/download-artifact@v4
+#        with:
+#          name: service-assembly-jar
+#
+#      - name: Rename JAR files to expected names
+#        run: |
+#          # The artifacts are downloaded into directories named after the artifact
+#          # We need to move them to the current directory with the expected names
+#          mv flink-assembly-jar/out.jar flink_assembly_deploy.jar
+#          mv cloud-aws-jar/out.jar cloud_aws_lib_deploy.jar
+#          mv service-assembly-jar/out.jar service_assembly_deploy.jar
+#
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v4
+#        with:
+#          role-to-assume: arn:aws:iam::${{env.AWS_ACCOUNT_ID}}:role/github_actions
+#          aws-region: ${{env.AWS_REGION}}
+#
+#      - name: Push Jars to s3 Bucket
+#        shell: bash
+#        run: |
+#          set -eo pipefail
+#          aws s3 cp ${{ needs.build_artifacts.outputs.wheel_file }} s3://zipline-artifacts-canary/release/passing-candidate/wheels/ --metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
+#          aws s3 cp flink_assembly_deploy.jar s3://zipline-artifacts-canary/release/passing-candidate/jars/flink_assembly_deploy.jar --metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
+#          aws s3 cp cloud_aws_lib_deploy.jar s3://zipline-artifacts-canary/release/passing-candidate/jars/cloud_aws_lib_deploy.jar --metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
+#          aws s3 cp service_assembly_deploy.jar s3://zipline-artifacts-canary/release/passing-candidate/jars/service_assembly_deploy.jar --metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
+#
+#
+#  push_to_gcp_passing:
+#    needs: [build_artifacts, run_gcp_integration_tests, run_aws_integration_tests]
+#    runs-on: ubuntu-latest
+#
+#    permissions:
+#      id-token: write
+#      contents: read
+#
+#    steps:
+#      - uses: actions/checkout@v4
+#
+#      - name: Download Python Wheel
+#        uses: actions/download-artifact@v4
+#        with:
+#          name: zipline-ai-wheel
+#
+#      - name: Download Flink Assembly Jar
+#        uses: actions/download-artifact@v4
+#        with:
+#          name: flink-assembly-jar
+#
+#      - name: Download Cloud GCP Lib Jar
+#        uses: actions/download-artifact@v4
+#        with:
+#          name: cloud-gcp-jar
+#
+#      - name: Download Service Assembly Jar
+#        uses: actions/download-artifact@v4
+#        with:
+#          name: service-assembly-jar
+#
+#      - name: Download PubSub Jar
+#        uses: actions/download-artifact@v4
+#        with:
+#          name: pubsub-jar
+#
+#      - name: Rename JAR files to expected names
+#        run: |
+#          # The artifacts are downloaded into directories named after the artifact
+#          # We need to move them to the current directory with the expected names
+#          mv flink-assembly-jar/out.jar flink_assembly_deploy.jar
+#          mv cloud-gcp-jar/out.jar cloud_gcp_lib_deploy.jar
+#          mv service-assembly-jar/out.jar service_assembly_deploy.jar
+#          mv pubsub-jar/out.jar connectors_pubsub_deploy.jar
+#
+#      - name: Configure GCP Credentials
+#        uses: google-github-actions/auth@v2
+#        with:
+#          project_id: ${{env.GCP_PROJECT_ID}}
+#          workload_identity_provider: projects/${{secrets.GCP_CANARY_PROJECT_NUMBER}}/locations/global/workloadIdentityPools/github-actions/providers/github
+#          service_account: github-actions@${{secrets.GCP_CANARY_PROJECT_ID}}.iam.gserviceaccount.com
+#
+#      - name: Set up Google Cloud SDK
+#        uses: google-github-actions/setup-gcloud@v2
+#
+#      - name: Push Jars to GCS Bucket
+#        shell: bash
+#        env:
+#          GAR_QUICKSTART_REPOSITORY: ${{env.GCP_REGION}}-docker.pkg.dev/${{env.GCP_PROJECT_ID}}/canary-images/quickstart
+#          IMAGE_TAG: main
+#        run: |
+#          set -eo pipefail
+#          gcloud storage cp ${{ needs.build_artifacts.outputs.wheel_file }} gs://zipline-artifacts-canary/release/passing-candidate/wheels/
+#          gcloud storage objects update gs://zipline-artifacts-canary/release/passing-candidate/wheels/${{ needs.build_artifacts.outputs.wheel_file }} --custom-metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
+#
+#          gcloud storage cp flink_assembly_deploy.jar gs://zipline-artifacts-canary/release/passing-candidate/jars/flink_assembly_deploy.jar
+#          gcloud storage objects update gs://zipline-artifacts-canary/release/passing-candidate/jars/flink_assembly_deploy.jar --custom-metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
+#
+#          gcloud storage cp cloud_gcp_lib_deploy.jar gs://zipline-artifacts-canary/release/passing-candidate/jars/cloud_gcp_lib_deploy.jar
+#          gcloud storage objects update gs://zipline-artifacts-canary/release/passing-candidate/jars/cloud_gcp_lib_deploy.jar --custom-metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
+#
+#          gcloud storage cp service_assembly_deploy.jar gs://zipline-artifacts-canary/release/passing-candidate/jars/service_assembly_deploy.jar
+#          gcloud storage objects update gs://zipline-artifacts-canary/release/passing-candidate/jars/service_assembly_deploy.jar --custom-metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
+#
+#          gcloud storage cp connectors_pubsub_deploy.jar gs://zipline-artifacts-canary/release/passing-candidate/jars/connectors_pubsub_deploy.jar
+#          gcloud storage objects update gs://zipline-artifacts-canary/release/passing-candidate/jars/connectors_pubsub_deploy.jar --custom-metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
 
   clean_up_artifacts:
     permissions:

--- a/.github/workflows/push_to_canary.yaml
+++ b/.github/workflows/push_to_canary.yaml
@@ -486,25 +486,25 @@ jobs:
 #
 #          gcloud storage cp connectors_pubsub_deploy.jar gs://zipline-artifacts-canary/release/passing-candidate/jars/connectors_pubsub_deploy.jar
 #          gcloud storage objects update gs://zipline-artifacts-canary/release/passing-candidate/jars/connectors_pubsub_deploy.jar --custom-metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
-
-  clean_up_artifacts:
-    permissions:
-      contents: read
-
-    runs-on: ubuntu-latest
-
-    needs: [ push_to_gcp_passing, push_to_aws_passing ]
-
-    steps:
-      - name: Delete Artifacts
-        uses: geekyeggo/delete-artifact@v5
-        with:
-          name: |
-            zipline-ai-wheel
-            flink-assembly-jar
-            cloud-aws-jar
-            cloud-gcp-jar
-            service-assembly-jar
+#
+#  clean_up_artifacts:
+#    permissions:
+#      contents: read
+#
+#    runs-on: ubuntu-latest
+#
+#    needs: [ push_to_gcp_passing, push_to_aws_passing ]
+#
+#    steps:
+#      - name: Delete Artifacts
+#        uses: geekyeggo/delete-artifact@v5
+#        with:
+#          name: |
+#            zipline-ai-wheel
+#            flink-assembly-jar
+#            cloud-aws-jar
+#            cloud-gcp-jar
+#            service-assembly-jar
 
 
   merge_to_main-passing-tests:


### PR DESCRIPTION
## Summary

Reference wheel name instead of the full wheel path.

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Standardized artifact naming in release pipelines for canary and passing channels to ensure consistent uploads to AWS S3 and Google Cloud Storage.
  - Improved reliability of copy/update steps post-artifact upload without changing how artifacts are initially built or uploaded.
  - Reduced risk of broken links or missing files in storage during pre-release and passing distributions.
  - No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->