### PR TITLE
Add table name into compiled output and use derived name in `output_table_name`

### DIFF
--- a/python/src/ai/chronon/cli/compile/parse_configs.py
+++ b/python/src/ai/chronon/cli/compile/parse_configs.py
@@ -5,6 +5,9 @@ import os
 import sys
 from typing import Any, List
 
+import gen_thrift.api.ttypes as api
+import gen_thrift.common.ttypes as common
+from ai.chronon import utils
 from ai.chronon import airflow_helpers
 from ai.chronon.cli.compile import parse_teams, serializer
 from ai.chronon.cli.compile.compile_context import CompileContext
@@ -13,6 +16,21 @@ from ai.chronon.cli.logger import get_logger
 from gen_thrift.api.ttypes import GroupBy, Join
 
 logger = get_logger()
+
+
+def populate_table_names(obj: Any):
+    """
+    Populate the outputTableInfo.table field in the object's metadata with the
+    resolved output table name for the object and any nested output targets.
+    """
+    for output_obj in utils.get_output_table_targets(obj):
+        execution_info = output_obj.metaData.executionInfo
+        if execution_info.outputTableInfo is None:
+            execution_info.outputTableInfo = common.TableInfo()
+        execution_info.outputTableInfo.table = utils.output_table_name(
+            output_obj,
+            full_name=True,
+        )
 
 
 def from_folder(cls: type, input_dir: str, compile_context: CompileContext) -> List[CompiledObj]:
@@ -33,6 +51,7 @@ def from_folder(cls: type, input_dir: str, compile_context: CompileContext) -> L
                 parse_teams.update_metadata(obj, compile_context.teams_dict)
                 # Populate columnHashes field with semantic hashes
                 populate_column_hashes(obj)
+                populate_table_names(obj)
 
                 # Airflow deps must be set AFTER updating metadata
                 airflow_helpers.set_airflow_deps(obj)
@@ -108,11 +127,7 @@ def from_file(file_path: str, cls: type, input_dir: str):
         if isinstance(obj, cls):
             copied_obj = copy.deepcopy(obj)
 
-            name = f"{mod_path}.{var_name}"
-
-            # Add version suffix if version is set
-            if copied_obj.metaData.version is not None:
-                name = name + "__" + str(copied_obj.metaData.version)
+            name = utils.get_object_name(module_name, var_name, copied_obj.metaData.version)
 
             copied_obj.metaData.name = name
             copied_obj.metaData.team = mod_path.split(".")[0]

--- a/python/src/ai/chronon/cli/compile/parse_configs.py
+++ b/python/src/ai/chronon/cli/compile/parse_configs.py
@@ -5,10 +5,8 @@ import os
 import sys
 from typing import Any, List
 
-import gen_thrift.api.ttypes as api
 import gen_thrift.common.ttypes as common
-from ai.chronon import utils
-from ai.chronon import airflow_helpers
+from ai.chronon import airflow_helpers, utils
 from ai.chronon.cli.compile import parse_teams, serializer
 from ai.chronon.cli.compile.compile_context import CompileContext
 from ai.chronon.cli.compile.display.compiled_obj import CompiledObj

--- a/python/src/ai/chronon/cli/compile/parse_configs.py
+++ b/python/src/ai/chronon/cli/compile/parse_configs.py
@@ -28,6 +28,7 @@ def populate_table_names(obj: Any):
         execution_info.outputTableInfo.table = utils.output_table_name(
             output_obj,
             full_name=True,
+            output_namespace=obj.metaData.outputNamespace,
         )
 
 

--- a/python/src/ai/chronon/cli/compile/parse_teams.py
+++ b/python/src/ai/chronon/cli/compile/parse_teams.py
@@ -98,6 +98,8 @@ def load_teams(conf_root: str, print: bool = True) -> Dict[str, Team]:
 
 
 def update_metadata(obj: Any, team_dict: Dict[str, Team]):
+    from ai.chronon import utils
+
     assert obj is not None, "Cannot update metadata None object"
 
     metadata = obj.metaData
@@ -150,8 +152,9 @@ def update_metadata(obj: Any, team_dict: Dict[str, Team]):
             for m in obj.models or []:
                 set_join_part_or_models_metadata(m, model_transforms_namespace)
 
-    if metadata.executionInfo is None:
-        metadata.executionInfo = ExecutionInfo()
+    for output_obj in utils.get_output_table_targets(obj):
+        if output_obj.metaData.executionInfo is None:
+            output_obj.metaData.executionInfo = ExecutionInfo()
 
     merge_team_execution_info(metadata, team_dict, team)
 

--- a/python/src/ai/chronon/group_by.py
+++ b/python/src/ai/chronon/group_by.py
@@ -31,9 +31,9 @@ def _get_output_table_name(obj, full_name: bool = False):
     Group by backfill output table name
     To be synced with api.Extensions.scala
     """
-    if not obj.metaData.name:
-        utils.__set_name(obj, ttypes.GroupBy, "group_bys")
-    return utils.output_table_name(obj, full_name)
+    name = utils.get_name(obj)
+    obj.metaData.name = name
+    return utils.output_table_name(obj, full_name=full_name)
 
 
 #  The GroupBy's default online/production status is None and it will inherit

--- a/python/src/ai/chronon/join.py
+++ b/python/src/ai/chronon/join.py
@@ -31,13 +31,11 @@ logging.basicConfig(level=logging.INFO)
 
 def _get_output_table_name(join: api.Join, full_name: bool = False):
     """generate output table name for join backfill job"""
-    # join sources could also be created inline alongside groupBy file
-    # so we specify fallback module as group_bys
-    if isinstance(join, api.Join):
-        utils.__set_name(join, api.Join, "joins")
+    name = utils.get_name(join)
+    join.metaData.name = name
     # set output namespace
     if not join.metaData.outputNamespace:
-        team_name = join.metaData.name.split(".")[0]
+        team_name = name.split(".")[0]
         namespace = (
             parse_teams.load_teams(utils.chronon_root_path, print=False)
             .get(team_name)

--- a/python/src/ai/chronon/model.py
+++ b/python/src/ai/chronon/model.py
@@ -296,7 +296,8 @@ def _get_model_transforms_output_table_name(
     model_transforms: ttypes.ModelTransforms, full_name: bool = False
 ):
     """Generate output table name for ModelTransforms"""
-    utils.__set_name(model_transforms, ttypes.ModelTransforms, "models")
+    name = utils.get_name(model_transforms)
+    model_transforms.metaData.name = name
     return utils.output_table_name(model_transforms, full_name=full_name)
 
 

--- a/python/src/ai/chronon/repo/compile.py
+++ b/python/src/ai/chronon/repo/compile.py
@@ -3,8 +3,6 @@ import os
 import sys
 
 import click
-
-from ai.chronon import utils
 from ai.chronon.cli.compile.compile_context import CompileContext
 from ai.chronon.cli.compile.compiler import Compiler
 from ai.chronon.cli.formatter import Format, jsonify_exceptions_if_json_format
@@ -71,7 +69,6 @@ def __compile(
     if chronon_root:
         chronon_root_path = os.path.expanduser(chronon_root)
         os.chdir(chronon_root_path)
-        utils.chronon_root_path = chronon_root_path
 
     # check that a "teams.py" file exists in the current directory
     if not (os.path.exists("teams.py") or os.path.exists("teams.json")):

--- a/python/src/ai/chronon/repo/compile.py
+++ b/python/src/ai/chronon/repo/compile.py
@@ -3,6 +3,7 @@ import os
 import sys
 
 import click
+
 from ai.chronon.cli.compile.compile_context import CompileContext
 from ai.chronon.cli.compile.compiler import Compiler
 from ai.chronon.cli.formatter import Format, jsonify_exceptions_if_json_format

--- a/python/src/ai/chronon/repo/compile.py
+++ b/python/src/ai/chronon/repo/compile.py
@@ -4,6 +4,7 @@ import sys
 
 import click
 
+from ai.chronon import utils
 from ai.chronon.cli.compile.compile_context import CompileContext
 from ai.chronon.cli.compile.compiler import Compiler
 from ai.chronon.cli.formatter import Format, jsonify_exceptions_if_json_format
@@ -70,6 +71,7 @@ def __compile(
     if chronon_root:
         chronon_root_path = os.path.expanduser(chronon_root)
         os.chdir(chronon_root_path)
+        utils.chronon_root_path = chronon_root_path
 
     # check that a "teams.py" file exists in the current directory
     if not (os.path.exists("teams.py") or os.path.exists("teams.json")):

--- a/python/src/ai/chronon/repo/extract_objects.py
+++ b/python/src/ai/chronon/repo/extract_objects.py
@@ -18,6 +18,7 @@ import importlib.util
 import logging
 import os
 
+from ai.chronon import utils
 from ai.chronon.logger import get_logger
 from ai.chronon.repo import FOLDER_NAME_TO_CLASS
 
@@ -75,11 +76,8 @@ def import_module_set_name(module, cls):
             # example module.__name__=group_bys.user.avg_session_length, version=1
             # obj.metaData.name=user.avg_session_length.v1__1
             # obj.metaData.team=user
-            base_name = module.__name__.partition(".")[2] + "." + name
-
-            # Add version suffix if version is set
-            if hasattr(obj.metaData, "version") and obj.metaData.version is not None:
-                base_name = base_name + "__" + str(obj.metaData.version)
+            version = obj.metaData.version if hasattr(obj.metaData, "version") else None
+            base_name = utils.get_object_name(module.__name__, name, version)
 
             obj.metaData.name = base_name
             obj.metaData.team = module.__name__.split(".")[1]

--- a/python/src/ai/chronon/repo/join_backfill.py
+++ b/python/src/ai/chronon/repo/join_backfill.py
@@ -9,6 +9,7 @@ from ai.chronon.utils import (
     dict_to_bash_commands,
     dict_to_exports,
     join_part_name,
+    output_table_name,
     sanitize,
 )
 
@@ -61,7 +62,7 @@ class JoinBackfill:
         """
         flow = Flow(self.join.metaData.name)
         final_node = Node(
-            f"{TASK_PREFIX}__{sanitize(self.join.table)}",
+            f"{TASK_PREFIX}__{sanitize(output_table_name(self.join, full_name=True))}",
             self.run_final_join(),
         )
         left_node = Node(f"{TASK_PREFIX}__left_table", self.run_left_table())

--- a/python/src/ai/chronon/staging_query.py
+++ b/python/src/ai/chronon/staging_query.py
@@ -12,7 +12,8 @@ from ai.chronon.constants import AIRFLOW_DEPENDENCIES_KEY
 
 def _get_output_table_name(staging_query: ttypes.StagingQuery, full_name: bool = False):
     """generate output table name for staging query job"""
-    utils.__set_name(staging_query, ttypes.StagingQuery, "staging_queries")
+    name = utils.get_name(staging_query)
+    staging_query.metaData.name = name
     return utils.output_table_name(staging_query, full_name=full_name)
 
 

--- a/python/src/ai/chronon/utils.py
+++ b/python/src/ai/chronon/utils.py
@@ -372,12 +372,11 @@ def output_table_name(obj, full_name: bool, output_namespace: str = None) -> str
 def join_part_name(jp):
     if jp.groupBy is None:
         raise NotImplementedError("Join Part names for non group bys is not implemented.")
-    if not jp.groupBy.metaData.name and isinstance(jp.groupBy, api.GroupBy):
-        __set_name(jp.groupBy, api.GroupBy, "group_bys")
+    group_by_name = get_name(jp.groupBy)
     return "_".join(
         [
             component
-            for component in [jp.prefix, sanitize(jp.groupBy.metaData.name)]
+            for component in [jp.prefix, sanitize(group_by_name)]
             if component is not None
         ]
     )
@@ -392,8 +391,6 @@ def join_part_output_table_name(join, jp, full_name: bool = False):
     def partOutputTable(jp: JoinPart): String = (Seq(join.metaData.outputTable) ++ Option(jp.prefix) :+
       jp.groupBy.metaData.cleanName).mkString("_")
     """
-    if not join.metaData.name and isinstance(join, api.Join):
-        __set_name(join, api.Join, "joins")
     return "_".join(
         [
             component

--- a/python/src/ai/chronon/utils.py
+++ b/python/src/ai/chronon/utils.py
@@ -15,6 +15,7 @@
 import gc
 import importlib
 import json
+import logging
 import os
 import re
 import shutil
@@ -36,6 +37,7 @@ ANY_SOURCE_TYPE = Union[
 ]
 
 chronon_root_path = ""  # passed from compile.py
+logger = logging.getLogger(__name__)
 
 
 def normalize_source(source: ANY_SOURCE_TYPE, output_namespace: str = None) -> api.Source:
@@ -213,7 +215,7 @@ def get_output_table_targets(obj) -> Iterator[OutputTableTypes]:
             get_name(target)
             yield target
         except ValueError:
-            pass
+            logger.info("Skipping unnamed output target during table-name population: %s", type(target).__name__)
 
 
 def get_query(source: api.Source) -> api.Query:

--- a/python/src/ai/chronon/utils.py
+++ b/python/src/ai/chronon/utils.py
@@ -351,7 +351,7 @@ def get_name(obj) -> str:
     version = obj.metaData.version if hasattr(obj.metaData, "version") else None
     return get_object_name(mod, var, version)
 
-def output_table_name(obj, full_name: bool) -> str:
+def output_table_name(obj, full_name: bool, output_namespace: str = None) -> str:
     """Return the stored output table when present, otherwise derive it from metadata."""
     metadata = obj.metaData
     execution_info = metadata.executionInfo
@@ -363,7 +363,7 @@ def output_table_name(obj, full_name: bool) -> str:
     name = get_name(obj)
     table_name = sanitize(name)
     if full_name:
-        db = metadata.outputNamespace or "{{ db }}"
+        db = metadata.outputNamespace or output_namespace or "{{ db }}"
         return db + "." + table_name
 
     return table_name

--- a/python/src/ai/chronon/utils.py
+++ b/python/src/ai/chronon/utils.py
@@ -21,13 +21,14 @@ import shutil
 import subprocess
 import tempfile
 from collections.abc import Iterable
-from typing import List, Optional, Union, cast
+from typing import Iterator, List, Optional, Union, cast
 
 import ai.chronon.repo.extract_objects as eo
 import gen_thrift.api.ttypes as api
 from ai.chronon.repo import FOLDER_NAME_TO_CLASS
 
 ChrononJobTypes = Union[api.GroupBy, api.Join, api.StagingQuery]
+OutputTableTypes = Union[ChrononJobTypes, api.ModelTransforms]
 
 # Common type definition for any source type used across the codebase
 ANY_SOURCE_TYPE = Union[
@@ -170,6 +171,51 @@ def get_root_source(
         return get_root_source(source.joinSource.join.left)
 
 
+def get_output_children(target: OutputTableTypes) -> Iterator[OutputTableTypes]:
+    """Yield output-producing child configs embedded in the target."""
+    if isinstance(target, api.GroupBy):
+        for source in target.sources or []:
+            if source is None:
+                continue
+            if source.joinSource and source.joinSource.join:
+                yield source.joinSource.join
+            if source.modelTransforms:
+                yield source.modelTransforms
+    elif isinstance(target, api.Join):
+        if target.left:
+            if target.left.joinSource and target.left.joinSource.join:
+                yield target.left.joinSource.join
+            if target.left.modelTransforms:
+                yield target.left.modelTransforms
+        for join_part in target.joinParts or []:
+            if join_part.groupBy:
+                yield join_part.groupBy
+    elif isinstance(target, api.ModelTransforms):
+        for source in target.sources or []:
+            if source is None:
+                continue
+            if source.joinSource and source.joinSource.join:
+                yield source.joinSource.join
+            if source.modelTransforms:
+                yield source.modelTransforms
+
+
+def get_output_table_targets(obj) -> Iterator[OutputTableTypes]:
+    """Yield named output-producing configs in a deterministic depth-first walk."""
+    visited, stack = set(), [obj]
+    while stack:
+        target = stack.pop()
+        if target is None or id(target) in visited:
+            continue
+        visited.add(id(target))
+        stack.extend(reversed(tuple(get_output_children(target))))
+        try:
+            get_name(target)
+            yield target
+        except ValueError:
+            pass
+
+
 def get_query(source: api.Source) -> api.Query:
     return _get_underlying_source(source).query
 
@@ -274,14 +320,53 @@ def dict_to_exports(d):
     return " && ".join(exports)
 
 
-def output_table_name(obj, full_name: bool):
-    table_name = sanitize(obj.metaData.name)
-    db = obj.metaData.outputNamespace
-    db = db or "{{ db }}"
-    if full_name:
-        return db + "." + table_name
+def get_object_name(module_name: str, object_name: str, version: Optional[object] = None) -> str:
+    """Build the canonical Chronon object name from module, variable, and version."""
+    base_name = module_name.partition(".")[2] + "." + object_name
+    if version is not None:
+        base_name = base_name + "__" + str(version)
+    return base_name
+
+
+def get_name(obj) -> str:
+    """Return the object's canonical name, inferring it from module context when needed."""
+    if obj.metaData.name:
+        return obj.metaData.name
+
+    if isinstance(obj, api.GroupBy):
+        mod_prefix = "group_bys"
+    elif isinstance(obj, api.Join):
+        mod_prefix = "joins"
+    elif isinstance(obj, api.StagingQuery):
+        mod_prefix = "staging_queries"
+    elif isinstance(obj, api.ModelTransforms):
+        mod_prefix = "models"
     else:
