### PR TITLE
feat: make the derived join output tables easy to consume downstream

### DIFF
--- a/api/src/main/scala/ai/chronon/api/planner/JoinPlanner.scala
+++ b/api/src/main/scala/ai/chronon/api/planner/JoinPlanner.scala
@@ -150,7 +150,7 @@ class JoinPlanner(join: Join)(implicit outputPartitionSpec: PartitionSpec)
         "merge",
         mergeNodeName,
         deps,
-        outputTableOverride = Some(join.metaData.outputTable + (if (hasDerivations) "__merged" + ""))
+        outputTableOverride = Some(join.metaData.outputTable + (if (hasDerivations) "__merged" else ""))
       )
 
     val copy = result.deepCopy()

--- a/api/src/main/scala/ai/chronon/api/planner/JoinPlanner.scala
+++ b/api/src/main/scala/ai/chronon/api/planner/JoinPlanner.scala
@@ -122,6 +122,8 @@ class JoinPlanner(join: Join)(implicit outputPartitionSpec: PartitionSpec)
 
   private val joinPartNodes: Seq[Node] = join.joinParts.toScala.map { buildJoinPartNode }.toSeq
 
+  val hasDerivations = join.derivations == null || join.derivations.isEmpty
+
   val mergeNode: Node = {
     val result = new JoinMergeNode()
       .setJoin(join)
@@ -148,7 +150,7 @@ class JoinPlanner(join: Join)(implicit outputPartitionSpec: PartitionSpec)
         "merge",
         mergeNodeName,
         deps,
-        outputTableOverride = Some(join.metaData.outputTable)
+        outputTableOverride = Some(join.metaData.outputTable + (if (hasDerivations) "__merged" + ""))
       )
 
     val copy = result.deepCopy()
@@ -158,27 +160,29 @@ class JoinPlanner(join: Join)(implicit outputPartitionSpec: PartitionSpec)
     toNode(metaData, _.setJoinMerge(result), copy)
   }
 
