### PR TITLE
Add tableStatsDataset scallop arg

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/kv_store/KVUploadNodeRunner.scala
+++ b/spark/src/main/scala/ai/chronon/spark/kv_store/KVUploadNodeRunner.scala
@@ -98,8 +98,8 @@ object KVUploadNodeRunner {
                                              descr = "Name of table in kv store to use to keep track of partitions",
                                              default = Option(NodeRunner.DefaultTablePartitionsDataset))
     val tableStatsDataset = opt[String](required = false,
-                                             descr = "Name of table in kv store to use to store partition statistics",
-                                             default = None)
+                                        descr = "Name of table in kv store to use to store partition statistics",
+                                        default = None)
     verify()
   }
 

--- a/spark/src/main/scala/ai/chronon/spark/kv_store/KVUploadNodeRunner.scala
+++ b/spark/src/main/scala/ai/chronon/spark/kv_store/KVUploadNodeRunner.scala
@@ -97,6 +97,9 @@ object KVUploadNodeRunner {
     val tablePartitionsDataset = opt[String](required = true,
                                              descr = "Name of table in kv store to use to keep track of partitions",
                                              default = Option(NodeRunner.DefaultTablePartitionsDataset))
+    val tableStatsDataset = opt[String](required = false,
+                                             descr = "Name of table in kv store to use to store partition statistics",
+                                             default = None)
     verify()
   }
 


### PR DESCRIPTION
## Summary

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional configuration to specify a KV-store table for storing partition statistics during KV uploads. Disabled by default, it only activates when provided, enabling improved observability of partition metrics without affecting existing workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->