### PR TITLE
[WIP] Push telemetry into gcp via local fetcher

### DIFF
--- a/docker/fetcher/README.md
+++ b/docker/fetcher/README.md
@@ -137,73 +137,6 @@ curl -s "http://localhost:9091/api/v1/label/__name__/values" | jq '.data[]'
 open http://localhost:9091
 ```
 
-### GCP Telemetry Setup
-
-For production deployments that push metrics to Google Cloud Monitoring:
-
-* **OTEL Collector**: Receives metrics and exports to both GCP Monitoring and local Prometheus
-* **Google Cloud Monitoring**: Cloud-native metrics storage and visualization
-* **Prometheus**: Local metrics access for debugging and development
-
-#### Prerequisites
-
-1. **GCP Setup**:
-   - Enable Cloud Monitoring API in your GCP project
-   - Authenticate with `gcloud auth application-default login`
-
-2. **Required Environment Variables**:
-   ```shell
-   export GCP_PROJECT_ID=your-project-id
-   export GCP_BIGTABLE_INSTANCE_ID=your-instance-id
-   ```
-
-#### Setup Steps
-
-1. **Start services**:
-   ```shell
-   docker-compose -f chronon-service-with-gcp-telemetry.yml up -d
-   ```
-
-#### Viewing Metrics
-
-Metrics are available in both locations:
-
-**Local Prometheus Access:**
-```bash
-# Prometheus UI (same as local setup)
-open http://localhost:9091
-
-# Raw metrics from OTEL Collector
-curl http://localhost:9464/metrics
-```
-
-**Google Cloud Monitoring:**
-
-Metrics are exported under the `custom.googleapis.com/chronon-fetcher` namespace:
-
-> **Configuration Reference:** For additional Google Cloud exporter configuration options, see the [OpenTelemetry Google Cloud Exporter documentation](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/googlecloudexporter/README.md).
-
-1. **Google Cloud Console**:
-   - Navigate to Monitoring > Metrics Explorer
-   - Search for metrics with prefix `custom.googleapis.com/chronon-fetcher`
-
-2. **gcloud CLI**:
-   ```bash
-   # List available metric types
-   gcloud logging metrics list --filter="name:chronon-fetcher"
-   
-   # View metrics in Cloud Monitoring
-   # Navigate to: https://console.cloud.google.com/monitoring
-   ```
-
-3. **Query via API**:
-   ```bash
-   # Example API call to retrieve metrics
-   curl -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
-     "https://monitoring.googleapis.com/v3/projects/$GCP_PROJECT_ID/metricDescriptors" | \
-     jq '.metricDescriptors[] | select(.type | contains("chronon-fetcher"))'
-   ```
-
 ### Google Managed Prometheus Setup (Recommended)
 
 For production deployments using Google Cloud Managed Service for Prometheus:
@@ -223,16 +156,20 @@ For production deployments using Google Cloud Managed Service for Prometheus:
    ```shell
    export GCP_PROJECT_ID=your-project-id
    export GCP_BIGTABLE_INSTANCE_ID=your-instance-id
-   # Optional: Configure cluster/location metadata
+   # For local/non-GKE deployments, configure metadata manually:
    export GCP_CLUSTER_NAME=chronon-cluster
    export GCP_NAMESPACE=default  
    export GCP_LOCATION=us-central1
    ```
 
+> **Note**: When deployed in a GKE cluster, the OTEL collector automatically detects cluster metadata (cluster name, location, namespace) using the GCP resource detector. Environment variables are only needed for local Docker deployments.
+
 #### Setup Steps
 
 1. **Start services**:
    ```shell
+   # For local deployments, set environment variables:
+   GCP_LOCATION=us-central1 GCP_NAMESPACE=default GCP_CLUSTER_NAME=chronon-local \
    docker-compose -f chronon-service-with-managed-prometheus.yml up -d
    ```
 
@@ -251,26 +188,28 @@ curl http://localhost:9464/metrics
 
 **Google Managed Prometheus:**
 
-Metrics are stored in Managed Service for Prometheus with automatic service discovery:
+Metrics are stored in Managed Service for Prometheus with resource labels from the OTEL processor:
 
 1. **Google Cloud Console**:
    - Navigate to Monitoring > Metrics Explorer
    - Use PromQL queries to filter Chronon metrics
-   - Look for metrics with `service_name="chronon-fetcher"`
+   - Metrics are available without prefixes and include resource labels like `cluster`, `namespace`, `location`
+   - If metrics are failing to publish check the [exporter troubleshooting guide](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlemanagedprometheusexporter#troubleshooting)
 
 2. **PromQL Queries**:
    ```promql
