### PR TITLE
correct GroupBy types to reflect correct k

### DIFF
--- a/python/src/ai/chronon/group_by.py
+++ b/python/src/ai/chronon/group_by.py
@@ -48,7 +48,7 @@ LOGGER = logging.getLogger()
 
 def collector(
     op: ttypes.Operation,
-) -> Callable[[ttypes.Operation], Tuple[ttypes.Operation, Dict[str, str]]]:
+) -> Callable[[int], Tuple[ttypes.Operation, Dict[str, str]]]:
     return lambda k: (op, {"k": str(k)})
 
 


### PR DESCRIPTION
## Summary

`collector` is incorrectly defined a callable of `int -> (op, dict)`, the returned callable should _only_ takes a `k` that is valid as an int. Note this ~is~ shouldn't be breaking. See:

```py
def collector(
    op: ttypes.Operation,
) -> Callable[[ttypes.Operation], Tuple[ttypes.Operation, Dict[str, str]]]:
    return lambda k: (op, {"k": str(k)})
```

and used in

```py
APPROX_UNIQUE_COUNT_LGK = collector(ttypes.Operation.APPROX_UNIQUE_COUNT)
FREQUENT_K = collector(ttypes.Operation.HISTOGRAM)
APPROX_FREQUENT_K = collector(ttypes.Operation.APPROX_FREQUENT_K)
APPROX_HEAVY_HITTERS_K = collector(ttypes.Operation.APPROX_HEAVY_HITTERS_K)
FIRST_K = collector(ttypes.Operation.FIRST_K)
LAST_K = collector(ttypes.Operation.LAST_K)
TOP_K = collector(ttypes.Operation.TOP_K)
BOTTOM_K = collector(ttypes.Operation.BOTTOM_K)
UNIQUE_TOP_K = collector(ttypes.Operation.UNIQUE_TOP_K)
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected type annotation in group aggregation logic to improve code reliability and type checking accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->