### PR TITLE
feat: entity compiling and exposing via CLI

### DIFF
--- a/python/src/ai/chronon/cli/compile/compile_context.py
+++ b/python/src/ai/chronon/cli/compile/compile_context.py
@@ -20,6 +20,7 @@ from ai.chronon.cli.compile.display.compiled_obj import CompiledObj
 from ai.chronon.cli.compile.serializer import file2thrift
 from ai.chronon.cli.formatter import Format
 from ai.chronon.cli.logger import get_logger, require
+from ai.chronon.repo.entity_register import EntityRegister
 
 logger = get_logger()
 
@@ -33,14 +34,14 @@ class ConfigInfo:
 
 @dataclass
 class CompileContext:
-    def __init__(self, ignore_python_errors: bool = False, format: Format = Format.TEXT, force: bool = False):
+    def __init__(self, ignore_python_errors: bool = False, format: Format = Format.TEXT, force: bool = False, entity_register: EntityRegister = None):
         self.chronon_root: str = os.getenv("CHRONON_ROOT", os.getcwd())
         self.teams_dict: Dict[str, Team] = teams.load_teams(self.chronon_root, print=format != Format.JSON)
         self.compile_dir: str = "compiled"
         self.ignore_python_errors: bool = ignore_python_errors
         self.format: Format = format
         self.force: bool = force
