### PR TITLE
feat: seeder - a module for seeding configs for testing in cloud

### DIFF
--- a/cloud_aws/src/main/scala/ai/chronon/integrations/aws/AwsFormatProvider.scala
+++ b/cloud_aws/src/main/scala/ai/chronon/integrations/aws/AwsFormatProvider.scala
@@ -1,0 +1,63 @@
+package ai.chronon.integrations.aws
+
+import ai.chronon.spark.catalog.{DefaultFormatProvider, Format, Iceberg}
+import org.apache.iceberg.aws.glue.GlueCatalog
+import org.apache.iceberg.spark.SparkCatalog
+import org.apache.spark.sql.SparkSession
+
+/** AWS-specific FormatProvider that handles Iceberg tables with AWS Glue Catalog.
+  *
+  * When using Iceberg with Glue, tables are managed through Iceberg's catalog
+  * and should be treated as Iceberg format rather than Hive format.
+  *
+  * Configuration example:
+  * {{{
+  * spark.sql.catalog.spark_catalog=org.apache.iceberg.spark.SparkCatalog
+  * spark.sql.catalog.spark_catalog.catalog-impl=org.apache.iceberg.aws.glue.GlueCatalog
+  * spark.sql.catalog.spark_catalog.warehouse=s3://bucket/path/
+  * }}}
+  */
+class AwsFormatProvider(override val sparkSession: SparkSession) extends DefaultFormatProvider(sparkSession) {
+
+  override def readFormat(tableName: String): Option[Format] = {
+    // Check if Iceberg format is explicitly configured
+    val configuredFormat = sparkSession.conf.getOption("spark.chronon.table_write.format")
+    if (configuredFormat.exists(_.equalsIgnoreCase("iceberg"))) {
+      logger.info(
+        s"Iceberg format configured via spark.chronon.table_write.format, using Iceberg for table: $tableName")
+      return Some(Iceberg)
+    }
+
+    try {
+      val parsedCatalog = Format.getCatalog(tableName)(sparkSession)
+      logger.info(s"Parsed catalog for table $tableName: $parsedCatalog")
+
+      val cat = sparkSession.sessionState.catalogManager.catalog(parsedCatalog)
+      logger.info(s"Catalog type for $tableName: ${cat.getClass.getName}")
+
+      cat match {
+        case iceberg: SparkCatalog =>
+          logger.info(s"Found SparkCatalog for $tableName")
+          val icebergCat = iceberg.icebergCatalog()
+          logger.info(s"Iceberg catalog type: ${icebergCat.getClass.getName}")
+
+          if (icebergCat.isInstanceOf[GlueCatalog]) {
+            // This is an Iceberg table backed by AWS Glue
+            logger.info(s"Detected Iceberg table with Glue catalog: $tableName")
+            Some(Iceberg)
+          } else {
+            logger.info(s"SparkCatalog found but not using GlueCatalog, falling back to default")
+            super.readFormat(tableName)
+          }
+        case _ =>
+          logger.info(s"Not a SparkCatalog (${cat.getClass.getName}), falling back to default format detection")
+          // Fall back to default format detection
+          super.readFormat(tableName)
+      }
+    } catch {
+      case e: Exception =>
+        logger.error(s"Error detecting format for table $tableName: ${e.getMessage}", e)
+        throw e
+    }
+  }
+}