-   # Example queries for Chronon metrics
-   {service_name="chronon-fetcher"}
+   # Example queries for Chronon metrics (note: no chronon-fetcher prefix)
+   # For local Docker deployments:
+   {cluster="chronon-cluster", namespace="default", location="us-central1"}
+   
+   # For GKE deployments (auto-detected metadata):
+   {cluster="my-gke-cluster", namespace="chronon-prod", location="us-west1"}
    
    # Filter by specific metric patterns
-   {service_name="chronon-fetcher", __name__=~"chronon.*"}
+   {__name__=~"chronon.*"}
+   
+   # Query specific service metrics
+   {service_name="chronon-fetcher"}
    ```
 
-3. **Grafana Integration**:
-   ```bash
-   # Connect Grafana to Managed Prometheus
-   # Data source URL: https://monitoring.googleapis.com/v1/projects/PROJECT_ID/location/global/prometheus/
-   ```
-
-> **Configuration Reference:** For advanced Managed Prometheus configuration, see the [Google Cloud Managed Prometheus documentation](https://cloud.google.com/stackdriver/docs/managed-prometheus) and [OpenTelemetry setup guide](https://cloud.google.com/stackdriver/docs/managed-prometheus/setup-otel).
+> **Configuration Reference:** The setup uses the `googlemanagedprometheus` exporter with a `resourcedetection` processor (auto-detects GKE metadata) and `resource` processor (fallback for local deployments). When deployed in GKE, cluster metadata is automatically discovered. For advanced configuration, see the [Google Cloud Managed Prometheus documentation](https://cloud.google.com/stackdriver/docs/managed-prometheus) and [OpenTelemetry Google Managed Prometheus Exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlemanagedprometheusexporter).

--- a/docker/fetcher/README.md
+++ b/docker/fetcher/README.md
@@ -98,32 +98,31 @@ $ curl -X POST http://localhost:9000/v1/fetch/join/ranking_listing -H 'Content-T
 }
 ```
 
-### Local Telemetry Docker Setup
+## Docker Compose Setups
 
-For local development with full observability stack, use the included Docker Compose configuration that provides:
+Three Docker Compose configurations are available for different telemetry scenarios:
+
+### Local Telemetry Setup
+
+For local development with full observability stack:
 
 * **OTEL Collector**: Receives and transforms Chronon metrics
 * **Prometheus**: Time-series database for metrics storage and querying
 
 #### Setup Steps
 
-1. **Configure environment** (copy and edit with your values):
+1. **Configure environment**:
    ```shell
-   cp .env.example .env
-   # Edit .env with your GCP project details
+   export GCP_PROJECT_ID=your-project-id
+   export GCP_BIGTABLE_INSTANCE_ID=your-instance-id
    ```
 
-2. **Build image** (optional - skip to use latest):
-   ```shell
-   ./scripts/distribution/publish_docker_images.sh --local
-   ```
-
-3. **Start services**:
+2. **Start services**:
    ```shell
    docker-compose -f chronon-service-with-local-telemetry.yml up -d
    ```
 
