### PR TITLE
Validate the partition column is provided when time partitioned

### DIFF
--- a/python/src/ai/chronon/cli/compile/conf_validator.py
+++ b/python/src/ai/chronon/cli/compile/conf_validator.py
@@ -21,7 +21,7 @@ import sys
 import textwrap
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import gen_thrift.common.ttypes as common
 from ai.chronon.cli.compile.column_hashing import (
@@ -44,6 +44,7 @@ from gen_thrift.api.ttypes import (
     GroupBy,
     Join,
     JoinPart,
+    Query,
     Source,
 )
 
@@ -283,6 +284,19 @@ class ConfValidator(object):
         old_obj = self._get_old_obj(type(obj), obj.metaData.name)
         return not old_obj or not self._has_diff(obj, old_obj) or not old_obj.metaData.online
 
+    def _validate_time_partitioned_query(
+        self, query: Optional[Query], source_context: str
+    ) -> BaseException | None:
+        if query is None:
+            return None
+
+        if query.timePartitioned and query.partitionColumn is None:
+            return ValueError(
+                f"{source_context}: timePartitioned sources must have partitionColumn set to the timestamp/date column name"
+            )
+
+        return None
+
     def _validate_derivations(
         self, pre_derived_cols: List[str], derivations: List[Derivation]
     ) -> List[BaseException]:
@@ -421,6 +435,21 @@ class ConfValidator(object):
             if not gb.metaData or gb.metaData.online is False
         ]
         errors = []
+
+        if join.left and (left_query := get_query(join.left)) is not None:
+            left_query_err = self._validate_time_partitioned_query(
+                left_query, f"join {join.metaData.name} left"
+            )
+            if left_query_err:
+                errors.append(left_query_err)
+
+        for index, bootstrap_part in enumerate(join.bootstrapParts or []):
+            bootstrap_query_err = self._validate_time_partitioned_query(
+                bootstrap_part.query, f"join {join.metaData.name} bootstrapParts[{index}]"
+            )
+            if bootstrap_query_err:
+                errors.append(bootstrap_query_err)
+
         old_group_bys = [
             group_by
             for group_by in included_group_bys
@@ -576,8 +605,14 @@ class ConfValidator(object):
                 columns = list(get_pre_derived_group_by_columns(group_by).keys())
             errors.extend(self._validate_derivations(columns, group_by.derivations))
 
-        for source in group_by.sources:
+        for index, source in enumerate(group_by.sources):
             src: Source = source
+            query_error = self._validate_time_partitioned_query(
+                get_query(src), f"group_by {group_by.metaData.name} source[{index}]"
+            )
+            if query_error:
+                errors.append(query_error)
+
             if src.events and src.events.isCumulative and (src.events.query.timeColumn is None):
                 errors.append(
                     ValueError(

--- a/python/test/test_conf_validator.py
+++ b/python/test/test_conf_validator.py
@@ -1,5 +1,6 @@
 from gen_thrift.api.ttypes import (
     Aggregation,
+    BootstrapPart,
     EventSource,
     GroupBy,
     Join,
@@ -65,6 +66,11 @@ def _make_validator(existing_gbs=None, existing_joins=None, existing_staging_que
 
 def _has_online_in_place_error(errors):
     return any("is online and cannot be changed in-place" in str(e) for e in errors)
+
+
+def _has_time_partitioned_missing_partition_column_error(errors, context=None):
+    message = "timePartitioned sources must have partitionColumn set to the timestamp/date column name"
+    return any(message in str(e) and (context is None or context in str(e)) for e in errors)
 
 
 class TestOnlineConfNotChangedInPlace:
@@ -137,3 +143,61 @@ class TestOnlineConfNotChangedInPlace:
         assert len(online_errors) == 1
         assert "team.important_gb" in str(online_errors[0])
         assert "GroupBy" in str(online_errors[0])
+
+
+class TestTimePartitionedValidation:
+    def test_group_by_source_requires_partition_column_when_time_partitioned(self):
+        group_by = _make_group_by()
+        group_by.sources[0].events.query.timePartitioned = True
+        group_by.sources[0].events.query.partitionColumn = None
+        validator = _make_validator()
+
+        errors = validator.validate_obj(group_by)
+        assert _has_time_partitioned_missing_partition_column_error(
+            errors, "group_by team.my_gb source[0]"
+        )
+
+    def test_join_left_requires_partition_column_when_time_partitioned(self):
+        join = _make_join()
+        join.left.events.query.timePartitioned = True
+        join.left.events.query.partitionColumn = None
+        validator = _make_validator()
+
+        errors = validator.validate_obj(join)
+        assert _has_time_partitioned_missing_partition_column_error(
+            errors, "join team.my_join left"
+        )
+
+    def test_join_bootstrap_part_requires_partition_column_when_time_partitioned(self):
+        join = _make_join()
+        bootstrap_query = Query()
+        bootstrap_query.timePartitioned = True
+        bootstrap_query.partitionColumn = None
+        join.bootstrapParts = [
+            BootstrapPart(
+                table="test.bootstrap_table",
+                query=bootstrap_query,
+            )
+        ]
+        validator = _make_validator()
+
+        errors = validator.validate_obj(join)
+        assert _has_time_partitioned_missing_partition_column_error(
+            errors, "join team.my_join bootstrapParts[0]"
+        )
+
+    def test_time_partitioned_with_partition_column_passes(self):
+        group_by = _make_group_by()
+        group_by.sources[0].events.query.timePartitioned = True
+        group_by.sources[0].events.query.partitionColumn = "created_at"
+        validator = _make_validator()
+
+        errors = validator.validate_obj(group_by)
+        assert not _has_time_partitioned_missing_partition_column_error(errors)
+
+    def test_non_time_partitioned_without_partition_column_passes_this_validation(self):
+        group_by = _make_group_by()
+        validator = _make_validator()
+
+        errors = validator.validate_obj(group_by)
+        assert not _has_time_partitioned_missing_partition_column_error(errors)


### PR DESCRIPTION
## Summary

When using a `timePartitioned` column, the only validation that occurs happens when the job is running. This pushes the validation down into the compile step to fail early. 

## Checklist
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration validation now requires partitionColumn specification for timePartitioned queries in group_by sources, join definitions, and bootstrap configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->