### PR TITLE
UNIQUE_TOP_K last seen mode

### DIFF
--- a/aggregator/src/main/scala/ai/chronon/aggregator/base/SimpleAggregators.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/base/SimpleAggregators.scala
@@ -760,7 +760,10 @@ class Kurtosis extends MomentAggregator {
     if (ir.n < 4 || ir.m2 == 0) Double.NaN else ir.n * ir.m4 / (ir.m2 * ir.m2) - 3
 }
 
-class UniqueTopKHelper[T](inputType: DataType, k: Int, maxSizeOpt: Option[Int] = None, dedupMode: String = DedupMode.FIRST_SEEN.toString) {
+class UniqueTopKHelper[T](inputType: DataType,
+                          k: Int,
+                          maxSizeOpt: Option[Int] = None,
+                          dedupMode: String = DedupMode.FIRST_SEEN.toString) {
 
   private val maxSize: Int = maxSizeOpt.getOrElse(2 * k)
   private val useLenient: Boolean = dedupMode == DedupMode.LAST_SEEN.toString
@@ -952,7 +955,10 @@ class UniqueTopKHelper[T](inputType: DataType, k: Int, maxSizeOpt: Option[Int] =
   }
 }
 
-class UniqueTopKAggregator[T](inputType: DataType, k: Int, maxSizeOpt: Option[Int] = None, dedupMode: String = DedupMode.FIRST_SEEN.toString)
+class UniqueTopKAggregator[T](inputType: DataType,
+                              k: Int,
+                              maxSizeOpt: Option[Int] = None,
+                              dedupMode: String = DedupMode.FIRST_SEEN.toString)
     extends SimpleAggregator[T, Any, util.ArrayList[T]] {
 
   private val uniqueTopK = new UniqueTopKHelper[T](inputType, k, maxSizeOpt, dedupMode)

--- a/aggregator/src/main/scala/ai/chronon/aggregator/base/SimpleAggregators.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/base/SimpleAggregators.scala
@@ -760,32 +760,51 @@ class Kurtosis extends MomentAggregator {
     if (ir.n < 4 || ir.m2 == 0) Double.NaN else ir.n * ir.m4 / (ir.m2 * ir.m2) - 3
 }
 
-class UniqueTopKHelper[T](inputType: DataType, k: Int, maxSizeOpt: Option[Int] = None) {
+class UniqueTopKHelper[T](inputType: DataType, k: Int, maxSizeOpt: Option[Int] = None, dedupMode: String = DedupMode.FIRST_SEEN.toString) {
 
   private val maxSize: Int = maxSizeOpt.getOrElse(2 * k)
+  private val useLenient: Boolean = dedupMode == DedupMode.LAST_SEEN.toString
 
   // Define the order type and create operator based on input type
-  val (operator, stateProvider) = inputType match {
+  val (operator, stateProvider): (Any, StateProviderTrait[T]) = inputType match {
     case IntType =>
       val getOrderKeyInt = (x: T) => x.asInstanceOf[Int]
       val getIdInt = (x: T) => x.asInstanceOf[Int].toLong
-      val op = UniqueOrderByLimit.Operator[T, Int](getOrderKeyInt, getIdInt, k, maxSize, topK = true)
-      val provider = new StateProvider[T, Int]
-      (op, provider)
+      if (useLenient) {
+        val op = UniqueOrderByLimit.LenientOperator[T, Int](getOrderKeyInt, getIdInt, k, maxSize, topK = true)
+        val provider = new LenientStateProvider[T, Int]
+        (op, provider)
+      } else {
+        val op = UniqueOrderByLimit.Operator[T, Int](getOrderKeyInt, getIdInt, k, maxSize, topK = true)
+        val provider = new StateProvider[T, Int]
+        (op, provider)
+      }
 
     case LongType =>
       val getOrderKeyLong = (x: T) => x.asInstanceOf[Long]
       val getIdLong = (x: T) => x.asInstanceOf[Long]
-      val op = UniqueOrderByLimit.Operator[T, Long](getOrderKeyLong, getIdLong, k, maxSize, topK = true)
-      val provider = new StateProvider[T, Long]
-      (op, provider)
+      if (useLenient) {
+        val op = UniqueOrderByLimit.LenientOperator[T, Long](getOrderKeyLong, getIdLong, k, maxSize, topK = true)
+        val provider = new LenientStateProvider[T, Long]
+        (op, provider)
+      } else {
+        val op = UniqueOrderByLimit.Operator[T, Long](getOrderKeyLong, getIdLong, k, maxSize, topK = true)
+        val provider = new StateProvider[T, Long]
+        (op, provider)
+      }
 
     case StringType =>
       val getOrderKeyString = (x: T) => x.asInstanceOf[String]
       val getIdString = (x: T) => x.asInstanceOf[String].hashCode.toLong
-      val op = UniqueOrderByLimit.Operator[T, String](getOrderKeyString, getIdString, k, maxSize, topK = true)
-      val provider = new StateProvider[T, String]
-      (op, provider)
+      if (useLenient) {
+        val op = UniqueOrderByLimit.LenientOperator[T, String](getOrderKeyString, getIdString, k, maxSize, topK = true)
+        val provider = new LenientStateProvider[T, String]
+        (op, provider)
+      } else {
+        val op = UniqueOrderByLimit.Operator[T, String](getOrderKeyString, getIdString, k, maxSize, topK = true)
+        val provider = new StateProvider[T, String]
+        (op, provider)
+      }
 
     case structType: StructType =>
       val sortKeyField = structType.fields.find(_.name == "sort_key")
@@ -813,9 +832,15 @@ class UniqueTopKHelper[T](inputType: DataType, k: Int, maxSizeOpt: Option[Int] =
           case map: Map[String, AnyRef]      => map("unique_id").asInstanceOf[Long]
         }
 
-      val op = UniqueOrderByLimit.Operator[T, String](getOrderKeyStruct, getIdStruct, k, maxSize, topK = true)
-      val provider = new StateProvider[T, String]
-      (op, provider)
+      if (useLenient) {
+        val op = UniqueOrderByLimit.LenientOperator[T, String](getOrderKeyStruct, getIdStruct, k, maxSize, topK = true)
+        val provider = new LenientStateProvider[T, String]
+        (op, provider)
+      } else {
+        val op = UniqueOrderByLimit.Operator[T, String](getOrderKeyStruct, getIdStruct, k, maxSize, topK = true)
+        val provider = new StateProvider[T, String]
+        (op, provider)
+      }
 
     case _ =>
       throw new IllegalArgumentException(
@@ -824,8 +849,19 @@ class UniqueTopKHelper[T](inputType: DataType, k: Int, maxSizeOpt: Option[Int] =
       )
   }
 
+  // Common trait for state providers
+  trait StateProviderTrait[T] {
+    def initState(): Any
+    def insert(elem: T, state: Any): Unit
+    def merge(state1: Any, state2: Any): Any
+    def finalize(state: Any): util.ArrayList[T]
+    def clone(state: Any): Any
+    def normalize(state: Any): Any
+    def denormalize(elems: Any): Any
+  }
+
   // Helper class to handle type erasure
-  class StateProvider[T, OrderType] {
+  class StateProvider[T, OrderType] extends StateProviderTrait[T] {
     def initState(): Any = UniqueOrderByLimit.initState[T, OrderType]
 
     def insert(elem: T, state: Any): Unit =
@@ -868,12 +904,58 @@ class UniqueTopKHelper[T](inputType: DataType, k: Int, maxSizeOpt: Option[Int] =
         .buildStateFromElems(elems.asInstanceOf[util.ArrayList[T]])
     }
   }
+
+  // Helper class to handle type erasure for lenient (LAST_SEEN) mode
+  class LenientStateProvider[T, OrderType] extends StateProviderTrait[T] {
+    def initState(): Any = UniqueOrderByLimit.initLenientState[T, OrderType]
+
+    def insert(elem: T, state: Any): Unit =
+      operator
+        .asInstanceOf[UniqueOrderByLimit.LenientOperator[T, OrderType]]
+        .insert(elem, state.asInstanceOf[UniqueOrderByLimit.LenientState[T, OrderType]])
+
+    def merge(state1: Any, state2: Any): Any = {
+      val s1 = state1.asInstanceOf[UniqueOrderByLimit.LenientState[T, OrderType]]
+      val s2 = state2.asInstanceOf[UniqueOrderByLimit.LenientState[T, OrderType]]
+
+      val it = s2.elems.iterator()
+      while (it.hasNext) {
+        val elem = it.next()
+        operator.asInstanceOf[UniqueOrderByLimit.LenientOperator[T, OrderType]].insert(elem, s1)
+      }
+
+      s1
+    }
+
+    def finalize(state: Any): util.ArrayList[T] = {
+      val s = state.asInstanceOf[UniqueOrderByLimit.LenientState[T, OrderType]]
+      operator.asInstanceOf[UniqueOrderByLimit.LenientOperator[T, OrderType]].sortAndPrune(s)
+      s.elems
+    }
+
+    def clone(state: Any): Any = {
+      val s = state.asInstanceOf[UniqueOrderByLimit.LenientState[T, OrderType]]
+      val clonedElems = new util.ArrayList[T](s.elems)
+      val clonedIdToIndex = new util.HashMap[Long, Int](s.idToIndex)
+      UniqueOrderByLimit.LenientState[T, OrderType](clonedElems, clonedIdToIndex, s.orderWaterMark, s.indicesDirty)
+    }
+
+    def normalize(state: Any): Any = {
+      state.asInstanceOf[UniqueOrderByLimit.LenientState[T, OrderType]].elems
+    }
+
+    def denormalize(elems: Any): Any = {
+      operator
+        .asInstanceOf[UniqueOrderByLimit.LenientOperator[T, OrderType]]
+        .buildStateFromElems(elems.asInstanceOf[util.ArrayList[T]])
+    }
+  }
 }
 
-class UniqueTopKAggregator[T](inputType: DataType, k: Int, maxSizeOpt: Option[Int] = None)
+class UniqueTopKAggregator[T](inputType: DataType, k: Int, maxSizeOpt: Option[Int] = None, dedupMode: String = DedupMode.FIRST_SEEN.toString)
     extends SimpleAggregator[T, Any, util.ArrayList[T]] {
 
-  private val uniqueTopK = new UniqueTopKHelper[T](inputType, k, maxSizeOpt)
+  private val uniqueTopK = new UniqueTopKHelper[T](inputType, k, maxSizeOpt, dedupMode)
 
   override def outputType: DataType = ListType(inputType)
 

--- a/aggregator/src/main/scala/ai/chronon/aggregator/base/SimpleAggregators.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/base/SimpleAggregators.scala
@@ -763,19 +763,19 @@ class Kurtosis extends MomentAggregator {
 class UniqueTopKHelper[T](inputType: DataType,
                           k: Int,
                           maxSizeOpt: Option[Int] = None,
-                          dedupMode: String = DedupMode.FIRST_SEEN.toString) {
+                          collisionStrategy: String = CollisionStrategy.IGNORE.toString) {
 
   private val maxSize: Int = maxSizeOpt.getOrElse(2 * k)
-  private val useLenient: Boolean = dedupMode == DedupMode.LAST_SEEN.toString
+  private val useUpdate: Boolean = collisionStrategy == CollisionStrategy.UPDATE.toString
 
   // Define the order type and create operator based on input type
   val (operator, stateProvider): (Any, StateProviderTrait[T]) = inputType match {
     case IntType =>
       val getOrderKeyInt = (x: T) => x.asInstanceOf[Int]
       val getIdInt = (x: T) => x.asInstanceOf[Int].toLong
-      if (useLenient) {
-        val op = UniqueOrderByLimit.LenientOperator[T, Int](getOrderKeyInt, getIdInt, k, maxSize, topK = true)
-        val provider = new LenientStateProvider[T, Int]
+      if (useUpdate) {
+        val op = UniqueOrderByLimit.UpdateOperator[T, Int](getOrderKeyInt, getIdInt, k, maxSize, topK = true)
+        val provider = new UpdateStateProvider[T, Int]
         (op, provider)
       } else {
         val op = UniqueOrderByLimit.Operator[T, Int](getOrderKeyInt, getIdInt, k, maxSize, topK = true)
@@ -786,9 +786,9 @@ class UniqueTopKHelper[T](inputType: DataType,
     case LongType =>
       val getOrderKeyLong = (x: T) => x.asInstanceOf[Long]
       val getIdLong = (x: T) => x.asInstanceOf[Long]
-      if (useLenient) {
-        val op = UniqueOrderByLimit.LenientOperator[T, Long](getOrderKeyLong, getIdLong, k, maxSize, topK = true)
-        val provider = new LenientStateProvider[T, Long]
+      if (useUpdate) {
+        val op = UniqueOrderByLimit.UpdateOperator[T, Long](getOrderKeyLong, getIdLong, k, maxSize, topK = true)
+        val provider = new UpdateStateProvider[T, Long]
         (op, provider)
       } else {
         val op = UniqueOrderByLimit.Operator[T, Long](getOrderKeyLong, getIdLong, k, maxSize, topK = true)
@@ -799,9 +799,9 @@ class UniqueTopKHelper[T](inputType: DataType,
     case StringType =>
       val getOrderKeyString = (x: T) => x.asInstanceOf[String]
       val getIdString = (x: T) => x.asInstanceOf[String].hashCode.toLong
-      if (useLenient) {
-        val op = UniqueOrderByLimit.LenientOperator[T, String](getOrderKeyString, getIdString, k, maxSize, topK = true)
-        val provider = new LenientStateProvider[T, String]
+      if (useUpdate) {
+        val op = UniqueOrderByLimit.UpdateOperator[T, String](getOrderKeyString, getIdString, k, maxSize, topK = true)
+        val provider = new UpdateStateProvider[T, String]
         (op, provider)
       } else {
         val op = UniqueOrderByLimit.Operator[T, String](getOrderKeyString, getIdString, k, maxSize, topK = true)
@@ -835,9 +835,9 @@ class UniqueTopKHelper[T](inputType: DataType,
           case map: Map[String, AnyRef]      => map("unique_id").asInstanceOf[Long]
         }
 
-      if (useLenient) {
-        val op = UniqueOrderByLimit.LenientOperator[T, String](getOrderKeyStruct, getIdStruct, k, maxSize, topK = true)
-        val provider = new LenientStateProvider[T, String]
+      if (useUpdate) {
+        val op = UniqueOrderByLimit.UpdateOperator[T, String](getOrderKeyStruct, getIdStruct, k, maxSize, topK = true)
+        val provider = new UpdateStateProvider[T, String]
         (op, provider)
       } else {
         val op = UniqueOrderByLimit.Operator[T, String](getOrderKeyStruct, getIdStruct, k, maxSize, topK = true)
@@ -908,48 +908,48 @@ class UniqueTopKHelper[T](inputType: DataType,
     }
   }
 
-  // Helper class to handle type erasure for lenient (LAST_SEEN) mode
-  class LenientStateProvider[T, OrderType] extends StateProviderTrait[T] {
-    def initState(): Any = UniqueOrderByLimit.initLenientState[T, OrderType]
+  // Helper class to handle type erasure for UPDATE collision strategy mode
+  class UpdateStateProvider[T, OrderType] extends StateProviderTrait[T] {
+    def initState(): Any = UniqueOrderByLimit.initUpdateState[T, OrderType]
 
     def insert(elem: T, state: Any): Unit =
       operator
-        .asInstanceOf[UniqueOrderByLimit.LenientOperator[T, OrderType]]
-        .insert(elem, state.asInstanceOf[UniqueOrderByLimit.LenientState[T, OrderType]])
+        .asInstanceOf[UniqueOrderByLimit.UpdateOperator[T, OrderType]]
+        .insert(elem, state.asInstanceOf[UniqueOrderByLimit.UpdateState[T, OrderType]])
 
     def merge(state1: Any, state2: Any): Any = {
-      val s1 = state1.asInstanceOf[UniqueOrderByLimit.LenientState[T, OrderType]]
-      val s2 = state2.asInstanceOf[UniqueOrderByLimit.LenientState[T, OrderType]]
+      val s1 = state1.asInstanceOf[UniqueOrderByLimit.UpdateState[T, OrderType]]
+      val s2 = state2.asInstanceOf[UniqueOrderByLimit.UpdateState[T, OrderType]]
 
       val it = s2.elems.iterator()
       while (it.hasNext) {
         val elem = it.next()
-        operator.asInstanceOf[UniqueOrderByLimit.LenientOperator[T, OrderType]].insert(elem, s1)
+        operator.asInstanceOf[UniqueOrderByLimit.UpdateOperator[T, OrderType]].insert(elem, s1)
       }
 
       s1
     }
 
     def finalize(state: Any): util.ArrayList[T] = {
-      val s = state.asInstanceOf[UniqueOrderByLimit.LenientState[T, OrderType]]
-      operator.asInstanceOf[UniqueOrderByLimit.LenientOperator[T, OrderType]].sortAndPrune(s)
+      val s = state.asInstanceOf[UniqueOrderByLimit.UpdateState[T, OrderType]]
+      operator.asInstanceOf[UniqueOrderByLimit.UpdateOperator[T, OrderType]].sortAndPrune(s)
       s.elems
     }
 
     def clone(state: Any): Any = {
-      val s = state.asInstanceOf[UniqueOrderByLimit.LenientState[T, OrderType]]
+      val s = state.asInstanceOf[UniqueOrderByLimit.UpdateState[T, OrderType]]
       val clonedElems = new util.ArrayList[T](s.elems)
       val clonedIdToIndex = new util.HashMap[Long, Int](s.idToIndex)
-      UniqueOrderByLimit.LenientState[T, OrderType](clonedElems, clonedIdToIndex, s.orderWaterMark, s.indicesDirty)
+      UniqueOrderByLimit.UpdateState[T, OrderType](clonedElems, clonedIdToIndex, s.orderWaterMark, s.indicesDirty)
     }
 
     def normalize(state: Any): Any = {
-      state.asInstanceOf[UniqueOrderByLimit.LenientState[T, OrderType]].elems
+      state.asInstanceOf[UniqueOrderByLimit.UpdateState[T, OrderType]].elems
     }
 
     def denormalize(elems: Any): Any = {
       operator
-        .asInstanceOf[UniqueOrderByLimit.LenientOperator[T, OrderType]]
+        .asInstanceOf[UniqueOrderByLimit.UpdateOperator[T, OrderType]]
         .buildStateFromElems(elems.asInstanceOf[util.ArrayList[T]])
     }
   }
@@ -958,10 +958,10 @@ class UniqueTopKHelper[T](inputType: DataType,
 class UniqueTopKAggregator[T](inputType: DataType,
                               k: Int,
                               maxSizeOpt: Option[Int] = None,
-                              dedupMode: String = DedupMode.FIRST_SEEN.toString)
+                              collisionStrategy: String = CollisionStrategy.IGNORE.toString)
     extends SimpleAggregator[T, Any, util.ArrayList[T]] {
 
-  private val uniqueTopK = new UniqueTopKHelper[T](inputType, k, maxSizeOpt, dedupMode)
+  private val uniqueTopK = new UniqueTopKHelper[T](inputType, k, maxSizeOpt, collisionStrategy)
 
   override def outputType: DataType = ListType(inputType)
 

--- a/aggregator/src/main/scala/ai/chronon/aggregator/base/UniqueOrderByLimit.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/base/UniqueOrderByLimit.scala
@@ -120,29 +120,29 @@ object UniqueOrderByLimit {
     }
   }
 
-  // Lenient (LAST_SEEN) implementation that allows replacing elements with same ID
-  def initLenientState[T, OrderType]: LenientState[T, OrderType] =
-    LenientState(new util.ArrayList[T](),
-                 new util.HashMap[Long, Int](),
-                 null.asInstanceOf[OrderType],
-                 indicesDirty = false)
+  // UPDATE collision strategy implementation that allows replacing elements with same ID
+  def initUpdateState[T, OrderType]: UpdateState[T, OrderType] =
+    UpdateState(new util.ArrayList[T](),
+                new util.HashMap[Long, Int](),
+                null.asInstanceOf[OrderType],
+                indicesDirty = false)
 
-  case class LenientState[T, OrderType](elems: java.util.ArrayList[T],
-                                        idToIndex: java.util.HashMap[Long, Int],
-                                        var orderWaterMark: OrderType,
-                                        var indicesDirty: Boolean)
+  case class UpdateState[T, OrderType](elems: java.util.ArrayList[T],
+                                       idToIndex: java.util.HashMap[Long, Int],
+                                       var orderWaterMark: OrderType,
+                                       var indicesDirty: Boolean)
 
-  // LenientOperator implements LAST_SEEN behavior: always replace when duplicate ID is seen
-  case class LenientOperator[T, OrderType: Ordering](getOrderKey: T => OrderType,
-                                                     getId: T => Long,
-                                                     k: Int,
-                                                     maxSize: Int,
-                                                     topK: Boolean = true) {
+  // UpdateOperator implements UPDATE collision strategy behavior: always replace when duplicate ID is seen
+  case class UpdateOperator[T, OrderType: Ordering](getOrderKey: T => OrderType,
+                                                    getId: T => Long,
+                                                    k: Int,
+                                                    maxSize: Int,
+                                                    topK: Boolean = true) {
 
     private val ordering = implicitly[Ordering[OrderType]]
 
     // Recompute the watermark from current elements (O(k), k is typically small)
-    private def recomputeOrderWaterMark(state: LenientState[T, OrderType]): Unit = {
+    private def recomputeOrderWaterMark(state: UpdateState[T, OrderType]): Unit = {
       if (state.elems.isEmpty) {
         state.orderWaterMark = null.asInstanceOf[OrderType]
       } else {
@@ -165,7 +165,7 @@ object UniqueOrderByLimit {
     }
 
     // Rebuild the idToIndex map after sorting (indices have changed)
-    private def rebuildIndexMap(state: LenientState[T, OrderType]): Unit = {
+    private def rebuildIndexMap(state: UpdateState[T, OrderType]): Unit = {
       state.idToIndex.clear()
       var i = 0
       while (i < state.elems.size()) {
@@ -177,7 +177,7 @@ object UniqueOrderByLimit {
     }
 
     // to be used in "finalize" of the aggregator
-    def sortAndPrune(state: LenientState[T, OrderType]): Unit = {
+    def sortAndPrune(state: UpdateState[T, OrderType]): Unit = {
       sort(state)
       val elems = state.elems
 
@@ -197,8 +197,8 @@ object UniqueOrderByLimit {
     }
 
     // to be used to impl "denormalize" of the aggregator
-    def buildStateFromElems(elems: java.util.ArrayList[T]): LenientState[T, OrderType] = {
-      val state: LenientState[T, OrderType] = UniqueOrderByLimit.initLenientState[T, OrderType]
+    def buildStateFromElems(elems: java.util.ArrayList[T]): UpdateState[T, OrderType] = {
+      val state: UpdateState[T, OrderType] = UniqueOrderByLimit.initUpdateState[T, OrderType]
       val it = elems.iterator()
 
       while (it.hasNext) {
@@ -208,11 +208,11 @@ object UniqueOrderByLimit {
       state
     }
 
-    def insert(elem: T, state: LenientState[T, OrderType]): Unit = {
+    def insert(elem: T, state: UpdateState[T, OrderType]): Unit = {
       val elemId = getId(elem)
       val orderKey = getOrderKey(elem)
 
-      // LAST_SEEN behavior: if ID exists, replace the element at that index
+      // UPDATE behavior: if ID exists, replace the element at that index
       if (state.idToIndex.containsKey(elemId)) {
         val existingIndex = state.idToIndex.get(elemId)
         state.elems.set(existingIndex, elem)
@@ -266,7 +266,7 @@ object UniqueOrderByLimit {
       }
     }
 
-    private def sort(state: LenientState[T, OrderType]): Unit = {
+    private def sort(state: UpdateState[T, OrderType]): Unit = {
       state.elems.sort(new Comparator[T] {
         override def compare(o1: T, o2: T): Int = {
           val o1Key = getOrderKey(o1)

--- a/aggregator/src/main/scala/ai/chronon/aggregator/base/UniqueOrderByLimit.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/base/UniqueOrderByLimit.scala
@@ -141,6 +141,30 @@ object UniqueOrderByLimit {
 
     private val ordering = implicitly[Ordering[OrderType]]
 
+    // Recompute the watermark from current elements (O(k), k is typically small)
+    private def recomputeOrderWaterMark(state: LenientState[T, OrderType]): Unit = {
+      if (state.elems.isEmpty) {
+        state.orderWaterMark = null.asInstanceOf[OrderType]
+      } else {
+        var i = 0
+        var candidate = getOrderKey(state.elems.get(0))
+        i += 1
+        while (i < state.elems.size()) {
+          val key = getOrderKey(state.elems.get(i))
+          candidate =
+            if (topK) {
+              // track minimum for top-k (k-th largest element)
+              if (ordering.lt(key, candidate)) key else candidate
+            } else {
+              // track maximum for bottom-k (k-th smallest element)
+              if (ordering.gt(key, candidate)) key else candidate
+            }
+          i += 1
+        }
+        state.orderWaterMark = candidate
+      }
+    }
+
     // Rebuild the idToIndex map after sorting (indices have changed)
     private def rebuildIndexMap(state: LenientState[T, OrderType]): Unit = {
       state.idToIndex.clear()
@@ -167,7 +191,6 @@ object UniqueOrderByLimit {
       if (elems.size > 0) {
         state.orderWaterMark = getOrderKey(elems.get(elems.size - 1))
       }
-
       // Lazy rebuild: only rebuild if we actually sorted and pruned
       if (state.indicesDirty) {
         rebuildIndexMap(state)
@@ -194,7 +217,8 @@ object UniqueOrderByLimit {
       if (state.idToIndex.containsKey(elemId)) {
         val existingIndex = state.idToIndex.get(elemId)
         state.elems.set(existingIndex, elem)
-        // Note: index doesn't change, so no need to update map or set dirty flag
+        // Index stays the same, but the orderKey may have changed; keep watermark consistent
+        recomputeOrderWaterMark(state)
         return
       }
 

--- a/aggregator/src/main/scala/ai/chronon/aggregator/base/UniqueOrderByLimit.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/base/UniqueOrderByLimit.scala
@@ -216,8 +216,10 @@ object UniqueOrderByLimit {
       if (state.idToIndex.containsKey(elemId)) {
         val existingIndex = state.idToIndex.get(elemId)
         state.elems.set(existingIndex, elem)
-        // Index stays the same, but the orderKey may have changed; keep watermark consistent
-        recomputeOrderWaterMark(state)
+        // Only recompute watermark if we're at capacity (size >= k), as that's when it affects filtering
+        if (state.elems.size() >= k) {
+          recomputeOrderWaterMark(state)
+        }
         return
       }
 

--- a/aggregator/src/main/scala/ai/chronon/aggregator/base/UniqueOrderByLimit.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/base/UniqueOrderByLimit.scala
@@ -151,14 +151,13 @@ object UniqueOrderByLimit {
         i += 1
         while (i < state.elems.size()) {
           val key = getOrderKey(state.elems.get(i))
-          candidate =
-            if (topK) {
-              // track minimum for top-k (k-th largest element)
-              if (ordering.lt(key, candidate)) key else candidate
-            } else {
-              // track maximum for bottom-k (k-th smallest element)
-              if (ordering.gt(key, candidate)) key else candidate
-            }
+          candidate = if (topK) {
+            // track minimum for top-k (k-th largest element)
+            if (ordering.lt(key, candidate)) key else candidate
+          } else {
+            // track maximum for bottom-k (k-th smallest element)
+            if (ordering.gt(key, candidate)) key else candidate
+          }
           i += 1
         }
         state.orderWaterMark = candidate

--- a/aggregator/src/main/scala/ai/chronon/aggregator/base/UniqueOrderByLimit.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/base/UniqueOrderByLimit.scala
@@ -120,4 +120,138 @@ object UniqueOrderByLimit {
     }
   }
 
+  // Lenient (LAST_SEEN) implementation that allows replacing elements with same ID
+  def initLenientState[T, OrderType]: LenientState[T, OrderType] =
+    LenientState(new util.ArrayList[T](), new util.HashMap[Long, Int](), null.asInstanceOf[OrderType], indicesDirty = false)
+
+  case class LenientState[T, OrderType](elems: java.util.ArrayList[T],
+                                         idToIndex: java.util.HashMap[Long, Int],
+                                         var orderWaterMark: OrderType,
+                                         var indicesDirty: Boolean)
+
+  // LenientOperator implements LAST_SEEN behavior: always replace when duplicate ID is seen
+  case class LenientOperator[T, OrderType: Ordering](getOrderKey: T => OrderType,
+                                                       getId: T => Long,
+                                                       k: Int,
+                                                       maxSize: Int,
+                                                       topK: Boolean = true) {
+
+    private val ordering = implicitly[Ordering[OrderType]]
+
+    // Rebuild the idToIndex map after sorting (indices have changed)
+    private def rebuildIndexMap(state: LenientState[T, OrderType]): Unit = {
+      state.idToIndex.clear()
+      var i = 0
+      while (i < state.elems.size()) {
+        val elem = state.elems.get(i)
+        state.idToIndex.put(getId(elem), i)
+        i += 1
+      }
+      state.indicesDirty = false
+    }
+
+    // to be used in "finalize" of the aggregator
+    def sortAndPrune(state: LenientState[T, OrderType]): Unit = {
+      sort(state)
+      val elems = state.elems
+
+      // Remove elements beyond k
+      while (elems.size > k) {
+        val removed = elems.remove(elems.size - 1)
+        state.idToIndex.remove(getId(removed))
+      }
+
+      if (elems.size > 0) {
+        state.orderWaterMark = getOrderKey(elems.get(elems.size - 1))
+      }
+
+      // Lazy rebuild: only rebuild if we actually sorted and pruned
+      if (state.indicesDirty) {
+        rebuildIndexMap(state)
+      }
+    }
+
+    // to be used to impl "denormalize" of the aggregator
+    def buildStateFromElems(elems: java.util.ArrayList[T]): LenientState[T, OrderType] = {
+      val state: LenientState[T, OrderType] = UniqueOrderByLimit.initLenientState[T, OrderType]
+      val it = elems.iterator()
+
+      while (it.hasNext) {
+        insert(it.next(), state)
+      }
+
+      state
+    }
+
+    def insert(elem: T, state: LenientState[T, OrderType]): Unit = {
+      val elemId = getId(elem)
+      val orderKey = getOrderKey(elem)
+
+      // LAST_SEEN behavior: if ID exists, replace the element at that index
+      if (state.idToIndex.containsKey(elemId)) {
+        val existingIndex = state.idToIndex.get(elemId)
+        state.elems.set(existingIndex, elem)
+        // Note: index doesn't change, so no need to update map or set dirty flag
+        return
+      }
+
+      // New element - same logic as strict version but track index instead of just ID
+      if (topK) {
+        if (state.elems.size() < k) {
+          state.orderWaterMark = if (state.orderWaterMark == null || ordering.lt(orderKey, state.orderWaterMark)) {
+            orderKey
+          } else {
+            state.orderWaterMark
+          }
+
+          val index = state.elems.size()
+          state.elems.add(elem)
+          state.idToIndex.put(elemId, index)
+
+        } else if (ordering.gt(orderKey, state.orderWaterMark)) {
+          val index = state.elems.size()
+          state.elems.add(elem)
+          state.idToIndex.put(elemId, index)
+        }
+      } else {
+        if (state.elems.size() < k) {
+          state.orderWaterMark = if (state.orderWaterMark == null || ordering.gt(orderKey, state.orderWaterMark)) {
+            orderKey
+          } else {
+            state.orderWaterMark
+          }
+
+          val index = state.elems.size()
+          state.elems.add(elem)
+          state.idToIndex.put(elemId, index)
+
+        } else if (ordering.lt(orderKey, state.orderWaterMark)) {
+          val index = state.elems.size()
+          state.elems.add(elem)
+          state.idToIndex.put(elemId, index)
+        }
+      }
+
+      if (state.elems.size() > maxSize) {
+        state.indicesDirty = true
+        sortAndPrune(state)
+      }
+    }
+
+    private def sort(state: LenientState[T, OrderType]): Unit = {
+      state.elems.sort(new Comparator[T] {
+        override def compare(o1: T, o2: T): Int = {
+          val o1Key = getOrderKey(o1)
+          val o2Key = getOrderKey(o2)
+
+          if (topK) {
+            ordering.compare(o2Key, o1Key)  // descending
+          } else {
+            ordering.compare(o1Key, o2Key)  // ascending
+          }
+        }
+      })
+    }
+  }
+
 }

--- a/aggregator/src/main/scala/ai/chronon/aggregator/base/UniqueOrderByLimit.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/base/UniqueOrderByLimit.scala
@@ -122,19 +122,22 @@ object UniqueOrderByLimit {
 
   // Lenient (LAST_SEEN) implementation that allows replacing elements with same ID
   def initLenientState[T, OrderType]: LenientState[T, OrderType] =
-    LenientState(new util.ArrayList[T](), new util.HashMap[Long, Int](), null.asInstanceOf[OrderType], indicesDirty = false)
+    LenientState(new util.ArrayList[T](),
+                 new util.HashMap[Long, Int](),
+                 null.asInstanceOf[OrderType],
+                 indicesDirty = false)
 
   case class LenientState[T, OrderType](elems: java.util.ArrayList[T],
-                                         idToIndex: java.util.HashMap[Long, Int],
-                                         var orderWaterMark: OrderType,
-                                         var indicesDirty: Boolean)
+                                        idToIndex: java.util.HashMap[Long, Int],
+                                        var orderWaterMark: OrderType,
+                                        var indicesDirty: Boolean)
 
   // LenientOperator implements LAST_SEEN behavior: always replace when duplicate ID is seen
   case class LenientOperator[T, OrderType: Ordering](getOrderKey: T => OrderType,
-                                                       getId: T => Long,
-                                                       k: Int,
-                                                       maxSize: Int,
-                                                       topK: Boolean = true) {
+                                                     getId: T => Long,
+                                                     k: Int,
+                                                     maxSize: Int,
+                                                     topK: Boolean = true) {
 
     private val ordering = implicitly[Ordering[OrderType]]
 
@@ -245,9 +248,9 @@ object UniqueOrderByLimit {
           val o2Key = getOrderKey(o2)
 
           if (topK) {
-            ordering.compare(o2Key, o1Key)  // descending
+            ordering.compare(o2Key, o1Key) // descending
           } else {
-            ordering.compare(o1Key, o2Key)  // ascending
+            ordering.compare(o1Key, o2Key) // ascending
           }
         }
       })

--- a/aggregator/src/main/scala/ai/chronon/aggregator/row/ColumnAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/row/ColumnAggregator.scala
@@ -393,14 +393,14 @@ object ColumnAggregator {
 
       case Operation.UNIQUE_TOP_K =>
         val k = aggregationPart.getInt("k")
-        val dedupMode = Option(aggregationPart.argMap)
-          .flatMap(_.toScala.get("dedup_mode"))
-          .getOrElse(DedupMode.FIRST_SEEN.toString)
+        val collisionStrategy = Option(aggregationPart.argMap)
+          .flatMap(_.toScala.get("collision_strategy"))
+          .getOrElse(CollisionStrategy.IGNORE.toString)
         inputType match {
-          case IntType        => simple(new UniqueTopKAggregator[Int](inputType, k, None, dedupMode))
-          case LongType       => simple(new UniqueTopKAggregator[Long](inputType, k, None, dedupMode))
-          case StringType     => simple(new UniqueTopKAggregator[String](inputType, k, None, dedupMode))
-          case st: StructType => simple(new UniqueTopKAggregator[Array[Any]](inputType, k, None, dedupMode))
+          case IntType        => simple(new UniqueTopKAggregator[Int](inputType, k, None, collisionStrategy))
+          case LongType       => simple(new UniqueTopKAggregator[Long](inputType, k, None, collisionStrategy))
+          case StringType     => simple(new UniqueTopKAggregator[String](inputType, k, None, collisionStrategy))
+          case st: StructType => simple(new UniqueTopKAggregator[Array[Any]](inputType, k, None, collisionStrategy))
           case _              => mismatchException
         }
 

--- a/aggregator/src/main/scala/ai/chronon/aggregator/row/ColumnAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/row/ColumnAggregator.scala
@@ -20,11 +20,12 @@ import ai.chronon.aggregator.base._
 import ai.chronon.api.Extensions.AggregationPartOps
 import ai.chronon.api.Extensions.OperationOps
 import ai.chronon.api._
+import ai.chronon.api.ScalaJavaConversions._
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.apache.datasketches.frequencies.ErrorType
 
 import java.util
-import scala.collection.JavaConverters.asScalaIteratorConverter
+import scala.collection.JavaConverters._
 
 abstract class ColumnAggregator extends Serializable {
   def outputType: DataType
@@ -392,11 +393,14 @@ object ColumnAggregator {
 
       case Operation.UNIQUE_TOP_K =>
         val k = aggregationPart.getInt("k")
+        val dedupMode = Option(aggregationPart.argMap)
+          .flatMap(_.toScala.get("dedup_mode"))
+          .getOrElse(DedupMode.FIRST_SEEN.toString)
         inputType match {
-          case IntType        => simple(new UniqueTopKAggregator[Int](inputType, k))
-          case LongType       => simple(new UniqueTopKAggregator[Long](inputType, k))
-          case StringType     => simple(new UniqueTopKAggregator[String](inputType, k))
-          case st: StructType => simple(new UniqueTopKAggregator[Array[Any]](inputType, k))
+          case IntType        => simple(new UniqueTopKAggregator[Int](inputType, k, None, dedupMode))
+          case LongType       => simple(new UniqueTopKAggregator[Long](inputType, k, None, dedupMode))
+          case StringType     => simple(new UniqueTopKAggregator[String](inputType, k, None, dedupMode))
+          case st: StructType => simple(new UniqueTopKAggregator[Array[Any]](inputType, k, None, dedupMode))
           case _              => mismatchException
         }
 

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/UniqueTopKTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/UniqueTopKTest.scala
@@ -253,11 +253,11 @@ class UniqueTopKAggregatorTest extends AnyFlatSpec {
     assertEquals(List(20, 19, 18), result.asScala.toList)
   }
 
-  // ===== LAST_SEEN mode tests =====
+  // ===== UPDATE collision strategy tests =====
 
-  "UniqueTopKAggregator with LAST_SEEN mode" should "replace elements with duplicate IDs" in {
+  "UniqueTopKAggregator with UPDATE collision strategy" should "replace elements with duplicate IDs" in {
     val k = 3
-    val aggregator = new UniqueTopKAggregator[Int](IntType, k, None, "LAST_SEEN")
+    val aggregator = new UniqueTopKAggregator[Int](IntType, k, None, "UPDATE")
 
     // Add same ID multiple times - LAST_SEEN should keep the last occurrence
     val inputs = List(5, 3, 8, 5, 3, 5)
@@ -272,9 +272,9 @@ class UniqueTopKAggregatorTest extends AnyFlatSpec {
     assertEquals(List(8, 5, 3), resultList)
   }
 
-  "UniqueTopKAggregator with LAST_SEEN mode and IntType" should "always keep last seen value" in {
+  "UniqueTopKAggregator with UPDATE collision strategy and IntType" should "always keep last seen value" in {
     val k = 5
-    val aggregator = new UniqueTopKAggregator[Int](IntType, k, None, "LAST_SEEN")
+    val aggregator = new UniqueTopKAggregator[Int](IntType, k, None, "UPDATE")
 
     val inputs = List(1, 2, 1, 3, 2, 1, 4, 3, 2, 1)
     val ir = aggregator.prepare(inputs.head)
@@ -287,7 +287,7 @@ class UniqueTopKAggregatorTest extends AnyFlatSpec {
     assertEquals(List(4, 3, 2, 1), resultList)
   }
 
-  "UniqueTopKAggregator with LAST_SEEN mode and StructType" should "replace struct when duplicate ID is seen" in {
+  "UniqueTopKAggregator with UPDATE collision strategy and StructType" should "replace struct when duplicate ID has better order key" in {
     val structType = StructType("TestStruct",
                                 Array(
                                   StructField("sort_key", StringType),
@@ -296,14 +296,15 @@ class UniqueTopKAggregatorTest extends AnyFlatSpec {
                                 ))
 
     val k = 3
-    val aggregator = new UniqueTopKAggregator[Array[Any]](structType, k, None, "LAST_SEEN")
+    val aggregator = new UniqueTopKAggregator[Array[Any]](structType, k, None, "UPDATE")
 
+    // With UPDATE collision strategy, we keep the element with the max sort_key (topK=true)
     val inputs = List(
-      Array("z", 1L, 10),  // ID=1, value=10
-      Array("y", 2L, 20),  // ID=2, value=20
-      Array("x", 3L, 30),  // ID=3, value=30
-      Array("w", 1L, 100), // ID=1 again - should REPLACE with value=100
-      Array("v", 2L, 200)  // ID=2 again - should REPLACE with value=200
+      Array("a", 1L, 10),  // ID=1, sort_key="a", value=10
+      Array("b", 2L, 20),  // ID=2, sort_key="b", value=20
+      Array("c", 3L, 30),  // ID=3, sort_key="c", value=30
+      Array("z", 1L, 100), // ID=1 again with sort_key="z" > "a" - should UPDATE to value=100
+      Array("y", 2L, 200)  // ID=2 again with sort_key="y" > "b" - should UPDATE to value=200
     )
 
     val ir = aggregator.prepare(inputs.head)
@@ -314,24 +315,24 @@ class UniqueTopKAggregatorTest extends AnyFlatSpec {
 
     assertEquals(3, result.size())
 
-    // Check that ID=1 now has value=100 (not 10), and ID=2 has value=200 (not 20)
+    // Check that ID=1 now has value=100 (from "z" > "a"), and ID=2 has value=200 (from "y" > "b")
     val id1Entry = resultList.find(arr => arr(1) == 1L).get
     val id2Entry = resultList.find(arr => arr(1) == 2L).get
     val id3Entry = resultList.find(arr => arr(1) == 3L).get
 
-    assertEquals(100, id1Entry(2)) // Last seen value for ID=1
-    assertEquals(200, id2Entry(2)) // Last seen value for ID=2
-    assertEquals(30, id3Entry(2))  // Original value for ID=3
+    assertEquals(100, id1Entry(2)) // Updated value for ID=1 (because "z" > "a")
+    assertEquals(200, id2Entry(2)) // Updated value for ID=2 (because "y" > "b")
+    assertEquals(30, id3Entry(2))  // Original value for ID=3 (no duplicate)
 
-    // Check sort keys also updated (last seen)
-    assertEquals("w", id1Entry(0))
-    assertEquals("v", id2Entry(0))
-    assertEquals("x", id3Entry(0))
+    // Check sort keys also updated to the max values
+    assertEquals("z", id1Entry(0))
+    assertEquals("y", id2Entry(0))
+    assertEquals("c", id3Entry(0))
   }
 
-  "UniqueTopKAggregator with LAST_SEEN mode" should "handle merge operations correctly" in {
+  "UniqueTopKAggregator with UPDATE collision strategy" should "handle merge operations correctly" in {
     val k = 3
-    val aggregator = new UniqueTopKAggregator[Int](IntType, k, None, "LAST_SEEN")
+    val aggregator = new UniqueTopKAggregator[Int](IntType, k, None, "UPDATE")
 
     // First batch
     val ir1 = aggregator.prepare(5)
@@ -354,9 +355,9 @@ class UniqueTopKAggregatorTest extends AnyFlatSpec {
     assertEquals(List(8, 7, 5), resultList)
   }
 
-  "UniqueTopKAggregator with FIRST_SEEN mode (default)" should "reject duplicates as before" in {
+  "UniqueTopKAggregator with IGNORE collision strategy (default)" should "reject duplicates as before" in {
     val k = 3
-    val aggregator = new UniqueTopKAggregator[Int](IntType, k, None, "FIRST_SEEN")
+    val aggregator = new UniqueTopKAggregator[Int](IntType, k, None, "IGNORE")
 
     val inputs = List(5, 3, 8, 5, 3) // Duplicates should be ignored
     val ir = aggregator.prepare(inputs.head)
@@ -369,9 +370,9 @@ class UniqueTopKAggregatorTest extends AnyFlatSpec {
     assertEquals(List(8, 5, 3), resultList) // First occurrence of each kept
   }
 
-  "UniqueTopKAggregator with LAST_SEEN mode" should "handle normalization round-trip" in {
+  "UniqueTopKAggregator with UPDATE collision strategy" should "handle normalization round-trip" in {
     val k = 3
-    val aggregator = new UniqueTopKAggregator[Int](IntType, k, None, "LAST_SEEN")
+    val aggregator = new UniqueTopKAggregator[Int](IntType, k, None, "UPDATE")
 
     val inputs = List(5, 3, 8, 5, 3) // With duplicates
     val ir = aggregator.prepare(inputs.head)
@@ -386,9 +387,9 @@ class UniqueTopKAggregatorTest extends AnyFlatSpec {
     assertEquals(originalResult, roundTripResult)
   }
 
-  "UniqueTopKAggregator with LAST_SEEN mode" should "handle clone operation correctly" in {
+  "UniqueTopKAggregator with UPDATE collision strategy" should "handle clone operation correctly" in {
     val k = 3
-    val aggregator = new UniqueTopKAggregator[Int](IntType, k, None, "LAST_SEEN")
+    val aggregator = new UniqueTopKAggregator[Int](IntType, k, None, "UPDATE")
 
     val inputs = List(5, 3, 8, 1)
     val ir = aggregator.prepare(inputs.head)
@@ -411,9 +412,9 @@ class UniqueTopKAggregatorTest extends AnyFlatSpec {
     assertEquals(List(8, 5, 3), clonedResult.asScala.toList)
   }
 
-  "UniqueTopKAggregator with LAST_SEEN mode and LongType" should "replace elements correctly" in {
+  "UniqueTopKAggregator with UPDATE collision strategy and LongType" should "replace elements correctly" in {
     val k = 3
-    val aggregator = new UniqueTopKAggregator[Long](LongType, k, None, "LAST_SEEN")
+    val aggregator = new UniqueTopKAggregator[Long](LongType, k, None, "UPDATE")
 
     val inputs = List(100L, 200L, 300L, 100L, 200L)
     val ir = aggregator.prepare(inputs.head)
@@ -426,9 +427,9 @@ class UniqueTopKAggregatorTest extends AnyFlatSpec {
     assertEquals(List(300L, 200L, 100L), resultList)
   }
 
-  "UniqueTopKAggregator with LAST_SEEN mode and StringType" should "replace elements correctly" in {
+  "UniqueTopKAggregator with UPDATE collision strategy and StringType" should "replace elements correctly" in {
     val k = 3
-    val aggregator = new UniqueTopKAggregator[String](StringType, k, None, "LAST_SEEN")
+    val aggregator = new UniqueTopKAggregator[String](StringType, k, None, "UPDATE")
 
     val inputs = List("apple", "banana", "cherry", "apple", "banana")
     val ir = aggregator.prepare(inputs.head)
@@ -440,5 +441,125 @@ class UniqueTopKAggregatorTest extends AnyFlatSpec {
     assertEquals(3, result.size())
     // String comparison by lexicographical order
     assertEquals(List("cherry", "banana", "apple"), resultList)
+  }
+
+  // ===== Determinism test for UPDATE collision strategy =====
+
+  "UniqueTopKAggregator with UPDATE collision strategy" should "be tested for determinism with different processing orders" in {
+    val structType = StructType("TestStruct",
+                                Array(
+                                  StructField("sort_key", StringType),
+                                  StructField("unique_id", LongType),
+                                  StructField("value", IntType)
+                                ))
+
+    val k = 3
+    val aggregator = new UniqueTopKAggregator[Array[Any]](structType, k, None, "UPDATE")
+
+    // First ordering: ID=1 appears with sort_key "a" (value=100), then "z" (value=200)
+    // With UPDATE, will replace first with second
+    val structInputs1 = List(
+      Array("a", 1L, 100),  // ID=1, sort_key="a", value=100, first
+      Array("y", 2L, 50),   // ID=2, sort_key="y", value=50
+      Array("x", 3L, 75),   // ID=3, sort_key="x", value=75
+      Array("z", 1L, 200)   // ID=1, sort_key="z", value=200, replaces first
+    )
+    val structIr1 = aggregator.prepare(structInputs1.head)
+    structInputs1.tail.foreach(input => aggregator.update(structIr1, input))
+    val structResult1 = aggregator.finalize(structIr1)
+
+    // Second ordering: ID=1 appears with sort_key "z" (value=200), then "a" (value=100)
+    // With UPDATE, will replace first with second
+    val structInputs2 = List(
+      Array("z", 1L, 200),  // ID=1, sort_key="z", value=200, first
+      Array("y", 2L, 50),   // ID=2, sort_key="y", value=50
+      Array("x", 3L, 75),   // ID=3, sort_key="x", value=75
+      Array("a", 1L, 100)   // ID=1, sort_key="a", value=100, replaces first
+    )
+    val structIr2 = aggregator.prepare(structInputs2.head)
+    structInputs2.tail.foreach(input => aggregator.update(structIr2, input))
+    val structResult2 = aggregator.finalize(structIr2)
+
+    // Extract the sort_key and value for ID=1 from both results
+    val result1ForId1 = structResult1.asScala.find(arr => arr.asInstanceOf[Array[Any]](1) == 1L)
+      .map { arr =>
+        val a = arr.asInstanceOf[Array[Any]]
+        (a(0).asInstanceOf[String], a(2).asInstanceOf[Int])
+      }
+    val result2ForId1 = structResult2.asScala.find(arr => arr.asInstanceOf[Array[Any]](1) == 1L)
+      .map { arr =>
+        val a = arr.asInstanceOf[Array[Any]]
+        (a(0).asInstanceOf[String], a(2).asInstanceOf[Int])
+      }
+
+    println(s"UPDATE mode result 1 (a first, z second): $result1ForId1")
+    println(s"UPDATE mode result 2 (z first, a second): $result2ForId1")
+
+    // This test should fail because UPDATE is non-deterministic (always replaces with last processed)
+    // Expected: Both should be ("z", 200) if deterministic (keeps maximum sort_key)
+    // Actual: result1 = ("z", 200), result2 = ("a", 100) - depends on processing order
+
+    // Assert they should be equal - this will fail, demonstrating the non-determinism issue
+    assertEquals(result1ForId1, result2ForId1)
+  }
+
+  // ===== Test IGNORE mode for determinism =====
+
+  "UniqueTopKAggregator with IGNORE collision strategy" should "be tested for determinism with different processing orders" in {
+    val structType = StructType("TestStruct",
+                                Array(
+                                  StructField("sort_key", StringType),
+                                  StructField("unique_id", LongType),
+                                  StructField("value", IntType)
+                                ))
+
+    val k = 3
+    val aggregator = new UniqueTopKAggregator[Array[Any]](structType, k, None, "IGNORE")
+
+    // First ordering: ID=1 appears with sort_key "a" (value=100), then "z" (value=200)
+    // With IGNORE, should keep first occurrence
+    val structInputs1 = List(
+      Array("a", 1L, 100),  // ID=1, sort_key="a", value=100, first
+      Array("y", 2L, 50),   // ID=2, sort_key="y", value=50
+      Array("x", 3L, 75),   // ID=3, sort_key="x", value=75
+      Array("z", 1L, 200)   // ID=1, sort_key="z", value=200, ignored?
+    )
+    val structIr1 = aggregator.prepare(structInputs1.head)
+    structInputs1.tail.foreach(input => aggregator.update(structIr1, input))
+    val structResult1 = aggregator.finalize(structIr1)
+
+    // Second ordering: ID=1 appears with sort_key "z" (value=200), then "a" (value=100)
+    // With IGNORE, should keep first occurrence
+    val structInputs2 = List(
+      Array("z", 1L, 200),  // ID=1, sort_key="z", value=200, first
+      Array("y", 2L, 50),   // ID=2, sort_key="y", value=50
+      Array("x", 3L, 75),   // ID=3, sort_key="x", value=75
+      Array("a", 1L, 100)   // ID=1, sort_key="a", value=100, ignored?
+    )
+    val structIr2 = aggregator.prepare(structInputs2.head)
+    structInputs2.tail.foreach(input => aggregator.update(structIr2, input))
+    val structResult2 = aggregator.finalize(structIr2)
+
+    // Extract the sort_key and value for ID=1 from both results
+    val result1ForId1 = structResult1.asScala.find(arr => arr.asInstanceOf[Array[Any]](1) == 1L)
+      .map { arr =>
+        val a = arr.asInstanceOf[Array[Any]]
+        (a(0).asInstanceOf[String], a(2).asInstanceOf[Int])
+      }
+    val result2ForId1 = structResult2.asScala.find(arr => arr.asInstanceOf[Array[Any]](1) == 1L)
+      .map { arr =>
+        val a = arr.asInstanceOf[Array[Any]]
+        (a(0).asInstanceOf[String], a(2).asInstanceOf[Int])
+      }
+
+    println(s"IGNORE mode result 1 (a first, z second): $result1ForId1")
+    println(s"IGNORE mode result 2 (z first, a second): $result2ForId1")
+
+    // This test should fail because IGNORE is non-deterministic (keeps first processed)
+    // Expected: Both should be ("a", 100) if deterministic (keeps minimum sort_key)
+    // Actual: result1 = ("a", 100), result2 = ("z", 200) - depends on processing order
+
+    // Assert they should be equal - this will fail, demonstrating the non-determinism issue
+    assertEquals(result1ForId1, result2ForId1)
   }
 }

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/UniqueTopKTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/UniqueTopKTest.scala
@@ -252,4 +252,193 @@ class UniqueTopKAggregatorTest extends AnyFlatSpec {
     assertEquals(k, result.size())
     assertEquals(List(20, 19, 18), result.asScala.toList)
   }
+
+  // ===== LAST_SEEN mode tests =====
+
+  "UniqueTopKAggregator with LAST_SEEN mode" should "replace elements with duplicate IDs" in {
+    val k = 3
+    val aggregator = new UniqueTopKAggregator[Int](IntType, k, None, "LAST_SEEN")
+
+    // Add same ID multiple times - LAST_SEEN should keep the last occurrence
+    val inputs = List(5, 3, 8, 5, 3, 5)
+    val ir = aggregator.prepare(inputs.head)
+    inputs.tail.foreach(input => aggregator.update(ir, input))
+
+    val result = aggregator.finalize(ir)
+    val resultList = result.asScala.toList
+
+    // Should have 3 unique values
+    assertEquals(3, result.size())
+    assertEquals(List(8, 5, 3), resultList)
+  }
+
+  "UniqueTopKAggregator with LAST_SEEN mode and IntType" should "always keep last seen value" in {
+    val k = 5
+    val aggregator = new UniqueTopKAggregator[Int](IntType, k, None, "LAST_SEEN")
+
+    val inputs = List(1, 2, 1, 3, 2, 1, 4, 3, 2, 1)
+    val ir = aggregator.prepare(inputs.head)
+    inputs.tail.foreach(input => aggregator.update(ir, input))
+
+    val result = aggregator.finalize(ir)
+    val resultList = result.asScala.toList
+
+    assertEquals(4, result.size()) // 4 unique IDs
+    assertEquals(List(4, 3, 2, 1), resultList)
+  }
+
+  "UniqueTopKAggregator with LAST_SEEN mode and StructType" should "replace struct when duplicate ID is seen" in {
+    val structType = StructType("TestStruct",
+                                Array(
+                                  StructField("sort_key", StringType),
+                                  StructField("unique_id", LongType),
+                                  StructField("value", IntType)
+                                ))
+
+    val k = 3
+    val aggregator = new UniqueTopKAggregator[Array[Any]](structType, k, None, "LAST_SEEN")
+
+    val inputs = List(
+      Array("z", 1L, 10),  // ID=1, value=10
+      Array("y", 2L, 20),  // ID=2, value=20
+      Array("x", 3L, 30),  // ID=3, value=30
+      Array("w", 1L, 100), // ID=1 again - should REPLACE with value=100
+      Array("v", 2L, 200)  // ID=2 again - should REPLACE with value=200
+    )
+
+    val ir = aggregator.prepare(inputs.head)
+    inputs.tail.foreach(input => aggregator.update(ir, input))
+
+    val result = aggregator.finalize(ir)
+    val resultList = result.asScala.toList
+
+    assertEquals(3, result.size())
+
+    // Check that ID=1 now has value=100 (not 10), and ID=2 has value=200 (not 20)
+    val id1Entry = resultList.find(arr => arr(1) == 1L).get
+    val id2Entry = resultList.find(arr => arr(1) == 2L).get
+    val id3Entry = resultList.find(arr => arr(1) == 3L).get
+
+    assertEquals(100, id1Entry(2)) // Last seen value for ID=1
+    assertEquals(200, id2Entry(2)) // Last seen value for ID=2
+    assertEquals(30, id3Entry(2))  // Original value for ID=3
+
+    // Check sort keys also updated (last seen)
+    assertEquals("w", id1Entry(0))
+    assertEquals("v", id2Entry(0))
+    assertEquals("x", id3Entry(0))
+  }
+
+  "UniqueTopKAggregator with LAST_SEEN mode" should "handle merge operations correctly" in {
+    val k = 3
+    val aggregator = new UniqueTopKAggregator[Int](IntType, k, None, "LAST_SEEN")
+
+    // First batch
+    val ir1 = aggregator.prepare(5)
+    aggregator.update(ir1, 3)
+    aggregator.update(ir1, 8)
+
+    // Second batch - has duplicate ID=5 which should replace
+    val ir2 = aggregator.prepare(7)
+    aggregator.update(ir2, 1)
+    aggregator.update(ir2, 5) // Duplicate of 5 from first batch
+
+    val merged = aggregator.merge(ir1, ir2)
+    val result = aggregator.finalize(merged)
+    val resultList = result.asScala.toList
+
+    // When merging, the 5 from ir2 should replace the 5 from ir1
+    // We have 5 unique values (8, 7, 5, 3, 1) but k=3 so only top 3
+    assertEquals(k, result.size())
+    // Top 3 should be 8, 7, 5
+    assertEquals(List(8, 7, 5), resultList)
+  }
+
+  "UniqueTopKAggregator with FIRST_SEEN mode (default)" should "reject duplicates as before" in {
+    val k = 3
+    val aggregator = new UniqueTopKAggregator[Int](IntType, k, None, "FIRST_SEEN")
+
+    val inputs = List(5, 3, 8, 5, 3) // Duplicates should be ignored
+    val ir = aggregator.prepare(inputs.head)
+    inputs.tail.foreach(input => aggregator.update(ir, input))
+
+    val result = aggregator.finalize(ir)
+    val resultList = result.asScala.toList
+
+    assertEquals(3, result.size())
+    assertEquals(List(8, 5, 3), resultList) // First occurrence of each kept
+  }
+
+  "UniqueTopKAggregator with LAST_SEEN mode" should "handle normalization round-trip" in {
+    val k = 3
+    val aggregator = new UniqueTopKAggregator[Int](IntType, k, None, "LAST_SEEN")
+
+    val inputs = List(5, 3, 8, 5, 3) // With duplicates
+    val ir = aggregator.prepare(inputs.head)
+    inputs.tail.foreach(input => aggregator.update(ir, input))
+
+    val originalResult = aggregator.finalize(aggregator.clone(ir))
+
+    val normalized = aggregator.normalize(ir)
+    val denormalized = aggregator.denormalize(normalized)
+    val roundTripResult = aggregator.finalize(denormalized)
+
+    assertEquals(originalResult, roundTripResult)
+  }
+
+  "UniqueTopKAggregator with LAST_SEEN mode" should "handle clone operation correctly" in {
+    val k = 3
+    val aggregator = new UniqueTopKAggregator[Int](IntType, k, None, "LAST_SEEN")
+
+    val inputs = List(5, 3, 8, 1)
+    val ir = aggregator.prepare(inputs.head)
+    inputs.tail.foreach(input => aggregator.update(ir, input))
+
+    val cloned = aggregator.clone(ir)
+    val originalResult = aggregator.finalize(aggregator.clone(ir)) // Clone before finalizing to preserve state
+    val clonedResult = aggregator.finalize(cloned)
+
+    assertEquals(originalResult, clonedResult)
+
+    // Verify they are independent - update original with new element
+    aggregator.update(ir, 10) // Add a new larger element
+    val newOriginalResult = aggregator.finalize(ir)
+
+    // The cloned state should not be affected
+    // Original should now have [10, 8, 5] (top 3 after adding 10)
+    assertEquals(List(10, 8, 5), newOriginalResult.asScala.toList)
+    // Cloned should still have original [8, 5, 3]
+    assertEquals(List(8, 5, 3), clonedResult.asScala.toList)
+  }
+
+  "UniqueTopKAggregator with LAST_SEEN mode and LongType" should "replace elements correctly" in {
+    val k = 3
+    val aggregator = new UniqueTopKAggregator[Long](LongType, k, None, "LAST_SEEN")
+
+    val inputs = List(100L, 200L, 300L, 100L, 200L)
+    val ir = aggregator.prepare(inputs.head)
+    inputs.tail.foreach(input => aggregator.update(ir, input))
+
+    val result = aggregator.finalize(ir)
+    val resultList = result.asScala.toList
+
+    assertEquals(3, result.size())
+    assertEquals(List(300L, 200L, 100L), resultList)
+  }
+
+  "UniqueTopKAggregator with LAST_SEEN mode and StringType" should "replace elements correctly" in {
+    val k = 3
+    val aggregator = new UniqueTopKAggregator[String](StringType, k, None, "LAST_SEEN")
+
+    val inputs = List("apple", "banana", "cherry", "apple", "banana")
+    val ir = aggregator.prepare(inputs.head)
+    inputs.tail.foreach(input => aggregator.update(ir, input))
+
+    val result = aggregator.finalize(ir)
+    val resultList = result.asScala.toList
+
+    assertEquals(3, result.size())
+    // String comparison by lexicographical order
+    assertEquals(List("cherry", "banana", "apple"), resultList)
+  }
 }

--- a/flink/src/test/scala/ai/chronon/flink/test/window/FlinkRowAggregationFunctionTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/window/FlinkRowAggregationFunctionTest.scala
@@ -264,14 +264,14 @@ class FlinkRowAggregationFunctionTest extends AnyFlatSpec {
     }
   }
 
-  it should "flink aggregator handles LAST_SEEN mode correctly for UNIQUE_TOP_K" in {
-    // Create aggregations with LAST_SEEN mode
+  it should "flink aggregator handles UPDATE mode correctly for UNIQUE_TOP_K" in {
+    // Create aggregations with UPDATE mode
     val aggregationsWithLastSeen: Seq[Aggregation] = Seq(
       Builders.Aggregation(
         Operation.UNIQUE_TOP_K,
         "struct_col",
         Seq(new Window(1, TimeUnit.DAYS)),
-        argMap = Map("k" -> "3", "dedup_mode" -> "LAST_SEEN")
+        argMap = Map("k" -> "3", "collision_strategy" -> "UPDATE")
       )
     )
 
@@ -323,13 +323,13 @@ class FlinkRowAggregationFunctionTest extends AnyFlatSpec {
     finalResult(0) shouldBe expectedUniqueTopK
   }
 
-  it should "flink aggregator LAST_SEEN mode merges correctly" in {
+  it should "flink aggregator UPDATE mode merges correctly" in {
     val aggregationsWithLastSeen: Seq[Aggregation] = Seq(
       Builders.Aggregation(
         Operation.UNIQUE_TOP_K,
         "struct_col",
         Seq(new Window(1, TimeUnit.DAYS)),
-        argMap = Map("k" -> "3", "dedup_mode" -> "LAST_SEEN")
+        argMap = Map("k" -> "3", "collision_strategy" -> "UPDATE")
       )
     )
 

--- a/flink/src/test/scala/ai/chronon/flink/test/window/FlinkRowAggregationFunctionTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/window/FlinkRowAggregationFunctionTest.scala
@@ -264,6 +264,129 @@ class FlinkRowAggregationFunctionTest extends AnyFlatSpec {
     }
   }
 
+  it should "flink aggregator handles LAST_SEEN mode correctly for UNIQUE_TOP_K" in {
+    // Create aggregations with LAST_SEEN mode
+    val aggregationsWithLastSeen: Seq[Aggregation] = Seq(
+      Builders.Aggregation(
+        Operation.UNIQUE_TOP_K,
+        "struct_col",
+        Seq(new Window(1, TimeUnit.DAYS)),
+        argMap = Map("k" -> "3", "dedup_mode" -> "LAST_SEEN")
+      )
+    )
+
+    val groupByMetadata = Builders.MetaData(name = "my_group_by_last_seen")
+    val groupBy = Builders.GroupBy(metaData = groupByMetadata, aggregations = aggregationsWithLastSeen)
+    val aggregateFunc = new FlinkRowAggregationFunction(groupBy, schema)
+
+    var acc = aggregateFunc.createAccumulator()
+    val rows = Seq(
+      createRow(1519862399984L, 4, 4.0f, "A", Struct(1, "8", "a")),    // ID=1, first occurrence
+      createRow(1519862399985L, 40, 5.0f, "B", Struct(2, "7", "b")),   // ID=2, first occurrence
+      createRow(1519862399988L, 3, 3.0f, "C", Struct(1, "9", "c")),    // ID=1 again - should REPLACE with payload "c"
+      createRow(1519862399990L, 5, 4.0f, "D", Struct(3, "6", "d")),    // ID=3, new entry
+      createRow(1519862399994L, 4, 4.0f, "E", Struct(2, "5", "e"))     // ID=2 again - should REPLACE with payload "e"
+    )
+    rows.foreach(row => acc = aggregateFunc.add(row, acc))
+    val result = aggregateFunc.getResult(acc)
+
+    val tileCodec = new TileCodec(groupBy, schema)
+    val expandedIr = tileCodec.expandWindowedTileIr(result.ir)
+    val finalResult = tileCodec.windowedRowAggregator.finalize(expandedIr)
+
+    // We should have 1 result (the unique_top_k aggregation)
+    assert(finalResult.length == 1)
+
+    // Expected: After all replacements, we have:
+    // - ID=1: sort_key="9", payload="c" (replaced)
+    // - ID=2: sort_key="5", payload="e" (replaced)
+    // - ID=3: sort_key="6", payload="d"
+    // Top 3 by lexicographical order descending: "9" > "6" > "5"
+    val expectedUniqueTopK = Seq(
+      Map(
+        "unique_id" -> 1L,
+        "sort_key" -> "9",
+        "payload" -> "c"   // Last seen payload for ID=1
+      ),
+      Map(
+        "unique_id" -> 3L,
+        "sort_key" -> "6",
+        "payload" -> "d"
+      ),
+      Map(
+        "unique_id" -> 2L,
+        "sort_key" -> "5",
+        "payload" -> "e"   // Last seen payload for ID=2
+      )
+    ).toJava
+
+    finalResult(0) shouldBe expectedUniqueTopK
+  }
+
+  it should "flink aggregator LAST_SEEN mode merges correctly" in {
+    val aggregationsWithLastSeen: Seq[Aggregation] = Seq(
+      Builders.Aggregation(
+        Operation.UNIQUE_TOP_K,
+        "struct_col",
+        Seq(new Window(1, TimeUnit.DAYS)),
+        argMap = Map("k" -> "3", "dedup_mode" -> "LAST_SEEN")
+      )
+    )
+
+    val groupByMetadata = Builders.MetaData(name = "my_group_by_merge_last_seen")
+    val groupBy = Builders.GroupBy(metaData = groupByMetadata, aggregations = aggregationsWithLastSeen)
+    val aggregateFunc = new FlinkRowAggregationFunction(groupBy, schema)
+
+    // Partial aggregate 1
+    var acc1 = aggregateFunc.createAccumulator()
+    val rows1 = Seq(
+      createRow(1519862399984L, 4, 4.0f, "A", Struct(1, "8", "a")),
+      createRow(1519862399985L, 40, 5.0f, "B", Struct(2, "7", "b"))
+    )
+    rows1.foreach(row => acc1 = aggregateFunc.add(row, acc1))
+    val partialResult1 = aggregateFunc.getResult(acc1)
+
+    // Partial aggregate 2 - has duplicate ID=1 which should replace
+    var acc2 = aggregateFunc.createAccumulator()
+    val rows2 = Seq(
+      createRow(1519862399988L, 3, 3.0f, "C", Struct(1, "9", "c")),    // ID=1 again - replace
+      createRow(1519862399990L, 5, 4.0f, "D", Struct(3, "6", "d"))
+    )
+    rows2.foreach(row => acc2 = aggregateFunc.add(row, acc2))
+    val partialResult2 = aggregateFunc.getResult(acc2)
+
+    // Merge the partial results
+    val mergedPartialAggregates = aggregateFunc.rowAggregator.merge(partialResult1.ir, partialResult2.ir)
+
+    val tileCodec = new TileCodec(groupBy, schema)
+    val expandedIr = tileCodec.expandWindowedTileIr(mergedPartialAggregates)
+    val finalResult = tileCodec.windowedRowAggregator.finalize(expandedIr)
+
+    assert(finalResult.length == 1)
+
+    // Expected: ID=1 should have last seen values (from acc2: sort_key="9", payload="c")
+    // Top 3 by sort_key: "9" > "7" > "6"
+    val expectedUniqueTopK = Seq(
+      Map(
+        "unique_id" -> 1L,
+        "sort_key" -> "9",
+        "payload" -> "c"   // Last seen from merge
+      ),
+      Map(
+        "unique_id" -> 2L,
+        "sort_key" -> "7",
+        "payload" -> "b"
+      ),
+      Map(
+        "unique_id" -> 3L,
+        "sort_key" -> "6",
+        "payload" -> "d"
+      )
+    ).toJava
+
+    finalResult(0) shouldBe expectedUniqueTopK
+  }
+
   case class Struct(uniqueId: Long, sortKey: String, payload: String)
   def createRow(ts: Long, views: Int, rating: Float, title: String, struct: Struct): ProjectedEvent = {
     val row = Map(

--- a/python/src/ai/chronon/group_by.py
+++ b/python/src/ai/chronon/group_by.py
@@ -154,7 +154,7 @@ class Operation:
     UNIQUE_TOP_K = generic_collector(
         ttypes.Operation.UNIQUE_TOP_K,
         ["k"],
-        dedup_mode="FIRST_SEEN",
+        collision_strategy="IGNORE",
     )
     """Returns top k unique elements ranked by their values. Automatically deduplicates inputs.
 
@@ -162,11 +162,15 @@ class Operation:
 
     Optional argMap parameters:
     - k: Number of top elements to keep (required)
-    - dedup_mode: Deduplication strategy (optional, default: "FIRST_SEEN")
-        - "FIRST_SEEN": Keep first occurrence of each unique_id (default behavior)
-        - "LAST_SEEN": Replace with last occurrence when duplicate unique_id is seen
+    - collision_strategy: Collision strategy for handling duplicate unique_ids (optional, default: "IGNORE")
+        - "IGNORE": Keep first occurrence of each unique_id (default behavior)
+        - "UPDATE": Keep occurrence with maximum sort_key (best order key wins)
+            * For timestamps: keeps latest timestamp
+            * For strings: keeps lexicographically greatest ("z" > "a")
+            * For numerics: keeps largest value
+            * Order-independent and deterministic
 
-    Example: Operation.UNIQUE_TOP_K(k=5, dedup_mode="LAST_SEEN")
+    Example: Operation.UNIQUE_TOP_K(k=5, collision_strategy="UPDATE")
     """
 
     APPROX_PERCENTILE = generic_collector(ttypes.Operation.APPROX_PERCENTILE, ["percentiles"], k=20)

--- a/python/src/ai/chronon/group_by.py
+++ b/python/src/ai/chronon/group_by.py
@@ -151,7 +151,11 @@ class Operation:
     BOTTOM_K = collector(ttypes.Operation.BOTTOM_K)
     """Returns k smallest values of the input column"""
 
-    UNIQUE_TOP_K = collector(ttypes.Operation.UNIQUE_TOP_K)
+    UNIQUE_TOP_K = generic_collector(
+        ttypes.Operation.UNIQUE_TOP_K,
+        ["k"],
+        dedup_mode="FIRST_SEEN",
+    )
     """Returns top k unique elements ranked by their values. Automatically deduplicates inputs.
 
     For structs, requires sort_key (String) and unique_id (Long) fields.

--- a/python/src/ai/chronon/group_by.py
+++ b/python/src/ai/chronon/group_by.py
@@ -152,7 +152,18 @@ class Operation:
     """Returns k smallest values of the input column"""
 
     UNIQUE_TOP_K = collector(ttypes.Operation.UNIQUE_TOP_K)
-    """Returns top k unique elements ranked by their values. Automatically deduplicates inputs. For structs, requires sort_key (String) and unique_id (Long) fields."""
+    """Returns top k unique elements ranked by their values. Automatically deduplicates inputs.
+
+    For structs, requires sort_key (String) and unique_id (Long) fields.
+
+    Optional argMap parameters:
+    - k: Number of top elements to keep (required)
+    - dedup_mode: Deduplication strategy (optional, default: "FIRST_SEEN")
+        - "FIRST_SEEN": Keep first occurrence of each unique_id (default behavior)
+        - "LAST_SEEN": Replace with last occurrence when duplicate unique_id is seen
+
+    Example: Operation.UNIQUE_TOP_K(k=5, dedup_mode="LAST_SEEN")
+    """
 
     APPROX_PERCENTILE = generic_collector(ttypes.Operation.APPROX_PERCENTILE, ["percentiles"], k=20)
     """Approximate percentile calculation with configurable accuracy parameter k=20"""

--- a/python/src/ai/chronon/group_by.py
+++ b/python/src/ai/chronon/group_by.py
@@ -164,11 +164,10 @@ class Operation:
     - k: Number of top elements to keep (required)
     - collision_strategy: Collision strategy for handling duplicate unique_ids (optional, default: "IGNORE")
         - "IGNORE": Keep first occurrence of each unique_id (default behavior)
-        - "UPDATE": Keep occurrence with maximum sort_key (best order key wins)
-            * For timestamps: keeps latest timestamp
-            * For strings: keeps lexicographically greatest ("z" > "a")
-            * For numerics: keeps largest value
-            * Order-independent and deterministic
+        - "UPDATE": Keep last-seen occurrence for each unique_id (replacement semantics)
+            * Uses last-seen replacement: later occurrences overwrite earlier ones
+            * Order-dependent and non-deterministic (depends on data arrival order)
+            * Does NOT select based on sort_key value
 
     Example: Operation.UNIQUE_TOP_K(k=5, collision_strategy="UPDATE")
     """

--- a/python/test/sample/joins/sample_team/sample_join.py
+++ b/python/test/sample/joins/sample_team/sample_join.py
@@ -25,7 +25,7 @@ from ai.chronon.types import EnvironmentVariables
 v1 = Join(
     left=test_sources.staging_entities,
     right_parts=[JoinPart(group_by=sample_group_by.v1)],
-    i donrow_ids="place_id",
+    row_ids="place_id",
     table_properties={"config_json": """{"sample_key": "sample_value"}"""},
     output_namespace="sample_namespace",
     env_vars=EnvironmentVariables(

--- a/python/test/sample/joins/sample_team/sample_join.py
+++ b/python/test/sample/joins/sample_team/sample_join.py
@@ -25,7 +25,7 @@ from ai.chronon.types import EnvironmentVariables
 v1 = Join(
     left=test_sources.staging_entities,
     right_parts=[JoinPart(group_by=sample_group_by.v1)],
-    row_ids="place_id",
+    i donrow_ids="place_id",
     table_properties={"config_json": """{"sample_key": "sample_value"}"""},
     output_namespace="sample_namespace",
     env_vars=EnvironmentVariables(

--- a/spark/src/main/scala/ai/chronon/spark/submission/ChrononKryoRegistrator.scala
+++ b/spark/src/main/scala/ai/chronon/spark/submission/ChrononKryoRegistrator.scala
@@ -107,6 +107,7 @@ class ChrononKryoRegistrator extends KryoRegistrator {
       "ai.chronon.aggregator.base.ApproxHistogramIr",
       "ai.chronon.aggregator.base.MomentsIR",
       "ai.chronon.aggregator.base.UniqueOrderByLimit$State",
+      "ai.chronon.aggregator.base.UniqueOrderByLimit$LenientState",
       "ai.chronon.aggregator.windowing.BatchIr",
       "ai.chronon.aggregator.windowing.FinalBatchIr",
       "ai.chronon.api.Row",

--- a/spark/src/main/scala/ai/chronon/spark/submission/ChrononKryoRegistrator.scala
+++ b/spark/src/main/scala/ai/chronon/spark/submission/ChrononKryoRegistrator.scala
@@ -107,7 +107,7 @@ class ChrononKryoRegistrator extends KryoRegistrator {
       "ai.chronon.aggregator.base.ApproxHistogramIr",
       "ai.chronon.aggregator.base.MomentsIR",
       "ai.chronon.aggregator.base.UniqueOrderByLimit$State",
-      "ai.chronon.aggregator.base.UniqueOrderByLimit$LenientState",
+      "ai.chronon.aggregator.base.UniqueOrderByLimit$UpdateState",
       "ai.chronon.aggregator.windowing.BatchIr",
       "ai.chronon.aggregator.windowing.FinalBatchIr",
       "ai.chronon.api.Row",

--- a/spark/src/test/scala/ai/chronon/spark/fetcher/FetcherUniqueTopKTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/fetcher/FetcherUniqueTopKTest.scala
@@ -16,8 +16,14 @@
 
 package ai.chronon.spark.fetcher
 
+import ai.chronon.api._
+import ai.chronon.api.ScalaJavaConversions._
+import ai.chronon.online.serde.SparkConversions
+import ai.chronon.spark.Extensions._
 import ai.chronon.spark.catalog.TableUtils
 import ai.chronon.spark.utils.SparkTestBase
+import ai.chronon.spark.{Join => _, _}
+import org.apache.spark.sql.Row
 import org.slf4j.{Logger, LoggerFactory}
 
 import java.util.TimeZone
@@ -32,6 +38,135 @@ class FetcherUniqueTopKTest extends SparkTestBase {
   it should "test temporal fetch join deterministic with UniqueTopK struct" in {
     val namespace = "deterministic_unique_topk_fetch"
     val joinConf = FetcherTestUtil.generateMutationDataWithUniqueTopK(namespace, tableUtils, spark)
+    FetcherTestUtil.compareTemporalFetch(joinConf,
+                                         "2021-04-10",
+                                         namespace,
+                                         consistencyCheck = false,
+                                         dropDsOnWrite = true)(spark)
+  }
+
+  it should "test temporal fetch join with UniqueTopK LAST_SEEN mode" in {
+    val namespace = "unique_topk_last_seen_fetch"
+    SparkTestBase.createDatabase(spark, namespace)
+
+    def toTs(arg: String): Long = TsUtils.datetimeToTs(arg)
+
+    // Event data for queries
+    val eventData = Seq(
+      Row(1L, toTs("2021-04-10 09:00:00"), "2021-04-10")
+    )
+
+    // Struct snapshot data with duplicates to test LAST_SEEN
+    val structData = Seq(
+      Row(1L, toTs("2021-04-04 00:30:00"), Row("z", 1L, 100), "2021-04-09"),  // ID=1, first occurrence
+      Row(1L, toTs("2021-04-05 00:30:00"), Row("y", 2L, 200), "2021-04-09"),  // ID=2
+      Row(1L, toTs("2021-04-06 00:30:00"), Row("x", 3L, 300), "2021-04-09"),  // ID=3
+      Row(1L, toTs("2021-04-07 00:30:00"), Row("w", 1L, 400), "2021-04-09")   // ID=1 again - should REPLACE
+    )
+
+    // Mutation data with another replacement for ID=1
+    val mutationData = Seq(
+      Row(1L, toTs("2021-04-08 00:30:00"), Row("v", 1L, 500), "2021-04-09", toTs("2021-04-08 00:30:00"), false)  // ID=1 LAST_SEEN
+    )
+
+    // Schemas
+    val eventSchema = StructType(
+      "listing_events_last_seen",
+      Array(StructField("listing_id", LongType), StructField("ts", LongType), StructField("ds", StringType))
+    )
+
+    val structSnapshotSchema = StructType(
+      "listing_struct_snapshot_last_seen",
+      Array(
+        StructField("listing_id", LongType),
+        StructField("ts", LongType),
+        StructField("rating_struct",
+                    StructType("RatingStruct",
+                               Array(
+                                 StructField("sort_key", StringType),
+                                 StructField("unique_id", LongType),
+                                 StructField("value", IntType)
+                               ))),
+        StructField("ds", StringType)
+      )
+    )
+
+    val structMutationSchema = StructType(
+      "listing_struct_mutation_last_seen",
+      Array(
+        StructField("listing_id", LongType),
+        StructField("ts", LongType),
+        StructField("rating_struct",
+                    StructType("RatingStruct",
+                               Array(
+                                 StructField("sort_key", StringType),
+                                 StructField("unique_id", LongType),
+                                 StructField("value", IntType)
+                               ))),
+        StructField("ds", StringType),
+        StructField("mutation_time", LongType),
+        StructField("is_before_reversal", BooleanType)
+      )
+    )
+
+    spark
+      .createDataFrame(eventData.toJava, SparkConversions.fromChrononSchema(eventSchema))
+      .save(s"$namespace.${eventSchema.name}")
+
+    spark
+      .createDataFrame(structData.toJava, SparkConversions.fromChrononSchema(structSnapshotSchema))
+      .save(s"$namespace.${structSnapshotSchema.name}")
+
+    spark
+      .createDataFrame(mutationData.toJava, SparkConversions.fromChrononSchema(structMutationSchema))
+      .save(s"$namespace.${structMutationSchema.name}")
+
+    val structSource = Builders.Source.entities(
+      query = Builders.Query(
+        selects = Map("listing_id" -> "listing_id", "ts" -> "ts", "rating_struct" -> "rating_struct"),
+        startPartition = "2021-04-01",
+        endPartition = "2021-04-10",
+        mutationTimeColumn = "mutation_time",
+        reversalColumn = "is_before_reversal"
+      ),
+      snapshotTable = s"$namespace.${structSnapshotSchema.name}",
+      mutationTable = s"$namespace.${structMutationSchema.name}",
+      mutationTopic = "blank"
+    )
+
+    val leftSource = Builders.Source.events(
+      query = Builders.Query(
+        selects = Builders.Selects("listing_id", "ts"),
+        startPartition = "2021-04-01"
+      ),
+      table = s"$namespace.${eventSchema.name}"
+    )
+
+    val groupBy = Builders.GroupBy(
+      sources = Seq(structSource),
+      keyColumns = Seq("listing_id"),
+      aggregations = Seq(
+        Builders.Aggregation(
+          operation = Operation.UNIQUE_TOP_K,
+          inputColumn = "rating_struct",
+          argMap = Map("k" -> "3", "dedup_mode" -> "LAST_SEEN"),  // LAST_SEEN mode
+          windows = null
+        )
+      ),
+      derivations = Seq(
+        Builders.Derivation("ids", "transform(rating_struct_unique_top3, x -> x.unique_id)"),
+        Builders.Derivation("values", "transform(rating_struct_unique_top3, x -> x.value)")
+      ),
+      accuracy = Accuracy.TEMPORAL,
+      metaData = Builders.MetaData(name = "unit_test.struct_unique_topk_last_seen_gb", namespace = namespace, team = "chronon")
+    )
+
+    val joinConf = Builders.Join(
+      left = leftSource,
+      joinParts = Seq(Builders.JoinPart(groupBy = groupBy)),
+      metaData = Builders.MetaData(name = "unit_test.struct_unique_topk_last_seen_join", namespace = namespace, team = "chronon")
+    )
+
     FetcherTestUtil.compareTemporalFetch(joinConf,
                                          "2021-04-10",
                                          namespace,

--- a/spark/src/test/scala/ai/chronon/spark/fetcher/FetcherUniqueTopKTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/fetcher/FetcherUniqueTopKTest.scala
@@ -45,7 +45,7 @@ class FetcherUniqueTopKTest extends SparkTestBase {
                                          dropDsOnWrite = true)(spark)
   }
 
-  it should "test temporal fetch join with UniqueTopK LAST_SEEN mode" in {
+  it should "test temporal fetch join with UniqueTopK UPDATE mode" in {
     val namespace = "unique_topk_last_seen_fetch"
     SparkTestBase.createDatabase(spark, namespace)
 
@@ -56,7 +56,7 @@ class FetcherUniqueTopKTest extends SparkTestBase {
       Row(1L, toTs("2021-04-10 09:00:00"), "2021-04-10")
     )
 
-    // Struct snapshot data with duplicates to test LAST_SEEN
+    // Struct snapshot data with duplicates to test UPDATE
     val structData = Seq(
       Row(1L, toTs("2021-04-04 00:30:00"), Row("z", 1L, 100), "2021-04-09"),  // ID=1, first occurrence
       Row(1L, toTs("2021-04-05 00:30:00"), Row("y", 2L, 200), "2021-04-09"),  // ID=2
@@ -66,7 +66,7 @@ class FetcherUniqueTopKTest extends SparkTestBase {
 
     // Mutation data with another replacement for ID=1
     val mutationData = Seq(
-      Row(1L, toTs("2021-04-08 00:30:00"), Row("v", 1L, 500), "2021-04-09", toTs("2021-04-08 00:30:00"), false)  // ID=1 LAST_SEEN
+      Row(1L, toTs("2021-04-08 00:30:00"), Row("v", 1L, 500), "2021-04-09", toTs("2021-04-08 00:30:00"), false)  // ID=1 UPDATE
     )
 
     // Schemas
@@ -149,7 +149,7 @@ class FetcherUniqueTopKTest extends SparkTestBase {
         Builders.Aggregation(
           operation = Operation.UNIQUE_TOP_K,
           inputColumn = "rating_struct",
-          argMap = Map("k" -> "3", "dedup_mode" -> "LAST_SEEN"),  // LAST_SEEN mode
+          argMap = Map("k" -> "3", "collision_strategy" -> "UPDATE"),  // UPDATE mode
           windows = null
         )
       ),

--- a/thrift/api.thrift
+++ b/thrift/api.thrift
@@ -217,6 +217,16 @@ enum Operation {
     UNIQUE_TOP_K = 20  // returns top k unique elements based on frequency
 }
 
+/**
+ * Deduplication mode for UNIQUE_TOP_K operation.
+ * Determines behavior when duplicate unique_id values are encountered.
+ */
+enum DedupMode {
+    // Keep the first occurrence when a duplicate unique_id is seen
+    FIRST_SEEN = 0
+    // Replace with the last occurrence when a duplicate unique_id is seen
+    LAST_SEEN = 1
+}
 
 
 /**

--- a/thrift/api.thrift
+++ b/thrift/api.thrift
@@ -218,14 +218,14 @@ enum Operation {
 }
 
 /**
- * Deduplication mode for UNIQUE_TOP_K operation.
+ * Collision strategy for UNIQUE_TOP_K operation.
  * Determines behavior when duplicate unique_id values are encountered.
  */
-enum DedupMode {
-    // Keep the first occurrence when a duplicate unique_id is seen
-    FIRST_SEEN = 0
-    // Replace with the last occurrence when a duplicate unique_id is seen
-    LAST_SEEN = 1
+enum CollisionStrategy {
+    // Keep the first occurrence when a duplicate unique_id is seen (ignore subsequent duplicates)
+    IGNORE = 0
+    // Replace with the most recent occurrence when a duplicate unique_id is seen
+    UPDATE = 1
 }
 
 


### PR DESCRIPTION
## Summary

Add an option to sort either on `FIRST_SEEN` or `LAST_SEEN` for any given unique_id

## Checklist
- [ x ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added collision strategy parameter to UNIQUE_TOP_K aggregations with two modes: IGNORE (default) and UPDATE. UPDATE mode replaces duplicates with the same ID with the latest value, enabling last-seen deduplication semantics across Int, Long, String, and Struct data types.

* **Documentation**
  * Updated UNIQUE_TOP_K documentation to explain collision strategy options and usage examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->