--- a/seeder/README.md
+++ b/seeder/README.md
@@ -1,0 +1,260 @@
+# Chronon Data Seeder
+
+The Chronon Data Seeder module generates test data for Chronon tables and writes them to cloud storage. This is useful for creating test datasets when running Chronon on cloud infrastructure like AWS Glue with Iceberg.
+
+## Overview
+
+The seeder module allows you to:
+- Define table schemas programmatically using Scala
+- Generate realistic test data with configurable cardinalities and row counts
+- Write data to cloud storage using Chronon's FormatProvider (supports Iceberg, Hudi, Delta, Parquet)
+- Seed data for both event tables and entity tables
+
+## Module Structure
+
+### Source Files
+
+- **TableSchema.scala**: Core schema definition classes
+  - `TableType` (Events/Entities) for different table types
+  - `ColumnDef` for defining column schemas with cardinality
+  - `TableSchema` for complete table definitions
+  - `SeederConfig` for grouping multiple tables
+
+- **SchemaLoader.scala**: Schema loading and validation
+  - `SeederSchema` trait for users to extend
+  - `SchemaLoader` object for loading schema definitions from compiled classes
+  - Validation logic for seeder configs
+
+- **DataSeeder.scala**: Main entry point
+  - CLI interface for running the seeder
+  - Uses TableUtils for cloud-agnostic table writing
+  - Uses DataFrameGen to generate test data based on schemas
+
+- **CanarySeeder.scala**: Example seeder implementation
+  - Defines schemas for AWS canary demo join tables
+  - Demonstrates how to create seeder configurations
+
+## Dependencies
+
+The seeder module depends on:
+- **cloud_aws**: For AWS-specific integrations
+- **spark**: For Spark SQL operations
+- **spark.test**: For DataFrameGen utility (test data generation)
+- **aggregator.test**: For Column type definitions
+
+## Building
+
+### Compile the module:
+```bash
+./mill seeder.compile
+```
+
+### Build assembly JAR:
+```bash
+./mill seeder.assembly
+```
+
+The assembly JAR will be created at: `out/seeder/2.12.18/assembly.dest/out.jar`
+
+## Usage
+
+### Creating a Seeder Schema
+
+Create a Scala object extending `SeederSchema` in your project:
+
+```scala
+package com.example
+
+import ai.chronon.api._
+import ai.chronon.seeder._
+
+object MySeeder extends SeederSchema {
+
+  val userEvents = TableSchema(
+    tableName = "demo.user_events",
+    columns = Seq(
+      ColumnDef("user_id", StringType, cardinality = 1000),
+      ColumnDef("event_type", StringType, cardinality = 10),
+      ColumnDef("value", LongType, cardinality = 10000)
+    ),
+    rowCount = 50000,
+    partitionCount = 30,
+    tableType = Events
+  )
+
+  val userProfiles = TableSchema(
+    tableName = "demo.user_profiles",
+    columns = Seq(
+      ColumnDef("user_id", StringType, cardinality = 1000),
+      ColumnDef("country", StringType, cardinality = 50),
+      ColumnDef("age", LongType, cardinality = 100)
+    ),
+    rowCount = 5000,
+    partitionCount = 7,
+    tableType = Entities
+  )
+
+  override def config: SeederConfig = SeederConfig(
+    Seq(userEvents, userProfiles)
+  )
+}
+```
+
+### Running the Seeder
+
+#### Basic Usage:
+```bash
+spark-submit --class ai.chronon.seeder.DataSeeder \
+  out/seeder/2.12.18/assembly.dest/out.jar \
+  --seeder-class com.example.MySeeder \
+  --file-format PARQUET
+```
+
+#### Dry Run (preview without writing):
+```bash
+spark-submit --class ai.chronon.seeder.DataSeeder \
+  out/seeder/2.12.18/assembly.dest/out.jar \
+  --seeder-class com.example.MySeeder \
+  --file-format PARQUET \
+  --dry-run
+```
+
+#### Available Options:
+- `--seeder-class`: Fully qualified class name of your seeder schema (required)
+- `--file-format`: Storage format (default: PARQUET). Options: PARQUET, ORC, ICEBERG, HUDI, DELTA
+- `--dry-run`: Generate and show data without writing (default: false)
+
+### Using with AWS Glue / Iceberg
+
+The seeder automatically uses Chronon's FormatProvider, which respects your Spark configuration. For AWS Glue with Iceberg:
+
+```bash
+spark-submit \
+  --class ai.chronon.seeder.DataSeeder \
+  --conf spark.sql.catalog.spark_catalog=org.apache.iceberg.spark.SparkCatalog \
+  --conf spark.sql.catalog.spark_catalog.catalog-impl=org.apache.iceberg.aws.glue.GlueCatalog \
+  --conf spark.sql.catalog.spark_catalog.warehouse=s3://your-bucket/data/tables/ \
+  --conf spark.chronon.table_write.format=iceberg \
+  out/seeder/2.12.18/assembly.dest/out.jar \
+  --seeder-class ai.chronon.seeder.CanarySeeder
+```
+
+## Table Types
+
+### Events
+Event tables have timestamps and are typically fact tables. The seeder generates:
+- Time-series data with timestamps
+- Partition column (defaults to 'ds' with format 'yyyy-MM-dd')
+
+### Entities
+Entity tables are dimension/snapshot tables. The seeder generates:
+- Static attributes
+- Partition column for snapshot versioning
+
+## CanarySeeder Example
+
+The module includes `CanarySeeder` which generates test data for the AWS canary demo join:
+
+**Tables created:**
+- `demo.user_activities` - Event data with user activity events
+- `demo.dim_listings` - Listing dimension attributes
+- `demo.dim_merchants` - Merchant dimension attributes
+
+**To run:**
+```bash
+./mill seeder.assembly
+
+spark-submit --class ai.chronon.seeder.DataSeeder \
+  out/seeder/2.12.18/assembly.dest/out.jar \
+  --seeder-class ai.chronon.seeder.CanarySeeder \
+  --file-format PARQUET
+```
+
+## Schema Definition Reference
+
+### ColumnDef
+```scala
+case class ColumnDef(
+  name: String,           // Column name
+  dataType: DataType,     // Chronon DataType (StringType, LongType, etc.)
+  cardinality: Int        // Number of unique values to generate
+)
+```
+
+### TableSchema
+```scala
+case class TableSchema(
+  tableName: String,                      // Full table name (database.table)
+  columns: Seq[ColumnDef],                // Column definitions
+  rowCount: Int = 1000,                   // Total rows to generate
+  partitionCount: Int = 10,               // Number of partitions
+  tableType: TableType = Events,          // Events or Entities
+  partitionColumn: Option[String] = None, // Override partition column name
+  partitionFormat: Option[String] = None  // Override partition format
+)
+```
+
+### SeederConfig
+```scala
+case class SeederConfig(
+  tables: Seq[TableSchema]  // List of tables to seed
+)
+```
+
+## How It Works
+
+1. **Schema Definition**: Define your table schemas using `TableSchema` objects
+2. **Class Loading**: The seeder loads your schema class at runtime using reflection
+3. **Data Generation**: Uses `DataFrameGen` from spark.test to generate realistic data based on cardinalities
+4. **Table Writing**: Uses `TableUtils` and FormatProvider to write data in the configured format
+5. **Cloud Integration**: Automatically integrates with your cloud provider (AWS Glue, GCP BigQuery, etc.)
+
+## Testing
+
+Run tests for the seeder module:
+```bash
+./mill seeder.test
+```
+
+## Integration with Chronon Workflows
+
+The seeder is designed to work seamlessly with Chronon:
+- Generates data that can be consumed by Chronon GroupBys and Joins
+- Respects partition columns and formats expected by Chronon
+- Uses the same TableUtils infrastructure as Chronon backfills
+- Compatible with all FormatProviders (AWS, GCP, local)
+
+## Troubleshooting
+
+### Compilation Issues
+If you encounter compilation issues, ensure dependencies are built:
+```bash
+./mill spark.compile
+./mill spark.test.compile
+./mill aggregator.test.compile
+./mill seeder.compile
+```
+
+### ClassNotFoundException at Runtime
+Make sure you're using the assembly JAR which includes all dependencies:
+```bash
+./mill seeder.assembly
+```
+
+### Table Already Exists
+The seeder uses `SaveMode.Overwrite` by default. If you encounter issues:
+- Check table permissions in your cloud provider
+- Verify the table location is writable
+- Ensure the format provider is correctly configured
+
+## Contributing
+
+When adding new features to the seeder:
+1. Update this README with usage examples
+2. Add tests to validate functionality
+3. Ensure compatibility with all supported FormatProviders
+4. Follow the existing code patterns in TableSchema.scala
+
+## License
+
+Licensed under the Apache License, Version 2.0. See the LICENSE.txt file in the repository root.