-        return table_name
+        raise ValueError(f"Name is undefined for unnamed {type(obj).__name__}")
+
+    mod, var = get_mod_and_var_name_from_gc(obj, mod_prefix) or (None, None)
+    if not mod or not var:
+        raise ValueError(f"Name is undefined for unnamed {type(obj).__name__}")
+
+    version = obj.metaData.version if hasattr(obj.metaData, "version") else None
+    return get_object_name(mod, var, version)
+
+def output_table_name(obj, full_name: bool) -> str:
+    """Return the stored output table when present, otherwise derive it from metadata."""
+    metadata = obj.metaData
+    execution_info = metadata.executionInfo
+    output_table_info = execution_info.outputTableInfo if execution_info else None
+    stored_table = output_table_info.table if output_table_info else None
+    if stored_table:
+        return stored_table if full_name else stored_table.rsplit(".", 1)[-1]
+
+    name = get_name(obj)
+    table_name = sanitize(name)
+    if full_name:
+        db = metadata.outputNamespace or "{{ db }}"
+        return db + "." + table_name
+
+    return table_name
 
 
 def join_part_name(jp):
@@ -321,7 +406,7 @@ def join_part_output_table_name(join, jp, full_name: bool = False):
     )
 
 
-def log_table_name(obj, full_name: bool = False):
+def log_table_name(obj, full_name: bool = False) -> str:
     return output_table_name(obj, full_name=full_name) + "_logged"
 
 

--- a/python/test/canary/compiled/group_bys/aws/dim_listings.v1__0
+++ b/python/test/canary/compiled/group_bys/aws/dim_listings.v1__0
@@ -110,6 +110,9 @@
       },
       "historicalBackfill": 0,
       "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.aws_dim_listings_v1__0"
+      },
       "stepDays": 30
     },
     "name": "aws.dim_listings.v1__0",

--- a/python/test/canary/compiled/group_bys/aws/dim_merchants.v1__0
+++ b/python/test/canary/compiled/group_bys/aws/dim_merchants.v1__0
@@ -96,6 +96,9 @@
       },
       "historicalBackfill": 0,
       "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.aws_dim_merchants_v1__0"
+      },
       "stepDays": 30
     },
     "name": "aws.dim_merchants.v1__0",

--- a/python/test/canary/compiled/group_bys/aws/item_event_canary.actions_v1__0
+++ b/python/test/canary/compiled/group_bys/aws/item_event_canary.actions_v1__0
@@ -144,7 +144,10 @@
         }
       },
       "historicalBackfill": 0,
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.aws_item_event_canary_actions_v1__0"
+      }
     },
     "name": "aws.item_event_canary.actions_v1__0",
     "online": 1,

--- a/python/test/canary/compiled/group_bys/aws/logging_schema.v1__2
+++ b/python/test/canary/compiled/group_bys/aws/logging_schema.v1__2
@@ -102,7 +102,10 @@
           }
         }
       },
-      "historicalBackfill": 0
+      "historicalBackfill": 0,
+      "outputTableInfo": {
+        "table": "data.aws_logging_schema_v1__2"
+      }
     },
     "name": "aws.logging_schema.v1__2",
     "outputNamespace": "data",

--- a/python/test/canary/compiled/group_bys/aws/purchases.v1_dev__0
+++ b/python/test/canary/compiled/group_bys/aws/purchases.v1_dev__0
@@ -170,7 +170,10 @@
         }
       },
       "historicalBackfill": 0,
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.aws_purchases_v1_dev__0"
+      }
     },
     "name": "aws.purchases.v1_dev__0",
     "online": 1,

--- a/python/test/canary/compiled/group_bys/aws/purchases.v1_test__0
+++ b/python/test/canary/compiled/group_bys/aws/purchases.v1_test__0
@@ -170,7 +170,10 @@
         }
       },
       "historicalBackfill": 0,
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.aws_purchases_v1_test__0"
+      }
     },
     "name": "aws.purchases.v1_test__0",
     "online": 1,

--- a/python/test/canary/compiled/group_bys/aws/user_activities.kafka_v1__1
+++ b/python/test/canary/compiled/group_bys/aws/user_activities.kafka_v1__1
@@ -477,6 +477,9 @@
       },
       "historicalBackfill": 0,
       "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.aws_user_activities_kafka_v1__1"
+      },
       "stepDays": 30
     },
     "name": "aws.user_activities.kafka_v1__1",

--- a/python/test/canary/compiled/group_bys/aws/user_activities.v1__1
+++ b/python/test/canary/compiled/group_bys/aws/user_activities.v1__1
@@ -477,6 +477,9 @@
       },
       "historicalBackfill": 0,
       "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.aws_user_activities_v1__1"
+      },
       "stepDays": 30
     },
     "name": "aws.user_activities.v1__1",

--- a/python/test/canary/compiled/group_bys/aws/user_activities_chained.chained_user_gb__0
+++ b/python/test/canary/compiled/group_bys/aws/user_activities_chained.chained_user_gb__0
@@ -110,7 +110,10 @@
         }
       },
       "historicalBackfill": 0,
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.aws_user_activities_chained_chained_user_gb__0"
+      }
     },
     "name": "aws.user_activities_chained.chained_user_gb__0",
     "online": 1,
@@ -133,6 +136,9 @@
                   "executionInfo": {
                     "historicalBackfill": 0,
                     "onlineSchedule": "@daily",
+                    "outputTableInfo": {
+                      "table": "{{ db }}.aws_dim_listings_v1__0"
+                    },
                     "stepDays": 30
                   },
                   "name": "aws.dim_listings.v1__0",
@@ -189,7 +195,10 @@
           "metaData": {
             "executionInfo": {
               "offlineSchedule": "@daily",
-              "onlineSchedule": "@daily"
+              "onlineSchedule": "@daily",
+              "outputTableInfo": {
+                "table": "data.aws_demo_parent_parent_join__0"
+              }
             },
             "name": "aws.demo_parent.parent_join__0",
             "online": 1,

--- a/python/test/canary/compiled/group_bys/aws/user_activities_chained.chained_user_gb__0
+++ b/python/test/canary/compiled/group_bys/aws/user_activities_chained.chained_user_gb__0
@@ -137,7 +137,7 @@
                     "historicalBackfill": 0,
                     "onlineSchedule": "@daily",
                     "outputTableInfo": {
-                      "table": "{{ db }}.aws_dim_listings_v1__0"
+                      "table": "data.aws_dim_listings_v1__0"
                     },
                     "stepDays": 30
                   },

--- a/python/test/canary/compiled/group_bys/azure/dim_listings.v3
+++ b/python/test/canary/compiled/group_bys/azure/dim_listings.v3
@@ -63,7 +63,10 @@
         }
       },
       "historicalBackfill": 0,
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.azure_dim_listings_v3"
+      }
     },
     "name": "azure.dim_listings.v3",
     "online": 1,

--- a/python/test/canary/compiled/group_bys/azure/dim_merchants.v2
+++ b/python/test/canary/compiled/group_bys/azure/dim_merchants.v2
@@ -49,7 +49,10 @@
         }
       },
       "historicalBackfill": 0,
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.azure_dim_merchants_v2"
+      }
     },
     "name": "azure.dim_merchants.v2",
     "online": 1,

--- a/python/test/canary/compiled/group_bys/azure/item_event_canary.actions_pubsub_v2__0
+++ b/python/test/canary/compiled/group_bys/azure/item_event_canary.actions_pubsub_v2__0
@@ -98,7 +98,10 @@
         }
       },
       "historicalBackfill": 0,
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.azure_item_event_canary_actions_pubsub_v2__0"
+      }
     },
     "name": "azure.item_event_canary.actions_pubsub_v2__0",
     "online": 1,

--- a/python/test/canary/compiled/group_bys/azure/item_event_canary.actions_v1__0
+++ b/python/test/canary/compiled/group_bys/azure/item_event_canary.actions_v1__0
@@ -98,7 +98,10 @@
         }
       },
       "historicalBackfill": 0,
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.azure_item_event_canary_actions_v1__0"
+      }
     },
     "name": "azure.item_event_canary.actions_v1__0",
     "online": 1,

--- a/python/test/canary/compiled/group_bys/azure/logging_schema.v1__2
+++ b/python/test/canary/compiled/group_bys/azure/logging_schema.v1__2
@@ -56,7 +56,10 @@
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
         }
       },
-      "historicalBackfill": 0
+      "historicalBackfill": 0,
+      "outputTableInfo": {
+        "table": "data.azure_logging_schema_v1__2"
+      }
     },
     "name": "azure.logging_schema.v1__2",
     "outputNamespace": "data",

--- a/python/test/canary/compiled/group_bys/azure/purchases.v1_dev__0
+++ b/python/test/canary/compiled/group_bys/azure/purchases.v1_dev__0
@@ -124,7 +124,10 @@
         }
       },
       "historicalBackfill": 0,
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.azure_purchases_v1_dev__0"
+      }
     },
     "name": "azure.purchases.v1_dev__0",
     "online": 1,

--- a/python/test/canary/compiled/group_bys/azure/purchases.v1_dev_notds__0
+++ b/python/test/canary/compiled/group_bys/azure/purchases.v1_dev_notds__0
@@ -124,7 +124,10 @@
         }
       },
       "historicalBackfill": 0,
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.azure_purchases_v1_dev_notds__0"
+      }
     },
     "name": "azure.purchases.v1_dev_notds__0",
     "online": 1,

--- a/python/test/canary/compiled/group_bys/azure/purchases.v1_test__0
+++ b/python/test/canary/compiled/group_bys/azure/purchases.v1_test__0
@@ -124,7 +124,10 @@
         }
       },
       "historicalBackfill": 0,
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.azure_purchases_v1_test__0"
+      }
     },
     "name": "azure.purchases.v1_test__0",
     "online": 1,

--- a/python/test/canary/compiled/group_bys/azure/purchases.v1_test_notds__0
+++ b/python/test/canary/compiled/group_bys/azure/purchases.v1_test_notds__0
@@ -124,7 +124,10 @@
         }
       },
       "historicalBackfill": 0,
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.azure_purchases_v1_test_notds__0"
+      }
     },
     "name": "azure.purchases.v1_test_notds__0",
     "online": 1,

--- a/python/test/canary/compiled/group_bys/azure/user_activities.v1__1
+++ b/python/test/canary/compiled/group_bys/azure/user_activities.v1__1
@@ -431,6 +431,9 @@
       },
       "historicalBackfill": 0,
       "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.azure_user_activities_v1__1"
+      },
       "stepDays": 30
     },
     "name": "azure.user_activities.v1__1",

--- a/python/test/canary/compiled/group_bys/azure/user_activities_chained.chained_user_gb__0
+++ b/python/test/canary/compiled/group_bys/azure/user_activities_chained.chained_user_gb__0
@@ -64,7 +64,10 @@
         }
       },
       "historicalBackfill": 0,
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.azure_user_activities_chained_chained_user_gb__0"
+      }
     },
     "name": "azure.user_activities_chained.chained_user_gb__0",
     "online": 1,
@@ -86,7 +89,10 @@
                 "metaData": {
                   "executionInfo": {
                     "historicalBackfill": 0,
-                    "onlineSchedule": "@daily"
+                    "onlineSchedule": "@daily",
+                    "outputTableInfo": {
+                      "table": "{{ db }}.azure_dim_listings_v3"
+                    }
                   },
                   "name": "azure.dim_listings.v3",
                   "online": 1,
@@ -141,7 +147,10 @@
           "metaData": {
             "executionInfo": {
               "offlineSchedule": "17 0 * * *",
-              "onlineSchedule": "@daily"
+              "onlineSchedule": "@daily",
+              "outputTableInfo": {
+                "table": "data.azure_demo_parent_parent_join__0"
+              }
             },
             "name": "azure.demo_parent.parent_join__0",
             "online": 1,

--- a/python/test/canary/compiled/group_bys/azure/user_activities_chained.chained_user_gb__0
+++ b/python/test/canary/compiled/group_bys/azure/user_activities_chained.chained_user_gb__0
@@ -91,7 +91,7 @@
                     "historicalBackfill": 0,
                     "onlineSchedule": "@daily",
                     "outputTableInfo": {
-                      "table": "{{ db }}.azure_dim_listings_v3"
+                      "table": "data.azure_dim_listings_v3"
                     }
                   },
                   "name": "azure.dim_listings.v3",

--- a/python/test/canary/compiled/group_bys/gcp/dim_listings.v1__0
+++ b/python/test/canary/compiled/group_bys/gcp/dim_listings.v1__0
@@ -89,7 +89,10 @@
         }
       },
       "historicalBackfill": 0,
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_dim_listings_v1__0"
+      }
     },
     "name": "gcp.dim_listings.v1__0",
     "online": 1,

--- a/python/test/canary/compiled/group_bys/gcp/dim_merchants.v1__0
+++ b/python/test/canary/compiled/group_bys/gcp/dim_merchants.v1__0
@@ -75,7 +75,10 @@
         }
       },
       "historicalBackfill": 0,
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_dim_merchants_v1__0"
+      }
     },
     "name": "gcp.dim_merchants.v1__0",
     "online": 1,

--- a/python/test/canary/compiled/group_bys/gcp/item_event_canary.actions_pubsub_v2__0
+++ b/python/test/canary/compiled/group_bys/gcp/item_event_canary.actions_pubsub_v2__0
@@ -124,7 +124,10 @@
         }
       },
       "historicalBackfill": 0,
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_item_event_canary_actions_pubsub_v2__0"
+      }
     },
     "name": "gcp.item_event_canary.actions_pubsub_v2__0",
     "online": 1,

--- a/python/test/canary/compiled/group_bys/gcp/item_event_canary.actions_v1__0
+++ b/python/test/canary/compiled/group_bys/gcp/item_event_canary.actions_v1__0
@@ -124,7 +124,10 @@
         }
       },
       "historicalBackfill": 0,
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_item_event_canary_actions_v1__0"
+      }
     },
     "name": "gcp.item_event_canary.actions_v1__0",
     "online": 1,

--- a/python/test/canary/compiled/group_bys/gcp/logging_schema.v1__2
+++ b/python/test/canary/compiled/group_bys/gcp/logging_schema.v1__2
@@ -82,7 +82,10 @@
           }
         }
       },
-      "historicalBackfill": 0
+      "historicalBackfill": 0,
+      "outputTableInfo": {
+        "table": "data.gcp_logging_schema_v1__2"
+      }
     },
     "name": "gcp.logging_schema.v1__2",
     "outputNamespace": "data",

--- a/python/test/canary/compiled/group_bys/gcp/purchases.v1_dev__0
+++ b/python/test/canary/compiled/group_bys/gcp/purchases.v1_dev__0
@@ -150,7 +150,10 @@
         }
       },
       "historicalBackfill": 0,
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_purchases_v1_dev__0"
+      }
     },
     "name": "gcp.purchases.v1_dev__0",
     "online": 1,