-
+        self.entity_register: EntityRegister = entity_register
         self.config_infos: List[ConfigInfo] = [
             ConfigInfo(folder_name="joins", cls=Join, config_type=ConfType.JOIN),
             ConfigInfo(

--- a/python/src/ai/chronon/group_by.py
+++ b/python/src/ai/chronon/group_by.py
@@ -420,7 +420,7 @@ def final_key_columns(key, source):
 
 def GroupBy(
     sources: Union[List[utils.ANY_SOURCE_TYPE], utils.ANY_SOURCE_TYPE],
-    keys: List[str],
+    keys: List[Union[str, Entity]],
     aggregations: Optional[List[ttypes.Aggregation]],
     version: Optional[int] = None,
     derivations: List[ttypes.Derivation] = None,

--- a/python/src/ai/chronon/group_by.py
+++ b/python/src/ai/chronon/group_by.py
@@ -23,6 +23,7 @@ import gen_thrift.common.ttypes as common
 
 import ai.chronon.utils as utils
 import ai.chronon.windows as window_utils
+from ai.chronon.repo.entity_register import Entity
 
 OperationType = int  # type(zthrift.Operation.FIRST)
 
@@ -412,6 +413,11 @@ def get_output_col_names(aggregation):
     return bucketed_names
 
 
+def final_key_columns(key, source):
+    if isinstance(key, Entity):   
+        return key.select_registrations[utils.get_table(source)].column
+    return key
+
 def GroupBy(
     sources: Union[List[utils.ANY_SOURCE_TYPE], utils.ANY_SOURCE_TYPE],
     keys: List[str],
@@ -576,7 +582,6 @@ def GroupBy(
     assert version is None or isinstance(version, int), (
         f"Version must be an integer or None, but found {type(version).__name__}"
     )
-
     agg_inputs = []
     if aggregations is not None:
         agg_inputs = [agg.inputColumn for agg in aggregations]
@@ -594,6 +599,8 @@ def GroupBy(
         if query.selects is None:
             query.selects = {}
         for col in required_columns:
+            if isinstance(col, Entity):
+                col = col.select_registrations[utils.get_table(source)].expr
             if col not in query.selects:
                 query.selects[col] = col
         if "ts" in query.selects:  # ts cannot be in selects.
@@ -654,10 +661,10 @@ def GroupBy(
         columnTags=column_tags if column_tags else None,
         version=str(version) if version is not None else None,
     )
-
+    final_keys = [final_key_columns(key, sources[0]) for key in keys]
     group_by = ttypes.GroupBy(
         sources=sources,
-        keyColumns=keys,
+        keyColumns=final_keys,
         aggregations=aggregations,
         metaData=metadata,
         accuracy=accuracy,
@@ -667,5 +674,14 @@ def GroupBy(
 
     # Add the table property that calls the private function
     group_by.__class__.table = property(lambda self: _get_output_table_name(self, full_name=True))
-
+    for key in keys:
+        if isinstance(key, Entity):
+            key.register_aggregation(
+                final_keys, 
+                aggregations, 
+                parent=group_by, 
+                input=utils.get_table(sources[0]), 
+                derivations=derivations, 
+                selects=utils.get_query(sources[0]).selects
+            )
     return group_by

--- a/python/src/ai/chronon/join.py
+++ b/python/src/ai/chronon/join.py
@@ -26,6 +26,7 @@ import ai.chronon.repo.extract_objects as eo
 import ai.chronon.utils as utils
 from ai.chronon.cli.compile import parse_teams
 from ai.chronon.data_types import DataType, FieldsType
+from ai.chronon.repo.entity_register import Entity
 
 logging.basicConfig(level=logging.INFO)
 
@@ -505,5 +506,17 @@ def Join(
 
     # Add the table property that calls the private function
     join.__class__.table = property(lambda self: _get_output_table_name(self, full_name=True))
+
+    # Register join with entities if applicable
+    if Entity._global_register is not None:
+        try:
+            left_table = utils.get_table(updated_left)
+            # Check all registered entities to see if any match this join's left source
+            for _entity_name, entity in Entity._global_register.entity_registrations.items():
+                if left_table in entity.select_registrations:
+                    entity.register_feature_query(join, left_table)
+        except Exception:
+            # Silently ignore errors in entity registration
+            pass
 
     return join

--- a/python/src/ai/chronon/join.py
+++ b/python/src/ai/chronon/join.py
@@ -515,8 +515,7 @@ def Join(
             for _entity_name, entity in Entity._global_register.entity_registrations.items():
                 if left_table in entity.select_registrations:
                     entity.register_feature_query(join, left_table)
-        except Exception:
-            # Silently ignore errors in entity registration
-            pass
+        except Exception as e:
+            logging.error(f"Error registering join {join.metaData.name} with entities: {e}")
 
     return join

--- a/python/src/ai/chronon/repo/compile.py
+++ b/python/src/ai/chronon/repo/compile.py
@@ -9,6 +9,7 @@ from ai.chronon.cli.compile.compile_context import CompileContext
 from ai.chronon.cli.compile.compiler import Compiler
 from ai.chronon.cli.compile.display.console import console
 from ai.chronon.cli.formatter import Format, jsonify_exceptions_if_json_format
+from ai.chronon.repo.entity_register import Entity, EntityRegister
 
 
 @click.command(name="compile")
@@ -35,8 +36,20 @@ from ai.chronon.cli.formatter import Format, jsonify_exceptions_if_json_format
     is_flag=True,
     help="Force compilation to proceed even with errors",
 )
+@click.option(
+    "--entity-summary",
+    is_flag=True,
+    default=False,
+    help="Print entity registry summary to console",
+)
+@click.option(
+    "--entity-csv",
+    type=str,
+    default=None,
+    help="Export entity registry to CSV file (provide file path)",
+)
 @jsonify_exceptions_if_json_format
-def compile(chronon_root, ignore_python_errors, format, force):
+def compile(chronon_root, ignore_python_errors, format, force, entity_summary, entity_csv):
     if chronon_root is None or chronon_root == "":
         chronon_root = os.getcwd()
 
@@ -49,10 +62,10 @@ def compile(chronon_root, ignore_python_errors, format, force):
     elif format != Format.JSON:
         console.print(f"\n[cyan italic]{chronon_root}[/cyan italic] already on python path.")
 
-    return __compile(chronon_root, ignore_python_errors, format=format, force=force)
+    return __compile(chronon_root, ignore_python_errors, format=format, force=force, entity_summary=entity_summary, entity_csv=entity_csv)
 
 
-def __compile(chronon_root, ignore_python_errors=False, format=Format.TEXT, force=False):
+def __compile(chronon_root, ignore_python_errors=False, format=Format.TEXT, force=False, entity_summary=False, entity_csv=None):
     if chronon_root:
         chronon_root_path = os.path.expanduser(chronon_root)
         os.chdir(chronon_root_path)
@@ -65,19 +78,38 @@ def __compile(chronon_root, ignore_python_errors=False, format=Format.TEXT, forc
                 " Please run from the top level of conf directory."
             )
         )
-
-    compile_context = CompileContext(ignore_python_errors=ignore_python_errors, format=format, force=force)
+    entity_register = EntityRegister()
+    Entity._global_register = entity_register  # Enable auto-registration during compilation
+    compile_context = CompileContext(ignore_python_errors=ignore_python_errors, format=format, force=force, entity_register=entity_register)
     compiler = Compiler(compile_context)
     results = compiler.compile()
+    # Handle JSON format output
     if format == Format.JSON:
-        print(json.dumps({
-            "status": "success", 
+        output = {
+            "status": "success",
             "results": {
                 ConfType._VALUES_TO_NAMES[conf_type]: list(conf_result.obj_dict.keys())
                 for conf_type, conf_result in results.items()
                 if conf_result.obj_dict
-            }}, indent=4))
+            }
+        }
+        if entity_summary:
+            output["entity_registry"] = compile_context.entity_register.to_dict()
+        print(json.dumps(output, indent=4))
         sys.exit(0)
+
+    # Handle text format output
+    if entity_summary:
+        compile_context.entity_register.pretty_print()
+
+    # Handle CSV export
+    if entity_csv:
+        csv_content = compile_context.entity_register.to_csv()
+        with open(entity_csv, 'w') as f:
+            f.write(csv_content)
+        if format != Format.JSON:
+            console.print(f"\n[green]Entity registry exported to CSV:[/green] {entity_csv}")
+
     return results
 
 

--- a/python/src/ai/chronon/repo/entity_register.py
+++ b/python/src/ai/chronon/repo/entity_register.py
@@ -1,8 +1,18 @@
 """
+Entity Registry System for Chronon
+
+This module provides a registry system to track how entities (business domain concepts like
+user_id, listing_id, merchant_id) are used across Chronon configurations including Sources,
+GroupBys, and Joins. This enables better data lineage tracking, feature documentation, and
+validation of entity usage consistency.
+
 Entity:
- The class holding all the information about the entity, which tables have been selecting it.
+    The class holding all the information about an entity, including which tables have
+    selected it, what aggregations use it as keys, and which joins consume features for it.
+
 EntityRegister:
-  The class controlling all the entities. Reset at compile time.
+    The class controlling all registered entities. Reset at compile time to track entity
+    usage across the entire configuration repository.
 """
 
 import csv
@@ -15,18 +25,78 @@ from gen_thrift.common.ttypes import TimeUnit
 
 SelectTuple = namedtuple("SelectTuple", ["column", "expr"])
 
-def window_to_str_pretty(length, timeUnit):
+
+def window_to_str_pretty(length: int, timeUnit: int) -> str:
+    """
+    Convert a window specification to a human-readable string format.
+
+    Args:
+        length: The numeric length of the time window
+        timeUnit: The TimeUnit enum value (DAYS, HOURS, MINUTES, etc.)
+
+    Returns:
+        A compact string representation like "7d", "24h", "30m"
+
+    Examples:
+        >>> window_to_str_pretty(7, TimeUnit.DAYS)
+        '7d'
+        >>> window_to_str_pretty(24, TimeUnit.HOURS)
+        '24h'
+    """
     unit = TimeUnit._VALUES_TO_NAMES[timeUnit].lower()
     return f"{length}{unit[0]}"
 
 
-def op_to_str(operation):
+def op_to_str(operation: int) -> str:
+    """
+    Convert an Operation enum value to its lowercase string name.
+
+    Args:
+        operation: The Operation enum value (SUM, COUNT, LAST, etc.)
+
+    Returns:
+        The lowercase string name of the operation
+
+    Examples:
+        >>> op_to_str(Operation.SUM)
+        'sum'
+        >>> op_to_str(Operation.LAST)
+        'last'
+    """
     return Operation._VALUES_TO_NAMES[operation].lower()
 
 class Entity:
+    """
+    Represents a business domain entity (e.g., user, listing, merchant) in Chronon.
+
+    An Entity tracks how a business concept is used across different sources, group_bys,
+    and joins. It maintains consistency by ensuring that the same entity uses consistent
+    column names and expressions across different tables and transformations.
+
+    Entities are registered during source definitions by passing an entity mapping via
+    the 'entities' parameter or by using an 'entity_registry' with default column patterns.
+
+    Attributes:
+        name: The unique identifier for this entity (e.g., "user", "listing")
+        description: Human-readable description of what this entity represents
+        default: List of default column names that should auto-register for this entity
+        select_registrations: Dict mapping table names to SelectTuple(column, expr)
+        aggregation_registrations: Dict mapping tables to list of GroupBy aggregations
+        feature_query_registrations: Dict mapping tables to list of Joins using this entity
+        _global_register: Class-level reference to the active EntityRegister during compilation
+    """
     _global_register = None  # Set by compile.py during compilation
 
-    def __init__(self, name, description="", default=None):
+    def __init__(self, name: str, description: str = "", default: list = None):
+        """
+        Initialize a new Entity.
+
+        Args:
+            name: Unique identifier for the entity (e.g., "user", "listing", "merchant")
+            description: Human-readable description of what this entity represents
+            default: List of column name patterns that should auto-register for this entity
+                     when found in source queries. Useful for automatic entity tracking.
+        """
         self.name = name
         self.description = description
         self.default = default if default else []
@@ -34,7 +104,20 @@ class Entity:
         self.aggregation_registrations = {}
         self.feature_query_registrations = {}
 
-    def pretty_print(self, show_all=False):
+    def pretty_print(self, show_all: bool = False) -> str:
+        """
+        Generate a human-readable string representation of this entity's registrations.
+
+        Args:
+            show_all: If True, show all select registrations even those without aggregations.
+                      If False (default), only show tables that have associated GroupBys.
+
+        Returns:
+            A formatted multi-line string showing:
+            - Entity name and description
+            - Feature definitions (tables, columns, GroupBys, aggregations, derivations)
+            - Feature queries (Joins that consume this entity's features)
+        """
         to_str = f" Entity Name: {self.name} \n"
         to_str += f" Description: {self.description}\n"
         to_str += " Feature Definitions:\n"
@@ -85,7 +168,16 @@ class Entity:
                 to_str += f"{' ' * 6} - Join: {join_name}\n"
         return to_str
 
-    def to_str_select_registrations(self, indent=5):
+    def to_str_select_registrations(self, indent: int = 5) -> str:
+        """
+        Generate a formatted string of all select registrations for this entity.
+
+        Args:
+            indent: Number of spaces to indent each line (default: 5)
+
+        Returns:
+            A multi-line string showing each table's column and expression registration
+        """
         result = "\n"
         for table, select_tuple in self.select_registrations.items():
             result += f"{' ' * indent}Table: {table}\n"
@@ -93,15 +185,31 @@ class Entity:
             result += f"{' ' * indent} - Expression: {select_tuple.expr}\n"
         return result
 
-    def select(self, column: str, table: str, expr=None) -> str:
+    def select(self, column: str, table: str, expr: str = None) -> "Entity":
         """
-        Main method of registration for an entity.
-        - column: The column name to register. Post transformation.
-        - table: The table name to register. Table the transformation is being applied to.
-        - expr: The expression to register. 
-        - Returns the column name.
+        Register a column as a representation of this entity in a specific table.
 
-        The objective is to guarantee consistency of entity definitions.
+        This is the primary registration method for entities. It records that a particular
+        column (potentially derived from an expression) represents this entity in a given
+        table. The method enforces consistency by raising an error if the same table is
+        registered with a different expression.
+
+        Args:
+            column: The column name after transformation (the final column name in the table)
+            table: The fully qualified table name where this entity appears
+            expr: The SQL expression used to derive the column. If None, defaults to column name.
+                  This captures transformations like "CAST(user_id AS STRING)" or "listing_id"
+
+        Returns:
+            Self, to enable method chaining
+
+        Raises:
+            ValueError: If this entity was already registered for the table with a different
+                       expression, indicating an inconsistency in entity definition
+
+        Note:
+            If a global EntityRegister is active (during compilation), this method will
+            automatically register the entity with that register on first use.
         """
         # Auto-register entity on first use
         if Entity._global_register is not None:
@@ -111,9 +219,36 @@ class Entity:
             self.select_registrations[table] = SelectTuple(column=column, expr=expr or column)
         if table in self.select_registrations and self.select_registrations[table].expr != expr:
             raise ValueError(f"Entity {self.name} has already registered for table {table} with expression {self.select_registrations[table].expr} but received expression {expr}")
-        return column
+        return self
     
-    def register_aggregation(self, keys, aggregations, parent, input, derivations=None, selects=None):
+    def register_aggregation(self, keys, aggregations, parent, input, derivations=None, selects=None) -> "Entity":
+        """
+        Register a GroupBy that uses this entity as a key.
+
+        This method is called internally by the GroupBy constructor when an entity is used
+        in the 'keys' parameter. It tracks which aggregations are computed for this entity,
+        enabling feature lineage and documentation.
+
+        Args:
+            keys: List of key columns (may include strings and Entity objects)
+            aggregations: List of Aggregation objects defining what's computed
+            parent: The GroupBy object that contains these aggregations
+            input: The source table name being aggregated
+            derivations: Optional list of Derivation objects for computed features
+            selects: Optional dict of passthrough fields (for non-aggregated GroupBys)
+
+        Returns:
+            Self, to enable method chaining
+
+        Raises:
+            ValueError: If the input table was not previously registered via select().
+                       This catches cases where an entity is used in a GroupBy but was
+                       not properly registered in the source's query selects.
+
+        Note:
+            This method is typically called automatically by the GroupBy constructor,
+            not by user code directly.
+        """
         # Validate that this table was registered via select()
         if input not in self.select_registrations:
             raise ValueError(
@@ -132,8 +267,27 @@ class Entity:
             "derivations": derivations,
             "selects": selects if not aggregations else None,
         })
+        return self
 
-    def register_feature_query(self, join, table):
+    def register_feature_query(self, join, table) -> "Entity":
+        """
+        Register a Join that consumes features for this entity.
+
+        This method tracks which Joins use this entity in their left source, enabling
+        understanding of feature consumption patterns and downstream dependencies.
+
+        Args:
+            join: The Join object that uses this entity
+            table: The left source table of the join
+
+        Returns:
+            Self, to enable method chaining
+
+        Note:
+            This method is called automatically by the Join constructor when a join's
+            left source matches a table registered for this entity. It does not perform
+            validation, unlike register_aggregation().
+        """
         if table not in self.feature_query_registrations:
             self.feature_query_registrations[table] = []
 
@@ -141,22 +295,119 @@ class Entity:
             "join": join,
             "table": table,
         })
+        return self
 
 class EntityRegister:
+    """
+    Central registry for all entities in a Chronon repository.
+
+    The EntityRegister maintains a collection of all Entity objects and provides methods
+    to export entity usage information in various formats (text, JSON, CSV). It is
+    typically instantiated once per compilation run and tracks all entity registrations
+    across the entire configuration repository.
+
+    Attributes:
+        entity_registrations: Dict mapping entity names to Entity objects
+    """
+
     def __init__(self):
+        """Initialize an empty EntityRegister."""
         self.entity_registrations = {}
 
-    def register_entity(self, entity):
-        self.entity_registrations[entity.name] = entity
+    def register_entity(self, entity: Entity) -> Entity:
+        """
+        Register an entity with this registry.
 
-    def get_entity(self, name):
+        Args:
+            entity: The Entity object to register
+
+        Returns:
+            The same entity object (for convenience in method chaining)
+
+        Note:
+            If an entity with the same name is already registered, it will be replaced.
+            Entities are typically auto-registered when first used via Entity.select().
+        """
+        self.entity_registrations[entity.name] = entity
+        return entity
+
+    def get_entity(self, name: str) -> Entity:
+        """
+        Retrieve an entity by name.
+
+        Args:
+            name: The entity name to look up
+
+        Returns:
+            The Entity object with the given name
+
+        Raises:
+            KeyError: If no entity with the given name is registered
+        """
         return self.entity_registrations[name]
 
-    def pretty_print(self):
+    def pretty_print(self) -> None:
+        """
+        Print a human-readable representation of all registered entities to stdout.
+
+        This iterates through all entities and prints their pretty_print() output,
+        which includes feature definitions, aggregations, and feature queries.
+        """
         for _entity_name, entity in self.entity_registrations.items():
             print(entity.pretty_print())
 
-    def to_dict(self):
+    def to_dict(self) -> dict:
+        """
+        Export all entity registrations as a nested dictionary structure.
+
+        Returns:
+            A dictionary with the following structure:
+            {
+                "entities": {
+                    "<entity_name>": {
+                        "name": str,
+                        "description": str,
+                        "feature_definitions": {
+                            "<table_name>": {
+                                "input_column": str,
+                                "expression": str,
+                                "group_bys": [
+                                    {
+                                        "name": str,
+                                        "keys": List[str],
+                                        "aggregations": [
+                                            {
+                                                "input_column": str,
+                                                "operation": str,
+                                                "windows": List[str],
+                                                "buckets": Optional[List],
+                                                "tags": Optional[Dict]
+                                            }
+                                        ],
+                                        "derivations": [
+                                            {
+                                                "name": str,
+                                                "expression": str
+                                            }
+                                        ],
+                                        "selects": Dict[str, str]
+                                    }
+                                ]
+                            }
+                        },
+                        "feature_queries": {
+                            "<table_name>": [
+                                {"name": str}  # Join names
+                            ]
+                        }
+                    }
+                }
+            }
+
+        Note:
+            Only tables that have associated aggregations are included in feature_definitions.
+            Tables that are merely selected but not aggregated are excluded.
+        """
         result = {"entities": {}}
         for entity_name, entity in self.entity_registrations.items():
             entity_dict = {
@@ -171,7 +422,7 @@ class EntityRegister:
                 if table in entity.aggregation_registrations:
                     feature_def = {
                         "input_column": select_tuple.column,
-                        "alias": select_tuple.alias,
+                        "expression": select_tuple.expr,
                         "group_bys": []
                     }
 
@@ -234,18 +485,48 @@ class EntityRegister:
 
         return result
 
-    def to_json(self, indent=2):
+    def to_json(self, indent: int = 2) -> str:
+        """
+        Export all entity registrations as a JSON string.
+
+        Args:
+            indent: Number of spaces for JSON indentation (default: 2)
+
+        Returns:
+            A JSON-formatted string containing all entity registration data.
+            See to_dict() for the structure.
+        """
         return json.dumps(self.to_dict(), indent=indent)
 
-    def to_csv(self):
+    def to_csv(self) -> str:
         """
-        Export entity registrations to CSV format with columns:
-        - entity: entity name
-        - input_column: input column from source table
-        - operation: aggregation operation (e.g., sum, count, last)
-        - window: time window for aggregation (e.g., 1d, 7d)
-        - joins: comma-separated list of joins that consume this feature
-        - online: whether the group by is online (true/false)
+        Export entity registrations to CSV format for analysis and reporting.
+
+        This method generates a flattened CSV representation where each row represents
+        a single feature (aggregation + window combination) for an entity. This format
+        is useful for feature catalogs, dependency analysis, and reporting.
+
+        CSV Columns:
+            - entity: Entity name (e.g., "user", "listing")
+            - input_column: The source column name from the table
+            - operation: Aggregation operation (e.g., "sum", "count", "last", "derivation:name", "passthrough")
+            - window: Time window for aggregation (e.g., "7d", "30d") or empty for non-windowed
+            - group_by: Name of the GroupBy that defines this feature
+            - joins: Comma-separated list of Join names that consume features from this entity
+            - online: "true" if the GroupBy is online-enabled, "false" otherwise
+
+        Returns:
+            A CSV-formatted string with headers and one row per feature variant.
+            Multi-window aggregations create multiple rows (one per window).
+
+        Special Operation Values:
+            - "derivation:<name>": For derived features
+            - "passthrough": For GroupBys with no aggregations (passthrough fields)
+            - Empty string: For tables with select but no aggregations
+
+        Note:
+            The joins column is populated based on which Joins have a left source matching
+            the entity's registered tables. A single entity may appear in multiple joins.
         """
         output = io.StringIO()
         writer = csv.writer(output)

--- a/python/src/ai/chronon/repo/entity_register.py
+++ b/python/src/ai/chronon/repo/entity_register.py
@@ -1,0 +1,351 @@
+"""
+Entity:
+ The class holding all the information about the entity, which tables have been selecting it.
+EntityRegister:
+  The class controlling all the entities. Reset at compile time.
+"""
+
+import csv
+import io
+import json
+from collections import namedtuple
+
+from gen_thrift.api.ttypes import Operation
+from gen_thrift.common.ttypes import TimeUnit
+
+SelectTuple = namedtuple("SelectTuple", ["column", "expr"])
+
+def window_to_str_pretty(length, timeUnit):
+    unit = TimeUnit._VALUES_TO_NAMES[timeUnit].lower()
+    return f"{length}{unit[0]}"
+
+
+def op_to_str(operation):
+    return Operation._VALUES_TO_NAMES[operation].lower()
+
+class Entity:
+    _global_register = None  # Set by compile.py during compilation
+
+    def __init__(self, name, description="", default=None):
+        self.name = name
+        self.description = description
+        self.default = default if default else []
+        self.select_registrations = {}
+        self.aggregation_registrations = {}
+        self.feature_query_registrations = {}
+
+    def pretty_print(self, show_all=False):
+        to_str = f" Entity Name: {self.name} \n"
+        to_str += f" Description: {self.description}\n"
+        to_str += " Feature Definitions:\n"
+        for table in self.select_registrations:
+            if not show_all and table not in self.aggregation_registrations:
+                continue
+            select_tuple = self.select_registrations[table]
+            to_str += f"{' ' * 4} Table: {table}\n"
+            to_str += f"{' ' * 4} Input Column: {select_tuple.column}"
+            if table not in self.aggregation_registrations:
+                to_str += f"[No group by on {self.name} registered for this table]\n"
+            if table in self.aggregation_registrations:
+                for aggregation_info in self.aggregation_registrations[table]:
+                    to_str += f"\n{' ' * 6} - GroupBy: {aggregation_info['groupBy'].metaData.name}\n"
+                    to_str += f"{' ' * 6} - Keys: {aggregation_info['keys']}\n"
+                    if aggregation_info['aggregations']:
+                        to_str += f"{' ' * 6} - Aggregations: \n"
+                        for aggregation in aggregation_info['aggregations']:
+                            aggregation_str = ""
+                            if aggregation.inputColumn:
+                                aggregation_str += f"inputColumn={aggregation.inputColumn}"
+                            if aggregation.operation:
+                                aggregation_str += f", operation={op_to_str(aggregation.operation)}"
+                            if aggregation.windows:
+                                aggregation_str += f", windows=[{','.join([window_to_str_pretty(window.length, window.timeUnit) for window in aggregation.windows])}]"
+                            if aggregation.buckets:
+                                aggregation_str += f", buckets={aggregation.buckets}"
+                            if aggregation.tags:
+                                aggregation_str += f", tags={aggregation.tags}"
+                            to_str += f"{' ' * 8} - Agg({aggregation_str}) \n"
+                    if aggregation_info['derivations']:
+                        to_str += f"{' ' * 6} - Derivations: \n"
+                        for derivation in aggregation_info['derivations']:
+                            to_str += f"{' ' * 8} - {derivation.name}: {derivation.expression}\n"
+                    if aggregation_info['selects']:
+                        to_str += f"{' ' * 6} - Passthrough fields (NoAgg): \n"
+                        for select in aggregation_info['selects']:
+                            to_str += f"{' ' * 8} - {select}: {aggregation_info['selects'][select]}\n"
+        to_str += " Feature Queries:\n"
+        if not self.feature_query_registrations:
+            to_str += f"{' ' * 4} No feature queries registered\n"
+            return to_str
+        for table in self.feature_query_registrations:
+            to_str += f"{' ' * 4} Table: {table}\n"
+            for query_info in self.feature_query_registrations[table]:
+                join = query_info['join']
+                join_name = join.metaData.name if join.metaData.name else "<name not set>"
+                to_str += f"{' ' * 6} - Join: {join_name}\n"
+        return to_str
+
+    def to_str_select_registrations(self, indent=5):
+        result = "\n"
+        for table, select_tuple in self.select_registrations.items():
+            result += f"{' ' * indent}Table: {table}\n"
+            result += f"{' ' * indent} - Column: {select_tuple.column}\n"
+            result += f"{' ' * indent} - Expression: {select_tuple.expr}\n"
+        return result
+
+    def select(self, column: str, table: str, expr=None) -> str:
+        """
+        Main method of registration for an entity.
+        - column: The column name to register. Post transformation.
+        - table: The table name to register. Table the transformation is being applied to.
+        - expr: The expression to register. 
+        - Returns the column name.
+
+        The objective is to guarantee consistency of entity definitions.
+        """
+        # Auto-register entity on first use
+        if Entity._global_register is not None:
+            Entity._global_register.register_entity(self)
+
+        if table not in self.select_registrations and column is not None:
+            self.select_registrations[table] = SelectTuple(column=column, expr=expr or column)
+        if table in self.select_registrations and self.select_registrations[table].expr != expr:
+            raise ValueError(f"Entity {self.name} has already registered for table {table} with expression {self.select_registrations[table].expr} but received expression {expr}")
+        return column
+    
+    def register_aggregation(self, keys, aggregations, parent, input, derivations=None, selects=None):
+        # Validate that this table was registered via select()
+        if input not in self.select_registrations:
+            raise ValueError(
+                f"Entity '{self.name}' used in GroupBy '{parent.metaData.name}' "
+                f"but no select() registration found for table '{input}'. "
+                f"Make sure to use entity.select() in the query's selects."
+            )
+
+        if input not in self.aggregation_registrations:
+            self.aggregation_registrations[input] = []
+
+        self.aggregation_registrations[input].append({
+            "groupBy": parent,
+            "keys": keys,
+            "aggregations": aggregations,
+            "derivations": derivations,
+            "selects": selects if not aggregations else None,
+        })
+
+    def register_feature_query(self, join, table):
+        if table not in self.feature_query_registrations:
+            self.feature_query_registrations[table] = []
+
+        self.feature_query_registrations[table].append({
+            "join": join,
+            "table": table,
+        })
+
+class EntityRegister:
+    def __init__(self):
+        self.entity_registrations = {}
+
+    def register_entity(self, entity):
+        self.entity_registrations[entity.name] = entity
+
+    def get_entity(self, name):
+        return self.entity_registrations[name]
+
+    def pretty_print(self):
+        for _entity_name, entity in self.entity_registrations.items():
+            print(entity.pretty_print())
+
+    def to_dict(self):
+        result = {"entities": {}}
+        for entity_name, entity in self.entity_registrations.items():
+            entity_dict = {
+                "name": entity.name,
+                "description": entity.description,
+                "feature_definitions": {},
+                "feature_queries": {}
+            }
+
+            # Add feature definitions (GroupBys)
+            for table, select_tuple in entity.select_registrations.items():
+                if table in entity.aggregation_registrations:
+                    feature_def = {
+                        "input_column": select_tuple.column,
+                        "alias": select_tuple.alias,
+                        "group_bys": []
+                    }
+
+                    for agg_info in entity.aggregation_registrations[table]:
+                        group_by_dict = {
+                            "name": agg_info['groupBy'].metaData.name,
+                            "keys": agg_info['keys'],
+                            "aggregations": [],
+                            "derivations": [],
+                            "selects": {}
+                        }
+
+                        # Add aggregations
+                        if agg_info['aggregations']:
+                            for agg in agg_info['aggregations']:
+                                agg_dict = {}
+                                if agg.inputColumn:
+                                    agg_dict['input_column'] = agg.inputColumn
+                                if agg.operation:
+                                    agg_dict['operation'] = op_to_str(agg.operation)
+                                if agg.windows:
+                                    agg_dict['windows'] = [
+                                        window_to_str_pretty(w.length, w.timeUnit)
+                                        for w in agg.windows
+                                    ]
+                                if agg.buckets:
+                                    agg_dict['buckets'] = agg.buckets
+                                if agg.tags:
+                                    agg_dict['tags'] = agg.tags
+                                group_by_dict['aggregations'].append(agg_dict)
+
+                        # Add derivations
+                        if agg_info['derivations']:
+                            for deriv in agg_info['derivations']:
+                                group_by_dict['derivations'].append({
+                                    'name': deriv.name,
+                                    'expression': deriv.expression
+                                })
+
+                        # Add selects
+                        if agg_info['selects']:
+                            group_by_dict['selects'] = agg_info['selects']
+
+                        feature_def['group_bys'].append(group_by_dict)
+
+                    entity_dict['feature_definitions'][table] = feature_def
+
+            # Add feature queries (Joins)
+            for table, query_list in entity.feature_query_registrations.items():
+                joins = []
+                for query_info in query_list:
+                    join = query_info['join']
+                    join_name = join.metaData.name if join.metaData.name else None
+                    if join_name:
+                        joins.append({"name": join_name})
+                if joins:
+                    entity_dict['feature_queries'][table] = joins
+
+            result["entities"][entity_name] = entity_dict
+
+        return result
+
+    def to_json(self, indent=2):
+        return json.dumps(self.to_dict(), indent=indent)
+
+    def to_csv(self):
+        """
+        Export entity registrations to CSV format with columns:
+        - entity: entity name
+        - input_column: input column from source table
+        - operation: aggregation operation (e.g., sum, count, last)
+        - window: time window for aggregation (e.g., 1d, 7d)
+        - joins: comma-separated list of joins that consume this feature
+        - online: whether the group by is online (true/false)
+        """
+        output = io.StringIO()
+        writer = csv.writer(output)
+
+        # Write header
+        writer.writerow(['entity', 'input_column', 'operation', 'window', 'group_by', 'joins', 'online'])
+
+        # Process each entity
+        for entity_name, entity in self.entity_registrations.items():
+            # Get joins that consume features for this entity
+            joins_by_table = {}
+            for table, query_list in entity.feature_query_registrations.items():
+                join_names = []
+                for query_info in query_list:
+                    join = query_info['join']
+                    if join.metaData and join.metaData.name:
+                        join_names.append(join.metaData.name)
+                if join_names:
+                    joins_by_table[table] = join_names
+
+            # Process each table's aggregations
+            for table, select_tuple in entity.select_registrations.items():
+                input_column = select_tuple.column
+                joins_list = joins_by_table.get(table, [])
+                joins_str = ','.join(joins_list) if joins_list else ''
+
+                # Check if this table has aggregations
+                if table in entity.aggregation_registrations:
+                    for agg_info in entity.aggregation_registrations[table]:
+                        group_by = agg_info['groupBy']
+                        group_by_name = group_by.metaData.name if (hasattr(group_by, 'metaData') and group_by.metaData and hasattr(group_by.metaData, 'name')) else ''
+                        is_online = 'true' if (hasattr(group_by, 'metaData') and
+                                                group_by.metaData and
+                                                hasattr(group_by.metaData, 'online') and
+                                                group_by.metaData.online) else 'false'
+
+                        # Process aggregations
+                        if agg_info['aggregations']:
+                            for aggregation in agg_info['aggregations']:
+                                operation = op_to_str(aggregation.operation) if aggregation.operation else ''
+
+                                # Handle windows - create one row per window
+                                if aggregation.windows:
+                                    for window in aggregation.windows:
+                                        window_str = window_to_str_pretty(window.length, window.timeUnit)
+                                        writer.writerow([
+                                            entity_name,
+                                            input_column,
+                                            operation,
+                                            window_str,
+                                            group_by_name,
+                                            joins_str,
+                                            is_online
+                                        ])
+                                else:
+                                    # No windows - single row
+                                    writer.writerow([
+                                        entity_name,
+                                        input_column,
+                                        operation,
+                                        '',
+                                        group_by_name,
+                                        joins_str,
+                                        is_online
+                                    ])
+
+                        # Handle derivations
+                        if agg_info['derivations']:
+                            for derivation in agg_info['derivations']:
+                                writer.writerow([
+                                    entity_name,
+                                    input_column,
+                                    f"derivation:{derivation.name}",
+                                    '',
+                                    group_by_name,
+                                    joins_str,
+                                    is_online
+                                ])
+
+                        # Handle passthrough selects (no aggregations)
+                        if agg_info['selects'] and not agg_info['aggregations']:
+                            writer.writerow([
+                                entity_name,
+                                input_column,
+                                'passthrough',
+                                '',
+                                group_by_name,
+                                joins_str,
+                                is_online
+                            ])
+                else:
+                    # No aggregations for this table, but it's registered
+                    writer.writerow([
+                        entity_name,
+                        input_column,
+                        '',
+                        '',
+                        '',
+                        joins_str,
+                        'false'
+                    ])
+
+        return output.getvalue()

--- a/python/src/ai/chronon/source.py
+++ b/python/src/ai/chronon/source.py
@@ -2,14 +2,52 @@
 Wrappers to directly create Source objects.
 """
 
+import logging
+from functools import wraps
+
 import gen_thrift.api.ttypes as ttypes
 
+import ai.chronon.utils as utils
+from ai.chronon.repo.entity_register import Entity, EntityRegister
 
+
+def apply_entities(fn):
+    """
+    Decorator that applies entity selections using the `entities`
+    kwarg passed to the wrapped function.
+    I entity_register is passed, it will be used to register the entities based on the query.selects.
+    """
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        source = fn(*args, **kwargs)
+
+        entities: Entity = kwargs.get("entities")
+        entity_registry: EntityRegister = kwargs.get("entity_registry")
+        if not entities and not entity_registry:
+            return source
+        query = kwargs.get("query")
+        table = utils.get_table(source)
+        if entities is not None:
+            for entity_col, entity in entities.items():
+                if entity_col in query.selects:
+                    entity.select(entity_col, table, expr=query.selects[entity_col])
+        elif entity_registry is not None:
+            for entity in entity_registry.entity_registrations.values():
+                for column in entity.default:
+                    if column in query.selects:
+                        logging.debug(f"Auto-registering entity {entity.name} for column {column} in table {table} based on default columns")
+                        entity.select(column, table, expr=query.selects[column])
+        return source
+    return wrapper
+
+@apply_entities
 def EventSource(
     table: str,
     query: ttypes.Query,
     topic: str = None,
     is_cumulative: bool = None,
+    entities: dict[str, Entity] = None,
+    entity_registry: EntityRegister = None,
 ) -> ttypes.Source:
     """
     Event Sources represent data that gets generated over-time.
@@ -33,11 +71,14 @@ def EventSource(
     )
 
 
+@apply_entities
 def EntitySource(
     snapshot_table: str,
     query: ttypes.Query,
     mutation_table: str = None,
     mutation_topic: str = None,
+    entities: dict[str, Entity] = None,
+    entity_registry: EntityRegister = None,
 ) -> ttypes.Source:
     """
     Entity Sources represent data that gets mutated over-time - at row-level. This is a group of three data elements.
@@ -68,8 +109,8 @@ def EntitySource(
         )
     )
 
-
-def JoinSource(join: ttypes.Join, query: ttypes.Query = None) -> ttypes.Source:
+@apply_entities
+def JoinSource(join: ttypes.Join, query: ttypes.Query = None, entities: dict[str, Entity] = None, entity_registry: EntityRegister = None) -> ttypes.Source:
     """
     The output of a join can be used as a source for `GroupBy`.
     Useful for expressing complex computation in chronon.

--- a/python/src/ai/chronon/utils.py
+++ b/python/src/ai/chronon/utils.py
@@ -235,8 +235,9 @@ def get_mod_and_var_name_from_gc(obj, mod_prefix):
 
 
 def __set_name(obj, cls, mod_prefix):
+    if obj is not None and hasattr(obj, "metaData") and obj.metaData.name is not None:
+        return obj.metaData.name
     module_qualifier = get_mod_name_from_gc(obj, mod_prefix)
-
     module = importlib.import_module(module_qualifier)
     eo.import_module_set_name(module, cls)
 

--- a/python/test/canary/compiled/group_bys/gcp/dim_merchants.v1__0
+++ b/python/test/canary/compiled/group_bys/gcp/dim_merchants.v1__0
@@ -5,6 +5,7 @@
   "metaData": {
     "columnHashes": {
       "listing_id": "56b684bc2ca64fd442ccd845604e5e70",
+      "merchant_id": "938b95eedc1ebfc3f60b417c2b6d0e21",
       "primary_category": "62491a3e7c13a27a3eeb765ba460169f"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_exports_dim_merchants__0_with_offset_0\", \"spec\": \"data.gcp_exports_dim_merchants__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
@@ -85,6 +86,7 @@
         "query": {
           "selects": {
             "listing_id": "merchant_id",
+            "merchant_id": "merchant_id",
             "primary_category": "primary_category"
           },
           "startPartition": "2025-01-01"

--- a/python/test/canary/compiled/group_bys/gcp/item_event_canary.actions_pubsub_v2__0
+++ b/python/test/canary/compiled/group_bys/gcp/item_event_canary.actions_pubsub_v2__0
@@ -133,6 +133,7 @@
       "events": {
         "query": {
           "selects": {
+            "EXPLODE(TRANSFORM(SPLIT(COALESCE(attributes['sold_listing_ids'], attributes['listing_id']), ','), e -> CAST(e AS LONG)))": "EXPLODE(TRANSFORM(SPLIT(COALESCE(attributes['sold_listing_ids'], attributes['listing_id']), ','), e -> CAST(e AS LONG)))",
             "add_cart": "IF(event_type = 'backend_add_to_cart', 1, 0)",
             "favorite": "IF(event_type = 'backend_favorite_item2', 1, 0)",
             "listing_id": "EXPLODE(TRANSFORM(SPLIT(COALESCE(attributes['sold_listing_ids'], attributes['listing_id']), ','), e -> CAST(e AS LONG)))",

--- a/python/test/canary/compiled/group_bys/gcp/item_event_canary.actions_v1__0
+++ b/python/test/canary/compiled/group_bys/gcp/item_event_canary.actions_v1__0
@@ -133,6 +133,7 @@
       "events": {
         "query": {
           "selects": {
+            "EXPLODE(TRANSFORM(SPLIT(COALESCE(attributes['sold_listing_ids'], attributes['listing_id']), ','), e -> CAST(e AS LONG)))": "EXPLODE(TRANSFORM(SPLIT(COALESCE(attributes['sold_listing_ids'], attributes['listing_id']), ','), e -> CAST(e AS LONG)))",
             "add_cart": "IF(event_type = 'backend_add_to_cart', 1, 0)",
             "favorite": "IF(event_type = 'backend_favorite_item2', 1, 0)",
             "listing_id": "EXPLODE(TRANSFORM(SPLIT(COALESCE(attributes['sold_listing_ids'], attributes['listing_id']), ','), e -> CAST(e AS LONG)))",

--- a/python/test/canary/compiled/joins/gcp/demo.v1__1
+++ b/python/test/canary/compiled/joins/gcp/demo.v1__1
@@ -622,6 +622,7 @@
         "metaData": {
           "columnHashes": {
             "listing_id": "56b684bc2ca64fd442ccd845604e5e70",
+            "merchant_id": "938b95eedc1ebfc3f60b417c2b6d0e21",
             "primary_category": "62491a3e7c13a27a3eeb765ba460169f"
           },
           "executionInfo": {
@@ -700,6 +701,7 @@
               "query": {
                 "selects": {
                   "listing_id": "merchant_id",
+                  "merchant_id": "merchant_id",
                   "primary_category": "primary_category"
                 },
                 "startPartition": "2025-01-01"
@@ -747,6 +749,7 @@
       "listing_id_tags": "b4a3e64fad103c2caf6fcadb2e68f1dd",
       "listing_id_weight_grams": "7d01ad6aa1db30922ff461f2d0d62ee7",
       "merchant__listing_id_listing_id": "74857a06805db28ecb0d7e350f031dfd",
+      "merchant__listing_id_merchant_id": "74857a06805db28ecb0d7e350f031dfd",
       "merchant__listing_id_primary_category": "c4a356b0561263aa879220c3829eb41f",
       "row_id": "596506e0a4fef5508ebdcda7e6eb1072",
       "ts": "d1ae44a8f84a262685dbf1bdb9f8d46e",

--- a/python/test/canary/compiled/joins/gcp/item_event_join.canary_combined_v1__0
+++ b/python/test/canary/compiled/joins/gcp/item_event_join.canary_combined_v1__0
@@ -134,6 +134,7 @@
             "events": {
               "query": {
                 "selects": {
+                  "EXPLODE(TRANSFORM(SPLIT(COALESCE(attributes['sold_listing_ids'], attributes['listing_id']), ','), e -> CAST(e AS LONG)))": "EXPLODE(TRANSFORM(SPLIT(COALESCE(attributes['sold_listing_ids'], attributes['listing_id']), ','), e -> CAST(e AS LONG)))",
                   "add_cart": "IF(event_type = 'backend_add_to_cart', 1, 0)",
                   "favorite": "IF(event_type = 'backend_favorite_item2', 1, 0)",
                   "listing_id": "EXPLODE(TRANSFORM(SPLIT(COALESCE(attributes['sold_listing_ids'], attributes['listing_id']), ','), e -> CAST(e AS LONG)))",

--- a/python/test/canary/compiled/joins/gcp/item_event_join.canary_streaming_v1__0
+++ b/python/test/canary/compiled/joins/gcp/item_event_join.canary_streaming_v1__0
@@ -134,6 +134,7 @@
             "events": {
               "query": {
                 "selects": {
+                  "EXPLODE(TRANSFORM(SPLIT(COALESCE(attributes['sold_listing_ids'], attributes['listing_id']), ','), e -> CAST(e AS LONG)))": "EXPLODE(TRANSFORM(SPLIT(COALESCE(attributes['sold_listing_ids'], attributes['listing_id']), ','), e -> CAST(e AS LONG)))",
                   "add_cart": "IF(event_type = 'backend_add_to_cart', 1, 0)",
                   "favorite": "IF(event_type = 'backend_favorite_item2', 1, 0)",
                   "listing_id": "EXPLODE(TRANSFORM(SPLIT(COALESCE(attributes['sold_listing_ids'], attributes['listing_id']), ','), e -> CAST(e AS LONG)))",

--- a/python/test/canary/compiled/model_transforms/gcp/listing.v1__2
+++ b/python/test/canary/compiled/model_transforms/gcp/listing.v1__2
@@ -670,6 +670,7 @@
                       "query": {
                         "selects": {
                           "listing_id": "merchant_id",
+                          "merchant_id": "merchant_id",
                           "primary_category": "primary_category"
                         },
                         "startPartition": "2025-01-01"

--- a/python/test/canary/entities/entities.py
+++ b/python/test/canary/entities/entities.py
@@ -1,0 +1,23 @@
+from ai.chronon.repo.entity_register import Entity, EntityRegister
+
+listing = Entity(
+    name="listing",
+    description="A listing is a product that is for sale on the platform.",
+    default=["listing_id", "id_listing", "listing"],
+)
+
+merchant = Entity(
+    name="merchant",
+    description="A merchant is a seller on the platform.",
+    default=["merchant_id", "id_merchant", "merchant"],
+)
+
+user = Entity(
+    name="customer",
+    description="A user is a customer on the platform.",
+)
+
+entity_register = EntityRegister()
+entity_register.register_entity(listing)
+entity_register.register_entity(merchant)
+entity_register.register_entity(user)

--- a/python/test/canary/group_bys/gcp/dim_listings.py
+++ b/python/test/canary/group_bys/gcp/dim_listings.py
@@ -3,20 +3,20 @@ from staging_queries.gcp import exports
 from ai.chronon.group_by import GroupBy
 from ai.chronon.query import Query, selects
 from ai.chronon.source import EntitySource
+from entities.entities import listing, merchant, entity_register
 
 """
 This GroupBy creates a simple passthrough transformation on the dim_listings table.
 It selects key columns from the dimension table with no aggregations,
 providing a clean interface to listing attributes for joins and feature engineering.
 """
-
 source = EntitySource(
     # BigQuery table written directly by the batch process
     snapshot_table=exports.dim_listings.table,
     query=Query(
         selects=selects(
             listing_id="listing_id",
-            merchant_id="merchant_id", 
+            merchant_id="merchant_id",
             headline="headline",
             brief_description="brief_description",
             long_description="long_description",
@@ -35,12 +35,13 @@ source = EntitySource(
         ),
         start_partition="2025-01-01"
     ),
-    
+    entity_registry=entity_register,
 )
+
 
 v1 = GroupBy(
     sources=[source],
-    keys=["listing_id"],  # Key by listing_id for point lookups
+    keys=[listing],  # Key by listing_id for point lookups
     online=True,
     version=0,
     aggregations=None,  # No aggregations - this is a simple passthrough

--- a/python/test/canary/group_bys/gcp/dim_merchants.py
+++ b/python/test/canary/group_bys/gcp/dim_merchants.py
@@ -3,6 +3,7 @@ from staging_queries.gcp import exports
 from ai.chronon.group_by import GroupBy
 from ai.chronon.query import Query, selects
 from ai.chronon.source import EntitySource
+from entities.entities import merchant
 
 """
 This GroupBy creates a simple passthrough transformation on the dim_listings table.
@@ -20,11 +21,12 @@ source = EntitySource(
         ),
         start_partition="2025-01-01"
     ),
+    entities={"listing_id": merchant},
 )
 
 v1 = GroupBy(
     sources=[source],
-    keys=["listing_id"],  # Key by listing_id for point lookups
+    keys=[merchant],  # Key by listing_id for point lookups
     online=True,
     version=0,
     aggregations=None,  # No aggregations - this is a simple passthrough

--- a/python/test/canary/group_bys/gcp/item_event_canary.py
+++ b/python/test/canary/group_bys/gcp/item_event_canary.py
@@ -3,6 +3,8 @@ from gen_thrift.api.ttypes import EventSource, Source
 from ai.chronon.group_by import Aggregation, GroupBy, Operation
 from ai.chronon.query import Query, selects
 from ai.chronon.types import ConfigProperties, EnvironmentVariables
+from entities.entities import listing, entity_register
+from ai.chronon.source import EventSource
 
 _action_events = [
     "backend_add_to_cart",
@@ -14,8 +16,7 @@ _action_events_csv = ", ".join([f"'{event}'" for event in _action_events])
 _action_events_filter = f"event_type in ({_action_events_csv})"
 
 def build_source(topic: str) -> Source:
-    return Source(
-        events=EventSource(
+    return EventSource(
             # This source table contains a custom struct ('attributes') that enables
             # attributes['key'] style access pattern in a BQ native table.
             table="data.item_events_parquet_compat_partitioned",
@@ -31,13 +32,13 @@ def build_source(topic: str) -> Source:
                 wheres=[_action_events_filter],
                 time_column="timestamp",
             ),
+            entity_registry=entity_register,
         )
-    )
 
 def build_actions_groupby(source: Source) -> GroupBy:
     return GroupBy(
         sources=[source],
-        keys=["listing_id"],
+        keys=[listing],
         online=True,
         version=0,
         aggregations=[

--- a/python/test/canary/group_bys/gcp/purchases.py
+++ b/python/test/canary/group_bys/gcp/purchases.py
@@ -2,28 +2,30 @@ from gen_thrift.api.ttypes import EventSource, Source
 
 from ai.chronon.group_by import Aggregation, GroupBy, Operation, TimeUnit, Window
 from ai.chronon.query import Query, selects
-
+from ai.chronon.source import EventSource
+from entities.entities import user
 """
 This GroupBy aggregates metrics about a user's previous purchases in various windows.
 """
 
 # This source is raw purchase events. Every time a user makes a purchase, it will be one entry in this source.
-source = Source(
-    events=EventSource(
-        table="data.purchases", # This points to the log table in the warehouse with historical purchase events, updated in batch daily
-        topic=None, # See the 'returns' GroupBy for an example that has a streaming source configured. In this case, this would be the streaming source topic that can be listened to for realtime events
-        query=Query(
-            selects=selects("user_id","purchase_price"), # Select the fields we care about
-            start_partition="2023-11-01",
-            time_column="ts") # The event time
-    ))
+source = EventSource(
+    table="data.purchases", # This points to the log table in the warehouse with historical purchase events, updated in batch daily
+    topic=None, # See the 'returns' GroupBy for an example that has a streaming source configured. In this case, this would be the streaming source topic that can be listened to for realtime events
+    query=Query(
+        selects=selects("user_id", "purchase_price"), # Select the fields we care about
+        start_partition="2023-11-01",
+        time_column="ts" # The event time
+    ),
+    entities={"user_id": user},
+)
 
 window_sizes = [Window(length=day, time_unit=TimeUnit.DAYS) for day in [1, 3, 7]] # Define some window sizes to use below
 
 
 v1_dev = GroupBy(
     sources=[source],
-    keys=["user_id"], # We are aggregating by user
+    keys=[user], # We are aggregating by user
     online=True,
     version=0,
     aggregations=[Aggregation(
@@ -50,7 +52,7 @@ v1_dev = GroupBy(
 
 v1_test = GroupBy(
     sources=[source],
-    keys=["user_id"], # We are aggregating by user
+    keys=[user], # We are aggregating by user
     online=True,
     version=0,
     aggregations=[Aggregation(
@@ -76,21 +78,21 @@ v1_test = GroupBy(
 )
 
 # This source is raw purchase events. Every time a user makes a purchase, it will be one entry in this source.
-source_notds = Source(
-    events=EventSource(
+source_notds = EventSource(
         table="data.purchases_notds", # This points to the log table in the warehouse with historical purchase events, updated in batch daily
         topic=None, # See the 'returns' GroupBy for an example that has a streaming source configured. In this case, this would be the streaming source topic that can be listened to for realtime events
         query=Query(
-            selects=selects("user_id","purchase_price"), # Select the fields we care about
+            selects=selects("user_id", "purchase_price"), # Select the fields we care about
             time_column="ts",
             start_partition="2023-11-01",
             partition_column="notds"
-        ) # The event time
-    ))
+        ), # The event time  
+    entities={"user_id": user},
+)
 
 v1_test_notds = GroupBy(
     sources=[source_notds],
-    keys=["user_id"], # We are aggregating by user
+    keys=[user], # We are aggregating by user
     online=True,
     version=0,
     aggregations=[Aggregation(
@@ -117,7 +119,7 @@ v1_test_notds = GroupBy(
 
 v1_dev_notds = GroupBy(
     sources=[source_notds],
-    keys=["user_id"], # We are aggregating by user
+    keys=[user], # We are aggregating by user
     online=True,
     version=0,
     aggregations=[Aggregation(

--- a/python/test/canary/group_bys/gcp/user_activities.py
+++ b/python/test/canary/group_bys/gcp/user_activities.py
@@ -3,7 +3,9 @@ from staging_queries.gcp import exports
 
 from ai.chronon.group_by import Aggregation, GroupBy, Operation, TimeUnit, Window
 from ai.chronon.query import Query, selects
+from ai.chronon.source import EventSource
 from ai.chronon.types import EnvironmentVariables
+from entities.entities import user
 
 """
 This GroupBy aggregates user activity metrics from the user-activities-v0 topic.
@@ -11,8 +13,7 @@ It tracks various user behaviors (views, clicks, purchases, favorites, add_to_ca
 with last_k, sum, and average aggregations over multiple time windows.
 """
 
-source = Source(
-    events=EventSource(
+source = EventSource(
         # This will be the BigQuery table that receives the PubSub data
         table=exports.user_activities.table,
         topic="pubsub://user-activities-v2/project=canary-443022/subscription=user-activities-v2-sub/serde=pubsub_schema/schemaId=user-activities",
@@ -35,8 +36,8 @@ source = Source(
             ),
             time_column="unix_millis(TIMESTAMP(event_time_ms))",
         ),
+        entities={"user_id": user},
     )
-)
 
 # Define window sizes for aggregations (1d, 7d, 14d, 30d)
 window_sizes = [Window(length=days, time_unit=TimeUnit.DAYS) for days in [1, 7, 14, 30]]
@@ -73,7 +74,7 @@ aggregations.extend([
 
 v1 = GroupBy(
     sources=[source],
-    keys=["user_id"],  # Aggregate by user
+    keys=[user],  # Aggregate by user
     online=True,
     version=1,
     aggregations=aggregations,

--- a/python/test/canary/group_bys/gcp/user_activities_chained.py
+++ b/python/test/canary/group_bys/gcp/user_activities_chained.py
@@ -3,6 +3,7 @@ from joins.gcp import demo_parent
 
 from ai.chronon.group_by import Aggregation, GroupBy, Operation, TimeUnit, Window
 from ai.chronon.types import EnvironmentVariables
+from entities.entities import user
 
 """
 Chained GroupBy that effectively enriches the last n listings the user interacted with to
@@ -10,7 +11,7 @@ include listing price information.
 """
 chained_user_gb = GroupBy(
     sources=[demo_parent.upstream_join_source],
-    keys=["user_id"],
+    keys=[user],
     online=True,
     version=0,
     aggregations=[

--- a/python/test/canary/joins/gcp/demo_parent.py
+++ b/python/test/canary/joins/gcp/demo_parent.py
@@ -1,13 +1,12 @@
-from gen_thrift.api.ttypes import EventSource, Source, JoinSource
-
 from group_bys.gcp import dim_listings, dim_merchants
 from staging_queries.gcp import exports
 
 from ai.chronon.group_by import Aggregation, Operation, TimeUnit, Window
 from ai.chronon.join import Derivation, Join, JoinPart
 from ai.chronon.query import Query, selects
-from ai.chronon.source import EventSource
+from ai.chronon.source import EventSource, JoinSource
 from ai.chronon.types import EnvironmentVariables
+from entities.entities import user, listing
 
 source = EventSource(
     # This will be the BigQuery table that receives the PubSub data
@@ -17,6 +16,7 @@ source = EventSource(
         selects=selects(user_id="user_id", listing_id="listing_id", row_id="event_id"),
         time_column="unix_millis(TIMESTAMP(event_time_ms))",
     ),
+    entities={"user_id": user, "listing_id": listing},
 )
 
 """
@@ -50,4 +50,5 @@ upstream_join_source = JoinSource(
         ),
         time_column="ts",
     ),
+    entities={"user_id": user, "listing_id": listing},
 )

--- a/python/test/test_entity_register.py
+++ b/python/test/test_entity_register.py
@@ -1,0 +1,224 @@
+#     Copyright (C) 2023 The Chronon Authors.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+
+import json
+
+from gen_thrift.api.ttypes import Operation
+from gen_thrift.common.ttypes import TimeUnit
+
+from ai.chronon.repo.entity_register import Entity, EntityRegister, window_to_str_pretty, op_to_str
+from ai.chronon.query import Query, selects
+from ai.chronon.source import EventSource, EntitySource
+from ai.chronon.group_by import GroupBy, Aggregation, Operation as AggOperation, TimeUnit as AggTimeUnit, Window
+from ai.chronon.join import Join, JoinPart
+
+
+class TestHelperFunctions:
+    """Test helper functions for formatting."""
+
+    def test_window_to_str_pretty_days(self):
+        result = window_to_str_pretty(7, TimeUnit.DAYS)
+        assert result == "7d"
+
+    def test_window_to_str_pretty_hours(self):
+        result = window_to_str_pretty(24, TimeUnit.HOURS)
+        assert result == "24h"
+
+    def test_window_to_str_pretty_minutes(self):
+        result = window_to_str_pretty(30, TimeUnit.MINUTES)
+        assert result == "30m"
+
+    def test_op_to_str_sum(self):
+        result = op_to_str(Operation.SUM)
+        assert result == "sum"
+
+    def test_op_to_str_count(self):
+        result = op_to_str(Operation.COUNT)
+        assert result == "count"
+
+    def test_op_to_str_last(self):
+        result = op_to_str(Operation.LAST)
+        assert result == "last"
+
+    def test_op_to_str_average(self):
+        result = op_to_str(Operation.AVERAGE)
+        assert result == "average"
+
+
+class TestEntityIntegration:
+    """Integration tests for Entity with Sources."""
+
+    def test_entity_registration_with_entity_mapping(self):
+        """Test that entity is registered when source uses entities parameter."""
+        # Create entity and register
+        user_entity = Entity(
+            name="user",
+            description="User entity for testing",
+            default=["user_id"]
+        )
+        entity_register = EntityRegister()
+        Entity._global_register = entity_register
+
+        # Create source with entity mapping
+        source = EventSource(
+            table="data.user_events",
+            query=Query(
+                selects=selects(
+                    user_id="user_id",
+                    event_type="event_type"
+                ),
+                time_column="ts"
+            ),
+            entities={"user_id": user_entity}
+        )
+
+        # Verify entity was registered
+        assert "user" in entity_register.entity_registrations
+        assert entity_register.entity_registrations["user"] == user_entity
+
+        # Verify entity has select registration for the table
+        assert "data.user_events" in user_entity.select_registrations
+        assert user_entity.select_registrations["data.user_events"].column == "user_id"
+        assert user_entity.select_registrations["data.user_events"].expr == "user_id"
+
+        # Create a GroupBy using the entity as a key
+        group_by = GroupBy(
+            sources=[source],
+            keys=[user_entity],
+            online=True,
+            aggregations=[
+                Aggregation(
+                    input_column="event_type",
+                    operation=AggOperation.COUNT,
+                    windows=[Window(length=7, time_unit=AggTimeUnit.DAYS)]
+                )
+            ]
+        )
+
+        # Set the name on the metadata for Join to work
+        group_by.metaData.name = "user_event_stats"
+
+        # Verify aggregations are registered for the entity
+        assert "data.user_events" in user_entity.aggregation_registrations
+        assert len(user_entity.aggregation_registrations["data.user_events"]) == 1
+
+        agg_info = user_entity.aggregation_registrations["data.user_events"][0]
+        assert agg_info["groupBy"] == group_by
+        assert agg_info["keys"] == ["user_id"]  # Should be the final key column
+        assert len(agg_info["aggregations"]) == 1
+        assert agg_info["aggregations"][0].inputColumn == "event_type"
+        assert agg_info["aggregations"][0].operation == AggOperation.COUNT
+
+        # Create a Join that uses the GroupBy
+        join = Join(
+            left=source,
+            right_parts=[
+                JoinPart(
+                    group_by=group_by,
+                    key_mapping={"user_id": "user_id"}
+                )
+            ],
+            row_ids=None
+        )
+
+        # Set the name on the join metadata for export
+        join.metaData.name = "user_features_join"
+
+        # Verify feature query is registered for the entity
+        assert "data.user_events" in user_entity.feature_query_registrations
+        assert len(user_entity.feature_query_registrations["data.user_events"]) == 1
+
+        query_info = user_entity.feature_query_registrations["data.user_events"][0]
+        assert query_info["join"] == join
+        assert query_info["table"] == "data.user_events"
+
+        # Test export methods
+        # Test pretty_print
+        result = user_entity.pretty_print()
+        assert "user" in result
+        assert "User entity for testing" in result
+        assert "data.user_events" in result
+        assert "event_type" in result
+        assert "Feature Queries:" in result
+        assert "Join:" in result
+
+        # Test to_json
+        json_output = entity_register.to_json()
+        json_data = json.loads(json_output)
+        assert "entities" in json_data
+        assert "user" in json_data["entities"]
+        assert json_data["entities"]["user"]["name"] == "user"
+
+        # Verify aggregation info is in JSON
+        assert "feature_definitions" in json_data["entities"]["user"]
+        assert "data.user_events" in json_data["entities"]["user"]["feature_definitions"]
+        feature_def = json_data["entities"]["user"]["feature_definitions"]["data.user_events"]
+        assert feature_def["input_column"] == "user_id"
+        assert len(feature_def["group_bys"]) == 1
+        assert len(feature_def["group_bys"][0]["aggregations"]) == 1
+        assert feature_def["group_bys"][0]["aggregations"][0]["operation"] == "count"
+        assert feature_def["group_bys"][0]["aggregations"][0]["windows"] == ["7d"]
+
+        # Verify feature query (Join) info is in JSON
+        assert "feature_queries" in json_data["entities"]["user"]
+        assert "data.user_events" in json_data["entities"]["user"]["feature_queries"]
+        assert len(json_data["entities"]["user"]["feature_queries"]["data.user_events"]) == 1
+
+        # Test to_csv
+        csv_output = entity_register.to_csv()
+        assert "entity,input_column,operation,window,group_by,joins,online" in csv_output
+        assert "user" in csv_output
+        assert "user_id" in csv_output
+        assert "count" in csv_output
+        assert "7d" in csv_output
+        assert "true" in csv_output  # online=True
+        # CSV should include the join in the joins column (though join name might not be set)
+        lines = csv_output.strip().split('\n')
+        assert len(lines) >= 2  # Header + data
+
+        # Cleanup
+        Entity._global_register = None
+
+    def test_entity_registration_with_entity_registry(self):
+        """Test that entity is auto-registered when source uses entity_registry parameter."""
+        # Create entity with default columns
+        listing_entity = Entity(
+            name="listing",
+            description="Listing entity",
+            default=["listing_id", "id_listing"]
+        )
+        entity_register = EntityRegister()
+        entity_register.register_entity(listing_entity)
+        Entity._global_register = entity_register
+
+        # Create source with entity_registry - should auto-register based on default columns
+        source = EntitySource(
+            snapshot_table="data.listings",
+            query=Query(
+                selects=selects(
+                    listing_id="listing_id",
+                    title="title",
+                    price="price"
+                ),
+                start_partition="2025-01-01"
+            ),
+            entity_registry=entity_register
+        )
+
+        # Verify entity has select registration for the table
+        assert "data.listings" in listing_entity.select_registrations
+        assert listing_entity.select_registrations["data.listings"].column == "listing_id"
+
+        # Cleanup
+        Entity._global_register = None


### PR DESCRIPTION
## Summary

We add a concept of `Entity` which can be used for defining and semantically bonding different group bys and joins.

For this the approach is to be as backwards compatible as possible while providing the visibility required. 
If entities are not used for definition, it works as well as before.
If entities are used during definition, we register these usages and then after compiling can provide a json or plaintext of the features per entity.

TODO: See if there's a less prone to mistakes way of associating a source to an entity (right now it's being done during definition. 

TODO: csv output.

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced entity registration framework to define and manage feature entities
  * Feature configurations now accept entity references for keys and field mappings
  * Added --entity-summary and --entity-csv CLI options to export entity metadata during compilation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->