--- a/seeder/package.mill
+++ b/seeder/package.mill
@@ -1,0 +1,65 @@
+package build.seeder
+import mill.api._
+import mill.scalalib._
+
+// Seeder module - for generating test data on cloud infrastructure
+object `package` extends Cross[SeederModule](build.Constants.scalaVersions) with SeederModule {
+  // Provide default scala version for bracket-free access
+  override val crossValue = build.Constants.defaultScalaVersion
+}
+
+trait SeederModule extends Cross.Module[String] with build.BaseModule {
+  // Depend on cloud_aws and spark
+  def moduleDeps = Seq(
+    build.cloud_aws(crossValue),
+    build.spark(crossValue)
+  )
+
+  // Add spark.test and aggregator.test classes to both compile and runtime classpath
+  // This allows us to use DataFrameGen (from spark.test) and Column (from aggregator.test)
+  def compileClasspath = Task {
+    super.compileClasspath() ++
+      build.spark(crossValue).test.localClasspath() ++
+      build.aggregator(crossValue).test.localClasspath()
+  }
+
+  def runClasspath = Task {
+    super.runClasspath() ++
+      build.spark(crossValue).test.localClasspath() ++
+      build.aggregator(crossValue).test.localClasspath()
+  }
+
+  // Include test classes in local classpath so they're included in the assembly JAR
+  override def localClasspath = Task {
+    super.localClasspath() ++
+      build.spark(crossValue).test.localClasspath() ++
+      build.aggregator(crossValue).test.localClasspath()
+  }
+
+  def mvnDeps = build.Constants.commonDeps ++
+    build.Constants.loggingDeps ++
+    build.Constants.utilityDeps ++
+    build.Constants.sparkDeps
+
+  object test extends build.BaseTestModule {
+    def scalaVersion = crossValue
+
+    def moduleDeps = Seq(
+      build.seeder(crossValue),
+      build.spark(crossValue).test
+    )
+
+    def mvnDeps = super.mvnDeps() ++ build.Constants.testDeps
+
+    override def testFramework = "org.scalatest.tools.Framework"
+
+    def forkArgs = build.Constants.commonTestForkArgs ++ Seq(
+      "-Dspark.sql.adaptive.enabled=false",
+      "-Dspark.sql.adaptive.coalescePartitions.enabled=false",
+      "-Dspark.serializer=org.apache.spark.serializer.KryoSerializer",
+      "-Dspark.sql.hive.convertMetastoreParquet=false"
+    )
+  }
+
+  def prependShellScript = ""
+}

