### PR TITLE
Switch to using an environment flag for enabling gcloud auth for zipline hub

### DIFF
--- a/python/src/ai/chronon/repo/hub_runner.py
+++ b/python/src/ai/chronon/repo/hub_runner.py
@@ -178,6 +178,10 @@ class ScheduleModes:
     online: str
     offline_schedule: str
 
+def get_hub_gcloud_auth_flag(conf_path):
+    common_env_map = get_common_env_map(conf_path)
+    enable_hub_gcloud_auth = common_env_map.get("ENABLE_HUB_GCLOUD_AUTH", os.environ.get("ENABLE_HUB_GCLOUD_AUTH", "false")).lower()
+    return enable_hub_gcloud_auth == "true"
 
 def get_hub_conf(conf_path):
     common_env_map = get_common_env_map(conf_path)

--- a/python/src/ai/chronon/repo/zipline_hub.py
+++ b/python/src/ai/chronon/repo/zipline_hub.py
@@ -7,7 +7,7 @@ from google.auth.transport.requests import Request
 
 
 class ZiplineHub:
-    def __init__(self, base_url, enable_gcloud_auth: bool = True):
+    def __init__(self, base_url, enable_gcloud_auth: bool):
         if not base_url:
             raise ValueError("Base URL for ZiplineHub cannot be empty.")
         self.base_url = base_url

--- a/python/src/ai/chronon/repo/zipline_hub.py
+++ b/python/src/ai/chronon/repo/zipline_hub.py
@@ -7,7 +7,7 @@ from google.auth.transport.requests import Request
 
 
 class ZiplineHub:
-    def __init__(self, base_url, enable_gcloud_auth: bool):
+    def __init__(self, base_url, enable_gcloud_auth: bool = False):
         if not base_url:
             raise ValueError("Base URL for ZiplineHub cannot be empty.")
         self.base_url = base_url

--- a/python/src/ai/chronon/repo/zipline_hub.py
+++ b/python/src/ai/chronon/repo/zipline_hub.py
@@ -7,11 +7,11 @@ from google.auth.transport.requests import Request
 
 
 class ZiplineHub:
-    def __init__(self, base_url):
+    def __init__(self, base_url, enable_gcloud_auth: bool = True):
         if not base_url:
             raise ValueError("Base URL for ZiplineHub cannot be empty.")
         self.base_url = base_url
-        if self.base_url.startswith("https"):
+        if enable_gcloud_auth:
             print("\n 🔐 Using Google Cloud authentication for ZiplineHub.")
 
             # First try to get ID token from environment (GitHub Actions)

--- a/python/test/canary/teams.py
+++ b/python/test/canary/teams.py
@@ -29,7 +29,7 @@ default = Team(
             "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
             "FRONTEND_URL": "http://localhost:5173", # "https://34.111.151.47.nip.io",
             "HUB_URL": "http://localhost:3903", #"http://34.133.227.246:3903",
-            "ENABLE_HUB_GCLOUD_AUTH": "true",
+            # "ENABLE_HUB_GCLOUD_AUTH": "false",
         },
     ),
 )

--- a/python/test/canary/teams.py
+++ b/python/test/canary/teams.py
@@ -28,7 +28,8 @@ default = Team(
             "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
             "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
             "FRONTEND_URL": "http://localhost:5173", # "https://34.111.151.47.nip.io",
-            "HUB_URL": "http://localhost:3903" #"http://34.133.227.246:3903",
+            "HUB_URL": "http://localhost:3903", #"http://34.133.227.246:3903",
+            "ENABLE_HUB_GCLOUD_AUTH": "true",
         },
     ),
 )


### PR DESCRIPTION
…ine hub

## Summary

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an explicit toggle to enable Google Cloud authentication for Hub connections. Authentication is now opt-in via a constructor flag, providing clearer control.
* **Chores**
  * Introduced an optional config/env flag to control Google Cloud authentication (disabled by default).
* **Tests**
  * Updated canary configuration to include a commented example for enabling Google Cloud authentication, with no runtime impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->