### PR TITLE
Support avro.java.string in Avro Schema

### DIFF
--- a/online/src/main/scala/ai/chronon/online/serde/AvroConversions.scala
+++ b/online/src/main/scala/ai/chronon/online/serde/AvroConversions.scala
@@ -257,10 +257,11 @@ object AvroConversions {
       },
       {
         case avString: Utf8 => avString.toString
-        case str: String => str
-        case other => throw new IllegalArgumentException(
-          s"Unexpected string type: ${other.getClass.getName}. Expected String or Utf8, got: $other"
-        )
+        case str: String    => str
+        case other =>
+          throw new IllegalArgumentException(
+            s"Unexpected string type: ${other.getClass.getName}. Expected String or Utf8, got: $other"
+          )
       }
     )
   }

--- a/online/src/main/scala/ai/chronon/online/serde/AvroConversions.scala
+++ b/online/src/main/scala/ai/chronon/online/serde/AvroConversions.scala
@@ -180,7 +180,7 @@ object AvroConversions {
   }
 
   private def toChrononRowCached(dataType: DataType): Any => Any = {
-    Row.fromCached[GenericRecord, ByteBuffer, Any, Utf8](
+    Row.fromCached[GenericRecord, ByteBuffer, Any, Any](
       dataType,
       { (record: GenericRecord, recordLength: Int) =>
         new AbstractIterator[Any]() {
@@ -255,7 +255,13 @@ object AvroConversions {
         case valueOfUnknownType =>
           throw new RuntimeException(s"Found unknown list type in avro record: ${valueOfUnknownType.getClass.getName}")
       },
-      { (avString: Utf8) => avString.toString }
+      {
+        case avString: Utf8 => avString.toString
+        case str: String => str
+        case other => throw new IllegalArgumentException(
+          s"Unexpected string type: ${other.getClass.getName}. Expected String or Utf8, got: $other"
+        )
+      }
     )
   }
 

--- a/online/src/test/scala/ai/chronon/online/test/AvroStringHandlingTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/AvroStringHandlingTest.scala
@@ -1,0 +1,145 @@
+package ai.chronon.online.test
+
+import ai.chronon.api._
+import ai.chronon.online.serde.AvroConversions
+import org.apache.avro.Schema
+import org.apache.avro.generic.GenericData
+import org.apache.avro.util.Utf8
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/**
+ * Test string handling in AvroConversions to ensure both java.lang.String
+ * and org.apache.avro.util.Utf8 types are properly handled.
+ *
+ * This addresses the ClassCastException that occurs when Avro schemas use
+ * "avro.java.string": "String" and produce String objects instead of Utf8.
+ */
+class AvroStringHandlingTest extends AnyFlatSpec with Matchers {
+
+  "AvroConversions" should "handle String objects from avro.java.string schemas" in {
+    // Create a schema with string fields
+    val schema = StructType(
+      "StringTestSchema",
+      Array(
+        StructField("stringField", StringType)
+      )
+    )
+
+    // Create Avro schema with String type preference
+    val avroSchemaStr = """{
+      "type": "record",
+      "name": "StringTestSchema",
+      "namespace": "ai.chronon.data",
+      "fields": [
+        {
+          "name": "stringField",
+          "type": ["null", {
+            "type": "string",
+            "avro.java.string": "String"
+          }],
+          "default": null
+        }
+      ]
+    }"""
+
+    val avroSchema = new Schema.Parser().parse(avroSchemaStr)
+
+    // Create test data with java.lang.String objects (not Utf8)
+    val record = new GenericData.Record(avroSchema)
+    record.put("stringField", "test_value")  // This will be java.lang.String
+
+    // Test the conversion using our fixed toChrononRowCached
+    val converter = AvroConversions.genericRecordToChrononRowConverter(schema)
+    val result = converter(record)
+
+    // Verify the conversion worked without ClassCastException
+    result should not be null
+    result.length shouldBe 1
+    result(0) shouldBe "test_value"
+  }
+
+  it should "handle Utf8 objects from standard Avro schemas" in {
+    // Standard Avro schema (without avro.java.string property)
+    val schema = StructType(
+      "Utf8TestSchema",
+      Array(
+        StructField("utf8Field", StringType)
+      )
+    )
+
+    val avroSchemaStr = """{
+      "type": "record",
+      "name": "Utf8TestSchema",
+      "namespace": "ai.chronon.data",
+      "fields": [
+        {
+          "name": "utf8Field",
+          "type": ["null", "string"],
+          "default": null
+        }
+      ]
+    }"""
+
+    val avroSchema = new Schema.Parser().parse(avroSchemaStr)
+
+    // Create record with Utf8 object
+    val record = new GenericData.Record(avroSchema)
+    record.put(0, new Utf8("utf8_test_value"))
+
+    // Test conversion
+    val converter = AvroConversions.genericRecordToChrononRowConverter(schema)
+    val result = converter(record)
+
+    // Verify it works with Utf8 too
+    result should not be null
+    result.length shouldBe 1
+    result(0) shouldBe "utf8_test_value"
+  }
+
+  it should "handle mixed String and Utf8 objects in the same schema" in {
+    val schema = StructType(
+      "MixedStringSchema",
+      Array(
+        StructField("stringField", StringType),
+        StructField("utf8Field", StringType)
+      )
+    )
+
+    val avroSchemaStr = """{
+      "type": "record",
+      "name": "MixedStringSchema",
+      "namespace": "ai.chronon.data",
+      "fields": [
+        {
+          "name": "stringField",
+          "type": ["null", {
+            "type": "string",
+            "avro.java.string": "String"
+          }],
+          "default": null
+        },
+        {
+          "name": "utf8Field",
+          "type": ["null", "string"],
+          "default": null
+        }
+      ]
+    }"""
+
+    val avroSchema = new Schema.Parser().parse(avroSchemaStr)
+    val record = new GenericData.Record(avroSchema)
+
+    // Mix String and Utf8 objects
+    record.put(0, "java_string")           // java.lang.String
+    record.put(1, new Utf8("utf8_string")) // Utf8
+
+    val converter = AvroConversions.genericRecordToChrononRowConverter(schema)
+    val result = converter(record)
+
+    result should not be null
+    result.length shouldBe 2
+    result(0) shouldBe "java_string"
+    result(1) shouldBe "utf8_string"
+  }
+}


### PR DESCRIPTION
## Summary
Fix ClassCastException in Flink Avro Deserialization with avro.java.string Configuration

- Problem
Flink jobs processing Avro messages from Kafka with Schema Registry were failing with a ClassCastException when the Avro schema used "avro.java.string": "String" configuration:
`java.lang.ClassCastException: class java.lang.String cannot be cast to class org.apache.avro.util.Utf8`
This error occurred in SourceProjectionDeserializationSchema during the deserialization process when AvroConversions.toChrononRowCached() expected Utf8 objects but received String objects.

-   Root Cause
The issue was in AvroConversions.scala where the string converter function only handled Utf8 types. When Avro schemas include "avro.java.string": "String", the Avro library produces java.lang.String
objects instead of the default org.apache.avro.util.Utf8 objects, causing the type mismatch.

-   Solution
1.Changed type parameter in toChrononRowCached from Utf8 to Any to enable pattern matching
2.Added type-safe string handling with pattern matching to support both String and Utf8 types

-   Impact
1.Backward compatible - existing Utf8 handling continues to work
2.Forward compatible - now supports modern avro.java.string configurations
3.Fail-fast behavior - provides clear error messages for unexpected types
4.Spark unaffected - Spark uses different abstraction layers that don't encounter this issue

## Checklist
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Avro deserialization to accept multiple string representations and provide clearer errors for unsupported types.

* **Tests**
  * Added tests verifying reliable string conversion across different Avro schema configurations, including mixed string representations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->