--- a/seeder/src/main/scala/ai/chronon/seeder/CanarySeeder.scala
+++ b/seeder/src/main/scala/ai/chronon/seeder/CanarySeeder.scala
@@ -1,0 +1,100 @@
+/*
+ *    Copyright (C) 2023 The Chronon Authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package ai.chronon.seeder
+
+import ai.chronon.api._
+
+/** Canary seeder schema for the AWS demo join: python/test/canary/compiled/joins/aws/demo.v1__1
+  *
+  * This generates test data for the three raw demo tables required by the canary:
+  * - demo.user_activities (event data with event_time partition)
+  * - demo.dim_listings (listing snapshots with ds partition)
+  * - demo.dim_merchants (merchant snapshots with ds partition)
+  *
+  * These raw tables feed into the export staging queries which then feed the join.
+  *
+  * To use this:
+  * ./mill seeder.compile
+  * ./mill seeder.assembly
+  *
+  * spark-submit --class ai.chronon.seeder.DataSeeder \
+  *   out/seeder/2.12.18/assembly.dest/out.jar \
+  *   --seeder-class ai.chronon.seeder.CanarySeeder \
+  *   --file-format PARQUET
+  */
+object CanarySeeder extends SeederSchema {
+
+  // User activities event table - source for event data
+  // This will have event_time as partition which gets converted to ds by the export
+  val userActivities = TableSchema(
+    tableName = "demo.user_activities",
+    columns = Seq(
+      ColumnDef("event_id", StringType, cardinality = 10000),
+      ColumnDef("user_id", StringType, cardinality = 100),
+      ColumnDef("listing_id", StringType, cardinality = 500),
+      ColumnDef("event_type", StringType, cardinality = 5), // view, click, purchase, favorite, add_to_cart
+      ColumnDef("device_type", StringType, cardinality = 3), // mobile, desktop, tablet
+      ColumnDef("event_time_ms", LongType, cardinality = 10000)
+    ),
+    rowCount = 2000,
+    partitionCount = 30,
+    tableType = Events,
+    partitionColumn = Some("event_time"),
+    partitionFormat = Some("yyyy-MM-dd HH:mm:ss")
+  )
+
+  // Listing dimension table - snapshot data
+  val dimListings = TableSchema(
+    tableName = "demo.dim_listings",
+    columns = Seq(
+      ColumnDef("listing_id", StringType, cardinality = 500),
+      ColumnDef("merchant_id", StringType, cardinality = 100),
+      ColumnDef("headline", StringType, cardinality = 500),
+      ColumnDef("brief_description", StringType, cardinality = 500),
+      ColumnDef("long_description", StringType, cardinality = 500),
+      ColumnDef("primary_category", StringType, cardinality = 20),
+      ColumnDef("price_cents", LongType, cardinality = 1000),
+      ColumnDef("currency", StringType, cardinality = 5), // USD, EUR, GBP, etc.
+      ColumnDef("inventory_count", LongType, cardinality = 1000),
+      ColumnDef("is_active", LongType, cardinality = 2), // 0 or 1
+      ColumnDef("weight_grams", LongType, cardinality = 500),
+      ColumnDef("main_image_path", StringType, cardinality = 500),
+      ColumnDef("secondary_image_paths", StringType, cardinality = 500),
+      ColumnDef("tags", StringType, cardinality = 10)
+    ),
+    rowCount = 100,
+    partitionCount = 30,
+    tableType = Entities
+  )
+
+  // Merchant dimension table - snapshot data
+  val dimMerchants = TableSchema(
+    tableName = "demo.dim_merchants",
+    columns = Seq(
+      ColumnDef("merchant_id", StringType, cardinality = 100),
+      ColumnDef("primary_category", StringType, cardinality = 20)
+    ),
+    rowCount = 50,
+    partitionCount = 30,
+    tableType = Entities
+  )
+
+  // Return all tables to seed
+  override def config: SeederConfig = SeederConfig(
+    Seq(userActivities, dimListings, dimMerchants)
+  )
+}

