### PR TITLE
fix: fix python api broken after google-api-core update

### DIFF
--- a/api/python/requirements/base.in
+++ b/api/python/requirements/base.in
@@ -10,3 +10,4 @@ rich
 google-cloud-storage==2.19.0
 google-cloud-bigquery-storage
 GitPython
+google-api-core==2.27.0


### PR DESCRIPTION
## Summary

Python API started to throw the following error after an upgrade on the `google-api-core` dependency:
```
Traceback (most recent call last):
  File "/workspace/tmp_chronon/bin/zipline", line 5, in <module>
    from ai.chronon.repo.zipline import zipline
  File "/workspace/tmp_chronon/lib/python3.11/site-packages/ai/chronon/repo/zipline.py", line 10, in <module>
    from ai.chronon.repo.run import main as run_main
  File "/workspace/tmp_chronon/lib/python3.11/site-packages/ai/chronon/repo/run.py", line 44, in <module>
    from ai.chronon.repo.gcp import (
  File "/workspace/tmp_chronon/lib/python3.11/site-packages/ai/chronon/repo/gcp.py", line 10, in <module>
    from google.cloud import storage
  File "/workspace/tmp_chronon/lib/python3.11/site-packages/google/cloud/storage/__init__.py", line 35, in <module>
    from google.cloud.storage.batch import Batch
  File "/workspace/tmp_chronon/lib/python3.11/site-packages/google/cloud/storage/batch.py", line 43, in <module>
    from google.cloud import exceptions
  File "/workspace/tmp_chronon/lib/python3.11/site-packages/google/cloud/exceptions/__init__.py", line 24, in <module>
    from google.api_core import exceptions
  File "/workspace/tmp_chronon/lib/python3.11/site-packages/google/api_core/__init__.py", line 20, in <module>
    from google.api_core import _python_package_support
  File "/workspace/tmp_chronon/lib/python3.11/site-packages/google/api_core/_python_package_support.py", line 28, in <module>
    from packaging.version import parse as parse_version
ModuleNotFoundError: No module named 'packaging'
```

We should pin the dependency to `2.27` or prior.

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [x] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python dependencies to include google-api-core.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->