### PR TITLE
extend catching LinkageError on Kyro registration for non-gcp case

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/submission/ChrononKryoRegistrator.scala
+++ b/spark/src/main/scala/ai/chronon/spark/submission/ChrononKryoRegistrator.scala
@@ -268,7 +268,8 @@ class ChrononKryoRegistrator extends KryoRegistrator {
     try {
       kryo.register(Class.forName("org.apache.iceberg.gcp.gcs.GCSFileIO"), new JavaSerializer)
     } catch {
-      case _: ClassNotFoundException => // GCP jars not on classpath
+      case _: ClassNotFoundException => // Optional GCP class missing
+      case _: LinkageError           => // Optional GCP dependency missing
     }
 
     kryo.register(classOf[Array[Array[Array[AnyRef]]]])
@@ -286,6 +287,7 @@ class ChrononKryoRegistrator extends KryoRegistrator {
       kryo.register(Class.forName(s"[L$name;")) // represents array of a type to jvm
     } catch {
       case _: ClassNotFoundException => // do nothing
+      case _: LinkageError           => // do nothing
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes regression on AWS (non GCP) environment likely introduced by

https://github.com/zipline-ai/chronon/pull/1471
https://github.com/zipline-ai/chronon/pull/1450 


Explanation: 
The exception type changed because the runtime condition changed from “class missing” to “class exists but its dependency is missing”.

  1. Before, Class.forName(...) on optional GCP classes often failed with ClassNotFoundException (class itself absent), which your code already ignored.
  2. After recent changes, those GCP classes became present on AWS job classpath, but Google auth classes were not.
  3. JVM then fails during class linking/resolution with NoClassDefFoundError: com/google/auth/Credentials, which is a LinkageError (not ClassNotFoundException), so it escaped the old catch.

  Where this happens:

  - GCP classes are eagerly registered in ChrononKryoRegistrator.scala:140 , ChrononKryoRegistrator.scala:256 , and loaded via ChrononKryoRegistrator.scala:285 

  Most likely commits that created this:

  1. ce622e392b1256bedd2920c635db6cb2c19b617b on 2026-02-13 (#1450)
     Consolidated registrators; moved GCP registrations into shared/default registrator (so non-GCP EMR jobs execute this path).
  2. 32bc57bf0b6b2bb5d5f9c3587fa5fe8bb97c13e7 on 2026-02-19 (#1471)
     Added iceberg-spark-runtime-3.5 explicitly to AWS assembly in cloud_aws/package.mill:30 , making Iceberg GCP
     classes present in AWS jar without guaranteed google-auth runtime deps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for optional GCP dependency availability, making the system more resilient when GCP integrations are not configured or available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->