--- a/seeder/src/main/scala/ai/chronon/seeder/DataSeeder.scala
+++ b/seeder/src/main/scala/ai/chronon/seeder/DataSeeder.scala
@@ -1,0 +1,264 @@
+/*
+ *    Copyright (C) 2023 The Chronon Authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package ai.chronon.seeder
+
+import ai.chronon.spark.catalog.TableUtils
+import ai.chronon.spark.utils.DataFrameGen
+import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
+import org.rogach.scallop.ScallopConf
+
+/** Main entry point for data seeding.
+  * Generates test data based on schema definitions and writes to cloud storage.
+  */
+object DataSeeder {
+
+  class Conf(args: Seq[String]) extends ScallopConf(args) {
+    val seederClass = opt[String](
+      required = true,
+      descr = "Fully qualified class name of the seeder schema (e.g., com.example.MySeeder)"
+    )
+
+    val fileFormat = opt[String](
+      default = Some("PARQUET"),
+      descr = "File format for table storage (PARQUET, ORC, etc.)"
+    )
+
+    val dryRun = opt[Boolean](
+      default = Some(false),
+      descr = "If true, generate and show data without writing"
+    )
+
+    val startDate = opt[String](
+      descr = "Start date for generated data (yyyy-MM-dd). Defaults to 30 days ago."
+    )
+
+    val endDate = opt[String](
+      descr = "End date for generated data (yyyy-MM-dd). Defaults to today."
+    )
+
+    val saveMode = opt[String](
+      default = Some("append"),
+      descr = "Save mode: 'append' (default, safe for cloud) or 'overwrite'"
+    )
+
+    val batchSize = opt[Int](
+      default = Some(30),
+      descr = "Number of partitions to process in each batch (default: 30). Lower values reduce memory usage."
+    )
+
+    verify()
+  }
+
+  def main(args: Array[String]): Unit = {
+    val conf = new Conf(args)
+
+    val spark = SparkSession
+      .builder()
+      .appName("Chronon Data Seeder")
+      .enableHiveSupport()
+      .getOrCreate()
+
+    try {
+      // Parse dates
+      import java.time.LocalDate
+      import java.time.format.DateTimeFormatter
+      val dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+
+      val endDate = conf.endDate.toOption match {
+        case Some(date) => LocalDate.parse(date, dateFormatter)
+        case None       => LocalDate.now()
+      }
+
+      val startDate = conf.startDate.toOption match {
+        case Some(date) => LocalDate.parse(date, dateFormatter)
+        case None       => endDate.minusDays(30)
+      }
+
+      val partitionCount = java.time.temporal.ChronoUnit.DAYS.between(startDate, endDate).toInt + 1
+
+      println(s"Data generation range: $startDate to $endDate ($partitionCount days)")
+
+      // Parse save mode
+      val saveMode = conf.saveMode().toLowerCase match {
+        case "overwrite" => SaveMode.Overwrite
+        case "append"    => SaveMode.Append
+        case other =>
+          println(s"Invalid save mode: $other. Using 'append' (safe for cloud)")
+          SaveMode.Append
+      }
+
+      println(s"Save mode: $saveMode")
+
+      // Load the seeder config
+      println(s"Loading seeder schema from: ${conf.seederClass()}")
+      val config = SchemaLoader.load(conf.seederClass())
+
+      // Validate the config
+      SchemaLoader.validate(config)
+      println(s"Loaded ${config.tables.size} table(s) to seed")
+
+      // Create TableUtils instance
+      val tableUtils = TableUtils(spark)
+
+      // Process each table
+      config.tables.foreach { tableSchema =>
+        processTable(tableSchema,
+                     conf.fileFormat(),
+                     conf.dryRun(),
+                     spark,
+                     tableUtils,
+                     saveMode,
+                     partitionCount,
+                     conf.batchSize())
+      }
+
+      println("Seeding completed successfully!")
+    } catch {
+      case e: Exception =>
+        println(s"Error during seeding: ${e.getMessage}")
+        e.printStackTrace()
+        System.exit(1)
+    } finally {
+      spark.stop()
+    }
+  }
+
+  /** Process a single table schema: generate data and write to cloud
+    *
+    * For large date ranges, we process in batches to avoid OOM
+    */
+  private def processTable(
+      schema: TableSchema,
+      fileFormat: String,
+      dryRun: Boolean,
+      spark: SparkSession,
+      tableUtils: TableUtils,
+      saveMode: SaveMode,
+      partitionCount: Int,
+      batchSize: Int
+  ): Unit = {
+    println(s"\n=== Processing table: ${schema.tableName} ===")
+    println(s"  Type: ${schema.tableType}")
+    println(s"  Rows: ${schema.rowCount}")
+    println(s"  Partitions: $partitionCount")
+    println(s"  Batch size: $batchSize partitions")
+    println(s"  Columns: ${schema.columns.map(_.name).mkString(", ")}")
+
+    // Process in batches to avoid OOM for large date ranges
+    val batches = (partitionCount + batchSize - 1) / batchSize
+
+    if (partitionCount > batchSize) {
+      println(s"  Processing in $batches batches of up to $batchSize partitions each")
+    }
+
+    for (batchIndex <- 0 until batches) {
+      val batchStart = batchIndex * batchSize
+      val batchEnd = Math.min(batchStart + batchSize, partitionCount)
+      val batchPartitionCount = batchEnd - batchStart
+
+      if (batches > 1) {
+        println(
+          s"\n  Batch ${batchIndex + 1}/$batches: Partitions $batchStart to ${batchEnd - 1} ($batchPartitionCount partitions)")
+      }
+
+      // Generate the data for this batch
+      val df = generateData(schema, spark, batchPartitionCount)
+
+      if (dryRun) {
+        println("\n--- Dry run mode: showing sample data ---")
+        df.show(20, truncate = false)
+        df.printSchema()
+        println(s"Total rows generated in this batch: ${df.count()}")
+      } else {
+        // For first batch, use the configured saveMode (overwrite or append)
+        // For subsequent batches, always append
+        val batchSaveMode = if (batchIndex == 0) saveMode else SaveMode.Append
+
+        // Write to cloud storage using TableUtils
+        writeToCloud(df, schema, fileFormat, tableUtils, batchSaveMode)
+      }
+    }
+  }
+
+  /** Generate test data for a table schema using DataFrameGen
+    */
+  private def generateData(schema: TableSchema, spark: SparkSession, partitionCount: Int): DataFrame = {
+    val columns = schema.columns.map(_.toColumn)
+
+    schema.tableType match {
+      case Events =>
+        DataFrameGen.events(
+          spark,
+          columns,
+          schema.rowCount,
+          partitionCount,
+          schema.partitionColumn,
+          schema.partitionFormat
+        )
+
+      case Entities =>
+        DataFrameGen.entities(
+          spark,
+          columns,
+          schema.rowCount,
+          partitionCount,
+          schema.partitionColumn,
+          schema.partitionFormat
+        )
+    }
+  }
+
+  /** Write DataFrame to cloud storage using TableUtils.
+    * TableUtils handles the format provider logic, supporting different table formats
+    * (Iceberg, Hudi, Delta, Parquet, etc.) based on configuration.
+    */
+  private def writeToCloud(
+      df: DataFrame,
+      schema: TableSchema,
+      fileFormat: String,
+      tableUtils: TableUtils,
+      saveMode: SaveMode
+  ): Unit = {
+    println(s"\nWriting to table: ${schema.tableName}")
+    println(s"  File format: $fileFormat")
+    println(s"  Save mode: $saveMode")
+
+    // Use the partition column from the schema, or default to the tableUtils partition column
+    val partitionCols = schema.partitionColumn match {
+      case Some(col) => List(col)
+      case None      => List(tableUtils.partitionColumn)
+    }
+
+    // Repartition by partition columns to ensure each partition is processed by a separate task
+    // This reduces memory pressure per task by distributing the data
+    val repartitionedDf = df.repartition(partitionCols.map(df(_)): _*)
+    println(s"  Repartitioned by ${partitionCols.mkString(", ")} to distribute memory load across partitions")
+
+    // Use TableUtils.insertPartitions which handles format provider logic
+    tableUtils.insertPartitions(
+      df = repartitionedDf,
+      tableName = schema.tableName,
+      tableProperties = null,
+      partitionColumns = partitionCols,
+      saveMode = saveMode,
+      fileFormat = fileFormat,
+      autoExpand = false
+    )
+
+    println(s"✓ Successfully wrote data to ${schema.tableName}")
+  }
+}

