### PR TITLE
Add user to the upload API request

### DIFF
--- a/python/src/ai/chronon/repo/zipline_hub.py
+++ b/python/src/ai/chronon/repo/zipline_hub.py
@@ -134,6 +134,7 @@ class ZiplineHub:
         upload_request = {
             "diffConfs": diff_confs,
             "branch": branch,
+            "user": os.environ.get("USER")
         }
         headers = {"Content-Type": "application/json"}
         if self.base_url.startswith("https") and self.sa is not None:


### PR DESCRIPTION
## Summary

^^^

We want to keep track of the origin user for a Conf in the orchestrator.

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upload requests now include the initiating user’s identifier, improving attribution and auditability of uploads.
  * This enhancement is transparent to existing workflows; no configuration changes are required.
  * Request behavior remains otherwise unchanged (e.g., headers, error handling, and flow), ensuring backward compatibility.
  * The added user metadata may appear in downstream systems or logs that display upload details, aiding ownership tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->