-#### Viewing Metrics
+#### Viewing Local Metrics
 
 After making API calls per [Example Usage](#example-usage):
 
@@ -137,3 +136,141 @@ curl -s "http://localhost:9091/api/v1/label/__name__/values" | jq '.data[]'
 # Query metrics in Prometheus UI
 open http://localhost:9091
 ```
+
+### GCP Telemetry Setup
+
+For production deployments that push metrics to Google Cloud Monitoring:
+
+* **OTEL Collector**: Receives metrics and exports to both GCP Monitoring and local Prometheus
+* **Google Cloud Monitoring**: Cloud-native metrics storage and visualization
+* **Prometheus**: Local metrics access for debugging and development
+
+#### Prerequisites
+
+1. **GCP Setup**:
+   - Enable Cloud Monitoring API in your GCP project
+   - Authenticate with `gcloud auth application-default login`
+
+2. **Required Environment Variables**:
+   ```shell
+   export GCP_PROJECT_ID=your-project-id
+   export GCP_BIGTABLE_INSTANCE_ID=your-instance-id
+   ```
+
+#### Setup Steps
+
+1. **Start services**:
+   ```shell
+   docker-compose -f chronon-service-with-gcp-telemetry.yml up -d
+   ```
+
+#### Viewing Metrics
+
+Metrics are available in both locations:
+
+**Local Prometheus Access:**
+```bash
+# Prometheus UI (same as local setup)
+open http://localhost:9091
+
+# Raw metrics from OTEL Collector
+curl http://localhost:9464/metrics
+```
+
+**Google Cloud Monitoring:**
+
+Metrics are exported under the `custom.googleapis.com/chronon-fetcher` namespace:
+
+> **Configuration Reference:** For additional Google Cloud exporter configuration options, see the [OpenTelemetry Google Cloud Exporter documentation](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/googlecloudexporter/README.md).
+
+1. **Google Cloud Console**:
+   - Navigate to Monitoring > Metrics Explorer
+   - Search for metrics with prefix `custom.googleapis.com/chronon-fetcher`
+
+2. **gcloud CLI**:
+   ```bash
+   # List available metric types
+   gcloud logging metrics list --filter="name:chronon-fetcher"
+   
+   # View metrics in Cloud Monitoring
+   # Navigate to: https://console.cloud.google.com/monitoring
+   ```
+
+3. **Query via API**:
+   ```bash
+   # Example API call to retrieve metrics
+   curl -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
+     "https://monitoring.googleapis.com/v3/projects/$GCP_PROJECT_ID/metricDescriptors" | \
+     jq '.metricDescriptors[] | select(.type | contains("chronon-fetcher"))'
+   ```
+
+### Google Managed Prometheus Setup (Recommended)
+
+For production deployments using Google Cloud Managed Service for Prometheus:
+
+* **OTEL Collector**: Receives metrics and exports to Google Managed Prometheus
+* **Google Managed Prometheus**: Fully managed Prometheus-compatible service
+* **Local Prometheus**: Optional local access for debugging
+
+#### Prerequisites
+
+1. **GCP Setup**:
+   - Enable Cloud Monitoring API in your GCP project
+   - Enable Managed Service for Prometheus
+   - Authenticate with `gcloud auth application-default login`
+
+2. **Required Environment Variables**:
+   ```shell
+   export GCP_PROJECT_ID=your-project-id
+   export GCP_BIGTABLE_INSTANCE_ID=your-instance-id
+   # Optional: Configure cluster/location metadata
+   export GCP_CLUSTER_NAME=chronon-cluster
+   export GCP_NAMESPACE=default  
+   export GCP_LOCATION=us-central1
+   ```
+
+#### Setup Steps
+
+1. **Start services**:
+   ```shell
+   docker-compose -f chronon-service-with-managed-prometheus.yml up -d
+   ```
+
+#### Viewing Metrics
+
+Metrics are available in multiple locations:
+
+**Local Prometheus Access (for debugging):**
+```bash
+# Prometheus UI 
+open http://localhost:9091
+
+# Raw metrics from OTEL Collector
+curl http://localhost:9464/metrics
+```
+
+**Google Managed Prometheus:**
+
+Metrics are stored in Managed Service for Prometheus with automatic service discovery:
+
+1. **Google Cloud Console**:
+   - Navigate to Monitoring > Metrics Explorer
+   - Use PromQL queries to filter Chronon metrics
+   - Look for metrics with `service_name="chronon-fetcher"`
+
+2. **PromQL Queries**:
+   ```promql
+   # Example queries for Chronon metrics
+   {service_name="chronon-fetcher"}
+   
+   # Filter by specific metric patterns
+   {service_name="chronon-fetcher", __name__=~"chronon.*"}
+   ```
+
+3. **Grafana Integration**:
+   ```bash
+   # Connect Grafana to Managed Prometheus
+   # Data source URL: https://monitoring.googleapis.com/v1/projects/PROJECT_ID/location/global/prometheus/
+   ```
+
+> **Configuration Reference:** For advanced Managed Prometheus configuration, see the [Google Cloud Managed Prometheus documentation](https://cloud.google.com/stackdriver/docs/managed-prometheus) and [OpenTelemetry setup guide](https://cloud.google.com/stackdriver/docs/managed-prometheus/setup-otel).

--- a/docker/fetcher/chronon-service-with-managed-prometheus.yml
+++ b/docker/fetcher/chronon-service-with-managed-prometheus.yml
@@ -1,0 +1,51 @@
+name: chronon-service-managed-prometheus
+
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:latest
+    restart: "no"
+    command: ["--config=/etc/otel-collector-managed-prometheus-config.yaml"]
+    volumes:
+      - ./resources/otel-collector-managed-prometheus-config.yaml:/etc/otel-collector-managed-prometheus-config.yaml:ro
+      - ~/.config/gcloud/application_default_credentials.json:/gcp/credentials.json:ro
+    environment:
+      - GOOGLE_APPLICATION_CREDENTIALS=/gcp/credentials.json
+      - GCP_PROJECT_ID=${GCP_PROJECT_ID}
+      - GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT:-${GCP_PROJECT_ID}}
+      - GCP_CLUSTER_NAME=${GCP_CLUSTER_NAME:-chronon-local}
+      - GCP_NAMESPACE=${GCP_NAMESPACE:-default}
+      - GCP_LOCATION=${GCP_LOCATION:-us-central1}
+    ports:
+      - "4317:4317"
+      - "4318:4318"
+      - "9464:9464"  # Local Prometheus endpoint for debugging
+
+  chronon-fetcher:
+    image: ziplineai/chronon-fetcher:latest
+    restart: "no"
+    ports:
+      - "9000:9000"
+      - "8907:8905"
+      - "8908:8906"
+    volumes:
+      - ~/.config/gcloud/application_default_credentials.json:/gcp/credentials.json:ro
+    environment:
+      - GCP_PROJECT_ID=${GCP_PROJECT_ID}
+      - GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT:-${GCP_PROJECT_ID}}
+      - GCP_BIGTABLE_INSTANCE_ID=${GCP_BIGTABLE_INSTANCE_ID}
+      - GOOGLE_APPLICATION_CREDENTIALS=/gcp/credentials.json
+      - CHRONON_METRICS_READER=http
+      - EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+    depends_on:
+      - otel-collector
+
+  # Optional: Local Prometheus for debugging (can be removed in production)
+  prometheus:
+    image: prom/prometheus:latest
+    restart: "no"
+    volumes:
+      - ./resources/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - "9091:9090"
+    depends_on:
+      - otel-collector

--- a/docker/fetcher/resources/otel-collector-managed-prometheus-config.yaml
+++ b/docker/fetcher/resources/otel-collector-managed-prometheus-config.yaml
@@ -7,16 +7,22 @@ receivers:
         endpoint: 0.0.0.0:4318
 
 processors:
-  resource:  # GCP requires these fields
+  # Detects GCP/GKE metadata automatically when deployed in cluster
+  resourcedetection:
+    detectors: [env, gcp]
+    timeout: 5s
+    override: false
+  # Fallback resource attributes for local/non-GKE deployments
+  resource:
     attributes:
       - key: location
-        value: us-central1
+        value: ${env:GCP_LOCATION}
         action: upsert
       - key: namespace
-        value: local
-        action: upsert
+        value: ${env:GCP_NAMESPACE}
+        action: upsert  
       - key: cluster
-        value: dev-docker
+        value: ${env:GCP_CLUSTER_NAME}
         action: upsert
 exporters:
   googlemanagedprometheus:
@@ -28,5 +34,5 @@ service:
   pipelines:
     metrics:
       receivers: [otlp]
-      processors: [resource]
+      processors: [resourcedetection, resource]
       exporters: [googlemanagedprometheus, prometheus]

--- a/docker/fetcher/resources/otel-collector-managed-prometheus-config.yaml
+++ b/docker/fetcher/resources/otel-collector-managed-prometheus-config.yaml
@@ -1,0 +1,32 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  resource:  # GCP requires these fields
+    attributes:
+      - key: location
+        value: us-central1
+        action: upsert
+      - key: namespace
+        value: local
+        action: upsert
+      - key: cluster
+        value: dev-docker
+        action: upsert
+exporters:
+  googlemanagedprometheus:
+    project: ${GCP_PROJECT_ID}
+  prometheus:
+    endpoint: "0.0.0.0:9464"
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [resource]
+      exporters: [googlemanagedprometheus, prometheus]


### PR DESCRIPTION
## Summary

As we develop we may want to test some telemetry changes and dashboards on GCP, etc.
Added a docker compose to push telemetry into GCP from a local fetcher.

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [x] Integration tested
- [ ] Documentation update

<img width="1443" height="761" alt="Screenshot 2025-09-11 at 4 25 45 PM" src="https://github.com/user-attachments/assets/7891fd5b-0642-4a46-a9c6-cff9e63a50a2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Docker Compose setup for Google Managed Prometheus (recommended) with OTLP export and optional local Prometheus for debugging.
  - Added a production-oriented managed Prometheus telemetry option with GCP integration and PromQL examples.

- **Documentation**
  - Reorganized telemetry docs under "Docker Compose Setups": Local Telemetry, GCP Telemetry, and Google Managed Prometheus.
  - Replaced .env copying with direct environment variable exports and clarified local vs production metrics viewing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->