### PR TITLE
improv: bump up spark version

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -89,7 +89,7 @@ object Constants {
   )
 
   // Version definitions
-  val sparkVersion = "3.5.3"
+  val sparkVersion = "3.5.7"
   def sparkDeps = Seq(
     mvn"org.apache.spark::spark-core:$sparkVersion",
     mvn"org.apache.spark::spark-sql:$sparkVersion",

--- a/spark/src/test/scala/ai/chronon/spark/join/EventsEntitiesSnapshotTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/join/EventsEntitiesSnapshotTest.scala
@@ -128,8 +128,12 @@ class EventsEntitiesSnapshotTest extends BaseJoinTest {
     val dropStart = tableUtils.partitionSpec.minus(today, new Window(55, TimeUnit.DAYS))
     val dropEnd = tableUtils.partitionSpec.minus(today, new Window(45, TimeUnit.DAYS))
 
-    // Delete data in the specified partition range (equivalent to dropping partitions in Iceberg)
-    spark.sql(s"DELETE FROM $namespace.test_user_transaction_features WHERE ds >= '$dropStart' AND ds <= '$dropEnd'")
+    // Drop partitions in the specified range
+    tableUtils.partitions(s"$namespace.test_user_transaction_features")
+      .filter(p => p >= dropStart && p <= dropEnd)
+      .foreach { p =>
+        spark.sql(s"ALTER TABLE $namespace.test_user_transaction_features DROP IF EXISTS PARTITION (ds='$p')")
+      }
     println(tableUtils.partitions(s"$namespace.test_user_transaction_features"))
 
     def resetUDFs(): Unit = {
@@ -215,8 +219,8 @@ class EventsEntitiesSnapshotTest extends BaseJoinTest {
     val endMinus1 = tableUtils.partitionSpec.minus(end, new Window(1, TimeUnit.DAYS))
     val endMinus2 = tableUtils.partitionSpec.minus(end, new Window(2, TimeUnit.DAYS))
 
-    // Delete specific partition data (equivalent to dropping single partitions in Iceberg)
-    spark.sql(s"DELETE FROM $namespace.test_user_transaction_features WHERE ds = '$endMinus1'")
+    // Drop the specific partition
+    spark.sql(s"ALTER TABLE $namespace.test_user_transaction_features DROP IF EXISTS PARTITION (ds='$endMinus1')")
     println(tableUtils.partitions(s"$namespace.test_user_transaction_features"))
 
     resetUDFs()

--- a/spark/src/test/scala/ai/chronon/spark/join/JoinUtilsTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/join/JoinUtilsTest.scala
@@ -231,7 +231,7 @@ class JoinUtilsTest extends BaseJoinTest {
     createDatabase(namespace)
     // left table
     val itemQueries = List(Column("item", api.StringType, 100))
-    val itemQueriesTable = "joinUtil.item_queries_table"
+    val itemQueriesTable = s"$namespace.item_queries_table"
     DataFrameGen
       .events(spark, itemQueries, 1000, partitions = 100)
       .save(itemQueriesTable)
@@ -247,7 +247,7 @@ class JoinUtilsTest extends BaseJoinTest {
     createDatabase(namespace)
     // left table
     val itemQueries = List(Column("item", api.StringType, 100))
-    val itemQueriesTable = "joinUtil.queries_table"
+    val itemQueriesTable = s"$namespace.queries_table"
     DataFrameGen
       .events(spark, itemQueries, 1000, partitions = 50)
       .save(itemQueriesTable)

--- a/spark/src/test/scala/ai/chronon/spark/utils/SparkTestBase.scala
+++ b/spark/src/test/scala/ai/chronon/spark/utils/SparkTestBase.scala
@@ -20,6 +20,7 @@ import java.nio.file.Files
 abstract class SparkTestBase extends AnyFlatSpec with BeforeAndAfterAll {
 
   protected lazy val icebergWarehouse = Files.createTempDirectory("iceberg-test").toString
+  protected lazy val hiveWarehouse = Files.createTempDirectory("hive-warehouse-test").toString
 
   /**
    * Override this method to provide additional Spark configurations.
@@ -30,7 +31,7 @@ abstract class SparkTestBase extends AnyFlatSpec with BeforeAndAfterAll {
   private[spark] lazy val DefaultSparkConfs = Map(
     "spark.sql.extensions" -> "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
     "spark.sql.catalog.spark_catalog" -> "org.apache.iceberg.spark.SparkSessionCatalog",
-    "spark.sql.warehouse.dir" -> s"${System.getProperty("java.io.tmpdir")}/warehouse",
+    "spark.sql.warehouse.dir" -> hiveWarehouse,
     "spark.sql.catalog.spark_catalog.type" -> "hadoop",
     "spark.sql.catalog.spark_catalog.warehouse" -> icebergWarehouse,
     "spark.driver.bindAddress" -> "127.0.0.1",


### PR DESCRIPTION
## Summary

Bumping up to address a CVE.

The runtime spark is cloud provided.

For sanity of mind testing:
- [x] Eval (GCP/AWS/Azure)
- [x] Backfill / run-adhoc
  - [x] GCP
  - [ ] AWS
  - [ ] Azure 


Pausing this as seeing:
```
Job submission failed for node gcp.user_activities.v1__1__upload with step ID: c3686c3a-4bf1-4138-a9a2-29627b014f0b. Error: Cluster zipline-transient-upload-cluster is in state ERROR and cannot be used for job submission.
Stack trace:
ai.chronon.integrations.cloud_gcp.DataprocSubmitter.ensureClusterReady(DataprocSubmitter.scala:631)
ai.chronon.orchestration.executor.NodeSubmitter.submitJob(NodeSubmitter.scala:85)
ai.chronon.orchestration.executor.StepTracker.$anonfun$submitJobForStep$6(StepTracker.scala:220)
scala.util.Success.$anonfun$map$1(Try.scala:255)
scala.util.Success.map(Try.scala:213)
scala.concurrent.Future.$anonfun$map$1(Future.scala:292)
scala.concurrent.impl.Promise.liftedTree1$1(Promise.scala:33)
scala.concurrent.impl.Promise.$anonfun$transform$1(Promise.scala:33)
scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64)
java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
java.base/java.lang.Thread.run(Thread.java:840)
```
## Checklist
- [ ] Added Unit Tests
- [x] Covered by existing CI
There were some test failures that had to be adjusted due to tightening with what spark tolerates.
<html><head></head><body><p>This is a <em>very solid</em> write-up—you’ve basically hit three real categories of regressions that show up in Spark patch upgrades. Let me sanity-check each one and add a bit more “why this changed” + what to watch going forward.</p><hr><h1>🧩 1. <code inline="">SCHEMA_NOT_FOUND: joinutil</code></h1><blockquote><p>camelCase → lowercased → mismatch with <code inline="">join_util</code></p></blockquote><h3>✔️ Your diagnosis is correct</h3><p>In Apache Spark 3.5.x, identifier handling has continued tightening toward:</p><ul><li><p><strong>case-insensitive resolution</strong></p></li><li><p><strong>normalized (lowercase) identifiers internally</strong></p></li></ul><p>So:</p><pre><code class="language-sql">joinUtil.table  →  joinutil.table
</code></pre><p>No automatic mapping to:</p><pre><code class="language-sql">join_util.table
</code></pre><hr><h3>🧠 What likely changed in 3.5.7</h3><p>Not a “new feature” per se, but:</p><ul><li><p>More consistent normalization in the analyzer</p></li><li><p>Fewer accidental passes where mixed-case names worked</p></li></ul><p>👉 These often show up as:</p><ul><li><p><code inline="">SCHEMA_NOT_FOUND</code></p></li><li><p><code inline="">TABLE_OR_VIEW_NOT_FOUND</code></p></li></ul><hr><h3>✅ Your fix is the <em>right</em> one</h3><pre><code class="language-scala">s"$namespace.table"
</code></pre><p>This avoids:</p><ul><li><p>hardcoded naming assumptions</p></li><li><p>implicit normalization surprises</p></li></ul><hr><h3>⚠️ Future-proofing tip</h3><p>Avoid:</p><pre><code class="language-sql">dbName.tableName
</code></pre><p>Prefer:</p><ul><li><p>explicit catalog + namespace if using custom catalogs</p></li><li><p>or programmatic namespace injection (like you did)</p></li></ul><hr><h1>🗂️ 2. <code inline="">LOCATION_ALREADY_EXISTS</code></h1><h3>✔️ This is a real behavioral tightening</h3><p>Spark has historically been <strong>too permissive</strong> about:</p><ul><li><p>reusing existing warehouse directories</p></li><li><p>silently overwriting metadata expectations</p></li></ul><p>In newer 3.5.x patches:</p><p>👉 Table creation now fails if:</p><ul><li><p>the directory already exists</p></li><li><p>and it’s not clearly a valid managed table location</p></li></ul><hr><h3>🧠 Why this change happened</h3><p>To prevent:</p><ul><li><p>corrupt table states</p></li><li><p>accidental reuse of stale data</p></li><li><p>inconsistencies between metastore and filesystem</p></li></ul><hr><h3>✅ Your fix is exactly what Spark expects</h3><p>Using a per-run temp dir:</p><pre><code class="language-scala">hiveWarehouse = Files.createTempDirectory(...)
</code></pre><p>This aligns with how:</p><ul><li><p>Apache Iceberg tests work</p></li><li><p>Spark’s own test suites isolate environments</p></li></ul><hr><h3>⚠️ Hidden gotcha</h3><p>Even with temp dirs:</p><ul><li><p>If tests run in parallel → collisions can still happen if not isolated per JVM</p></li><li><p>Cleanup matters (especially on CI agents)</p></li></ul><hr><h1>🧨 3. <code inline="">DELETE</code> no longer supported (Iceberg catalog)</h1><p>This is the most interesting one.</p><hr><h2>✔️ Your observation is correct</h2><blockquote><p><code inline="">DELETE FROM</code> no longer supported on non-Iceberg tables in Iceberg catalog</p></blockquote><p>This is <strong>intentional tightening</strong>, not a bug.</p><hr><h2>🧠 What changed conceptually</h2><p>In Spark:</p><ul><li><p><code inline="">DELETE</code> is <strong>delegated to the table provider</strong></p></li><li><p>The catalog decides whether the operation is valid</p></li></ul><p>With Apache Iceberg:</p><ul><li><p><code inline="">SparkSessionCatalog</code> enforces:</p><ul><li><p>only Iceberg tables support row-level operations like <code inline="">DELETE</code></p></li></ul></li></ul><p>So if your table is:</p><ul><li><p>Hive / Parquet / V1 table<br>👉 <code inline="">DELETE</code> → ❌ rejected</p></li></ul><hr><h2>🚨 Why your test used to work</h2><p>Before:</p><ul><li><p>Spark sometimes allowed <code inline="">DELETE</code> to slip through</p></li><li><p>or fallback paths behaved inconsistently</p></li></ul><p>Now:</p><ul><li><p>stricter validation → correct behavior</p></li></ul><hr><h2>✅ Your fix is <em>semantically correct</em></h2><p>You replaced:</p><pre><code class="language-sql">DELETE FROM table WHERE ds = '...'
</code></pre><p>with:</p><pre><code class="language-sql">ALTER TABLE table DROP IF EXISTS PARTITION (ds='...')
</code></pre><p>This is actually <strong>better modeling</strong>:</p>
Intent | Correct operation
-- | --
Remove rows by predicate | DELETE
Remove partition | DROP PARTITION

<hr><h2>⚠️ Subtle but important difference</h2><p>Your old test:</p><ul><li><p>simulated <strong>row-level deletion</strong></p></li></ul><p>Your new test:</p><ul><li><p>performs <strong>partition-level deletion</strong></p></li></ul><p>👉 If anything depended on partial partition deletes, behavior is now different</p><hr><h1>🧠 Big picture: what these 3 issues have in common</h1><p>They all come from the same direction in Spark evolution:</p><h3>👉 Spark is getting stricter about:</h3><ol><li><p><strong>Identifier resolution</strong></p></li><li><p><strong>Filesystem ↔ metastore consistency</strong></p></li><li><p><strong>Table capability enforcement (via catalogs)</strong></p></li></ol><hr><h1>🔍 What I’d double-check next (based on these failures)</h1><p>Given these surfaced, I’d proactively test:</p><h3>1. Catalog behavior</h3><ul><li><p>Are you mixing:</p><ul><li><p><code inline="">spark_catalog</code></p></li><li><p>Iceberg catalog</p></li><li><p>Hive catalog?</p></li></ul></li></ul><p>👉 Resolution rules may have shifted subtly</p><hr><h3>2. Table types</h3><p>Verify for each test:</p><pre><code class="language-sql">DESCRIBE DETAIL table
</code></pre><ul><li><p>Is it actually Iceberg?</p></li><li><p>Or fallback Hive/Parquet?</p></li></ul><hr><h3>3. Other row-level ops</h3><p>If <code inline="">DELETE</code> broke, also test:</p><pre><code class="language-sql">UPDATE table SET ...
MERGE INTO table ...
</code></pre><p>These follow the same capability checks.</p><hr><h1>✔️ TL;DR</h1><p>Your fixes are not just patches—they align with <strong>how Spark expects things to work now</strong>:</p><ul><li><p>✅ Namespace fix → avoids stricter identifier normalization</p></li><li><p>✅ Temp warehouse → matches stricter location validation</p></li><li><p>✅ DROP PARTITION → respects catalog-enforced capabilities</p></li></ul><hr><p>If you want, I can help you turn this into a <strong>migration checklist or CI guardrails</strong> so future Spark bumps don’t rediscover the same class of issues.</p></body></html>
- [x] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Apache Spark dependency to version 3.5.7.

* **Tests**
  * Improved test isolation by using a dedicated temporary Hive warehouse.
  * Stabilized join/partition tests and updated partition handling to better reflect real partition operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->