### PR TITLE
customize kafka offset to catch up old data

### DIFF
--- a/docs/source/setup/Flink.md
+++ b/docs/source/setup/Flink.md
@@ -19,6 +19,31 @@ you will find both options.
 
 You will also likely need to modify your `KVStore` implementation while integrating Flink.
 
+### Configuration Properties
+
+When running Flink jobs, you can configure various properties. These properties control the behavior of Flink execution.
+
+**`kv_concurrency`**
+- **Type**: Integer
+- **Required**: No
+- **Default**: Default AsyncKVStoreWriter concurrency
+- **Description**: Controls the concurrency level for KV store writes, affecting throughput and resource usage.
+
+**`trigger`**
+- **Type**: String
+- **Required**: No
+- **Default**: `always_fire`
+- **Valid values**: `always_fire`, `buffered`
+- **Description**: Controls when the Flink window triggers output:
+  - `always_fire`: Triggers on every incoming event (lower latency, higher write volume)
+  - `buffered`: Batches writes for efficiency (higher latency, reduced write volume)
+
+**`start_offset`**
+- **Type**: Long (timestamp in milliseconds)
+- **Required**: No
+- **Default**: Uses committed offsets with LATEST strategy
+- **Description**: Specifies the timestamp from which to start consuming Kafka messages. Useful for catching up with historical data or reprocessing events from a specific point in time.
+
 ## Overview of the Flink operators
 
 The operators for the tiled and untiled Flink jobs differ slightly. The main difference is that the tiled job is

--- a/flink/src/main/scala/ai/chronon/flink/source/KafkaFlinkSource.scala
+++ b/flink/src/main/scala/ai/chronon/flink/source/KafkaFlinkSource.scala
@@ -35,13 +35,26 @@ class KafkaFlinkSource[T](props: Map[String, String],
     // confirm the topic exists
     TopicChecker.topicShouldExist(topicInfo.name, bootstrap, topicInfo.params)
 
+    val startingOffsets = FlinkUtils.getProperty("start_offset", props, topicInfo) match {
+      case Some(timestampStr) =>
+        try {
+          val timestamp = timestampStr.toLong
+          OffsetsInitializer.timestamp(timestamp)
+        } catch {
+          case _: NumberFormatException =>
+            throw new IllegalArgumentException(s"Invalid timestamp format for start_offset: '$timestampStr'. Expected a valid long value in millisecond.")
+        }
+      case None =>
+        OffsetsInitializer.committedOffsets(OffsetResetStrategy.LATEST)
+    }
+
     val kafkaSource = KafkaSource
       .builder[T]()
       .setTopics(topicInfo.name)
       .setGroupId(s"chronon-$groupByName")
       // we might have a fairly large backlog to catch up on, so we choose to go with the latest offset when we're
       // starting afresh
-      .setStartingOffsets(OffsetsInitializer.committedOffsets(OffsetResetStrategy.LATEST))
+      .setStartingOffsets(startingOffsets)
       .setValueOnlyDeserializer(deserializationSchema)
       .setBootstrapServers(bootstrap)
       .setProperties(TopicChecker.mapToJavaProperties(topicInfo.params))

--- a/flink/src/main/scala/ai/chronon/flink/source/KafkaFlinkSource.scala
+++ b/flink/src/main/scala/ai/chronon/flink/source/KafkaFlinkSource.scala
@@ -42,7 +42,8 @@ class KafkaFlinkSource[T](props: Map[String, String],
           OffsetsInitializer.timestamp(timestamp)
         } catch {
           case _: NumberFormatException =>
-            throw new IllegalArgumentException(s"Invalid timestamp format for start_offset: '$timestampStr'. Expected a valid long value in milliseconds.")
+            throw new IllegalArgumentException(
+              s"Invalid timestamp format for start_offset: '$timestampStr'. Expected a valid long value in milliseconds.")
         }
       case None =>
         OffsetsInitializer.committedOffsets(OffsetResetStrategy.LATEST)

--- a/flink/src/main/scala/ai/chronon/flink/source/KafkaFlinkSource.scala
+++ b/flink/src/main/scala/ai/chronon/flink/source/KafkaFlinkSource.scala
@@ -42,7 +42,7 @@ class KafkaFlinkSource[T](props: Map[String, String],
           OffsetsInitializer.timestamp(timestamp)
         } catch {
           case _: NumberFormatException =>
-            throw new IllegalArgumentException(s"Invalid timestamp format for start_offset: '$timestampStr'. Expected a valid long value in millisecond.")
+            throw new IllegalArgumentException(s"Invalid timestamp format for start_offset: '$timestampStr'. Expected a valid long value in milliseconds.")
         }
       case None =>
         OffsetsInitializer.committedOffsets(OffsetResetStrategy.LATEST)

--- a/flink/src/main/scala/ai/chronon/flink/source/KafkaFlinkSource.scala
+++ b/flink/src/main/scala/ai/chronon/flink/source/KafkaFlinkSource.scala
@@ -52,8 +52,7 @@ class KafkaFlinkSource[T](props: Map[String, String],
       .builder[T]()
       .setTopics(topicInfo.name)
       .setGroupId(s"chronon-$groupByName")
-      // we might have a fairly large backlog to catch up on, so we choose to go with the latest offset when we're
-      // starting afresh
+      // starting offsets are configurable via start_offset (timestamp) or default to latest when starting afresh
       .setStartingOffsets(startingOffsets)
       .setValueOnlyDeserializer(deserializationSchema)
       .setBootstrapServers(bootstrap)


### PR DESCRIPTION
## Summary
  This PR adds configurable Kafka offset initialization to support catching up with historical data in Flink streaming jobs. The change allows users to specify a
  custom starting timestamp for Kafka consumption instead of being limited to the latest committed offsets.

  What Changed

  - Enhanced offset configuration: Modified KafkaFlinkSource.scala:38-49 to support a new start_offset property that accepts timestamp values
  - Flexible offset initialization:
    - When start_offset is provided, the system uses OffsetsInitializer.timestamp() to start consuming from that specific point in time
    - When start_offset is not provided, maintains the existing behavior of using committed offsets with LATEST strategy
  - Input validation: Added proper error handling for invalid timestamp formats with descriptive error messages

  Use Case

  This enhancement enables scenarios where Flink jobs need to:
  - Process historical data from a specific point in time
  - Catch up on missed events during system downtime
  - Replay data for debugging or reprocessing purposes

  Technical Details

  The implementation checks for the start_offset property using FlinkUtils.getProperty() and:
  1. Parses the timestamp string as a long value (milliseconds)
  2. Creates an OffsetsInitializer.timestamp() for the specified time
  3. Falls back to the original behavior (OffsetsInitializer.committedOffsets(OffsetResetStrategy.LATEST)) when no offset is specified
  4. Throws an IllegalArgumentException for invalid timestamp formats

  This change is backward compatible and doesn't affect existing functionality when the start_offset property is not configured.

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure Kafka consumption start via an optional start_offset timestamp to enable backfills from a specific time.
  * Defaults to latest committed offsets when start_offset is omitted; invalid start_offset values are rejected with clear errors.

* **Documentation**
  * Added Flink configuration docs describing kv_concurrency, trigger (always_fire|buffered) and start_offset behavior and defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->