--- a/python/test/canary/compiled/group_bys/gcp/purchases.v1_dev_notds__0
+++ b/python/test/canary/compiled/group_bys/gcp/purchases.v1_dev_notds__0
@@ -150,7 +150,10 @@
         }
       },
       "historicalBackfill": 0,
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_purchases_v1_dev_notds__0"
+      }
     },
     "name": "gcp.purchases.v1_dev_notds__0",
     "online": 1,

--- a/python/test/canary/compiled/group_bys/gcp/purchases.v1_test__0
+++ b/python/test/canary/compiled/group_bys/gcp/purchases.v1_test__0
@@ -150,7 +150,10 @@
         }
       },
       "historicalBackfill": 0,
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_purchases_v1_test__0"
+      }
     },
     "name": "gcp.purchases.v1_test__0",
     "online": 1,

--- a/python/test/canary/compiled/group_bys/gcp/purchases.v1_test_notds__0
+++ b/python/test/canary/compiled/group_bys/gcp/purchases.v1_test_notds__0
@@ -150,7 +150,10 @@
         }
       },
       "historicalBackfill": 0,
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_purchases_v1_test_notds__0"
+      }
     },
     "name": "gcp.purchases.v1_test_notds__0",
     "online": 1,

--- a/python/test/canary/compiled/group_bys/gcp/user_activities.v1__1
+++ b/python/test/canary/compiled/group_bys/gcp/user_activities.v1__1
@@ -457,6 +457,9 @@
       },
       "historicalBackfill": 0,
       "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_user_activities_v1__1"
+      },
       "stepDays": 30
     },
     "name": "gcp.user_activities.v1__1",

--- a/python/test/canary/compiled/group_bys/gcp/user_activities_chained.chained_user_gb__0
+++ b/python/test/canary/compiled/group_bys/gcp/user_activities_chained.chained_user_gb__0
@@ -90,7 +90,10 @@
         }
       },
       "historicalBackfill": 0,
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_user_activities_chained_chained_user_gb__0"
+      }
     },
     "name": "gcp.user_activities_chained.chained_user_gb__0",
     "online": 1,
@@ -112,7 +115,10 @@
                 "metaData": {
                   "executionInfo": {
                     "historicalBackfill": 0,
-                    "onlineSchedule": "@daily"
+                    "onlineSchedule": "@daily",
+                    "outputTableInfo": {
+                      "table": "{{ db }}.gcp_dim_listings_v1__0"
+                    }
                   },
                   "name": "gcp.dim_listings.v1__0",
                   "online": 1,
@@ -168,7 +174,10 @@
           "metaData": {
             "executionInfo": {
               "offlineSchedule": "17 0 * * *",
-              "onlineSchedule": "@daily"
+              "onlineSchedule": "@daily",
+              "outputTableInfo": {
+                "table": "data.gcp_demo_parent_parent_join__0"
+              }
             },
             "name": "gcp.demo_parent.parent_join__0",
             "online": 1,

--- a/python/test/canary/compiled/group_bys/gcp/user_activities_chained.chained_user_gb__0
+++ b/python/test/canary/compiled/group_bys/gcp/user_activities_chained.chained_user_gb__0
@@ -117,7 +117,7 @@
                     "historicalBackfill": 0,
                     "onlineSchedule": "@daily",
                     "outputTableInfo": {
-                      "table": "{{ db }}.gcp_dim_listings_v1__0"
+                      "table": "data.gcp_dim_listings_v1__0"
                     }
                   },
                   "name": "gcp.dim_listings.v1__0",

--- a/python/test/canary/compiled/group_bys/quickstart/dim_listings.v1__0
+++ b/python/test/canary/compiled/group_bys/quickstart/dim_listings.v1__0
@@ -166,7 +166,10 @@
         }
       },
       "historicalBackfill": 0,
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "quickstart.quickstart_dim_listings_v1__0"
+      }
     },
     "name": "quickstart.dim_listings.v1__0",
     "online": 1,

--- a/python/test/canary/compiled/group_bys/quickstart/dim_merchants.v1__0
+++ b/python/test/canary/compiled/group_bys/quickstart/dim_merchants.v1__0
@@ -152,7 +152,10 @@
         }
       },
       "historicalBackfill": 0,
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "quickstart.quickstart_dim_merchants_v1__0"
+      }
     },
     "name": "quickstart.dim_merchants.v1__0",
     "online": 1,

--- a/python/test/canary/compiled/group_bys/quickstart/user_activities.v1__1
+++ b/python/test/canary/compiled/group_bys/quickstart/user_activities.v1__1
@@ -538,6 +538,9 @@
       },
       "historicalBackfill": 0,
       "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "quickstart.quickstart_user_activities_v1__1"
+      },
       "stepDays": 4
     },
     "name": "quickstart.user_activities.v1__1",

--- a/python/test/canary/compiled/joins/aws/demo.derivations_v1__2
+++ b/python/test/canary/compiled/joins/aws/demo.derivations_v1__2
@@ -134,6 +134,9 @@
             },
             "historicalBackfill": 0,
             "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.aws_dim_listings_v1__0"
+            },
             "stepDays": 30
           },
           "name": "aws.dim_listings.v1__0",
@@ -652,6 +655,9 @@
             },
             "historicalBackfill": 0,
             "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.aws_user_activities_v1__1"
+            },
             "stepDays": 30
           },
           "name": "aws.user_activities.v1__1",
@@ -875,6 +881,9 @@
       },
       "offlineSchedule": "@daily",
       "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.aws_demo_derivations_v1__2"
+      },
       "stepDays": 30
     },
     "name": "aws.demo.derivations_v1__2",

--- a/python/test/canary/compiled/joins/aws/demo.v1__1
+++ b/python/test/canary/compiled/joins/aws/demo.v1__1
@@ -479,6 +479,9 @@
             },
             "historicalBackfill": 0,
             "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.aws_user_activities_v1__1"
+            },
             "stepDays": 30
           },
           "name": "aws.user_activities.v1__1",
@@ -626,6 +629,9 @@
             },
             "historicalBackfill": 0,
             "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.aws_dim_listings_v1__0"
+            },
             "stepDays": 30
           },
           "name": "aws.dim_listings.v1__0",
@@ -763,6 +769,9 @@
             },
             "historicalBackfill": 0,
             "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.aws_dim_merchants_v1__0"
+            },
             "stepDays": 30
           },
           "name": "aws.dim_merchants.v1__0",
@@ -975,6 +984,9 @@
       },
       "offlineSchedule": "@daily",
       "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.aws_demo_v1__1"
+      },
       "stepDays": 30
     },
     "name": "aws.demo.v1__1",

--- a/python/test/canary/compiled/joins/aws/demo_chaining.downstream_join__0
+++ b/python/test/canary/compiled/joins/aws/demo_chaining.downstream_join__0
@@ -138,7 +138,7 @@
                           "historicalBackfill": 0,
                           "onlineSchedule": "@daily",
                           "outputTableInfo": {
-                            "table": "{{ db }}.aws_dim_listings_v1__0"
+                            "table": "data.aws_dim_listings_v1__0"
                           },
                           "stepDays": 30
                         },

--- a/python/test/canary/compiled/joins/aws/demo_chaining.downstream_join__0
+++ b/python/test/canary/compiled/joins/aws/demo_chaining.downstream_join__0
@@ -112,7 +112,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.aws_user_activities_chained_chained_user_gb__0"
+            }
           },
           "name": "aws.user_activities_chained.chained_user_gb__0",
           "online": 1,
@@ -134,6 +137,9 @@
                         "executionInfo": {
                           "historicalBackfill": 0,
                           "onlineSchedule": "@daily",
+                          "outputTableInfo": {
+                            "table": "{{ db }}.aws_dim_listings_v1__0"
+                          },
                           "stepDays": 30
                         },
                         "name": "aws.dim_listings.v1__0",
@@ -190,7 +196,10 @@
                 "metaData": {
                   "executionInfo": {
                     "offlineSchedule": "@daily",
-                    "onlineSchedule": "@daily"
+                    "onlineSchedule": "@daily",
+                    "outputTableInfo": {
+                      "table": "data.aws_demo_parent_parent_join__0"
+                    }
                   },
                   "name": "aws.demo_parent.parent_join__0",
                   "online": 1,
@@ -331,7 +340,10 @@
         }
       },
       "offlineSchedule": "@daily",
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.aws_demo_chaining_downstream_join__0"
+      }
     },
     "name": "aws.demo_chaining.downstream_join__0",
     "online": 1,

--- a/python/test/canary/compiled/joins/aws/demo_parent.parent_join__0
+++ b/python/test/canary/compiled/joins/aws/demo_parent.parent_join__0
@@ -112,6 +112,9 @@
             },
             "historicalBackfill": 0,
             "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.aws_dim_listings_v1__0"
+            },
             "stepDays": 30
           },
           "name": "aws.dim_listings.v1__0",
@@ -278,7 +281,10 @@
         }
       },
       "offlineSchedule": "@daily",
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.aws_demo_parent_parent_join__0"
+      }
     },
     "name": "aws.demo_parent.parent_join__0",
     "online": 1,

--- a/python/test/canary/compiled/joins/aws/item_event_join.canary_batch_v1__0
+++ b/python/test/canary/compiled/joins/aws/item_event_join.canary_batch_v1__0
@@ -172,7 +172,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.aws_purchases_v1_test__0"
+            }
           },
           "name": "aws.purchases.v1_test__0",
           "online": 1,
@@ -316,7 +319,10 @@
         }
       },
       "offlineSchedule": "@daily",
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.aws_item_event_join_canary_batch_v1__0"
+      }
     },
     "name": "aws.item_event_join.canary_batch_v1__0",
     "online": 1,

--- a/python/test/canary/compiled/joins/aws/item_event_join.canary_combined_v1__0
+++ b/python/test/canary/compiled/joins/aws/item_event_join.canary_combined_v1__0
@@ -146,7 +146,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.aws_item_event_canary_actions_v1__0"
+            }
           },
           "name": "aws.item_event_canary.actions_v1__0",
           "online": 1,
@@ -350,7 +353,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.aws_purchases_v1_test__0"
+            }
           },
           "name": "aws.purchases.v1_test__0",
           "online": 1,
@@ -498,7 +504,10 @@
         }
       },
       "offlineSchedule": "@daily",
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.aws_item_event_join_canary_combined_v1__0"
+      }
     },
     "name": "aws.item_event_join.canary_combined_v1__0",
     "online": 1,

--- a/python/test/canary/compiled/joins/aws/item_event_join.canary_streaming_v1__0
+++ b/python/test/canary/compiled/joins/aws/item_event_join.canary_streaming_v1__0
@@ -146,7 +146,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.aws_item_event_canary_actions_v1__0"
+            }
           },
           "name": "aws.item_event_canary.actions_v1__0",
           "online": 1,
@@ -290,7 +293,10 @@
         }
       },
       "offlineSchedule": "@daily",
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.aws_item_event_join_canary_streaming_v1__0"
+      }
     },
     "name": "aws.item_event_join.canary_streaming_v1__0",
     "online": 1,

--- a/python/test/canary/compiled/joins/aws/training_set.v1_dev__0
+++ b/python/test/canary/compiled/joins/aws/training_set.v1_dev__0
@@ -172,7 +172,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.aws_purchases_v1_dev__0"
+            }
           },
           "name": "aws.purchases.v1_dev__0",
           "online": 1,
@@ -313,7 +316,10 @@
           }
         }
       },
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.aws_training_set_v1_dev__0"
+      }
     },
     "name": "aws.training_set.v1_dev__0",
     "online": 0,

--- a/python/test/canary/compiled/joins/aws/training_set.v1_hub__0
+++ b/python/test/canary/compiled/joins/aws/training_set.v1_hub__0
@@ -172,7 +172,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.aws_purchases_v1_test__0"
+            }
           },
           "name": "aws.purchases.v1_test__0",
           "online": 1,
@@ -313,7 +316,10 @@
           }
         }
       },
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.aws_training_set_v1_hub__0"
+      }
     },
     "name": "aws.training_set.v1_hub__0",
     "online": 0,

--- a/python/test/canary/compiled/joins/aws/training_set.v1_test__0
+++ b/python/test/canary/compiled/joins/aws/training_set.v1_test__0
@@ -172,7 +172,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.aws_purchases_v1_test__0"
+            }
           },
           "name": "aws.purchases.v1_test__0",
           "online": 1,
@@ -313,7 +316,10 @@
           }
         }
       },
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.aws_training_set_v1_test__0"
+      }
     },
     "name": "aws.training_set.v1_test__0",
     "online": 0,

--- a/python/test/canary/compiled/joins/azure/demo.derivations_v3
+++ b/python/test/canary/compiled/joins/azure/demo.derivations_v3
@@ -87,7 +87,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.azure_dim_listings_v3"
+            }
           },
           "name": "azure.dim_listings.v3",
           "online": 1,
@@ -210,6 +213,9 @@
       },
       "offlineSchedule": "@daily",
       "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.azure_demo_derivations_v3"
+      },
       "stepDays": 30
     },
     "name": "azure.demo.derivations_v3",

--- a/python/test/canary/compiled/joins/azure/demo.v2
+++ b/python/test/canary/compiled/joins/azure/demo.v2
@@ -65,7 +65,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.azure_dim_listings_v3"
+            }
           },
           "name": "azure.dim_listings.v3",
           "online": 1,
@@ -154,7 +157,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.azure_dim_merchants_v2"
+            }
           },
           "name": "azure.dim_merchants.v2",
           "online": 1,
@@ -263,6 +269,9 @@
       },
       "offlineSchedule": "@daily",
       "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.azure_demo_v2"
+      },
       "stepDays": 30
     },
     "name": "azure.demo.v2",

--- a/python/test/canary/compiled/joins/azure/demo_chaining.downstream_join__0
+++ b/python/test/canary/compiled/joins/azure/demo_chaining.downstream_join__0
@@ -66,7 +66,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.azure_user_activities_chained_chained_user_gb__0"
+            }
           },
           "name": "azure.user_activities_chained.chained_user_gb__0",
           "online": 1,
@@ -87,7 +90,10 @@
                       "metaData": {
                         "executionInfo": {
                           "historicalBackfill": 0,
-                          "onlineSchedule": "@daily"
+                          "onlineSchedule": "@daily",
+                          "outputTableInfo": {
+                            "table": "{{ db }}.azure_dim_listings_v3"
+                          }
                         },
                         "name": "azure.dim_listings.v3",
                         "online": 1,
@@ -142,7 +148,10 @@
                 "metaData": {
                   "executionInfo": {
                     "offlineSchedule": "17 0 * * *",
-                    "onlineSchedule": "@daily"
+                    "onlineSchedule": "@daily",
+                    "outputTableInfo": {
+                      "table": "data.azure_demo_parent_parent_join__0"
+                    }
                   },
                   "name": "azure.demo_parent.parent_join__0",
                   "online": 1,
@@ -237,7 +246,10 @@
         }
       },
       "offlineSchedule": "@daily",
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.azure_demo_chaining_downstream_join__0"
+      }
     },
     "name": "azure.demo_chaining.downstream_join__0",
     "online": 1,

--- a/python/test/canary/compiled/joins/azure/demo_chaining.downstream_join__0
+++ b/python/test/canary/compiled/joins/azure/demo_chaining.downstream_join__0
@@ -92,7 +92,7 @@
                           "historicalBackfill": 0,
                           "onlineSchedule": "@daily",
                           "outputTableInfo": {
-                            "table": "{{ db }}.azure_dim_listings_v3"
+                            "table": "data.azure_dim_listings_v3"
                           }
                         },
                         "name": "azure.dim_listings.v3",

--- a/python/test/canary/compiled/joins/azure/demo_parent.parent_join__0
+++ b/python/test/canary/compiled/joins/azure/demo_parent.parent_join__0
@@ -65,7 +65,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.azure_dim_listings_v3"
+            }
           },
           "name": "azure.dim_listings.v3",
           "online": 1,
@@ -184,7 +187,10 @@
         }
       },
       "offlineSchedule": "17 0 * * *",
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.azure_demo_parent_parent_join__0"
+      }
     },
     "name": "azure.demo_parent.parent_join__0",
     "online": 1,