--- a/seeder/src/main/scala/ai/chronon/seeder/SchemaLoader.scala
+++ b/seeder/src/main/scala/ai/chronon/seeder/SchemaLoader.scala
@@ -1,0 +1,95 @@
+/*
+ *    Copyright (C) 2023 The Chronon Authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package ai.chronon.seeder
+
+import scala.reflect.runtime.universe
+
+/** Base trait for seeder schema files.
+  * Users create objects extending this trait to define their table schemas.
+  *
+  * Example:
+  * {{{
+  * object MySeeder extends SeederSchema {
+  *   import ai.chronon.api._
+  *
+  *   val userEvents = TableSchema(
+  *     tableName = "db.user_events",
+  *     columns = Seq(
+  *       ColumnDef("user_id", StringType, cardinality = 1000),
+  *       ColumnDef("event_type", StringType, cardinality = 10),
+  *       ColumnDef("value", LongType, cardinality = 10000)
+  *     ),
+  *     rowCount = 50000,
+  *     partitionCount = 30,
+  *     tableType = Events
+  *   )
+  *
+  *   override def config = SeederConfig(Seq(userEvents))
+  * }
+  * }}}
+  */
+trait SeederSchema {
+  def config: SeederConfig
+}
+
+/** Loads seeder schema definitions from compiled Scala classes
+  */
+object SchemaLoader {
+
+  /** Load a seeder schema from a fully qualified class name
+    *
+    * @param className Fully qualified class name (e.g., "com.example.MySeeder")
+    * @return SeederConfig loaded from the class
+    */
+  def load(className: String): SeederConfig = {
+    try {
+      val runtimeMirror = universe.runtimeMirror(getClass.getClassLoader)
+      val module = runtimeMirror.staticModule(className)
+      val obj = runtimeMirror.reflectModule(module)
+      val instance = obj.instance
+
+      instance match {
+        case schema: SeederSchema => schema.config
+        case _ =>
+          throw new IllegalArgumentException(
+            s"Class $className does not extend SeederSchema trait"
+          )
+      }
+    } catch {
+      case e: Exception =>
+        throw new RuntimeException(s"Failed to load seeder schema from class $className", e)
+    }
+  }
+
+  /** Validate a seeder config
+    */
+  def validate(config: SeederConfig): Unit = {
+    require(config.tables.nonEmpty, "SeederConfig must contain at least one table")
+
+    config.tables.foreach { table =>
+      require(table.tableName.nonEmpty, "Table name cannot be empty")
+      require(table.columns.nonEmpty, "Table must have at least one column")
+      require(table.rowCount > 0, "Row count must be positive")
+      require(table.partitionCount > 0, "Partition count must be positive")
+
+      table.columns.foreach { col =>
+        require(col.name.nonEmpty, "Column name cannot be empty")
+        require(col.cardinality > 0, "Column cardinality must be positive")
+      }
+    }
+  }
+}

