### PR TITLE
relax Backfill join temporal window boundary

### DIFF
--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/SawtoothAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/SawtoothAggregator.scala
@@ -185,7 +185,7 @@ class SawtoothAggregator(aggregations: Seq[Aggregation], inputSchema: Seq[(Strin
 
     while (queryIdx < sortedEndTimes.length) {
 
-      while (inputIdx < sortedInputs.length && sortedInputs(inputIdx).ts < sortedEndTimes(queryIdx).ts) {
+      while (inputIdx < sortedInputs.length && sortedInputs(inputIdx).ts <= sortedEndTimes(queryIdx).ts) {
         queryIr = windowedAggregator.update(queryIr, sortedInputs(inputIdx))
         inputIdx += 1
       }
@@ -219,7 +219,7 @@ class SawtoothAggregator(aggregations: Seq[Aggregation], inputSchema: Seq[(Strin
     }
 
     sortedEndTimes.indices.iterator.map { queryIdx =>
-      while (inputIdx < sortedInputs.length && sortedInputs(inputIdx).ts < sortedEndTimes(queryIdx).ts) {
+      while (inputIdx < sortedInputs.length && sortedInputs(inputIdx).ts <= sortedEndTimes(queryIdx).ts) {
         queryIr = windowedAggregator.update(queryIr, sortedInputs(inputIdx))
         inputIdx += 1
       }

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/SawtoothAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/SawtoothAggregator.scala
@@ -127,9 +127,10 @@ class SawtoothAggregator(aggregations: Seq[Aggregation], inputSchema: Seq[(Strin
       val row = inputs.next()
       val inputTs = row.ts
       var updateIndex = util.Arrays.binarySearch(sortedEndTimes, inputTs)
-      if (updateIndex >= 0) { // we found an exact match so we need to search further to get updateIndex
-        while (updateIndex < sortedEndTimes.length && sortedEndTimes(updateIndex) == inputTs)
-          updateIndex += 1
+      if (updateIndex >= 0) { // we found an exact match - include event at queryTs in the window
+        // Find the FIRST occurrence of this timestamp to ensure temporal window includes boundary
+        while (updateIndex > 0 && sortedEndTimes(updateIndex - 1) == inputTs)
+          updateIndex -= 1
       } else {
         // binary search didn't find an exact match
         updateIndex = math.abs(updateIndex) - 1

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/NaiveAggregator.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/NaiveAggregator.scala
@@ -42,7 +42,8 @@ class NaiveAggregator(aggregator: RowAggregator,
 
           val windowStart = TsUtils.round(queryTime - windows(col).millis, tailHops(col))
 
-          if (windowStart <= inputRow.ts && inputRow.ts < TsUtils.round(queryTime, headRoundingMillis)) {
+          // Use <= for inclusive temporal window boundary [T-window, T]
+          if (windowStart <= inputRow.ts && inputRow.ts <= TsUtils.round(queryTime, headRoundingMillis)) {
             aggregator.columnAggregators(col).update(results(endTimeIndex), inputRow)
           }
         }

--- a/docs/source/authoring_features/Join.md
+++ b/docs/source/authoring_features/Join.md
@@ -212,7 +212,7 @@ The following explain the backfill accuracy for each possible combination of lef
 
 ### Left side events, right side streaming events
 
-In this case you will get point-in-time correct feature backfills in your join table, meaning that every feature for this GroupBy will be accurate as of the millisecond that is provided on the left side `time_column`. For example, if a row on the left side has a timestamp of `2023-12-20 12:01:01.923` and an aggregation in the `GroupBy` has a `10 day` window, then only raw events between `2023-12-10 12:01:01.923` and `2023-12-20 12:01:01.922` will be included in the aggregation value.
+In this case you will get point-in-time correct feature backfills in your join table, meaning that every feature for this GroupBy will be accurate as of the millisecond that is provided on the left side `time_column`. For example, if a row on the left side has a timestamp of `2023-12-20 12:01:01.923` and an aggregation in the `GroupBy` has a `10 day` window, then only raw events between `2023-12-10 12:01:01.923` and `2023-12-20 12:01:01.923` will be included in the aggregation value.
 
 This is because these are the values that would have been observed online for that feature at that particular left side timestamp (values are updated in realtime).
 


### PR DESCRIPTION
## Summary

This PR fixes a bug in temporal join backfills where events occurring at the exact same timestamp as a query were incorrectly excluded from the aggregation window, resulting in NULL values instead of the correct aggregated results.

The bug affected both execution modes:
  - skewFree mode (spark.chronon.join.backfill.mode.skewFree=true)
  - non-skewFree mode (spark.chronon.join.backfill.mode.skewFree=false)

---
**Problem Description**

Issue: Temporal Window Boundary Inconsistency

In the documentation example at https://zipline.ai/docs/authoring_features/Join#left-side-events-right-side-streaming-events, for a left-side row with timestamp 2023-12-20 12:01:01.923, the aggregation window is defined as:
  - Range: [2023-12-10 12:01:01.923, 2023-12-20 12:01:01.923)
  - Excluded: The right boundary 2023-12-20 12:01:01.923 itself is not included

Inconsistency Between Online and Offline Behavior

Online Fetch (Streaming)
  - When a GroupBy key appears for the first time, aggregations like COUNT return a non-null value (e.g., 1)
  - This is because queryTs is always > event_time, so the current event is included in its own aggregation

  Backfill Join (Batch)
  - When a GroupBy key appears for the first time, aggregations return NULL
  - This is because the current event at timestamp T is excluded from the window [T-window, T)
  - Consequently, backfilled values are systematically off by 1 compared to online fetch values

---
**Root Cause**
Two different bugs in two execution paths:
  1. SkewFree mode (cumulateAndFinalizeSortedIterator method):
    - Used strict inequality sortedInputs(inputIdx).ts < sortedEndTimes(queryIdx).ts
    - Events at ts == queryTs were excluded
  2. Non-skewFree mode (cumulate method):
    - Binary search logic would skip forward past matching timestamps
    - Events at ts == queryTs were added to the next query's window instead

---
**Use Cases Affected**
This fix is especially important for:
  - Self-joins where left and right sources are the same table
  - Temporal accuracy joins with events at identical timestamps
  - Fraud detection and other use cases sensitive to first-occurrence detection


## Checklist
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [x] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed temporal window boundary handling to include events whose timestamps equal window boundaries, ensuring aggregations count and sum those events.

* **Tests**
  * Added test coverage verifying inclusion of events at window boundaries (new cases added to aggregation tests).

* **Documentation**
  * Updated example to reflect the inclusive boundary behavior (adjusted example timestamp).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->