--- a/python/test/canary/compiled/joins/azure/item_event_join.canary_batch_v1__0
+++ b/python/test/canary/compiled/joins/azure/item_event_join.canary_batch_v1__0
@@ -126,7 +126,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.azure_purchases_v1_test__0"
+            }
           },
           "name": "azure.purchases.v1_test__0",
           "online": 1,
@@ -224,7 +227,10 @@
         }
       },
       "offlineSchedule": "@daily",
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.azure_item_event_join_canary_batch_v1__0"
+      }
     },
     "name": "azure.item_event_join.canary_batch_v1__0",
     "online": 1,

--- a/python/test/canary/compiled/joins/azure/item_event_join.canary_combined_v1__0
+++ b/python/test/canary/compiled/joins/azure/item_event_join.canary_combined_v1__0
@@ -100,7 +100,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.azure_item_event_canary_actions_pubsub_v2__0"
+            }
           },
           "name": "azure.item_event_canary.actions_pubsub_v2__0",
           "online": 1,
@@ -258,7 +261,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.azure_purchases_v1_test__0"
+            }
           },
           "name": "azure.purchases.v1_test__0",
           "online": 1,
@@ -360,7 +366,10 @@
         }
       },
       "offlineSchedule": "@daily",
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.azure_item_event_join_canary_combined_v1__0"
+      }
     },
     "name": "azure.item_event_join.canary_combined_v1__0",
     "online": 1,

--- a/python/test/canary/compiled/joins/azure/item_event_join.canary_streaming_v1__0
+++ b/python/test/canary/compiled/joins/azure/item_event_join.canary_streaming_v1__0
@@ -100,7 +100,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.azure_item_event_canary_actions_pubsub_v2__0"
+            }
           },
           "name": "azure.item_event_canary.actions_pubsub_v2__0",
           "online": 1,
@@ -198,7 +201,10 @@
         }
       },
       "offlineSchedule": "@daily",
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.azure_item_event_join_canary_streaming_v1__0"
+      }
     },
     "name": "azure.item_event_join.canary_streaming_v1__0",
     "online": 1,

--- a/python/test/canary/compiled/joins/azure/training_set.v1_dev__0
+++ b/python/test/canary/compiled/joins/azure/training_set.v1_dev__0
@@ -126,7 +126,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.azure_purchases_v1_dev__0"
+            }
           },
           "name": "azure.purchases.v1_dev__0",
           "online": 1,
@@ -221,7 +224,10 @@
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
         }
       },
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.azure_training_set_v1_dev__0"
+      }
     },
     "name": "azure.training_set.v1_dev__0",
     "online": 0,

--- a/python/test/canary/compiled/joins/azure/training_set.v1_dev_notds__0
+++ b/python/test/canary/compiled/joins/azure/training_set.v1_dev_notds__0
@@ -126,7 +126,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.azure_purchases_v1_dev_notds__0"
+            }
           },
           "name": "azure.purchases.v1_dev_notds__0",
           "online": 1,
@@ -223,7 +226,10 @@
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
         }
       },
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.azure_training_set_v1_dev_notds__0"
+      }
     },
     "name": "azure.training_set.v1_dev_notds__0",
     "online": 0,

--- a/python/test/canary/compiled/joins/azure/training_set.v1_hub__0
+++ b/python/test/canary/compiled/joins/azure/training_set.v1_hub__0
@@ -126,7 +126,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.azure_purchases_v1_test__0"
+            }
           },
           "name": "azure.purchases.v1_test__0",
           "online": 1,
@@ -221,7 +224,10 @@
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
         }
       },
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.azure_training_set_v1_hub__0"
+      }
     },
     "name": "azure.training_set.v1_hub__0",
     "online": 0,

--- a/python/test/canary/compiled/joins/azure/training_set.v1_test__0
+++ b/python/test/canary/compiled/joins/azure/training_set.v1_test__0
@@ -126,7 +126,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.azure_purchases_v1_test__0"
+            }
           },
           "name": "azure.purchases.v1_test__0",
           "online": 1,
@@ -221,7 +224,10 @@
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
         }
       },
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.azure_training_set_v1_test__0"
+      }
     },
     "name": "azure.training_set.v1_test__0",
     "online": 0,

--- a/python/test/canary/compiled/joins/azure/training_set.v1_test_notds__0
+++ b/python/test/canary/compiled/joins/azure/training_set.v1_test_notds__0
@@ -126,7 +126,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.azure_purchases_v1_test_notds__0"
+            }
           },
           "name": "azure.purchases.v1_test_notds__0",
           "online": 1,
@@ -223,7 +226,10 @@
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
         }
       },
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.azure_training_set_v1_test_notds__0"
+      }
     },
     "name": "azure.training_set.v1_test_notds__0",
     "online": 0,

--- a/python/test/canary/compiled/joins/gcp/demo.derivations_v1__2
+++ b/python/test/canary/compiled/joins/gcp/demo.derivations_v1__2
@@ -113,7 +113,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.gcp_dim_listings_v1__0"
+            }
           },
           "name": "gcp.dim_listings.v1__0",
           "online": 1,
@@ -611,6 +614,9 @@
             },
             "historicalBackfill": 0,
             "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.gcp_user_activities_v1__1"
+            },
             "stepDays": 30
           },
           "name": "gcp.user_activities.v1__1",
@@ -813,6 +819,9 @@
       },
       "offlineSchedule": "0 4 * * *",
       "onlineSchedule": "0 3 * * *",
+      "outputTableInfo": {
+        "table": "data.gcp_demo_derivations_v1__2"
+      },
       "stepDays": 30
     },
     "name": "gcp.demo.derivations_v1__2",

--- a/python/test/canary/compiled/joins/gcp/demo.v1__1
+++ b/python/test/canary/compiled/joins/gcp/demo.v1__1
@@ -459,6 +459,9 @@
             },
             "historicalBackfill": 0,
             "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.gcp_user_activities_v1__1"
+            },
             "stepDays": 30
           },
           "name": "gcp.user_activities.v1__1",
@@ -585,7 +588,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.gcp_dim_listings_v1__0"
+            }
           },
           "name": "gcp.dim_listings.v1__0",
           "online": 1,
@@ -701,7 +707,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.gcp_dim_merchants_v1__0"
+            }
           },
           "name": "gcp.dim_merchants.v1__0",
           "online": 1,
@@ -893,6 +902,9 @@
       },
       "offlineSchedule": "@daily",
       "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_demo_v1__1"
+      },
       "stepDays": 30
     },
     "name": "gcp.demo.v1__1",

--- a/python/test/canary/compiled/joins/gcp/demo_chaining.downstream_join__0
+++ b/python/test/canary/compiled/joins/gcp/demo_chaining.downstream_join__0
@@ -118,7 +118,7 @@
                           "historicalBackfill": 0,
                           "onlineSchedule": "@daily",
                           "outputTableInfo": {
-                            "table": "{{ db }}.gcp_dim_listings_v1__0"
+                            "table": "data.gcp_dim_listings_v1__0"
                           }
                         },
                         "name": "gcp.dim_listings.v1__0",

--- a/python/test/canary/compiled/joins/gcp/demo_chaining.downstream_join__0
+++ b/python/test/canary/compiled/joins/gcp/demo_chaining.downstream_join__0
@@ -92,7 +92,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.gcp_user_activities_chained_chained_user_gb__0"
+            }
           },
           "name": "gcp.user_activities_chained.chained_user_gb__0",
           "online": 1,
@@ -113,7 +116,10 @@
                       "metaData": {
                         "executionInfo": {
                           "historicalBackfill": 0,
-                          "onlineSchedule": "@daily"
+                          "onlineSchedule": "@daily",
+                          "outputTableInfo": {
+                            "table": "{{ db }}.gcp_dim_listings_v1__0"
+                          }
                         },
                         "name": "gcp.dim_listings.v1__0",
                         "online": 1,
@@ -169,7 +175,10 @@
                 "metaData": {
                   "executionInfo": {
                     "offlineSchedule": "17 0 * * *",
-                    "onlineSchedule": "@daily"
+                    "onlineSchedule": "@daily",
+                    "outputTableInfo": {
+                      "table": "data.gcp_demo_parent_parent_join__0"
+                    }
                   },
                   "name": "gcp.demo_parent.parent_join__0",
                   "online": 1,
@@ -290,7 +299,10 @@
         }
       },
       "offlineSchedule": "@daily",
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_demo_chaining_downstream_join__0"
+      }
     },
     "name": "gcp.demo_chaining.downstream_join__0",
     "online": 1,

--- a/python/test/canary/compiled/joins/gcp/demo_parent.parent_join__0
+++ b/python/test/canary/compiled/joins/gcp/demo_parent.parent_join__0
@@ -91,7 +91,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.gcp_dim_listings_v1__0"
+            }
           },
           "name": "gcp.dim_listings.v1__0",
           "online": 1,
@@ -237,7 +240,10 @@
         }
       },
       "offlineSchedule": "17 0 * * *",
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_demo_parent_parent_join__0"
+      }
     },
     "name": "gcp.demo_parent.parent_join__0",
     "online": 1,

--- a/python/test/canary/compiled/joins/gcp/item_event_join.canary_batch_v1__0
+++ b/python/test/canary/compiled/joins/gcp/item_event_join.canary_batch_v1__0
@@ -152,7 +152,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.gcp_purchases_v1_test__0"
+            }
           },
           "name": "gcp.purchases.v1_test__0",
           "online": 1,
@@ -276,7 +279,10 @@
         }
       },
       "offlineSchedule": "@daily",
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_item_event_join_canary_batch_v1__0"
+      }
     },
     "name": "gcp.item_event_join.canary_batch_v1__0",
     "online": 1,

--- a/python/test/canary/compiled/joins/gcp/item_event_join.canary_combined_v1__0
+++ b/python/test/canary/compiled/joins/gcp/item_event_join.canary_combined_v1__0
@@ -126,7 +126,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.gcp_item_event_canary_actions_pubsub_v2__0"
+            }
           },
           "name": "gcp.item_event_canary.actions_pubsub_v2__0",
           "online": 1,
@@ -310,7 +313,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.gcp_purchases_v1_test__0"
+            }
           },
           "name": "gcp.purchases.v1_test__0",
           "online": 1,
@@ -438,7 +444,10 @@
         }
       },
       "offlineSchedule": "@daily",
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_item_event_join_canary_combined_v1__0"
+      }
     },
     "name": "gcp.item_event_join.canary_combined_v1__0",
     "online": 1,

--- a/python/test/canary/compiled/joins/gcp/item_event_join.canary_streaming_v1__0
+++ b/python/test/canary/compiled/joins/gcp/item_event_join.canary_streaming_v1__0
@@ -126,7 +126,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.gcp_item_event_canary_actions_pubsub_v2__0"
+            }
           },
           "name": "gcp.item_event_canary.actions_pubsub_v2__0",
           "online": 1,
@@ -250,7 +253,10 @@
         }
       },
       "offlineSchedule": "@daily",
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_item_event_join_canary_streaming_v1__0"
+      }
     },
     "name": "gcp.item_event_join.canary_streaming_v1__0",
     "online": 1,

--- a/python/test/canary/compiled/joins/gcp/training_set.v1_dev__0
+++ b/python/test/canary/compiled/joins/gcp/training_set.v1_dev__0
@@ -152,7 +152,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.gcp_purchases_v1_dev__0"
+            }
           },
           "name": "gcp.purchases.v1_dev__0",
           "online": 1,
@@ -273,7 +276,10 @@
           }
         }
       },
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_training_set_v1_dev__0"
+      }
     },
     "name": "gcp.training_set.v1_dev__0",
     "online": 0,

--- a/python/test/canary/compiled/joins/gcp/training_set.v1_dev_notds__0
+++ b/python/test/canary/compiled/joins/gcp/training_set.v1_dev_notds__0
@@ -152,7 +152,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.gcp_purchases_v1_dev_notds__0"
+            }
           },
           "name": "gcp.purchases.v1_dev_notds__0",
           "online": 1,
@@ -275,7 +278,10 @@
           }
         }
       },
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_training_set_v1_dev_notds__0"
+      }
     },
     "name": "gcp.training_set.v1_dev_notds__0",
     "online": 0,

--- a/python/test/canary/compiled/joins/gcp/training_set.v1_hub__0
+++ b/python/test/canary/compiled/joins/gcp/training_set.v1_hub__0
@@ -152,7 +152,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.gcp_purchases_v1_test__0"
+            }
           },
           "name": "gcp.purchases.v1_test__0",
           "online": 1,
@@ -273,7 +276,10 @@
           }
         }
       },
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_training_set_v1_hub__0"
+      }
     },
     "name": "gcp.training_set.v1_hub__0",
     "online": 0,

--- a/python/test/canary/compiled/joins/gcp/training_set.v1_test__0
+++ b/python/test/canary/compiled/joins/gcp/training_set.v1_test__0
@@ -152,7 +152,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.gcp_purchases_v1_test__0"
+            }
           },
           "name": "gcp.purchases.v1_test__0",
           "online": 1,
@@ -273,7 +276,10 @@
           }
         }
       },
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_training_set_v1_test__0"
+      }
     },
     "name": "gcp.training_set.v1_test__0",
     "online": 0,

--- a/python/test/canary/compiled/joins/gcp/training_set.v1_test_notds__0
+++ b/python/test/canary/compiled/joins/gcp/training_set.v1_test_notds__0
@@ -152,7 +152,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "data.gcp_purchases_v1_test_notds__0"
+            }
           },
           "name": "gcp.purchases.v1_test_notds__0",
           "online": 1,
@@ -275,7 +278,10 @@
           }
         }
       },
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_training_set_v1_test_notds__0"
+      }
     },
     "name": "gcp.training_set.v1_test_notds__0",
     "online": 0,

--- a/python/test/canary/compiled/joins/quickstart/demo.derivations_v1__1
+++ b/python/test/canary/compiled/joins/quickstart/demo.derivations_v1__1
@@ -190,7 +190,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "quickstart.quickstart_dim_listings_v1__0"
+            }
           },
           "name": "quickstart.dim_listings.v1__0",
           "online": 1,
@@ -769,6 +772,9 @@
             },
             "historicalBackfill": 0,
             "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "quickstart.quickstart_user_activities_v1__1"
+            },
             "stepDays": 4
           },
           "name": "quickstart.user_activities.v1__1",
@@ -1049,6 +1055,9 @@
       },
       "offlineSchedule": "0 3 * * *",
       "onlineSchedule": "0 3 * * *",
+      "outputTableInfo": {
+        "table": "quickstart.quickstart_demo_derivations_v1__1"
+      },
       "stepDays": 5
     },
     "name": "quickstart.demo.derivations_v1__1",

--- a/python/test/canary/compiled/joins/quickstart/demo.v1__1
+++ b/python/test/canary/compiled/joins/quickstart/demo.v1__1
@@ -540,6 +540,9 @@
             },
             "historicalBackfill": 0,
             "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "quickstart.quickstart_user_activities_v1__1"
+            },
             "stepDays": 4
           },
           "name": "quickstart.user_activities.v1__1",
@@ -743,7 +746,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "quickstart.quickstart_dim_listings_v1__0"
+            }
           },
           "name": "quickstart.dim_listings.v1__0",
           "online": 1,
@@ -1023,6 +1029,9 @@
       },
       "offlineSchedule": "@daily",
       "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "quickstart.quickstart_demo_v1__1"
+      },
       "stepDays": 5
     },
     "name": "quickstart.demo.v1__1",

--- a/python/test/canary/compiled/model_transforms/aws/ctr.v1__1
+++ b/python/test/canary/compiled/model_transforms/aws/ctr.v1__1
@@ -115,6 +115,9 @@
             "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
           }
         }
+      },
+      "outputTableInfo": {
+        "table": "data.aws_ctr_v1__1"
       }
     },
     "name": "aws.ctr.v1__1",
@@ -342,6 +345,9 @@
                   "executionInfo": {
                     "historicalBackfill": 0,
                     "onlineSchedule": "@daily",
+                    "outputTableInfo": {
+                      "table": "{{ db }}.aws_dim_listings_v1__0"
+                    },
                     "stepDays": 30
                   },
                   "name": "aws.dim_listings.v1__0",
@@ -719,6 +725,9 @@
                     },
                     "historicalBackfill": 0,
                     "onlineSchedule": "@daily",