--- a/seeder/src/main/scala/ai/chronon/seeder/TableSchema.scala
+++ b/seeder/src/main/scala/ai/chronon/seeder/TableSchema.scala
@@ -1,0 +1,68 @@
+/*
+ *    Copyright (C) 2023 The Chronon Authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package ai.chronon.seeder
+
+import ai.chronon.aggregator.test.Column
+import ai.chronon.api.DataType
+
+/** Defines the data type for generated tables
+  */
+sealed trait TableType
+case object Events extends TableType // Event tables with timestamps
+case object Entities extends TableType // Entity tables with snapshots
+
+/** Configuration for a column in a table schema
+  *
+  * @param name Column name
+  * @param dataType Chronon data type (e.g., LongType, StringType, etc.)
+  * @param cardinality Number of unique values to generate
+  */
+case class ColumnDef(
+    name: String,
+    dataType: DataType,
+    cardinality: Int
+) {
+  def toColumn: Column = Column(name, dataType, cardinality)
+}
+
+/** Schema definition for a table to seed
+  *
+  * @param tableName Name of the table to create
+  * @param columns Column definitions
+  * @param rowCount Number of rows to generate
+  * @param partitionCount Number of partitions to generate
+  * @param tableType Type of table (Events or Entities)
+  * @param partitionColumn Optional partition column name (defaults to standard)
+  * @param partitionFormat Optional partition format (defaults to standard)
+  */
+case class TableSchema(
+    tableName: String,
+    columns: Seq[ColumnDef],
+    rowCount: Int = 1000,
+    partitionCount: Int = 10,
+    tableType: TableType = Events,
+    partitionColumn: Option[String] = None,
+    partitionFormat: Option[String] = None
+)
+
+/** Collection of table schemas to seed
+  *
+  * @param tables Sequence of table schemas to generate
+  */
+case class SeederConfig(
+    tables: Seq[TableSchema]
+)


