### PR TITLE
Rename dest for UC cannot include the catalog name

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/batch/BatchNodeRunner.scala
+++ b/spark/src/main/scala/ai/chronon/spark/batch/BatchNodeRunner.scala
@@ -713,7 +713,7 @@ class BatchNodeRunner(node: Node, tableUtils: TableUtils, api: Api) extends Node
                   if (tableUtils.tableReachable(outputTable)) {
                     tableUtils.sql(s"DROP TABLE IF EXISTS $outputTable")
                   }
-                  su.renameTable(archivedTable, outputTable)
+                  tableUtils.renameTable(archivedTable, outputTable)
                   logger.info(s"Rolled back archival: restored $archivedTable to $outputTable")
                 }
               } catch {

--- a/spark/src/main/scala/ai/chronon/spark/batch/MergeJob.scala
+++ b/spark/src/main/scala/ai/chronon/spark/batch/MergeJob.scala
@@ -248,9 +248,8 @@ class MergeJob(node: JoinMergeNode, metaData: MetaData, range: DateRange, joinPa
     // If there is an existing _archive_reuse table then rename that to archive_currtime
     // Then rename the current output table to _archive_reuse
     tableUtils.archiveOrDropTableIfExists(archiveReuseTable, Option(Instant.now()))
-    val archiveCommand = s"ALTER TABLE $outputTable RENAME TO $archiveReuseTable"
     logger.info(s"Archiving current output table $outputTable to $archiveReuseTable")
-    tableUtils.sql(archiveCommand)
+    tableUtils.renameTable(outputTable, archiveReuseTable)
   }
 
   private def getExistingColHashes(table: String): Map[String, String] = {

--- a/spark/src/main/scala/ai/chronon/spark/catalog/Format.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/Format.scala
@@ -28,8 +28,7 @@ trait Format {
       case Some(hash) =>
         val parts = sparkSession.sessionState.sqlParser.parseMultipartIdentifier(tableName).toList
         val hashedParts = parts.init :+ s"${parts.last}_$hash"
-        (hashedParts.map(QuotingUtils.quoteIdentifier).mkString("."),
-         parts.map(QuotingUtils.quoteIdentifier).mkString("."))
+        (hashedParts.map(QuotingUtils.quoteIdentifier).mkString("."), tableName)
       case None => (tableName, tableName)
     }
     sparkSession.sql(
@@ -37,7 +36,7 @@ trait Format {
         .createTableSql(creationName, schema, partitionColumns, providedProperties, tableTypeString))
     if (semanticHash.isDefined) {
       try {
-        sparkSession.sql(s"ALTER TABLE $creationName RENAME TO $quotedOriginal")
+        sparkSession.sql(Format.renameTableSql(creationName, tableName))
       } catch {
         case _: TableAlreadyExistsException =>
           // Another writer already created the target table — safe to clean up our intermediate table
@@ -200,6 +199,17 @@ object Format {
       case _ :: Nil                 => defaultCatalog
       case _ => throw new IllegalStateException(s"Invalid table naming convention specified: ${inputTableName}")
     }
+  }
+
+  def renameTableSql(srcTable: String, destTable: String)(implicit sparkSession: SparkSession): String = {
+    val srcResolved = resolveTableName(srcTable)
+    val destResolved = resolveTableName(destTable)
+    val normalizedDest = if (srcResolved.catalog == destResolved.catalog) {
+      s"${QuotingUtils.quoteIdentifier(destResolved.namespace)}.${QuotingUtils.quoteIdentifier(destResolved.table)}"
+    } else {
+      s"${QuotingUtils.quoteIdentifier(destResolved.catalog)}.${QuotingUtils.quoteIdentifier(destResolved.namespace)}.${QuotingUtils.quoteIdentifier(destResolved.table)}"
+    }
+    s"ALTER TABLE $srcTable RENAME TO $normalizedDest"
   }
 
 }

--- a/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
@@ -477,6 +477,12 @@ class TableUtils(@transient val sparkSession: SparkSession) extends Serializable
     sql(command)
   }
 
+  def renameTable(srcTable: String, destTable: String): Unit = {
+    val command = Format.renameTableSql(srcTable, destTable)(sparkSession)
+    logger.info(s"Renaming table with command: $command")
+    sql(command)
+  }
+
   def archiveOrDropTableIfExists(tableName: String, timestamp: Option[Instant]): Option[String] = {
     val archiveTry = Try(archiveTableIfExists(tableName, timestamp))
     archiveTry match {
@@ -496,9 +502,7 @@ class TableUtils(@transient val sparkSession: SparkSession) extends Serializable
     if (tableReachable(tableName)) {
       val humanReadableTimestamp = archiveTimestampFormatter.format(timestamp.getOrElse(Instant.now()))
       val finalArchiveTableName = s"${tableName}_$humanReadableTimestamp"
-      val command = s"ALTER TABLE $tableName RENAME TO $finalArchiveTableName"
-      logger.info(s"Archiving table with command: $command")
-      sql(command)
+      renameTable(tableName, finalArchiveTableName)
       Some(finalArchiveTableName)
     } else {
       None

--- a/spark/src/main/scala/ai/chronon/spark/utils/SemanticUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/utils/SemanticUtils.scala
@@ -1,13 +1,12 @@
 package ai.chronon.spark.utils
 
 import ai.chronon.api.Constants
-import ai.chronon.spark.catalog.{CreationUtils, TableUtils}
+import ai.chronon.spark.catalog.{CreationUtils, Format, TableUtils}
 import org.apache.spark.sql.catalyst.util.QuotingUtils
 import org.slf4j.{Logger, LoggerFactory}
 
 import java.time.format.DateTimeFormatter
 import java.time.{Instant, ZoneOffset}
-import scala.util.Try
 
 class SemanticUtils(tableUtils: TableUtils) {
 
@@ -15,17 +14,9 @@ class SemanticUtils(tableUtils: TableUtils) {
 
   def renameTable(srcTable: String, destTable: String): Unit = {
 
-    val normalizedDestTable = Try {
-      val parser = tableUtils.sparkSession.sessionState.sqlParser
-      val destParts = parser.parseMultipartIdentifier(destTable).toList
-
-      destParts match {
-        case _ :: destNamespace :: destName :: Nil =>
-          s"${QuotingUtils.quoteIdentifier(destNamespace)}.${QuotingUtils.quoteIdentifier(destName)}"
-        case _ =>
-          destTable
-      }
-    }.getOrElse(destTable)
+    val resolvedDest = Format.resolveTableName(destTable)(tableUtils.sparkSession)
+    val normalizedDestTable =
+      s"${QuotingUtils.quoteIdentifier(resolvedDest.namespace)}.${QuotingUtils.quoteIdentifier(resolvedDest.table)}"
 
     val alterStatement = s"ALTER TABLE $srcTable RENAME TO $normalizedDestTable"
 

--- a/spark/src/main/scala/ai/chronon/spark/utils/SemanticUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/utils/SemanticUtils.scala
@@ -1,8 +1,7 @@
 package ai.chronon.spark.utils
 
 import ai.chronon.api.Constants
-import ai.chronon.spark.catalog.{CreationUtils, Format, TableUtils}
-import org.apache.spark.sql.catalyst.util.QuotingUtils
+import ai.chronon.spark.catalog.{CreationUtils, TableUtils}
 import org.slf4j.{Logger, LoggerFactory}
 
 import java.time.format.DateTimeFormatter
@@ -11,20 +10,6 @@ import java.time.{Instant, ZoneOffset}
 class SemanticUtils(tableUtils: TableUtils) {
 
   private val logger: Logger = LoggerFactory.getLogger(this.getClass)
-
-  def renameTable(srcTable: String, destTable: String): Unit = {
-
-    val resolvedDest = Format.resolveTableName(destTable)(tableUtils.sparkSession)
-    val normalizedDestTable =
-      s"${QuotingUtils.quoteIdentifier(resolvedDest.namespace)}.${QuotingUtils.quoteIdentifier(resolvedDest.table)}"
-
-    val alterStatement = s"ALTER TABLE $srcTable RENAME TO $normalizedDestTable"
-
-    logger.info(s"Renaming table: $alterStatement")
-
-    tableUtils.sql(alterStatement)
-
-  }
 
   // tries to archive to a "reuse" table,
   // if a reuse table is already present, it first moves the reuse table to "shelf" table - suffixed with timestamp
@@ -42,11 +27,11 @@ class SemanticUtils(tableUtils: TableUtils) {
     val shelfTable = shelfTableOpt.getOrElse(outputTable + "_archive_" + nowSecondsStr)
 
     if (tableUtils.tableReachable(reuseTable)) {
-      renameTable(reuseTable, shelfTable)
+      tableUtils.renameTable(reuseTable, shelfTable)
     }
 
     if (tableUtils.tableReachable(outputTable)) {
-      renameTable(outputTable, reuseTable)
+      tableUtils.renameTable(outputTable, reuseTable)
     }
 
     logger.info(s"Archived table $outputTable to $reuseTable")

--- a/spark/src/main/scala/ai/chronon/spark/utils/SemanticUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/utils/SemanticUtils.scala
@@ -2,10 +2,12 @@ package ai.chronon.spark.utils
 
 import ai.chronon.api.Constants
 import ai.chronon.spark.catalog.{CreationUtils, TableUtils}
+import org.apache.spark.sql.catalyst.util.QuotingUtils
 import org.slf4j.{Logger, LoggerFactory}
 
 import java.time.format.DateTimeFormatter
 import java.time.{Instant, ZoneOffset}
+import scala.util.Try
 
 class SemanticUtils(tableUtils: TableUtils) {
 
@@ -13,7 +15,19 @@ class SemanticUtils(tableUtils: TableUtils) {
 
   def renameTable(srcTable: String, destTable: String): Unit = {
 
-    val alterStatement = s"ALTER TABLE $srcTable RENAME TO $destTable"
+    val normalizedDestTable = Try {
+      val parser = tableUtils.sparkSession.sessionState.sqlParser
+      val destParts = parser.parseMultipartIdentifier(destTable).toList
+
+      destParts match {
+        case _ :: destNamespace :: destName :: Nil =>
+          s"${QuotingUtils.quoteIdentifier(destNamespace)}.${QuotingUtils.quoteIdentifier(destName)}"
+        case _ =>
+          destTable
+      }
+    }.getOrElse(destTable)
+
+    val alterStatement = s"ALTER TABLE $srcTable RENAME TO $normalizedDestTable"
 
     logger.info(s"Renaming table: $alterStatement")
 

--- a/spark/src/test/scala/ai/chronon/spark/catalog/FormatTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/catalog/FormatTest.scala
@@ -44,4 +44,24 @@ class FormatTest extends SparkTestBase {
     assertEquals("tbl", resolved.table)
   }
 
+  it should "strip destination catalog in rename SQL when source and destination share a catalog" in {
+    val sql = Format.renameTableSql(
+      "spark_non_default_catalog.custom_test_db.src_table",
+      "spark_non_default_catalog.custom_test_db.dest_table"
+    )
+    assertEquals(
+      "ALTER TABLE spark_non_default_catalog.custom_test_db.src_table RENAME TO `custom_test_db`.`dest_table`",
+      sql)
+  }
+
+  it should "keep destination catalog in rename SQL when source and destination catalogs differ" in {
+    val sql = Format.renameTableSql(
+      "spark_non_default_catalog.custom_test_db.src_table",
+      "spark_catalog.default.dest_table"
+    )
+    assertEquals(
+      "ALTER TABLE spark_non_default_catalog.custom_test_db.src_table RENAME TO `spark_catalog`.`default`.`dest_table`",
+      sql)
+  }
+
 }

--- a/spark/src/test/scala/ai/chronon/spark/other/TableUtilsTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/other/TableUtilsTest.scala
@@ -587,6 +587,27 @@ class TableUtilsTest extends AnyFlatSpec {
     }
   }
 
+  it should "rename tables" in {
+    val dbName = "db"
+    val srcTable = s"$dbName.test_rename_src"
+    val destTable = s"$dbName.test_rename_dest"
+
+    spark.sql(s"CREATE DATABASE IF NOT EXISTS $dbName")
+    try {
+      spark.sql(s"CREATE TABLE $srcTable (id INT, ds STRING)")
+      spark.sql(s"INSERT INTO $srcTable VALUES (1, '2024-01-01'), (2, '2024-01-02')")
+
+      tableUtils.renameTable(srcTable, destTable)
+
+      assertFalse(s"Original table should not exist after rename", spark.catalog.tableExists(srcTable))
+      assertTrue(s"Destination table should exist after rename", spark.catalog.tableExists(destTable))
+      assertEquals(2L, spark.table(destTable).count())
+    } finally {
+      spark.sql(s"DROP TABLE IF EXISTS $srcTable")
+      spark.sql(s"DROP TABLE IF EXISTS $destTable")
+    }
+  }
+
   it should "test catalog detection" in {
     implicit val localSparkRef: SparkSession = spark
     assertEquals("catalogA", Format.getCatalog("catalogA.foo.bar"))

--- a/spark/src/test/scala/ai/chronon/spark/utils/SemanticUtilsTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/utils/SemanticUtilsTest.scala
@@ -4,7 +4,7 @@ import ai.chronon.api.{Constants, LongType, StringType, StructField, StructType}
 import ai.chronon.spark.catalog.{CreationUtils, TableUtils}
 import ai.chronon.spark.submission.SparkSessionBuilder
 import ai.chronon.spark.utils.TestUtils.makeDf
-import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import org.junit.Assert.{assertEquals, assertFalse, assertTrue}
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.flatspec.AnyFlatSpec
@@ -322,5 +322,22 @@ class SemanticUtilsTest extends AnyFlatSpec with BeforeAndAfterEach {
     val archivedTableOpt = semanticUtils.checkSemanticHashAndArchive(tableName, longHash)
     assertEquals(None, archivedTableOpt) // Should not archive
     assertTrue(spark.catalog.tableExists(tableName))
+  }
+
+  it should "normalize destination rename identifier by stripping catalog in renameTable" in {
+    var capturedStatement = ""
+    val capturingTableUtils = new TableUtils(spark) {
+      override def sql(query: String): DataFrame = {
+        capturedStatement = query
+        spark.emptyDataFrame
+      }
+    }
+    val semanticUtilsWithCapture = new SemanticUtils(capturingTableUtils)
+
+    val srcTable = s"spark_catalog.$testDb.src_table"
+    val destTable = s"spark_catalog.$testDb.dest_table"
+
+    semanticUtilsWithCapture.renameTable(srcTable, destTable)
+    assertEquals(s"ALTER TABLE $srcTable RENAME TO `$testDb`.`dest_table`", capturedStatement)
   }
 }

--- a/spark/src/test/scala/ai/chronon/spark/utils/SemanticUtilsTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/utils/SemanticUtilsTest.scala
@@ -4,7 +4,7 @@ import ai.chronon.api.{Constants, LongType, StringType, StructField, StructType}
 import ai.chronon.spark.catalog.{CreationUtils, TableUtils}
 import ai.chronon.spark.submission.SparkSessionBuilder
 import ai.chronon.spark.utils.TestUtils.makeDf
-import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import org.apache.spark.sql.{Row, SparkSession}
 import org.junit.Assert.{assertEquals, assertFalse, assertTrue}
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.flatspec.AnyFlatSpec
@@ -322,22 +322,5 @@ class SemanticUtilsTest extends AnyFlatSpec with BeforeAndAfterEach {
     val archivedTableOpt = semanticUtils.checkSemanticHashAndArchive(tableName, longHash)
     assertEquals(None, archivedTableOpt) // Should not archive
     assertTrue(spark.catalog.tableExists(tableName))
-  }
-
-  it should "normalize destination rename identifier by stripping catalog in renameTable" in {
-    var capturedStatement = ""
-    val capturingTableUtils = new TableUtils(spark) {
-      override def sql(query: String): DataFrame = {
-        capturedStatement = query
-        spark.emptyDataFrame
-      }
-    }
-    val semanticUtilsWithCapture = new SemanticUtils(capturingTableUtils)
-
-    val srcTable = s"spark_catalog.$testDb.src_table"
-    val destTable = s"spark_catalog.$testDb.dest_table"
-
-    semanticUtilsWithCapture.renameTable(srcTable, destTable)
-    assertEquals(s"ALTER TABLE $srcTable RENAME TO `$testDb`.`dest_table`", capturedStatement)
   }
 }


### PR DESCRIPTION
## Summary

Unity Catalog's rename path is not entirely cooperative on the catalog aliases. The catalog name is inferred off of the endpoint and then it expects only the schema and table name to be provided during the rename. If the catalog name is also provided in the rename we get:

```
SemanticUtils.scala:17: Renaming table: ALTER TABLE <catalog>.<schema>.<table> RENAME TO <catalog>.<schema>.<table>_reuse
TableUtils.scala:343: 
  [1m[38;5;131m---- running query ----[0m

[38;5;172m    ALTER TABLE <catalog>.<schema>.<table> RENAME TO <catalog>.<schema>.<table>_archive_reuse[0m

  ---- call path ----

    catalog.TableUtils.sql(TableUtils.scala:334)
    utils.SemanticUtils.renameTable(SemanticUtils.scala:19)
    utils.SemanticUtils.archiveForReuse(SemanticUtils.scala:42)
    utils.SemanticUtils.checkSemanticHashAndArchive(SemanticUtils.scala:68)
    batch.BatchNodeRunner.$anonfun$runFromArgs$1(BatchNodeRunner.scala:679)
    batch.BatchNodeRunner.runFromArgs(BatchNodeRunner.scala:650)
    batch.BatchNodeRunner$.main(BatchNodeRunner.scala:769)
    batch.BatchNodeRunner.main(BatchNodeRunner.scala)

  ---- end ----

TableUtils.scala:356: Error running query:
org.apache.iceberg.exceptions.BadRequestException: Malformed request: Malformed request: BAD_REQUEST: Namespace must have exactly one level
	at org.apache.iceberg.rest.ErrorHandlers$DefaultErrorHandler.accept(ErrorHandlers.java:234) ~[cloud_aws_lib_deploy.jar:0.0.32]
	at org.apache.iceberg.rest.ErrorHandlers$TableErrorHandler.accept(ErrorHandlers.java:124) ~[cloud_aws_lib_deploy.jar:0.0.32]
	at org.apache.iceberg.rest.ErrorHandlers$TableErrorHandler.accept(ErrorHandlers.java:108) ~[cloud_aws_lib_deploy.jar:0.0.32]
	at org.apache.iceberg.rest.HTTPClient.throwFailure(HTTPClient.java:240) ~[cloud_aws_lib_deploy.jar:0.0.32]
	at org.apache.iceberg.rest.HTTPClient.execute(HTTPClient.java:336) ~[cloud_aws_lib_deploy.jar:0.0.32]
	at org.apache.iceberg.rest.HTTPClient.execute(HTTPClient.java:297) ~[cloud_aws_lib_deploy.jar:0.0.32]
	at org.apache.iceberg.rest.BaseHTTPClient.post(BaseHTTPClient.java:100) ~[cloud_aws_lib_deploy.jar:0.0.32]
```

Updates the rename to just drop the catalog part as we only rename within catalog. This works. See: https://github.com/apache/iceberg/pull/12159/

## Checklist
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update