+                    "outputTableInfo": {
+                      "table": "{{ db }}.aws_user_activities_v1__1"
+                    },
                     "stepDays": 30
                   },
                   "name": "aws.user_activities.v1__1",
@@ -772,6 +781,9 @@
               "enableStatsCompute": 1,
               "offlineSchedule": "@daily",
               "onlineSchedule": "@daily",
+              "outputTableInfo": {
+                "table": "data.aws_demo_derivations_v1__2"
+              },
               "stepDays": 30
             },
             "name": "aws.demo.derivations_v1__2",

--- a/python/test/canary/compiled/model_transforms/aws/ctr.v1__1
+++ b/python/test/canary/compiled/model_transforms/aws/ctr.v1__1
@@ -346,7 +346,7 @@
                     "historicalBackfill": 0,
                     "onlineSchedule": "@daily",
                     "outputTableInfo": {
-                      "table": "{{ db }}.aws_dim_listings_v1__0"
+                      "table": "data.aws_dim_listings_v1__0"
                     },
                     "stepDays": 30
                   },
@@ -726,7 +726,7 @@
                     "historicalBackfill": 0,
                     "onlineSchedule": "@daily",
                     "outputTableInfo": {
-                      "table": "{{ db }}.aws_user_activities_v1__1"
+                      "table": "data.aws_user_activities_v1__1"
                     },
                     "stepDays": 30
                   },

--- a/python/test/canary/compiled/model_transforms/aws/listing.v1__2
+++ b/python/test/canary/compiled/model_transforms/aws/listing.v1__2
@@ -103,6 +103,9 @@
             "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
           }
         }
+      },
+      "outputTableInfo": {
+        "table": "data.aws_listing_transforms_v1__2"
       }
     },
     "name": "aws.listing.v1__2",
@@ -621,6 +624,9 @@
                     },
                     "historicalBackfill": 0,
                     "onlineSchedule": "@daily",
+                    "outputTableInfo": {
+                      "table": "{{ db }}.aws_user_activities_v1__1"
+                    },
                     "stepDays": 30
                   },
                   "name": "aws.user_activities.v1__1",
@@ -663,6 +669,9 @@
                   "executionInfo": {
                     "historicalBackfill": 0,
                     "onlineSchedule": "@daily",
+                    "outputTableInfo": {
+                      "table": "{{ db }}.aws_dim_listings_v1__0"
+                    },
                     "stepDays": 30
                   },
                   "name": "aws.dim_listings.v1__0",
@@ -709,6 +718,9 @@
                   "executionInfo": {
                     "historicalBackfill": 0,
                     "onlineSchedule": "@daily",
+                    "outputTableInfo": {
+                      "table": "{{ db }}.aws_dim_merchants_v1__0"
+                    },
                     "stepDays": 30
                   },
                   "name": "aws.dim_merchants.v1__0",
@@ -753,6 +765,9 @@
               "enableStatsCompute": 1,
               "offlineSchedule": "@daily",
               "onlineSchedule": "@daily",
+              "outputTableInfo": {
+                "table": "data.aws_demo_v1__1"
+              },
               "stepDays": 30
             },
             "name": "aws.demo.v1__1",

--- a/python/test/canary/compiled/model_transforms/aws/listing.v1__2
+++ b/python/test/canary/compiled/model_transforms/aws/listing.v1__2
@@ -625,7 +625,7 @@
                     "historicalBackfill": 0,
                     "onlineSchedule": "@daily",
                     "outputTableInfo": {
-                      "table": "{{ db }}.aws_user_activities_v1__1"
+                      "table": "data.aws_user_activities_v1__1"
                     },
                     "stepDays": 30
                   },
@@ -670,7 +670,7 @@
                     "historicalBackfill": 0,
                     "onlineSchedule": "@daily",
                     "outputTableInfo": {
-                      "table": "{{ db }}.aws_dim_listings_v1__0"
+                      "table": "data.aws_dim_listings_v1__0"
                     },
                     "stepDays": 30
                   },
@@ -719,7 +719,7 @@
                     "historicalBackfill": 0,
                     "onlineSchedule": "@daily",
                     "outputTableInfo": {
-                      "table": "{{ db }}.aws_dim_merchants_v1__0"
+                      "table": "data.aws_dim_merchants_v1__0"
                     },
                     "stepDays": 30
                   },

--- a/python/test/canary/compiled/model_transforms/aws/listing.v1__2
+++ b/python/test/canary/compiled/model_transforms/aws/listing.v1__2
@@ -105,7 +105,7 @@
         }
       },
       "outputTableInfo": {
-        "table": "data.aws_listing_transforms_v1__2"
+        "table": "data.aws_listing_v1__2"
       }
     },
     "name": "aws.listing.v1__2",

--- a/python/test/canary/compiled/model_transforms/gcp/ctr.v1__1
+++ b/python/test/canary/compiled/model_transforms/gcp/ctr.v1__1
@@ -305,7 +305,7 @@
                     "historicalBackfill": 0,
                     "onlineSchedule": "@daily",
                     "outputTableInfo": {
-                      "table": "{{ db }}.gcp_dim_listings_v1__0"
+                      "table": "data.gcp_dim_listings_v1__0"
                     }
                   },
                   "name": "gcp.dim_listings.v1__0",
@@ -684,7 +684,7 @@
                     "historicalBackfill": 0,
                     "onlineSchedule": "@daily",
                     "outputTableInfo": {
-                      "table": "{{ db }}.gcp_user_activities_v1__1"
+                      "table": "data.gcp_user_activities_v1__1"
                     },
                     "stepDays": 30
                   },

--- a/python/test/canary/compiled/model_transforms/gcp/ctr.v1__1
+++ b/python/test/canary/compiled/model_transforms/gcp/ctr.v1__1
@@ -95,6 +95,9 @@
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
           }
         }
+      },
+      "outputTableInfo": {
+        "table": "data.gcp_ctr_v1__1"
       }
     },
     "name": "gcp.ctr.v1__1",
@@ -300,7 +303,10 @@
                 "metaData": {
                   "executionInfo": {
                     "historicalBackfill": 0,
-                    "onlineSchedule": "@daily"
+                    "onlineSchedule": "@daily",
+                    "outputTableInfo": {
+                      "table": "{{ db }}.gcp_dim_listings_v1__0"
+                    }
                   },
                   "name": "gcp.dim_listings.v1__0",
                   "online": 1,
@@ -677,6 +683,9 @@
                     },
                     "historicalBackfill": 0,
                     "onlineSchedule": "@daily",
+                    "outputTableInfo": {
+                      "table": "{{ db }}.gcp_user_activities_v1__1"
+                    },
                     "stepDays": 30
                   },
                   "name": "gcp.user_activities.v1__1",
@@ -729,6 +738,9 @@
             "executionInfo": {
               "offlineSchedule": "0 4 * * *",
               "onlineSchedule": "0 3 * * *",
+              "outputTableInfo": {
+                "table": "data.gcp_demo_derivations_v1__2"
+              },
               "stepDays": 30
             },
             "name": "gcp.demo.derivations_v1__2",

--- a/python/test/canary/compiled/model_transforms/gcp/listing.v1__2
+++ b/python/test/canary/compiled/model_transforms/gcp/listing.v1__2
@@ -85,7 +85,7 @@
         }
       },
       "outputTableInfo": {
-        "table": "data.gcp_listing_transforms_v1__2"
+        "table": "data.gcp_listing_v1__2"
       }
     },
     "name": "gcp.listing.v1__2",

--- a/python/test/canary/compiled/model_transforms/gcp/listing.v1__2
+++ b/python/test/canary/compiled/model_transforms/gcp/listing.v1__2
@@ -83,6 +83,9 @@
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
           }
         }
+      },
+      "outputTableInfo": {
+        "table": "data.gcp_listing_transforms_v1__2"
       }
     },
     "name": "gcp.listing.v1__2",
@@ -581,6 +584,9 @@
                     },
                     "historicalBackfill": 0,
                     "onlineSchedule": "@daily",
+                    "outputTableInfo": {
+                      "table": "{{ db }}.gcp_user_activities_v1__1"
+                    },
                     "stepDays": 30
                   },
                   "name": "gcp.user_activities.v1__1",
@@ -622,7 +628,10 @@
                 "metaData": {
                   "executionInfo": {
                     "historicalBackfill": 0,
-                    "onlineSchedule": "@daily"
+                    "onlineSchedule": "@daily",
+                    "outputTableInfo": {
+                      "table": "{{ db }}.gcp_dim_listings_v1__0"
+                    }
                   },
                   "name": "gcp.dim_listings.v1__0",
                   "online": 1,
@@ -667,7 +676,10 @@
                 "metaData": {
                   "executionInfo": {
                     "historicalBackfill": 0,
-                    "onlineSchedule": "@daily"
+                    "onlineSchedule": "@daily",
+                    "outputTableInfo": {
+                      "table": "{{ db }}.gcp_dim_merchants_v1__0"
+                    }
                   },
                   "name": "gcp.dim_merchants.v1__0",
                   "online": 1,
@@ -711,6 +723,9 @@
               "enableStatsCompute": 1,
               "offlineSchedule": "@daily",
               "onlineSchedule": "@daily",
+              "outputTableInfo": {
+                "table": "data.gcp_demo_v1__1"
+              },
               "stepDays": 30
             },
             "name": "gcp.demo.v1__1",

--- a/python/test/canary/compiled/model_transforms/gcp/listing.v1__2
+++ b/python/test/canary/compiled/model_transforms/gcp/listing.v1__2
@@ -585,7 +585,7 @@
                     "historicalBackfill": 0,
                     "onlineSchedule": "@daily",
                     "outputTableInfo": {
-                      "table": "{{ db }}.gcp_user_activities_v1__1"
+                      "table": "data.gcp_user_activities_v1__1"
                     },
                     "stepDays": 30
                   },
@@ -630,7 +630,7 @@
                     "historicalBackfill": 0,
                     "onlineSchedule": "@daily",
                     "outputTableInfo": {
-                      "table": "{{ db }}.gcp_dim_listings_v1__0"
+                      "table": "data.gcp_dim_listings_v1__0"
                     }
                   },
                   "name": "gcp.dim_listings.v1__0",
@@ -678,7 +678,7 @@
                     "historicalBackfill": 0,
                     "onlineSchedule": "@daily",
                     "outputTableInfo": {
-                      "table": "{{ db }}.gcp_dim_merchants_v1__0"
+                      "table": "data.gcp_dim_merchants_v1__0"
                     }
                   },
                   "name": "gcp.dim_merchants.v1__0",

--- a/python/test/canary/compiled/models/aws/click_through_rate.ctr_model__1.0
+++ b/python/test/canary/compiled/models/aws/click_through_rate.ctr_model__1.0
@@ -111,6 +111,9 @@
             "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
           }
         }
+      },
+      "outputTableInfo": {
+        "table": "data.aws_click_through_rate_ctr_model__1_0"
       }
     },
     "name": "aws.click_through_rate.ctr_model__1.0",

--- a/python/test/canary/compiled/models/aws/listing.item_description_model__1
+++ b/python/test/canary/compiled/models/aws/listing.item_description_model__1
@@ -95,6 +95,9 @@
             "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
           }
         }
+      },
+      "outputTableInfo": {
+        "table": "data.aws_listing_model_item_description_model__1"
       }
     },
     "name": "aws.listing.item_description_model__1",

--- a/python/test/canary/compiled/models/aws/listing.item_description_model__1
+++ b/python/test/canary/compiled/models/aws/listing.item_description_model__1
@@ -97,7 +97,7 @@
         }
       },
       "outputTableInfo": {
-        "table": "data.aws_listing_model_item_description_model__1"
+        "table": "data.aws_listing_item_description_model__1"
       }
     },
     "name": "aws.listing.item_description_model__1",

--- a/python/test/canary/compiled/models/aws/listing.item_img_model__001
+++ b/python/test/canary/compiled/models/aws/listing.item_img_model__001
@@ -98,7 +98,7 @@
         }
       },
       "outputTableInfo": {
-        "table": "data.aws_listing_model_item_img_model__001"
+        "table": "data.aws_listing_item_img_model__001"
       }
     },
     "name": "aws.listing.item_img_model__001",

--- a/python/test/canary/compiled/models/aws/listing.item_img_model__001
+++ b/python/test/canary/compiled/models/aws/listing.item_img_model__001
@@ -96,6 +96,9 @@
             "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
           }
         }
+      },
+      "outputTableInfo": {
+        "table": "data.aws_listing_model_item_img_model__001"
       }
     },
     "name": "aws.listing.item_img_model__001",

--- a/python/test/canary/compiled/models/gcp/click_through_rate.ctr_model__1.0
+++ b/python/test/canary/compiled/models/gcp/click_through_rate.ctr_model__1.0
@@ -91,6 +91,9 @@
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
           }
         }
+      },
+      "outputTableInfo": {
+        "table": "data.gcp_click_through_rate_ctr_model__1_0"
       }
     },
     "name": "gcp.click_through_rate.ctr_model__1.0",

--- a/python/test/canary/compiled/models/gcp/listing.item_description_model__1
+++ b/python/test/canary/compiled/models/gcp/listing.item_description_model__1
@@ -77,7 +77,7 @@
         }
       },
       "outputTableInfo": {
-        "table": "data.gcp_listing_model_item_description_model__1"
+        "table": "data.gcp_listing_item_description_model__1"
       }
     },
     "name": "gcp.listing.item_description_model__1",

--- a/python/test/canary/compiled/models/gcp/listing.item_description_model__1
+++ b/python/test/canary/compiled/models/gcp/listing.item_description_model__1
@@ -75,6 +75,9 @@
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
           }
         }
+      },
+      "outputTableInfo": {
+        "table": "data.gcp_listing_model_item_description_model__1"
       }
     },
     "name": "gcp.listing.item_description_model__1",

--- a/python/test/canary/compiled/models/gcp/listing.item_img_model__001
+++ b/python/test/canary/compiled/models/gcp/listing.item_img_model__001
@@ -77,6 +77,9 @@
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
           }
         }
+      },
+      "outputTableInfo": {
+        "table": "data.gcp_listing_model_item_img_model__001"
       }
     },
     "name": "gcp.listing.item_img_model__001",

--- a/python/test/canary/compiled/models/gcp/listing.item_img_model__001
+++ b/python/test/canary/compiled/models/gcp/listing.item_img_model__001
@@ -79,7 +79,7 @@
         }
       },
       "outputTableInfo": {
-        "table": "data.gcp_listing_model_item_img_model__001"
+        "table": "data.gcp_listing_item_img_model__001"
       }
     },
     "name": "gcp.listing.item_img_model__001",

--- a/python/test/canary/compiled/staging_queries/aws/ctr_labels.v1__0
+++ b/python/test/canary/compiled/staging_queries/aws/ctr_labels.v1__0
@@ -87,7 +87,10 @@
           }
         }
       },
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.aws_ctr_labels_v1__0"
+      }
     },
     "name": "aws.ctr_labels.v1__0",
     "outputNamespace": "data",

--- a/python/test/canary/compiled/staging_queries/aws/exports.checkouts__0
+++ b/python/test/canary/compiled/staging_queries/aws/exports.checkouts__0
@@ -89,6 +89,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.aws_exports_checkouts__0"
+      },
       "stepDays": 30
     },
     "name": "aws.exports.checkouts__0",

--- a/python/test/canary/compiled/staging_queries/aws/exports.dim_listings__0
+++ b/python/test/canary/compiled/staging_queries/aws/exports.dim_listings__0
@@ -89,6 +89,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.aws_exports_dim_listings__0"
+      },
       "stepDays": 30
     },
     "name": "aws.exports.dim_listings__0",

--- a/python/test/canary/compiled/staging_queries/aws/exports.dim_merchants__0
+++ b/python/test/canary/compiled/staging_queries/aws/exports.dim_merchants__0
@@ -89,6 +89,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.aws_exports_dim_merchants__0"
+      },
       "stepDays": 30
     },
     "name": "aws.exports.dim_merchants__0",

