### PR TITLE
Enhance TopicInfo parsing, add metrics logging, and refactor consistency job

### DIFF
--- a/online/src/main/scala/ai/chronon/online/metrics/Metrics.scala
+++ b/online/src/main/scala/ai/chronon/online/metrics/Metrics.scala
@@ -20,10 +20,14 @@ import ai.chronon.api.Extensions._
 import ai.chronon.api.ScalaJavaConversions._
 import ai.chronon.api._
 import io.opentelemetry.api.OpenTelemetry
+import org.slf4j.{Logger, LoggerFactory}
 
 import scala.collection.mutable
 
 object Metrics {
+  @transient implicit lazy val logger: Logger = LoggerFactory.getLogger(getClass)
+  private val globalMetricPrefix: Option[String] = sys.env.get("METRIC_PREFIX").filter(_.nonEmpty)
+
   object Environment extends Enumeration {
     type Environment = String
     val MetaDataFetching = "metadata.fetch"
@@ -136,6 +140,7 @@ object Metrics {
       // Metrics collection is turned off by default, we explicitly turn on in serving contexts
       val metricsEnabled: Boolean = System.getProperty(MetricsEnabled, "false").toBoolean
       val reporter: String = System.getProperty(MetricsReporter, "otel")
+      logger.info(s"create metrics reporter with enabled: $metricsEnabled, reporter: $reporter")
 
       reporter.toLowerCase match {
         case "otel" | "opentelemetry" =>
@@ -169,7 +174,8 @@ object Metrics {
 
     def withSuffix(suffixN: String): Context = copy(suffix = (Option(suffix) ++ Seq(suffixN)).mkString("."))
 
-    private val prefixString = environment + Option(suffix).map("." + _).getOrElse("")
+    private val prefixString =
+      globalMetricPrefix.map(_ + ".").getOrElse("") + environment + Option(suffix).map("." + _).getOrElse("")
 
     private def prefix(s: String): String =
       new java.lang.StringBuilder(prefixString.length + s.length + 1)

--- a/online/src/test/scala/ai/chronon/online/test/DataStreamBuilderTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/DataStreamBuilderTest.scala
@@ -75,6 +75,10 @@ class DataStreamBuilderTest extends AnyFlatSpec {
     checkTopicInfo(parse("topic_name/host=X/port=Y"),
                    TopicInfo("topic_name", "kafka", Map("host" -> "X", "port" -> "Y")))
     checkTopicInfo(parse("topic_name"), TopicInfo("topic_name", "kafka", Map.empty))
+
+    // Test cases for double slash in parameter values
+    checkTopicInfo(parse("kafka://topic_name/host=X/ssl.truststore.location=//etc//kafka//truststore.jks"),
+                   TopicInfo("topic_name", "kafka", Map("host" -> "X", "ssl.truststore.location" -> "/etc/kafka/truststore.jks")))
   }
 
   def checkTopicInfo(actual: TopicInfo, expected: TopicInfo): Unit = {

--- a/python/src/ai/chronon/repo/constants.py
+++ b/python/src/ai/chronon/repo/constants.py
@@ -18,6 +18,7 @@ class RunMode(str, Enum):
     METADATA_UPLOAD = "metadata-upload"
     FETCH = "fetch"
     CONSISTENCY_METRICS_COMPUTE = "consistency-metrics-compute"
+    BUILD_COMPARISON_TABLE = "build-comparison-table"
     COMPARE = "compare"
     LOCAL_STREAMING = "local-streaming"
     LOG_FLATTENER = "log-flattener"
@@ -52,6 +53,7 @@ SPARK_MODES = [
     RunMode.STREAMING,
     RunMode.STREAMING_CLIENT,
     RunMode.CONSISTENCY_METRICS_COMPUTE,
+    RunMode.BUILD_COMPARISON_TABLE,
     RunMode.COMPARE,
     RunMode.ANALYZE,
     RunMode.STATS_SUMMARY,
@@ -91,6 +93,7 @@ MODE_ARGS = {
     RunMode.METADATA_UPLOAD: ONLINE_WRITE_ARGS,
     RunMode.FETCH: ONLINE_ARGS,
     RunMode.CONSISTENCY_METRICS_COMPUTE: OFFLINE_ARGS,
+    RunMode.BUILD_COMPARISON_TABLE: OFFLINE_ARGS,
     RunMode.COMPARE: OFFLINE_ARGS,
     RunMode.LOCAL_STREAMING: ONLINE_WRITE_ARGS + " -d",
     RunMode.LOG_FLATTENER: OFFLINE_ARGS,
@@ -124,6 +127,7 @@ ROUTES = {
         RunMode.METADATA_UPLOAD: "metadata-upload",
         RunMode.FETCH: "fetch",
         RunMode.CONSISTENCY_METRICS_COMPUTE: "consistency-metrics-compute",
+        RunMode.BUILD_COMPARISON_TABLE: "build-comparison-table",
         RunMode.COMPARE: "compare-join-query",
         RunMode.STATS_SUMMARY: "stats-summary",
         RunMode.LOG_SUMMARY: "log-summary",

--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -524,6 +524,21 @@ object Driver {
     }
   }
 
+  object BuildComparisonTable {
+    class Args extends Subcommand("build-comparison-table") with OfflineSubcommand {
+      override def subcommandName() = "build-comparison-table"
+    }
+
+    def run(args: Args): Unit = {
+      val joinConf = parseConf[api.Join](args.confPath())
+      new ConsistencyJob(
+        args.sparkSession,
+        joinConf,
+        args.endDate()
+      ).buildComparisonTable()
+    }
+  }
+
   object ConsistencyMetricsCompute {
     class Args extends Subcommand("consistency-metrics-compute") with OfflineSubcommand {
       override def subcommandName() = "consistency-metrics-compute"
@@ -1110,6 +1125,8 @@ object Driver {
     addSubcommand(JoinBackFillArgs)
     object LogFlattenerArgs extends LogFlattener.Args
     addSubcommand(LogFlattenerArgs)
+    object ComparisonTableArgs extends BuildComparisonTable.Args
+    addSubcommand(ComparisonTableArgs)
     object ConsistencyMetricsArgs extends ConsistencyMetricsCompute.Args
     addSubcommand(ConsistencyMetricsArgs)
     object GroupByBackfillArgs extends GroupByBackfill.Args
@@ -1180,6 +1197,7 @@ object Driver {
             GroupByUploadToKVBulkLoad.run(args.GroupByUploadToKVBulkLoadArgs)
           case args.FetcherCliArgs         => FetcherCli.run(args.FetcherCliArgs)
           case args.LogFlattenerArgs       => LogFlattener.run(args.LogFlattenerArgs)
+          case args.ComparisonTableArgs    => BuildComparisonTable.run(args.ComparisonTableArgs)
           case args.ConsistencyMetricsArgs => ConsistencyMetricsCompute.run(args.ConsistencyMetricsArgs)
           case args.CompareJoinQueryArgs   => CompareJoinQuery.run(args.CompareJoinQueryArgs)
           case args.AnalyzerArgs           => Analyzer.run(args.AnalyzerArgs)

--- a/spark/src/main/scala/ai/chronon/spark/stats/ConsistencyJob.scala
+++ b/spark/src/main/scala/ai/chronon/spark/stats/ConsistencyJob.scala
@@ -125,7 +125,18 @@ class ConsistencyJob(session: SparkSession, joinConf: Join, endDate: String) ext
     copiedJoin
   }
 
-  private def buildComparisonTable(): Unit = {
+  def buildComparisonTable(): Unit = {
+    // migrate legacy configs without consistencySamplePercent param
+    if (!joinConf.metaData.isSetConsistencySamplePercent) {
+      logger.info("consistencySamplePercent is unset and will default to 100")
+      joinConf.metaData.consistencySamplePercent = 100
+    }
+    logger.info(s"consistencySamplePercent is ${joinConf.metaData.consistencySamplePercent}")
+
+    if (joinConf.metaData.consistencySamplePercent == 0) {
+      return
+    }
+
     val unfilledRanges = tableUtils
       .unfilledRanges(joinConf.metaData.comparisonTable,
                       PartitionRange(null, endDate),
@@ -140,12 +151,6 @@ class ConsistencyJob(session: SparkSession, joinConf: Join, endDate: String) ext
   }
 
   def buildConsistencyMetrics(): fetcher.DataMetrics = {
-    // migrate legacy configs without consistencySamplePercent param
-    if (!joinConf.metaData.isSetConsistencySamplePercent) {
-      logger.info("consistencySamplePercent is unset and will default to 100")
-      joinConf.metaData.consistencySamplePercent = 100
-    }
-
     if (joinConf.metaData.consistencySamplePercent == 0) {
       logger.info(s"Exit ConsistencyJob because consistencySamplePercent = 0 for join conf ${joinConf.metaData.name}")
       return fetcher.DataMetrics(Seq())


### PR DESCRIPTION
## Summary
This MR introduces three minor changes:
1. Enhanced TopicInfo parsing to handle slash in parameter values
some config value may contains slash such as `ssl.truststore.location`, we need to support escape slashes on the uri, here we use double slash to escape slash in config value. Example: kafka://topic/host=X/ssl.truststore.location=//etc//kafka//truststore.jks
2. Added metrics logging with configurable prefix support
Added global metric prefix support via METRIC_PREFIX environment variable
3. Refactored ConsistencyJob to separate comparison table building logic
make buildComparisonTable as a standalone run mode (we nee this so that we can run our customized comparison which is much more faster than the consistency-metric-compute job)

All changes maintain backward compatibility, test cases added to cover the change.

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "build-comparison-table" CLI subcommand/run mode and corresponding run-mode mapping.
  * Introduced a global metrics prefix affecting metric naming.

* **Bug Fixes**
  * Corrected topic parameter parsing to handle escaped double-slashes and empty values.
  * Consistency sampling: defaults to 100% when unset and skips processing when set to 0.

* **Chores**
  * Enhanced logging around topic parsing and metrics reporter setup.

* **Tests**
  * Added a test covering double-slash topic parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->