### PR TITLE
Add dependency on streaming GB's upload to kv nodes in join metadata

### DIFF
--- a/api/src/main/scala/ai/chronon/api/planner/JoinPlanner.scala
+++ b/api/src/main/scala/ai/chronon/api/planner/JoinPlanner.scala
@@ -197,20 +197,31 @@ class JoinPlanner(join: Join)(implicit outputPartitionSpec: PartitionSpec)
       val groupBy = joinPart.groupBy
       val hasStreamingSource = groupBy.streamingSource.isDefined
 
-      // Add dependency on the GroupBy node (either uploadToKV or streaming)
-      val groupByTableName = if (hasStreamingSource) {
-        groupBy.metaData.outputTable + s"__${GroupByPlanner.Streaming}"
-      } else {
-        groupBy.metaData.outputTable + s"__${GroupByPlanner.UploadToKV}"
-      }
-
-      val groupByDep = new TableDependency()
+      // Always create dependency on the GroupBy upload node
+      val uploadTableName = groupBy.metaData.outputTable + s"__${GroupByPlanner.UploadToKV}"
+      val uploadDep = new TableDependency()
         .setTableInfo(
           new TableInfo()
-            .setTable(groupByTableName)
+            .setTable(uploadTableName)
         )
         .setStartOffset(WindowUtils.zero())
         .setEndOffset(WindowUtils.zero())
+
+      // For streaming sources, also add dependency on the streaming node
+      val streamingDep = if (hasStreamingSource) {
+        val streamingTableName = groupBy.metaData.outputTable + s"__${GroupByPlanner.Streaming}"
+        Some(
+          new TableDependency()
+            .setTableInfo(
+              new TableInfo()
+                .setTable(streamingTableName)
+            )
+            .setStartOffset(WindowUtils.zero())
+            .setEndOffset(WindowUtils.zero())
+        )
+      } else {
+        None
+      }
 
       // Add dependencies on upstream join metadata uploads if GroupBy has JoinSource
       val upstreamJoinDeps = if (hasStreamingSource) {
@@ -221,15 +232,15 @@ class JoinPlanner(join: Join)(implicit outputPartitionSpec: PartitionSpec)
       }
 
       // Return both the GroupBy dependency and any upstream join dependencies
-      Seq(groupByDep) ++ upstreamJoinDeps
+      Seq(uploadDep) ++ streamingDep ++ upstreamJoinDeps
     }
 
     val metaData =
       MetaDataUtils.layer(join.metaData,
-                          "metadata_upload",
-                          join.metaData.name + "__metadata_upload",
-                          allDeps.toSeq,
-                          Some(stepDays))
+        "metadata_upload",
+        join.metaData.name + "__metadata_upload",
+        allDeps.toSeq,
+        Some(stepDays))
     val node = new JoinMetadataUpload().setJoin(joinWithoutExecutionInfo)
 
     val copy = joinWithoutExecutionInfo.deepCopy()
@@ -237,6 +248,7 @@ class JoinPlanner(join: Join)(implicit outputPartitionSpec: PartitionSpec)
 
     toNode(metaData, _.setJoinMetadataUpload(node), copy)
   }
+
 
   def unionJoinNode: Node = {
     val result = new planner.UnionJoinNode()

--- a/api/src/main/scala/ai/chronon/api/planner/JoinPlanner.scala
+++ b/api/src/main/scala/ai/chronon/api/planner/JoinPlanner.scala
@@ -237,10 +237,10 @@ class JoinPlanner(join: Join)(implicit outputPartitionSpec: PartitionSpec)
 
     val metaData =
       MetaDataUtils.layer(join.metaData,
-        "metadata_upload",
-        join.metaData.name + "__metadata_upload",
-        allDeps.toSeq,
-        Some(stepDays))
+                          "metadata_upload",
+                          join.metaData.name + "__metadata_upload",
+                          allDeps.toSeq,
+                          Some(stepDays))
     val node = new JoinMetadataUpload().setJoin(joinWithoutExecutionInfo)
 
     val copy = joinWithoutExecutionInfo.deepCopy()