--- a/python/test/canary/compiled/staging_queries/aws/exports.dim_users__0
+++ b/python/test/canary/compiled/staging_queries/aws/exports.dim_users__0
@@ -89,6 +89,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.aws_exports_dim_users__0"
+      },
       "stepDays": 30
     },
     "name": "aws.exports.dim_users__0",

--- a/python/test/canary/compiled/staging_queries/aws/exports.user_activities__0
+++ b/python/test/canary/compiled/staging_queries/aws/exports.user_activities__0
@@ -89,6 +89,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.aws_exports_user_activities__0"
+      },
       "stepDays": 30
     },
     "name": "aws.exports.user_activities__0",

--- a/python/test/canary/compiled/staging_queries/aws/partitioned_logging.v0__2
+++ b/python/test/canary/compiled/staging_queries/aws/partitioned_logging.v0__2
@@ -87,7 +87,10 @@
           }
         }
       },
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.aws_partitioned_logging_v0__2"
+      }
     },
     "name": "aws.partitioned_logging.v0__2",
     "outputNamespace": "data",

--- a/python/test/canary/compiled/staging_queries/aws/sample_staging_query.cart__0
+++ b/python/test/canary/compiled/staging_queries/aws/sample_staging_query.cart__0
@@ -88,6 +88,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.aws_sample_staging_query_cart__0"
+      },
       "stepDays": 30
     },
     "name": "aws.sample_staging_query.cart__0",

--- a/python/test/canary/compiled/staging_queries/aws/sample_staging_query.item__0
+++ b/python/test/canary/compiled/staging_queries/aws/sample_staging_query.item__0
@@ -88,6 +88,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.aws_sample_staging_query_item__0"
+      },
       "stepDays": 30
     },
     "name": "aws.sample_staging_query.item__0",

--- a/python/test/canary/compiled/staging_queries/aws/sample_staging_query.order__0
+++ b/python/test/canary/compiled/staging_queries/aws/sample_staging_query.order__0
@@ -88,6 +88,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.aws_sample_staging_query_order__0"
+      },
       "stepDays": 30
     },
     "name": "aws.sample_staging_query.order__0",

--- a/python/test/canary/compiled/staging_queries/aws/sample_staging_query.payment__0
+++ b/python/test/canary/compiled/staging_queries/aws/sample_staging_query.payment__0
@@ -88,6 +88,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.aws_sample_staging_query_payment__0"
+      },
       "stepDays": 30
     },
     "name": "aws.sample_staging_query.payment__0",

--- a/python/test/canary/compiled/staging_queries/aws/sample_staging_query.purchases_labels__0
+++ b/python/test/canary/compiled/staging_queries/aws/sample_staging_query.purchases_labels__0
@@ -88,6 +88,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.aws_sample_staging_query_purchases_labels__0"
+      },
       "stepDays": 30
     },
     "name": "aws.sample_staging_query.purchases_labels__0",

--- a/python/test/canary/compiled/staging_queries/aws/sample_staging_query.shipping__0
+++ b/python/test/canary/compiled/staging_queries/aws/sample_staging_query.shipping__0
@@ -88,6 +88,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.aws_sample_staging_query_shipping__0"
+      },
       "stepDays": 30
     },
     "name": "aws.sample_staging_query.shipping__0",

--- a/python/test/canary/compiled/staging_queries/aws/sample_staging_query.terminal__0
+++ b/python/test/canary/compiled/staging_queries/aws/sample_staging_query.terminal__0
@@ -88,6 +88,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.aws_sample_staging_query_terminal__0"
+      },
       "stepDays": 30
     },
     "name": "aws.sample_staging_query.terminal__0",

--- a/python/test/canary/compiled/staging_queries/aws/sample_staging_query.user__0
+++ b/python/test/canary/compiled/staging_queries/aws/sample_staging_query.user__0
@@ -88,6 +88,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.aws_sample_staging_query_user__0"
+      },
       "stepDays": 30
     },
     "name": "aws.sample_staging_query.user__0",

--- a/python/test/canary/compiled/staging_queries/aws/sample_staging_query.v1_bigquery_import__0
+++ b/python/test/canary/compiled/staging_queries/aws/sample_staging_query.v1_bigquery_import__0
@@ -89,6 +89,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.aws_sample_staging_query_v1_bigquery_import__0"
+      },
       "stepDays": 30
     },
     "name": "aws.sample_staging_query.v1_bigquery_import__0",

--- a/python/test/canary/compiled/staging_queries/aws/sample_staging_query.v1_hub__0
+++ b/python/test/canary/compiled/staging_queries/aws/sample_staging_query.v1_hub__0
@@ -88,6 +88,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.aws_sample_staging_query_v1_hub__0"
+      },
       "stepDays": 30
     },
     "name": "aws.sample_staging_query.v1_hub__0",

--- a/python/test/canary/compiled/staging_queries/aws_databricks/exports.dim_listings__0
+++ b/python/test/canary/compiled/staging_queries/aws_databricks/exports.dim_listings__0
@@ -52,7 +52,10 @@
           "WAREHOUSE_PREFIX": "s3://zipline-warehouse-dev"
         }
       },
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "workspace_iceberg.poc.aws_databricks_exports_dim_listings__0"
+      }
     },
     "name": "aws_databricks.exports.dim_listings__0",
     "outputNamespace": "workspace_iceberg.poc",

--- a/python/test/canary/compiled/staging_queries/aws_databricks/exports.dim_listings_non_partitioned__0
+++ b/python/test/canary/compiled/staging_queries/aws_databricks/exports.dim_listings_non_partitioned__0
@@ -52,7 +52,10 @@
           "WAREHOUSE_PREFIX": "s3://zipline-warehouse-dev"
         }
       },
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "workspace_iceberg.poc.aws_databricks_exports_dim_listings__2"
+      }
     },
     "name": "aws_databricks.exports.dim_listings_non_partitioned__0",
     "outputNamespace": "workspace_iceberg.poc",

--- a/python/test/canary/compiled/staging_queries/aws_databricks/exports.dim_listings_non_partitioned__0
+++ b/python/test/canary/compiled/staging_queries/aws_databricks/exports.dim_listings_non_partitioned__0
@@ -54,7 +54,7 @@
       },
       "offlineSchedule": "@daily",
       "outputTableInfo": {
-        "table": "workspace_iceberg.poc.aws_databricks_exports_dim_listings__2"
+        "table": "workspace_iceberg.poc.aws_databricks_exports_dim_listings_non_partitioned__0"
       }
     },
     "name": "aws_databricks.exports.dim_listings_non_partitioned__0",

--- a/python/test/canary/compiled/staging_queries/azure/ctr_labels.v1__0
+++ b/python/test/canary/compiled/staging_queries/azure/ctr_labels.v1__0
@@ -41,7 +41,10 @@
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
         }
       },
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.azure_ctr_labels_v1__0"
+      }
     },
     "name": "azure.ctr_labels.v1__0",
     "outputNamespace": "data",

--- a/python/test/canary/compiled/staging_queries/azure/exports.checkouts__0
+++ b/python/test/canary/compiled/staging_queries/azure/exports.checkouts__0
@@ -43,6 +43,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.azure_exports_checkouts__0"
+      },
       "stepDays": 30
     },
     "name": "azure.exports.checkouts__0",

--- a/python/test/canary/compiled/staging_queries/azure/exports.dim_listings__0
+++ b/python/test/canary/compiled/staging_queries/azure/exports.dim_listings__0
@@ -43,6 +43,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.azure_exports_dim_listings__0"
+      },
       "stepDays": 30
     },
     "name": "azure.exports.dim_listings__0",

--- a/python/test/canary/compiled/staging_queries/azure/exports.dim_merchants__0
+++ b/python/test/canary/compiled/staging_queries/azure/exports.dim_merchants__0
@@ -43,6 +43,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.azure_exports_dim_merchants__0"
+      },
       "stepDays": 30
     },
     "name": "azure.exports.dim_merchants__0",

--- a/python/test/canary/compiled/staging_queries/azure/exports.dim_users__0
+++ b/python/test/canary/compiled/staging_queries/azure/exports.dim_users__0
@@ -43,6 +43,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.azure_exports_dim_users__0"
+      },
       "stepDays": 30
     },
     "name": "azure.exports.dim_users__0",

--- a/python/test/canary/compiled/staging_queries/azure/exports.user_activities__0
+++ b/python/test/canary/compiled/staging_queries/azure/exports.user_activities__0
@@ -43,6 +43,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.azure_exports_user_activities__0"
+      },
       "stepDays": 30
     },
     "name": "azure.exports.user_activities__0",

--- a/python/test/canary/compiled/staging_queries/azure/local_staging_query.simple__0
+++ b/python/test/canary/compiled/staging_queries/azure/local_staging_query.simple__0
@@ -42,6 +42,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.azure_local_staging_query_simple__0"
+      },
       "stepDays": 30
     },
     "name": "azure.local_staging_query.simple__0",

--- a/python/test/canary/compiled/staging_queries/azure/partitioned_logging.v0__2
+++ b/python/test/canary/compiled/staging_queries/azure/partitioned_logging.v0__2
@@ -41,7 +41,10 @@
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
         }
       },
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.azure_partitioned_logging_v0__2"
+      }
     },
     "name": "azure.partitioned_logging.v0__2",
     "outputNamespace": "data",

--- a/python/test/canary/compiled/staging_queries/gcp/checkouts_import.v1__0
+++ b/python/test/canary/compiled/staging_queries/gcp/checkouts_import.v1__0
@@ -68,7 +68,10 @@
           }
         }
       },
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_checkouts_import_v1__0"
+      }
     },
     "name": "gcp.checkouts_import.v1__0",
     "outputNamespace": "data",

--- a/python/test/canary/compiled/staging_queries/gcp/checkouts_notds_import.v1__0
+++ b/python/test/canary/compiled/staging_queries/gcp/checkouts_notds_import.v1__0
@@ -68,7 +68,10 @@
           }
         }
       },
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_checkouts_notds_import_v1__0"
+      }
     },
     "name": "gcp.checkouts_notds_import.v1__0",
     "outputNamespace": "data",

--- a/python/test/canary/compiled/staging_queries/gcp/ctr_labels.v1__0
+++ b/python/test/canary/compiled/staging_queries/gcp/ctr_labels.v1__0
@@ -67,7 +67,10 @@
           }
         }
       },
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_ctr_labels_v1__0"
+      }
     },
     "name": "gcp.ctr_labels.v1__0",
     "outputNamespace": "data",

--- a/python/test/canary/compiled/staging_queries/gcp/exports.checkouts__0
+++ b/python/test/canary/compiled/staging_queries/gcp/exports.checkouts__0
@@ -69,6 +69,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_exports_checkouts__0"
+      },
       "stepDays": 30
     },
     "name": "gcp.exports.checkouts__0",

--- a/python/test/canary/compiled/staging_queries/gcp/exports.dim_listings__0
+++ b/python/test/canary/compiled/staging_queries/gcp/exports.dim_listings__0
@@ -69,6 +69,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_exports_dim_listings__0"
+      },
       "stepDays": 30
     },
     "name": "gcp.exports.dim_listings__0",

--- a/python/test/canary/compiled/staging_queries/gcp/exports.dim_merchants__0
+++ b/python/test/canary/compiled/staging_queries/gcp/exports.dim_merchants__0
@@ -69,6 +69,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_exports_dim_merchants__0"
+      },
       "stepDays": 30
     },
     "name": "gcp.exports.dim_merchants__0",

--- a/python/test/canary/compiled/staging_queries/gcp/exports.dim_users__0
+++ b/python/test/canary/compiled/staging_queries/gcp/exports.dim_users__0
@@ -69,6 +69,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_exports_dim_users__0"
+      },
       "stepDays": 30
     },
     "name": "gcp.exports.dim_users__0",

--- a/python/test/canary/compiled/staging_queries/gcp/exports.user_activities__0
+++ b/python/test/canary/compiled/staging_queries/gcp/exports.user_activities__0
@@ -69,6 +69,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_exports_user_activities__0"
+      },
       "stepDays": 30
     },
     "name": "gcp.exports.user_activities__0",

--- a/python/test/canary/compiled/staging_queries/gcp/partitioned_logging.v0__2
+++ b/python/test/canary/compiled/staging_queries/gcp/partitioned_logging.v0__2
@@ -67,7 +67,10 @@
           }
         }
       },
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_partitioned_logging_v0__2"
+      }
     },
     "name": "gcp.partitioned_logging.v0__2",
     "outputNamespace": "data",

--- a/python/test/canary/compiled/staging_queries/gcp/purchases_import.v1__0
+++ b/python/test/canary/compiled/staging_queries/gcp/purchases_import.v1__0
@@ -68,7 +68,10 @@
           }
         }
       },
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_purchases_import_v1__0"
+      }
     },
     "name": "gcp.purchases_import.v1__0",
     "outputNamespace": "data",

--- a/python/test/canary/compiled/staging_queries/gcp/purchases_notds_import.v1__0
+++ b/python/test/canary/compiled/staging_queries/gcp/purchases_notds_import.v1__0
@@ -68,7 +68,10 @@
           }
         }
       },
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_purchases_notds_import_v1__0"
+      }
     },
     "name": "gcp.purchases_notds_import.v1__0",
     "outputNamespace": "data",

--- a/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.cart__0
+++ b/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.cart__0
@@ -68,6 +68,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_sample_staging_query_cart__0"
+      },
       "stepDays": 30
     },
     "name": "gcp.sample_staging_query.cart__0",

--- a/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.item__0
+++ b/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.item__0
@@ -68,6 +68,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_sample_staging_query_item__0"
+      },
       "stepDays": 30
     },
     "name": "gcp.sample_staging_query.item__0",

--- a/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.order__0
+++ b/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.order__0
@@ -68,6 +68,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_sample_staging_query_order__0"
+      },
       "stepDays": 30
     },
     "name": "gcp.sample_staging_query.order__0",

--- a/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.payment__0
+++ b/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.payment__0
@@ -68,6 +68,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_sample_staging_query_payment__0"
+      },
       "stepDays": 30
     },
     "name": "gcp.sample_staging_query.payment__0",

--- a/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.purchases_labels__0
+++ b/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.purchases_labels__0
@@ -68,6 +68,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_sample_staging_query_purchases_labels__0"
+      },
       "stepDays": 30
     },
     "name": "gcp.sample_staging_query.purchases_labels__0",

--- a/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.shipping__0
+++ b/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.shipping__0
@@ -68,6 +68,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_sample_staging_query_shipping__0"
+      },
       "stepDays": 30
     },
     "name": "gcp.sample_staging_query.shipping__0",

--- a/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.terminal__0
+++ b/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.terminal__0
@@ -68,6 +68,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_sample_staging_query_terminal__0"
+      },
       "stepDays": 30
     },
     "name": "gcp.sample_staging_query.terminal__0",

--- a/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.user__0
+++ b/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.user__0
@@ -68,6 +68,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_sample_staging_query_user__0"
+      },
       "stepDays": 30
     },
     "name": "gcp.sample_staging_query.user__0",

--- a/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.v1_bigquery_import__0
+++ b/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.v1_bigquery_import__0
@@ -69,6 +69,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_sample_staging_query_v1_bigquery_import__0"
+      },
       "stepDays": 30
     },
     "name": "gcp.sample_staging_query.v1_bigquery_import__0",

--- a/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.v1_hub__0
+++ b/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.v1_hub__0
@@ -68,6 +68,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "data.gcp_sample_staging_query_v1_hub__0"
+      },
       "stepDays": 30
     },
     "name": "gcp.sample_staging_query.v1_hub__0",

--- a/python/test/canary/compiled/staging_queries/quickstart/exports.dim_listings__0
+++ b/python/test/canary/compiled/staging_queries/quickstart/exports.dim_listings__0
@@ -146,6 +146,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "quickstart.quickstart_exports_dim_listings__0"
+      },
       "stepDays": 20
     },
     "name": "quickstart.exports.dim_listings__0",

--- a/python/test/canary/compiled/staging_queries/quickstart/exports.dim_merchants__0
+++ b/python/test/canary/compiled/staging_queries/quickstart/exports.dim_merchants__0
@@ -146,6 +146,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "quickstart.quickstart_exports_dim_merchants__0"
+      },
       "stepDays": 20
     },
     "name": "quickstart.exports.dim_merchants__0",

