### PR TITLE
Disable backfills from the main branch

### DIFF
--- a/python/src/ai/chronon/repo/hub_runner.py
+++ b/python/src/ai/chronon/repo/hub_runner.py
@@ -64,6 +64,9 @@ def submit_workflow(repo, conf, mode, start_ds, end_ds, force_recompute=False, h
     conf_name_to_hash_dict = hub_uploader.build_local_repo_hashmap(root_dir=repo)
     branch = get_current_branch()
 
+    if branch == "main" and  mode == RunMode.BACKFILL.value:
+        raise ValueError("Backfilling from the main branch is not allowed. Please switch to a feature branch.")
+
     hub_uploader.compute_and_upload_diffs(
         branch, zipline_hub=zipline_hub, local_repo_confs=conf_name_to_hash_dict
     )

--- a/python/src/ai/chronon/repo/hub_runner.py
+++ b/python/src/ai/chronon/repo/hub_runner.py
@@ -64,7 +64,7 @@ def submit_workflow(repo, conf, mode, start_ds, end_ds, force_recompute=False, h
     conf_name_to_hash_dict = hub_uploader.build_local_repo_hashmap(root_dir=repo)
     branch = get_current_branch()
 
-    if branch == "main" and  mode == RunMode.BACKFILL.value:
+    if branch == "main" and mode == RunMode.BACKFILL.value:
         raise ValueError("Backfilling from the main branch is not allowed. Please switch to a feature branch.")
 
     hub_uploader.compute_and_upload_diffs(


### PR DESCRIPTION
## Summary

^^^

Do not want users to accidentally backfill from the main branch as that will do a branch "sync" and can disrupt any other schedules or deploys on main to be disrupted. 

We will though need to allow for "CI" to be able to run off of main though.

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Blocks backfilling when on the main branch, stopping the workflow early and surfacing a clear error message. This prevents unintended backfills on protected branches and reduces wasted compute.
  * Improves user feedback by validating branch/mode combinations earlier in the run; no other behavior changes. No impact to public APIs. Defaults and performance unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->