### PR DESCRIPTION
## Summary

Sometimes after doing the quickstart, people exploring Chronon want to experience more of it, however setting up and hooking up with the data warehouse can be a higher project and need more signal.

Enter seeder. The idea behind seeder is to create test data (using the same modules we already use in our tests) so people can test Chronon in cloud or other isolated environments with higher scales. 

Some improvements that could come:
* sampling from possible values, I think this is not part of our DataFrameGen.

Tested by generating data to aws via for canary configs via:

```
aws emr add-steps \
    --cluster-id $AWS_CLUSTER \
    --region us-west-2 \
    --steps file:///tmp/steps.json
```

```json
[
  {
    "Type": "Spark",
    "Name": "ChrononDataSeeder-Cristian",
    "ActionOnFailure": "CONTINUE",
    "Args": [
      "--deploy-mode",
      "cluster",
      "--conf",
      "spark.sql.catalog.spark_catalog=org.apache.iceberg.spark.SparkCatalog",
      "--conf",
      "spark.sql.catalog.spark_catalog.catalog-impl=org.apache.iceberg.aws.glue.GlueCatalog",
      "--conf",
      "spark.sql.catalog.spark_catalog.warehouse=s3://<warehouse_dir>/data/tables/",
      "--conf",
      "spark.chronon.table_write.format=iceberg",
      "--conf",
      "spark.chronon.table_write.prefix=s3://<warehouse_dir>/data/tables/",
      "--conf",
      "spark.chronon.table.format_provider.class=ai.chronon.integrations.aws.AwsFormatProvider",
      "--conf",
      "spark.chronon.partition.column=ds",
      "--conf",
      "spark.chronon.partition.format=yyyy-MM-dd",
      "--class",
      "ai.chronon.seeder.DataSeeder",
      "s3://<artifacts_dir>/jars/seeder.jar",
      "--seeder-class",
      "ai.chronon.seeder.CanarySeeder",
      "--file-format",
      "PARQUET",
      "--start-date",
      "2026-01-04",
      "--end-date",
      "2027-01-04",
      "--batch-size",
      "7",
      "--save-mode",
      "append"
    ]
  }
]
```

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added data seeding capabilities with schema-based configuration for generating and writing test datasets to cloud storage
  * Added AWS Glue Catalog integration for automatic Iceberg table detection and format management
  * Introduced pre-configured canary datasets for AWS demo environments

* **Documentation**
  * Added comprehensive guide for the data seeding module, including usage examples and AWS integration details

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->