--- a/python/test/canary/compiled/staging_queries/quickstart/exports.dim_users__0
+++ b/python/test/canary/compiled/staging_queries/quickstart/exports.dim_users__0
@@ -146,6 +146,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "quickstart.quickstart_exports_dim_users__0"
+      },
       "stepDays": 20
     },
     "name": "quickstart.exports.dim_users__0",

--- a/python/test/canary/compiled/staging_queries/quickstart/exports.user_activities__0
+++ b/python/test/canary/compiled/staging_queries/quickstart/exports.user_activities__0
@@ -146,6 +146,9 @@
         }
       },
       "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "quickstart.quickstart_exports_user_activities__0"
+      },
       "stepDays": 20
     },
     "name": "quickstart.exports.user_activities__0",

--- a/python/test/sample/compiled/group_bys/quickstart/users.v1__0
+++ b/python/test/sample/compiled/group_bys/quickstart/users.v1__0
@@ -52,7 +52,10 @@
         }
       },
       "historicalBackfill": 0,
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "quickstart.quickstart_users_v1__0"
+      }
     },
     "name": "quickstart.users.v1__0",
     "online": 1,

--- a/python/test/sample/compiled/group_bys/risk/merchant_data.merchant_group_by__0
+++ b/python/test/sample/compiled/group_bys/risk/merchant_data.merchant_group_by__0
@@ -55,7 +55,10 @@
           }
         }
       },
-      "historicalBackfill": 0
+      "historicalBackfill": 0,
+      "outputTableInfo": {
+        "table": "risk.risk_merchant_data_merchant_group_by__0"
+      }
     },
     "name": "risk.merchant_data.merchant_group_by__0",
     "outputNamespace": "risk",

--- a/python/test/sample/compiled/group_bys/risk/transaction_events.txn_group_by_merchant__0
+++ b/python/test/sample/compiled/group_bys/risk/transaction_events.txn_group_by_merchant__0
@@ -86,7 +86,10 @@
         }
       },
       "historicalBackfill": 0,
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "risk.risk_transaction_events_txn_group_by_merchant__0"
+      }
     },
     "name": "risk.transaction_events.txn_group_by_merchant__0",
     "online": 1,

--- a/python/test/sample/compiled/group_bys/risk/transaction_events.txn_group_by_user__0
+++ b/python/test/sample/compiled/group_bys/risk/transaction_events.txn_group_by_user__0
@@ -86,7 +86,10 @@
         }
       },
       "historicalBackfill": 0,
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "risk.risk_transaction_events_txn_group_by_user__0"
+      }
     },
     "name": "risk.transaction_events.txn_group_by_user__0",
     "online": 1,

--- a/python/test/sample/compiled/group_bys/risk/user_data.user_group_by__0
+++ b/python/test/sample/compiled/group_bys/risk/user_data.user_group_by__0
@@ -56,7 +56,10 @@
           }
         }
       },
-      "historicalBackfill": 0
+      "historicalBackfill": 0,
+      "outputTableInfo": {
+        "table": "risk.risk_user_data_user_group_by__0"
+      }
     },
     "name": "risk.user_data.user_group_by__0",
     "outputNamespace": "risk",

--- a/python/test/sample/compiled/group_bys/sample_team/chaining_group_by.chaining_group_by_v1__0
+++ b/python/test/sample/compiled/group_bys/sample_team/chaining_group_by.chaining_group_by_v1__0
@@ -59,7 +59,10 @@
         }
       },
       "historicalBackfill": 0,
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "sample_namespace.sample_team_chaining_group_by_chaining_group_by_v1__0"
+      }
     },
     "name": "sample_team.chaining_group_by.chaining_group_by_v1__0",
     "online": 1,
@@ -112,7 +115,10 @@
                 "metaData": {
                   "executionInfo": {
                     "historicalBackfill": 0,
-                    "onlineSchedule": "@daily"
+                    "onlineSchedule": "@daily",
+                    "outputTableInfo": {
+                      "table": "sample_namespace.sample_team_event_sample_group_by_v1__0"
+                    }
                   },
                   "name": "sample_team.event_sample_group_by.v1__0",
                   "online": 1,
@@ -167,7 +173,10 @@
                 "metaData": {
                   "executionInfo": {
                     "historicalBackfill": 0,
-                    "onlineSchedule": "@daily"
+                    "onlineSchedule": "@daily",
+                    "outputTableInfo": {
+                      "table": "{{ db }}.sample_team_entity_sample_group_by_from_module_v1__0"
+                    }
                   },
                   "name": "sample_team.entity_sample_group_by_from_module.v1__0",
                   "online": 1,
@@ -218,7 +227,10 @@
             "executionInfo": {
               "historicalBackfill": 0,
               "offlineSchedule": "@daily",
-              "onlineSchedule": "@daily"
+              "onlineSchedule": "@daily",
+              "outputTableInfo": {
+                "table": "sample_namespace.sample_team_sample_chaining_join_parent_parent_join__0"
+              }
             },
             "name": "sample_team.sample_chaining_join_parent.parent_join__0",
             "online": 1,

--- a/python/test/sample/compiled/group_bys/sample_team/chaining_group_by.chaining_group_by_v1__0
+++ b/python/test/sample/compiled/group_bys/sample_team/chaining_group_by.chaining_group_by_v1__0
@@ -175,7 +175,7 @@
                     "historicalBackfill": 0,
                     "onlineSchedule": "@daily",
                     "outputTableInfo": {
-                      "table": "{{ db }}.sample_team_entity_sample_group_by_from_module_v1__0"
+                      "table": "sample_namespace.sample_team_entity_sample_group_by_from_module_v1__0"
                     }
                   },
                   "name": "sample_team.entity_sample_group_by_from_module.v1__0",

--- a/python/test/sample/compiled/group_bys/sample_team/entity_sample_group_by_from_module.v1__0
+++ b/python/test/sample/compiled/group_bys/sample_team/entity_sample_group_by_from_module.v1__0
@@ -70,7 +70,10 @@
         }
       },
       "historicalBackfill": 0,
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "test.sample_team_entity_sample_group_by_from_module_v1__0"
+      }
     },
     "name": "sample_team.entity_sample_group_by_from_module.v1__0",
     "online": 1,

--- a/python/test/sample/compiled/group_bys/sample_team/event_sample_group_by.v1__0
+++ b/python/test/sample/compiled/group_bys/sample_team/event_sample_group_by.v1__0
@@ -79,7 +79,10 @@
         }
       },
       "historicalBackfill": 0,
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "sample_namespace.sample_team_event_sample_group_by_v1__0"
+      }
     },
     "name": "sample_team.event_sample_group_by.v1__0",
     "online": 1,

--- a/python/test/sample/compiled/group_bys/sample_team/event_with_derivations.v1__0
+++ b/python/test/sample/compiled/group_bys/sample_team/event_with_derivations.v1__0
@@ -75,7 +75,10 @@
         }
       },
       "historicalBackfill": 0,
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "sample_namespace.sample_team_event_with_derivations_v1__0"
+      }
     },
     "name": "sample_team.event_with_derivations.v1__0",
     "online": 1,

--- a/python/test/sample/compiled/group_bys/sample_team/event_with_derivations.v2__0
+++ b/python/test/sample/compiled/group_bys/sample_team/event_with_derivations.v2__0
@@ -81,7 +81,10 @@
         }
       },
       "historicalBackfill": 0,
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "sample_namespace.sample_team_event_with_derivations_v2__0"
+      }
     },
     "name": "sample_team.event_with_derivations.v2__0",
     "online": 1,

--- a/python/test/sample/compiled/group_bys/sample_team/group_by_with_kwargs.v1__0
+++ b/python/test/sample/compiled/group_bys/sample_team/group_by_with_kwargs.v1__0
@@ -79,7 +79,10 @@
         }
       },
       "historicalBackfill": 0,
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "test.sample_team_group_by_with_kwargs_v1__0"
+      }
     },
     "name": "sample_team.group_by_with_kwargs.v1__0",
     "online": 1,

--- a/python/test/sample/compiled/group_bys/sample_team/mutation_sample_group_by.v0__0
+++ b/python/test/sample/compiled/group_bys/sample_team/mutation_sample_group_by.v0__0
@@ -58,7 +58,10 @@
           }
         }
       },
-      "historicalBackfill": 0
+      "historicalBackfill": 0,
+      "outputTableInfo": {
+        "table": "test.sample_team_mutation_sample_group_by_v0__0"
+      }
     },
     "name": "sample_team.mutation_sample_group_by.v0__0",
     "outputNamespace": "test",

--- a/python/test/sample/compiled/group_bys/sample_team/sample_chaining_group_by.chaining_group_by_v1__0
+++ b/python/test/sample/compiled/group_bys/sample_team/sample_chaining_group_by.chaining_group_by_v1__0
@@ -175,7 +175,7 @@
                     "historicalBackfill": 0,
                     "onlineSchedule": "@daily",
                     "outputTableInfo": {
-                      "table": "{{ db }}.sample_team_entity_sample_group_by_from_module_v1__0"
+                      "table": "test_namespace.sample_team_entity_sample_group_by_from_module_v1__0"
                     }
                   },
                   "name": "sample_team.entity_sample_group_by_from_module.v1__0",

--- a/python/test/sample/compiled/group_bys/sample_team/sample_chaining_group_by.chaining_group_by_v1__0
+++ b/python/test/sample/compiled/group_bys/sample_team/sample_chaining_group_by.chaining_group_by_v1__0
@@ -59,7 +59,10 @@
         }
       },
       "historicalBackfill": 0,
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "test_namespace.sample_team_sample_chaining_group_by_chaining_group_by_v1__0"
+      }
     },
     "name": "sample_team.sample_chaining_group_by.chaining_group_by_v1__0",
     "online": 1,
@@ -112,7 +115,10 @@
                 "metaData": {
                   "executionInfo": {
                     "historicalBackfill": 0,
-                    "onlineSchedule": "@daily"
+                    "onlineSchedule": "@daily",
+                    "outputTableInfo": {
+                      "table": "sample_namespace.sample_team_event_sample_group_by_v1__0"
+                    }
                   },
                   "name": "sample_team.event_sample_group_by.v1__0",
                   "online": 1,
@@ -167,7 +173,10 @@
                 "metaData": {
                   "executionInfo": {
                     "historicalBackfill": 0,
-                    "onlineSchedule": "@daily"
+                    "onlineSchedule": "@daily",
+                    "outputTableInfo": {
+                      "table": "{{ db }}.sample_team_entity_sample_group_by_from_module_v1__0"
+                    }
                   },
                   "name": "sample_team.entity_sample_group_by_from_module.v1__0",
                   "online": 1,
@@ -217,7 +226,10 @@
             "consistencySamplePercent": 5.0,
             "executionInfo": {
               "offlineSchedule": "@daily",
-              "onlineSchedule": "@daily"
+              "onlineSchedule": "@daily",
+              "outputTableInfo": {
+                "table": "test_namespace.sample_team_sample_chaining_group_by_parent_join__0"
+              }
             },
             "name": "sample_team.sample_chaining_group_by.parent_join__0",
             "online": 1,

--- a/python/test/sample/compiled/group_bys/sample_team/sample_group_by.require_backfill__0
+++ b/python/test/sample/compiled/group_bys/sample_team/sample_group_by.require_backfill__0
@@ -77,7 +77,10 @@
         }
       },
       "historicalBackfill": 0,
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "sample_namespace.sample_team_sample_group_by_require_backfill__0"
+      }
     },
     "name": "sample_team.sample_group_by.require_backfill__0",
     "outputNamespace": "sample_namespace",

--- a/python/test/sample/compiled/group_bys/sample_team/sample_group_by.v1__0
+++ b/python/test/sample/compiled/group_bys/sample_team/sample_group_by.v1__0
@@ -66,7 +66,10 @@
         }
       },
       "historicalBackfill": 0,
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "sample_namespace.sample_team_sample_group_by_v1__0"
+      }
     },
     "name": "sample_team.sample_group_by.v1__0",
     "online": 1,

--- a/python/test/sample/compiled/group_bys/sample_team/sample_group_by_from_join_part.v2__0
+++ b/python/test/sample/compiled/group_bys/sample_team/sample_group_by_from_join_part.v2__0
@@ -60,7 +60,10 @@
           }
         }
       },
-      "historicalBackfill": 0
+      "historicalBackfill": 0,
+      "outputTableInfo": {
+        "table": "sample_namespace.sample_team_sample_group_by_from_join_part_v2__0"
+      }
     },
     "name": "sample_team.sample_group_by_from_join_part.v2__0",
     "outputNamespace": "sample_namespace",

--- a/python/test/sample/compiled/group_bys/sample_team/sample_group_by_from_module.v1__0
+++ b/python/test/sample/compiled/group_bys/sample_team/sample_group_by_from_module.v1__0
@@ -69,7 +69,10 @@
           }
         }
       },
-      "historicalBackfill": 0
+      "historicalBackfill": 0,
+      "outputTableInfo": {
+        "table": "test.sample_team_sample_group_by_from_module_v1__0"
+      }
     },
     "name": "sample_team.sample_group_by_from_module.v1__0",
     "outputNamespace": "test",

--- a/python/test/sample/compiled/group_bys/sample_team/sample_group_by_group_by.require_backfill__0
+++ b/python/test/sample/compiled/group_bys/sample_team/sample_group_by_group_by.require_backfill__0
@@ -77,7 +77,10 @@
         }
       },
       "historicalBackfill": 0,
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "sample_namespace.sample_team_sample_group_by_group_by_require_backfill__0"
+      }
     },
     "name": "sample_team.sample_group_by_group_by.require_backfill__0",
     "outputNamespace": "sample_namespace",

--- a/python/test/sample/compiled/group_bys/sample_team/sample_group_by_group_by.v1__0
+++ b/python/test/sample/compiled/group_bys/sample_team/sample_group_by_group_by.v1__0
@@ -59,7 +59,10 @@
           }
         }
       },
-      "historicalBackfill": 0
+      "historicalBackfill": 0,
+      "outputTableInfo": {
+        "table": "sample_namespace.sample_team_sample_group_by_group_by_v1__0"
+      }
     },
     "name": "sample_team.sample_group_by_group_by.v1__0",
     "outputNamespace": "sample_namespace",

--- a/python/test/sample/compiled/group_bys/sample_team/sample_group_by_with_derivations.v1__0
+++ b/python/test/sample/compiled/group_bys/sample_team/sample_group_by_with_derivations.v1__0
@@ -70,7 +70,10 @@
           }
         }
       },
-      "historicalBackfill": 0
+      "historicalBackfill": 0,
+      "outputTableInfo": {
+        "table": "sample_namespace.sample_team_sample_group_by_with_derivations_v1__0"
+      }
     },
     "name": "sample_team.sample_group_by_with_derivations.v1__0",
     "outputNamespace": "sample_namespace",

--- a/python/test/sample/compiled/group_bys/sample_team/sample_non_prod_group_by.v1__0
+++ b/python/test/sample/compiled/group_bys/sample_team/sample_non_prod_group_by.v1__0
@@ -69,7 +69,10 @@
           }
         }
       },
-      "historicalBackfill": 0
+      "historicalBackfill": 0,
+      "outputTableInfo": {
+        "table": "sample_namespace.sample_team_sample_non_prod_group_by_v1__0"
+      }
     },
     "name": "sample_team.sample_non_prod_group_by.v1__0",
     "online": 0,

--- a/python/test/sample/compiled/joins/sample_team/sample_backfill_mutation_join.v0__0
+++ b/python/test/sample/compiled/joins/sample_team/sample_backfill_mutation_join.v0__0
@@ -60,7 +60,10 @@
                 }
               }
             },
-            "historicalBackfill": 0
+            "historicalBackfill": 0,
+            "outputTableInfo": {
+              "table": "test.sample_team_mutation_sample_group_by_v0__0"
+            }
           },
           "name": "sample_team.mutation_sample_group_by.v0__0",
           "outputNamespace": "test",
@@ -154,7 +157,10 @@
           }
         }
       },
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "test.sample_team_sample_backfill_mutation_join_v0__0"
+      }
     },
     "name": "sample_team.sample_backfill_mutation_join.v0__0",
     "online": 0,

