### PR TITLE
Only allow one set of integration tests to run when attempting merge to main

### DIFF
--- a/.github/workflows/push_to_canary.yaml
+++ b/.github/workflows/push_to_canary.yaml
@@ -9,7 +9,8 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'merge_group' && 'merge-queue' || github.ref }}
+  cancel-in-progress: false
 
 env:
   SCALA_VERSION: "2.12.18"


### PR DESCRIPTION
## Summary

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow configuration to optimize concurrency handling for merge queue events and prevent cancellation of in-progress jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->