### PR TITLE
Fail when no cluster conf is provided for GCP

### DIFF
--- a/cloud_gcp/src/main/scala/ai/chronon/integrations/cloud_gcp/DataprocSubmitter.scala
+++ b/cloud_gcp/src/main/scala/ai/chronon/integrations/cloud_gcp/DataprocSubmitter.scala
@@ -1,7 +1,6 @@
 package ai.chronon.integrations.cloud_gcp
 import ai.chronon.api.Builders.MetaData
 import ai.chronon.api.JobStatusType
-import ai.chronon.spark.submission.JobSubmitterConstants
 import ai.chronon.spark.submission.JobSubmitterConstants._
 import ai.chronon.spark.submission.{JobSubmitter, JobType, FlinkJob => TypeFlinkJob, SparkJob => TypeSparkJob}
 import com.google.api.gax.rpc.ApiException
@@ -653,6 +652,10 @@ class DataprocSubmitter(jobControllerClient: JobControllerClient,
       }.recover { case ex: Exception =>
         logger.error(s"Failed to create cluster $clusterName asynchronously", ex)
       }
+    } else {
+      logger.error(s"Cluster $clusterName does not exist and no cluster configuration provided to create it.")
+      throw new IllegalArgumentException(
+        s"Cluster $clusterName does not exist and no cluster configuration provided to create it. Please provide one.")
     }
   }
 

--- a/cloud_gcp/src/test/scala/ai/chronon/integrations/cloud_gcp/DataprocSubmitterTest.scala
+++ b/cloud_gcp/src/test/scala/ai/chronon/integrations/cloud_gcp/DataprocSubmitterTest.scala
@@ -1178,4 +1178,162 @@ class DataprocSubmitterTest extends AnyFlatSpec with MockitoSugar {
     )
     println(jobId)
   }