--- a/python/test/sample/compiled/joins/sample_team/sample_chaining_join_parent.parent_join__0
+++ b/python/test/sample/compiled/joins/sample_team/sample_chaining_join_parent.parent_join__0
@@ -81,7 +81,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "sample_namespace.sample_team_event_sample_group_by_v1__0"
+            }
           },
           "name": "sample_team.event_sample_group_by.v1__0",
           "online": 1,
@@ -183,7 +186,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "sample_namespace.sample_team_entity_sample_group_by_from_module_v1__0"
+            }
           },
           "name": "sample_team.entity_sample_group_by_from_module.v1__0",
           "online": 1,
@@ -289,7 +295,10 @@
       },
       "historicalBackfill": 0,
       "offlineSchedule": "@daily",
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "sample_namespace.sample_team_sample_chaining_join_parent_parent_join__0"
+      }
     },
     "name": "sample_team.sample_chaining_join_parent.parent_join__0",
     "online": 1,

--- a/python/test/sample/compiled/joins/sample_team/sample_join.consistency_check__0
+++ b/python/test/sample/compiled/joins/sample_team/sample_join.consistency_check__0
@@ -68,7 +68,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "sample_namespace.sample_team_sample_group_by_v1__0"
+            }
           },
           "name": "sample_team.sample_group_by.v1__0",
           "online": 1,
@@ -169,7 +172,10 @@
           }
         }
       },
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "sample_namespace.sample_team_sample_join_consistency_check__0"
+      }
     },
     "name": "sample_team.sample_join.consistency_check__0",
     "online": 0,

--- a/python/test/sample/compiled/joins/sample_team/sample_join.group_by_of_group_by__0
+++ b/python/test/sample/compiled/joins/sample_team/sample_join.group_by_of_group_by__0
@@ -61,7 +61,10 @@
                 }
               }
             },
-            "historicalBackfill": 0
+            "historicalBackfill": 0,
+            "outputTableInfo": {
+              "table": "sample_namespace.sample_team_sample_group_by_group_by_v1__0"
+            }
           },
           "name": "sample_team.sample_group_by_group_by.v1__0",
           "outputNamespace": "sample_namespace",
@@ -160,7 +163,10 @@
           }
         }
       },
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "sample_namespace.sample_team_sample_join_group_by_of_group_by__0"
+      }
     },
     "name": "sample_team.sample_join.group_by_of_group_by__0",
     "online": 0,

--- a/python/test/sample/compiled/joins/sample_team/sample_join.never__0
+++ b/python/test/sample/compiled/joins/sample_team/sample_join.never__0
@@ -68,7 +68,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "sample_namespace.sample_team_sample_group_by_v1__0"
+            }
           },
           "name": "sample_team.sample_group_by.v1__0",
           "online": 1,
@@ -167,7 +170,10 @@
           }
         }
       },
-      "offlineSchedule": "@never"
+      "offlineSchedule": "@never",
+      "outputTableInfo": {
+        "table": "sample_namespace.sample_team_sample_join_never__0"
+      }
     },
     "name": "sample_team.sample_join.never__0",
     "online": 0,

--- a/python/test/sample/compiled/joins/sample_team/sample_join.no_log_flattener__0
+++ b/python/test/sample/compiled/joins/sample_team/sample_join.no_log_flattener__0
@@ -68,7 +68,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "sample_namespace.sample_team_sample_group_by_v1__0"
+            }
           },
           "name": "sample_team.sample_group_by.v1__0",
           "online": 1,
@@ -167,7 +170,10 @@
           }
         }
       },
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "sample_namespace.sample_team_sample_join_no_log_flattener__0"
+      }
     },
     "name": "sample_team.sample_join.no_log_flattener__0",
     "online": 0,

--- a/python/test/sample/compiled/joins/sample_team/sample_join.v1__0
+++ b/python/test/sample/compiled/joins/sample_team/sample_join.v1__0
@@ -68,7 +68,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "sample_namespace.sample_team_sample_group_by_v1__0"
+            }
           },
           "name": "sample_team.sample_group_by.v1__0",
           "online": 1,
@@ -169,7 +172,10 @@
         }
       },
       "offlineSchedule": "@daily",
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "sample_namespace.sample_team_sample_join_v1__0"
+      }
     },
     "name": "sample_team.sample_join.v1__0",
     "online": 1,

--- a/python/test/sample/compiled/joins/sample_team/sample_join_bootstrap.v1__0
+++ b/python/test/sample/compiled/joins/sample_team/sample_join_bootstrap.v1__0
@@ -100,7 +100,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "sample_namespace.sample_team_event_sample_group_by_v1__0"
+            }
           },
           "name": "sample_team.event_sample_group_by.v1__0",
           "online": 1,
@@ -202,7 +205,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "test.sample_team_entity_sample_group_by_from_module_v1__0"
+            }
           },
           "name": "sample_team.entity_sample_group_by_from_module.v1__0",
           "online": 1,
@@ -305,7 +311,10 @@
         }
       },
       "offlineSchedule": "@daily",
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "test.sample_team_sample_join_bootstrap_v1__0"
+      }
     },
     "name": "sample_team.sample_join_bootstrap.v1__0",
     "online": 1,

--- a/python/test/sample/compiled/joins/sample_team/sample_join_bootstrap.v2__0
+++ b/python/test/sample/compiled/joins/sample_team/sample_join_bootstrap.v2__0
@@ -92,7 +92,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "sample_namespace.sample_team_event_sample_group_by_v1__0"
+            }
           },
           "name": "sample_team.event_sample_group_by.v1__0",
           "online": 1,
@@ -194,7 +197,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "test.sample_team_entity_sample_group_by_from_module_v1__0"
+            }
           },
           "name": "sample_team.entity_sample_group_by_from_module.v1__0",
           "online": 1,
@@ -306,7 +312,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "test.sample_team_group_by_with_kwargs_v1__0"
+            }
           },
           "name": "sample_team.group_by_with_kwargs.v1__0",
           "online": 1,
@@ -424,7 +433,10 @@
         }
       },
       "offlineSchedule": "@daily",
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "test.sample_team_sample_join_bootstrap_v2__0"
+      }
     },
     "name": "sample_team.sample_join_bootstrap.v2__0",
     "online": 1,

--- a/python/test/sample/compiled/joins/sample_team/sample_join_derivation.v2__0
+++ b/python/test/sample/compiled/joins/sample_team/sample_join_derivation.v2__0
@@ -91,7 +91,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "sample_namespace.sample_team_event_sample_group_by_v1__0"
+            }
           },
           "name": "sample_team.event_sample_group_by.v1__0",
           "online": 1,
@@ -193,7 +196,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "test.sample_team_entity_sample_group_by_from_module_v1__0"
+            }
           },
           "name": "sample_team.entity_sample_group_by_from_module.v1__0",
           "online": 1,
@@ -296,7 +302,10 @@
           }
         }
       },
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "test.sample_team_sample_join_derivation_v2__0"
+      }
     },
     "name": "sample_team.sample_join_derivation.v2__0",
     "online": 0,

--- a/python/test/sample/compiled/joins/sample_team/sample_join_derivation.v3__0
+++ b/python/test/sample/compiled/joins/sample_team/sample_join_derivation.v3__0
@@ -87,7 +87,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "sample_namespace.sample_team_event_with_derivations_v1__0"
+            }
           },
           "name": "sample_team.event_with_derivations.v1__0",
           "online": 1,
@@ -197,7 +200,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "sample_namespace.sample_team_event_with_derivations_v2__0"
+            }
           },
           "name": "sample_team.event_with_derivations.v2__0",
           "online": 1,
@@ -295,7 +301,10 @@
           }
         }
       },
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "test.sample_team_sample_join_derivation_v3__0"
+      }
     },
     "name": "sample_team.sample_join_derivation.v3__0",
     "online": 0,

--- a/python/test/sample/compiled/joins/sample_team/sample_join_external_parts.v1__0
+++ b/python/test/sample/compiled/joins/sample_team/sample_join_external_parts.v1__0
@@ -68,7 +68,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "sample_namespace.sample_team_sample_group_by_v1__0"
+            }
           },
           "name": "sample_team.sample_group_by.v1__0",
           "online": 1,
@@ -172,7 +175,10 @@
           }
         }
       },
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "sample_namespace.sample_team_sample_join_external_parts_v1__0"
+      }
     },
     "name": "sample_team.sample_join_external_parts.v1__0",
     "online": 0,

--- a/python/test/sample/compiled/joins/sample_team/sample_join_from_group_by_from_join.v1__0
+++ b/python/test/sample/compiled/joins/sample_team/sample_join_from_group_by_from_join.v1__0
@@ -62,7 +62,10 @@
                 }
               }
             },
-            "historicalBackfill": 0
+            "historicalBackfill": 0,
+            "outputTableInfo": {
+              "table": "sample_namespace.sample_team_sample_group_by_from_join_part_v2__0"
+            }
           },
           "name": "sample_team.sample_group_by_from_join_part.v2__0",
           "outputNamespace": "sample_namespace",
@@ -161,7 +164,10 @@
           }
         }
       },
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "sample_namespace.sample_team_sample_join_from_group_by_from_join_v1__0"
+      }
     },
     "name": "sample_team.sample_join_from_group_by_from_join.v1__0",
     "online": 0,

--- a/python/test/sample/compiled/joins/sample_team/sample_join_with_derivations_on_external_parts.v1__0
+++ b/python/test/sample/compiled/joins/sample_team/sample_join_with_derivations_on_external_parts.v1__0
@@ -107,7 +107,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "sample_namespace.sample_team_event_sample_group_by_v1__0"
+            }
           },
           "name": "sample_team.event_sample_group_by.v1__0",
           "online": 1,
@@ -209,7 +212,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "test.sample_team_entity_sample_group_by_from_module_v1__0"
+            }
           },
           "name": "sample_team.entity_sample_group_by_from_module.v1__0",
           "online": 1,
@@ -321,7 +327,10 @@
           }
         }
       },
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "test.sample_team_sample_join_with_derivations_on_external_parts_v1__0"
+      }
     },
     "name": "sample_team.sample_join_with_derivations_on_external_parts.v1__0",
     "online": 0,

--- a/python/test/sample/compiled/joins/sample_team/sample_online_join.v1__0
+++ b/python/test/sample/compiled/joins/sample_team/sample_online_join.v1__0
@@ -81,7 +81,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "sample_namespace.sample_team_event_sample_group_by_v1__0"
+            }
           },
           "name": "sample_team.event_sample_group_by.v1__0",
           "online": 1,
@@ -183,7 +186,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "test.sample_team_entity_sample_group_by_from_module_v1__0"
+            }
           },
           "name": "sample_team.entity_sample_group_by_from_module.v1__0",
           "online": 1,
@@ -295,7 +301,10 @@
               }
             },
             "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "onlineSchedule": "@daily",
+            "outputTableInfo": {
+              "table": "test.sample_team_group_by_with_kwargs_v1__0"
+            }
           },
           "name": "sample_team.group_by_with_kwargs.v1__0",
           "online": 1,
@@ -416,7 +425,10 @@
         }
       },
       "offlineSchedule": "@daily",
-      "onlineSchedule": "@daily"
+      "onlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "test.sample_team_sample_online_join_v1__0"
+      }
     },
     "name": "sample_team.sample_online_join.v1__0",
     "online": 1,

--- a/python/test/sample/compiled/models/quickstart/test.model__1.0
+++ b/python/test/sample/compiled/models/quickstart/test.model__1.0
@@ -47,6 +47,9 @@
             "VERSION": "latest"
           }
         }
+      },
+      "outputTableInfo": {
+        "table": "quickstart.quickstart_test_model__1_0"
       }
     },
     "name": "quickstart.test.model__1.0",

--- a/python/test/sample/compiled/models/risk/transaction_model.model__1.0
+++ b/python/test/sample/compiled/models/risk/transaction_model.model__1.0
@@ -47,6 +47,9 @@
             "VERSION": "latest"
           }
         }
+      },
+      "outputTableInfo": {
+        "table": "risk.risk_transaction_model_model__1_0"
       }
     },
     "name": "risk.transaction_model.model__1.0",

--- a/python/test/sample/compiled/staging_queries/sample_team/sample_staging_query.v1__0
+++ b/python/test/sample/compiled/staging_queries/sample_team/sample_staging_query.v1__0
@@ -43,7 +43,10 @@
           }
         }
       },
-      "offlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "outputTableInfo": {
+        "table": "sample_namespace.sample_team_sample_staging_query_v1__0"
+      }
     },
     "name": "sample_team.sample_staging_query.v1__0",
     "outputNamespace": "sample_namespace",

--- a/python/test/test_compile.py
+++ b/python/test/test_compile.py
@@ -3,9 +3,9 @@ import json
 from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
-from gen_thrift.api.ttypes import GroupBy, MetaData
+from gen_thrift.api.ttypes import GroupBy, Join, JoinSource, MetaData, Source, Team
 
-from ai.chronon.cli.compile import parse_configs
+from ai.chronon.cli.compile import parse_configs, parse_teams
 from ai.chronon.cli.compile.compile_context import CompileContext
 from ai.chronon.repo.compile import __compile, compile
 
@@ -81,6 +81,29 @@ def test_parse_configs_relative_source_file():
     expected_relative_path = "group_bys/team/test_group_by.py"
     assert results[0].obj.metaData.sourceFile == expected_relative_path
     assert not results[0].obj.metaData.sourceFile.startswith("/")  # Should be relative, not absolute
+
+
+def test_populate_table_names_uses_root_namespace_for_nested_outputs():
+    team_dict = {
+        "default": Team(outputNamespace="default_namespace"),
+        "test_team": Team(outputNamespace="team_namespace"),
+    }
+
+    nested_join = Join(metaData=MetaData(name="test_team.nested_join.v1"))
+    obj = GroupBy(
+        metaData=MetaData(
+            team="test_team",
+            name="test.group_by.name",
+        ),
+        sources=[Source(joinSource=JoinSource(join=nested_join))],
+    )
+
+    parse_teams.update_metadata(obj, team_dict)
+    parse_configs.populate_table_names(obj)
+
+    assert obj.metaData.outputNamespace == "team_namespace"
+    assert nested_join.metaData.outputNamespace is None
+    assert nested_join.metaData.executionInfo.outputTableInfo.table == "team_namespace.test_team_nested_join_v1"
 
 
 def test_compile_with_json_format(canary):

--- a/python/test/test_parse_teams.py
+++ b/python/test/test_parse_teams.py
@@ -166,7 +166,6 @@ def test_update_metadata_sets_missing_join_part_namespace():
     # Verify outputNamespace values were set correctly
     assert join.metaData.outputNamespace == "join_namespace"
     assert join.joinParts[0].groupBy.metaData.outputNamespace == "join_namespace"
-
 def test_merge_team_execution_info():
     """Test that merge_team_execution_info correctly merges team execution info."""
     # Setup


### PR DESCRIPTION
## Summary

We're making a few (backwards compatible) changes, because I wanted a typed output table name 🥲: 

- Add the table name into the compiled output. This happens through `populate_table_names` during compile but it requires the very unpleasant `get_output_children` call, which must walk down the compiled tree to find all nodes that require an output table to be set. Compile being a set of passes over the tree and not a node by node walk is maybe something to think about longer-term (e.g. switch to `handle_group_by`, `handle_join`, ... and walk down the left/right/source fields once. Open to doing this now honestly but it'd be a larger diff against upstream. 
  
  Note: This (1) causes a large initial compile diff as every object will change and (2) means the compiled table names are the only source used. Currently there is a [separate path in Scala](https://github.com/BenMagyar/zipline-chronon/blob/main/api/src/main/scala/ai/chronon/api/Extensions.scala#L157-L174) that derives the table names too, I'm leaving it there for any CLI <> remote mismatch but it is a fallback that should be consistent anyway. 

- Uses a single table name source of `get_object_name`, this matches the two locs in `parse_configs` and `extract_objects` that existed, for deriving the name. 



## Checklist
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Output table information is now explicitly captured and stored in metadata across GroupBys, Joins, Models, ModelTransforms, and StagingQueries, enabling better tracking and routing of data outputs.

* **Refactor**
  * Improved internal metadata assignment logic for consistent and deterministic handling of object naming and output table information population across the compilation pipeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->