@@ -248,7 +248,6 @@ class JoinPlanner(join: Join)(implicit outputPartitionSpec: PartitionSpec)
 
     toNode(metaData, _.setJoinMetadataUpload(node), copy)
   }
-
 
   def unionJoinNode: Node = {
     val result = new planner.UnionJoinNode()

--- a/api/src/main/scala/ai/chronon/api/planner/MonolithJoinPlanner.scala
+++ b/api/src/main/scala/ai/chronon/api/planner/MonolithJoinPlanner.scala
@@ -86,10 +86,10 @@ case class MonolithJoinPlanner(join: Join)(implicit outputPartitionSpec: Partiti
 
     val metaData =
       MetaDataUtils.layer(join.metaData,
-        "metadata_upload",
-        join.metaData.name + "__metadata_upload",
-        allDeps,
-        Some(stepDays))
+                          "metadata_upload",
+                          join.metaData.name + "__metadata_upload",
+                          allDeps,
+                          Some(stepDays))
     val node = new planner.JoinMetadataUpload().setJoin(join)
     toNode(metaData, _.setJoinMetadataUpload(node), semanticMonolithJoin(join))
   }

--- a/api/src/main/scala/ai/chronon/api/planner/MonolithJoinPlanner.scala
+++ b/api/src/main/scala/ai/chronon/api/planner/MonolithJoinPlanner.scala
@@ -46,20 +46,31 @@ case class MonolithJoinPlanner(join: Join)(implicit outputPartitionSpec: Partiti
       val groupBy = joinPart.groupBy
       val hasStreamingSource = groupBy.streamingSource.isDefined
 
-      // Add dependency on the GroupBy node (either uploadToKV or streaming)
-      val groupByTableName = if (hasStreamingSource) {
-        groupBy.metaData.outputTable + s"__${GroupByPlanner.Streaming}"
-      } else {
-        groupBy.metaData.outputTable + s"__${GroupByPlanner.UploadToKV}"
-      }
-
-      val groupByDep = new TableDependency()
+      // Always create dependency on the GroupBy upload node
+      val uploadTableName = groupBy.metaData.outputTable + s"__${GroupByPlanner.UploadToKV}"
+      val uploadDep = new TableDependency()
         .setTableInfo(
           new TableInfo()
-            .setTable(groupByTableName)
+            .setTable(uploadTableName)
         )
         .setStartOffset(WindowUtils.zero())
         .setEndOffset(WindowUtils.zero())
+
+      // For streaming sources, also add dependency on the streaming node
+      val streamingDep = if (hasStreamingSource) {
+        val streamingTableName = groupBy.metaData.outputTable + s"__${GroupByPlanner.Streaming}"
+        Some(
+          new TableDependency()
+            .setTableInfo(
+              new TableInfo()
+                .setTable(streamingTableName)
+            )
+            .setStartOffset(WindowUtils.zero())
+            .setEndOffset(WindowUtils.zero())
+        )
+      } else {
+        None
+      }
 
       // Add dependencies on upstream join metadata uploads if GroupBy has JoinSource
       val upstreamJoinDeps = if (hasStreamingSource) {
@@ -70,15 +81,15 @@ case class MonolithJoinPlanner(join: Join)(implicit outputPartitionSpec: Partiti
       }
 
       // Return both the GroupBy dependency and any upstream join dependencies
-      Seq(groupByDep) ++ upstreamJoinDeps
+      Seq(uploadDep) ++ streamingDep ++ upstreamJoinDeps
     }
 
     val metaData =
       MetaDataUtils.layer(join.metaData,
-                          "metadata_upload",
-                          join.metaData.name + "__metadata_upload",
-                          allDeps,
-                          Some(stepDays))
+        "metadata_upload",
+        join.metaData.name + "__metadata_upload",
+        allDeps,
+        Some(stepDays))
     val node = new planner.JoinMetadataUpload().setJoin(join)
     toNode(metaData, _.setJoinMetadataUpload(node), semanticMonolithJoin(join))
   }