+
+  it should "return cluster name when cluster is RUNNING" in {
+    val mockClusterControllerClient = mock[ClusterControllerClient]
+    val mockCluster = Cluster
+      .newBuilder()
+      .setStatus(ClusterStatus.newBuilder().setState(ClusterStatus.State.RUNNING))
+      .build()
+
+    when(mockClusterControllerClient.getCluster(any[String], any[String], any[String]))
+      .thenReturn(mockCluster)
+
+    val submitterWithClusterClient = new DataprocSubmitter(
+      jobControllerClient = mock[JobControllerClient],
+      gcsClient = mock[GCSClient],
+      region = "test-region",
+      projectId = "test-project",
+      clusterControllerClient = Some(mockClusterControllerClient)
+    )
+
+    val result = submitterWithClusterClient.ensureClusterReady(
+      "test-cluster",
+      None
+    )(scala.concurrent.ExecutionContext.global)
+
+    assert(result.isDefined)
+    assertEquals(result.get, "test-cluster")
+  }
+
+  it should "return None when cluster is in CREATING state" in {
+    val mockClusterControllerClient = mock[ClusterControllerClient]
+    val mockCluster = Cluster
+      .newBuilder()
+      .setStatus(ClusterStatus.newBuilder().setState(ClusterStatus.State.CREATING))
+      .build()
+
+    when(mockClusterControllerClient.getCluster(any[String], any[String], any[String]))
+      .thenReturn(mockCluster)
+
+    val submitterWithClusterClient = new DataprocSubmitter(
+      jobControllerClient = mock[JobControllerClient],
+      gcsClient = mock[GCSClient],
+      region = "test-region",
+      projectId = "test-project",
+      clusterControllerClient = Some(mockClusterControllerClient)
+    )
+
+    val result = submitterWithClusterClient.ensureClusterReady(
+      "test-cluster",
+      None
+    )(scala.concurrent.ExecutionContext.global)
+
+    assert(result.isEmpty)
+  }
+
+  it should "throw IllegalStateException when cluster is in ERROR state and no config provided" in {
+    val mockClusterControllerClient = mock[ClusterControllerClient]
+    val mockCluster = Cluster
+      .newBuilder()
+      .setStatus(ClusterStatus.newBuilder().setState(ClusterStatus.State.ERROR))
+      .build()
+
+    when(mockClusterControllerClient.getCluster(any[String], any[String], any[String]))
+      .thenReturn(mockCluster)
+
+    val submitterWithClusterClient = new DataprocSubmitter(
+      jobControllerClient = mock[JobControllerClient],
+      gcsClient = mock[GCSClient],
+      region = "test-region",
+      projectId = "test-project",
+      clusterControllerClient = Some(mockClusterControllerClient)
+    )
+
+    val exception = intercept[IllegalStateException] {
+      submitterWithClusterClient.ensureClusterReady(
+        "test-cluster",
+        None
+      )(scala.concurrent.ExecutionContext.global)
+    }
+
+    assert(exception.getMessage.contains("cannot be used for job submission"))
+  }
+
+  it should "throw IllegalArgumentException when getOrCreateCluster is called with no config" in {
+    val mockDataprocClient = mock[ClusterControllerClient]
+
+    when(mockDataprocClient.getCluster(any[String], any[String], any[String]))
+      .thenReturn(null)
+
+    val exception = intercept[Exception] {
+      DataprocSubmitter.getOrCreateCluster(
+        "test-cluster",
+        None,
+        "test-project",
+        "test-region",
+        mockDataprocClient
+      )
+    }
+
+    assert(exception.getMessage.contains("does not exist and no cluster config provided"))
+  }
+
+  it should "throw IllegalArgumentException when getOrCreateCluster is called with config missing dataproc.config key" in {
+    val mockDataprocClient = mock[ClusterControllerClient]
+
+    when(mockDataprocClient.getCluster(any[String], any[String], any[String]))
+      .thenReturn(null)
+
+    val exception = intercept[Exception] {
+      DataprocSubmitter.getOrCreateCluster(
+        "test-cluster",
+        Some(Map("other-key" -> "value")),
+        "test-project",
+        "test-region",
+        mockDataprocClient
+      )
+    }
+
+    assert(exception.getMessage.contains("does not exist and no cluster config provided"))
+  }
+
+  it should "create cluster when config is properly provided" in {
+    val mockDataprocClient = mock[ClusterControllerClient]
+
+    when(mockDataprocClient.getCluster(any[String], any[String], any[String]))
+      .thenReturn(null)
+
+    val mockOperationFuture = mock[OperationFuture[Cluster, ClusterOperationMetadata]]
+    val mockRunningCluster = Cluster
+      .newBuilder()
+      .setStatus(ClusterStatus.newBuilder().setState(ClusterStatus.State.RUNNING))
+      .build()
+
+    when(mockDataprocClient.createClusterAsync(any[CreateClusterRequest]))
+      .thenReturn(mockOperationFuture)
+    when(mockOperationFuture.get(anyLong(), any[TimeUnit]))
+      .thenReturn(mockRunningCluster)
+    when(mockDataprocClient.getCluster(any[String], any[String], any[String]))
+      .thenReturn(null)
+      .thenReturn(mockRunningCluster)
+
+    val clusterConfigStr = """{
+      "masterConfig": {
+        "numInstances": 1,
+        "machineTypeUri": "n1-standard-4"
+      }
+    }"""
+
+    val result = DataprocSubmitter.getOrCreateCluster(
+      "new-cluster",
+      Some(Map("dataproc.config" -> clusterConfigStr)),
+      "test-project",
+      "test-region",
+      mockDataprocClient
+    )
+
+    assertEquals(result, "new-cluster")
+    verify(mockDataprocClient).createClusterAsync(any[CreateClusterRequest])
+  }
 }


### PR DESCRIPTION
## Summary

^^^

At the moment, if no cluster conf is provided when attempting to create cluster, the code no-ops. Failing so that the exception will surface

## Checklist
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [x] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and input validation for GCP Dataproc operations to better manage cases where cluster configuration is missing or unavailable, with clearer error messages.

* **Tests**
  * Added extensive unit tests covering cluster readiness across multiple states, cluster creation workflows, and various error conditions with comprehensive mocking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<img width="1566" height="1458" alt="image" src="https://github.com/user-attachments/assets/5e03eaf4-18ba-4de0-a6e6-1eb849591f75" />
