### PR TITLE
Fixing endTs bug in metrics loading

### DIFF
--- a/cloud_gcp/src/main/scala/ai/chronon/integrations/cloud_gcp/EnhancedDatasetKVStoreImpl.scala
+++ b/cloud_gcp/src/main/scala/ai/chronon/integrations/cloud_gcp/EnhancedDatasetKVStoreImpl.scala
@@ -194,8 +194,10 @@ class EnhancedDatasetKVStoreImpl(dataClient: BigtableDataClient,
     * Returns timestamps for the start of each date in the range.
     */
   private def generateDateRange(startTs: Long, endTs: Long): List[Long] = {
+    // Cap endTs to now to avoid querying future date rows that don't exist in Bigtable
+    val effectiveEndTs = math.min(endTs, System.currentTimeMillis())
     val startZoned = Instant.ofEpochMilli(startTs).atZone(ZoneOffset.UTC)
-    val endZoned = Instant.ofEpochMilli(endTs).atZone(ZoneOffset.UTC)
+    val endZoned = Instant.ofEpochMilli(effectiveEndTs).atZone(ZoneOffset.UTC)
 
     val startDate = startZoned.toLocalDate
     val endDate = endZoned.toLocalDate


### PR DESCRIPTION
## Summary
Fix bug that occurs when you fetch metrics with an endTs that overshoots latest existing data.

## Checklist
Did not add unit tests but tested locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed date range generation to prevent queries for future dates that don't exist in the data store.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->