--- a/api/src/test/scala/ai/chronon/api/test/planner/MonolithJoinPlannerTest.scala
+++ b/api/src/test/scala/ai/chronon/api/test/planner/MonolithJoinPlannerTest.scala
@@ -264,11 +264,14 @@ class MonolithJoinPlannerTest extends AnyFlatSpec with Matchers {
 
     val metadataUploadNode = plan.nodes.asScala.find(_.content.isSetJoinMetadataUpload).get
 
-    // Should have dependencies on streaming GroupBy node
+    // Should have dependencies on both streaming and upload GroupBy nodes
     val tableDeps = metadataUploadNode.metaData.executionInfo.tableDependencies.asScala
     tableDeps should not be empty
-    val streamingDep = tableDeps.head
-    streamingDep.tableInfo.table should equal(streamingGroupBy.metaData.outputTable + "__streaming")
+    tableDeps should have size 2
+
+    val depTables = tableDeps.map(_.tableInfo.table).toSet
+    depTables should contain(streamingGroupBy.metaData.outputTable + "__uploadToKV")
+    depTables should contain(streamingGroupBy.metaData.outputTable + "__streaming")
   }
 
   it should "metadata upload node should depend on uploadToKV GroupBy nodes when join parts have non-streaming sources" in {
@@ -345,13 +348,14 @@ class MonolithJoinPlannerTest extends AnyFlatSpec with Matchers {
 
     val metadataUploadNode = plan.nodes.asScala.find(_.content.isSetJoinMetadataUpload).get
 
-    // Should have dependencies on both streaming and uploadToKV nodes
+    // Should have dependencies on streaming node, upload node for streaming GB, and uploadToKV for non-streaming GB
     val tableDeps = metadataUploadNode.metaData.executionInfo.tableDependencies.asScala
     tableDeps should not be empty
-    tableDeps should have size 2
+    tableDeps should have size 3
 
     val depTables = tableDeps.map(_.tableInfo.table).toSet
     depTables should contain(streamingGroupBy.metaData.outputTable + "__streaming")
+    depTables should contain(streamingGroupBy.metaData.outputTable + "__uploadToKV")
     depTables should contain(nonStreamingGroupBy.metaData.outputTable + "__uploadToKV")
   }
 
@@ -565,12 +569,15 @@ class MonolithJoinPlannerTest extends AnyFlatSpec with Matchers {
     val metadataUploadNode = plan.nodes.asScala.find(_.content.isSetJoinMetadataUpload).get
     val tableDeps = metadataUploadNode.metaData.executionInfo.tableDependencies.asScala
 
-    // Should only have dependency on the streaming GroupBy (streaming table)
-    tableDeps.size should be(1)
-    
+    // Should have dependency on both the streaming GroupBy (streaming table) and upload table
+    tableDeps.size should be(2)
+
     val streamingDep = tableDeps.find(_.tableInfo.table.contains("streaming_chained_gb__streaming"))
     streamingDep should be(defined)
-    
+
+    val uploadDep = tableDeps.find(_.tableInfo.table.contains("streaming_chained_gb__uploadToKV"))
+    uploadDep should be(defined)
+
     // Should NOT have upstream join metadata upload dependency (streaming node handles it)
     val upstreamJoinDeps = tableDeps.filter(_.tableInfo.table.contains("upstream_join__metadata_upload"))
     upstreamJoinDeps should be(empty)


### PR DESCRIPTION
## Summary
To make things safer for new joins with streaming GBs, we want to add a dep to the GB upload to kv node as well. This along with a change to wait for ~day for the streaming job will ensure that we mark a join metadata as ready when we have data primed. As an example a job deployed at 2025-10-10 at 1:00am, we wait for the streaming node in our orchestrator for a day (1:00am 10-11) but we don't open it up till the upload to kv for 10-11 is done as part of the 10-11 metadata upload with this dep. 

## Checklist
- [X] Added Unit Tests
- [X] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined dependency management for join operations with enhanced handling of both streaming and upload-based dependencies.
  * Optimized dependency resolution for improved consistency and reliability in operation execution order.

* **Tests**
  * Significantly expanded test coverage to validate complex dependency scenarios for metadata upload operations across streaming and non-streaming configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->