-  private val derivationNodeOpt: Option[Node] = Option(join.derivations).map { _ =>
-    val result = new JoinDerivationNode()
-      .setJoin(join)
+  private val derivationNodeOpt: Option[Node] = Option(join.derivations)
+    .filterNot { _.isEmpty }
+    .map { _ =>
+      val result = new JoinDerivationNode()
+        .setJoin(join)
 
-    val derivationNodeName = join.metaData.name + "__derived"
-    val derivationOutputTable = join.metaData.outputTable + "__derived"
+      val derivationNodeName = join.metaData.name + "__derived"
+      val derivationOutputTable = join.metaData.outputTable
 
-    val metaData = MetaDataUtils
-      .layer(
-        join.metaData,
-        "derive",
-        derivationNodeName,
-        Seq(TableDependencies.fromTable(mergeNode.metaData.outputTable)),
-        outputTableOverride = Some(derivationOutputTable)
-      )
+      val metaData = MetaDataUtils
+        .layer(
+          join.metaData,
+          "derive",
+          derivationNodeName,
+          Seq(TableDependencies.fromTable(mergeNode.metaData.outputTable)),
+          outputTableOverride = Some(derivationOutputTable)
+        )
 
-    val copy = result.deepCopy()
-    joinWithoutMetadata(copy.join)
+      val copy = result.deepCopy()
+      joinWithoutMetadata(copy.join)
 
-    toNode(metaData, _.setJoinDerivation(result), copy)
-  }
+      toNode(metaData, _.setJoinDerivation(result), copy)
+    }
 
   def offlineNodes: Seq[Node] = {
 

--- a/api/src/main/scala/ai/chronon/api/planner/JoinPlanner.scala
+++ b/api/src/main/scala/ai/chronon/api/planner/JoinPlanner.scala
@@ -122,7 +122,7 @@ class JoinPlanner(join: Join)(implicit outputPartitionSpec: PartitionSpec)
 
   private val joinPartNodes: Seq[Node] = join.joinParts.toScala.map { buildJoinPartNode }.toSeq
 
-  val hasDerivations = join.derivations == null || join.derivations.isEmpty
+  private val hasDerivations: Boolean = Option(join.derivations).exists(!_.isEmpty)
 
   val mergeNode: Node = {
     val result = new JoinMergeNode()

--- a/spark/src/main/scala/ai/chronon/spark/batch/JoinDerivationJob.scala
+++ b/spark/src/main/scala/ai/chronon/spark/batch/JoinDerivationJob.scala
@@ -29,7 +29,7 @@ class JoinDerivationJob(node: JoinDerivationNode, metaData: MetaData, range: Dat
   private val trueLeftTable = JoinUtils.computeFullLeftSourceTableName(join)
 
   // The base table is the output of the merge job
-  private val baseTable = join.metaData.outputTable
+  private val baseTable = join.metaData.outputTable ++ "__merged"
 
   // Output table for this derivation job comes from the metadata
   private val outputTable = metaData.outputTable

--- a/spark/src/test/scala/ai/chronon/spark/batch/ModularJoinTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/batch/ModularJoinTest.scala
@@ -245,7 +245,7 @@ class ModularJoinTest extends SparkTestBase {
     tableUtils.sql(s"SELECT * FROM $mergeJobOutputTable").show()
 
     // Verify derivation job output
-    val derivationOutputTable = s"$namespace.test_user_transaction_features__derived"
+    val derivationOutputTable = s"$namespace.test_user_transaction_features"
     tableUtils.sql(s"SELECT * FROM $derivationOutputTable").show()
 
     val expectedQuery = s"""

--- a/spark/src/test/scala/ai/chronon/spark/batch/ShortNamesTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/batch/ShortNamesTest.scala
@@ -391,7 +391,7 @@ class ShortNamesTest extends SparkTestBase {
     tableUtils.sql(s"SELECT * FROM $joinPart2FullTableName").show()
 
     // Skip the joinPart that does have a bootstrap, and go straight to merge job
-    val mergeJobOutputTable = joinConf.metaData.outputTable
+    val mergeJobOutputTable = joinConf.metaData.outputTable + "__merged"
 
     val mergeJobRange = new DateRange()
       .setStartDate(start)
@@ -401,16 +401,22 @@ class ShortNamesTest extends SparkTestBase {
     val mergeMetaData = new api.MetaData()
       .setName(joinConf.metaData.name)
       .setOutputNamespace(namespace)
+      .setExecutionInfo(
+        new ExecutionInfo().setOutputTableInfo(
+          new TableInfo().setTable(
+            mergeJobOutputTable
+          )
+        )
+      )
 
-    val mergeNode = new JoinMergeNode()
-      .setJoin(joinConf)
+    val mergeNode = new JoinMergeNode().setJoin(joinConf)
 
     val finalJoinJob = new MergeJob(mergeNode, mergeMetaData, mergeJobRange, Seq(jp1, jp2))
     finalJoinJob.run()
     tableUtils.sql(s"SELECT * FROM $mergeJobOutputTable").show()
 
     // Now run the derivations job
-    val derivationOutputTable = s"$namespace.test_user_transaction_features_v1_derived"
+    val derivationOutputTable = s"$namespace.test_user_transaction_features_v1"
 
     val derivationRange = new DateRange()
       .setStartDate(start)


### PR DESCRIPTION
## Summary

adding a derivation to a join without derivations currently produces a new table with a _derived prefix.

however that makes it hard to consistently consume it downstream. we instead un_prefix the terminal table

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Merge outputs now receive a "__merged" suffix when derivations exist.
  * Derivation artifacts are only created when derivations are present, reducing clutter.
  * Derivation outputs no longer use a "__derived" suffix; naming and metadata consistently reference the final merge output.

* **Chores**
  * Metadata/execution info is now recorded and propagated with merge/derivation steps.

* **Tests**
  * Updated tests to validate the new naming and execution metadata flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->