### PR TITLE
Add MegaTile streaming pipeline: 2 point gets instead of prefix scan

### DIFF
--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/InMemoryTileStore.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/InMemoryTileStore.scala
@@ -1,0 +1,39 @@
+package ai.chronon.aggregator.windowing
+
+import ai.chronon.aggregator.row.RowAggregator
+
+import scala.collection.mutable
+
+/** In-memory TileStore backed by mutable maps. No serde overhead.
+  * Used for testing and for the MegaTileStreamProcessorTest simulation.
+  */
+class InMemoryTileStore(windowedAgg: RowAggregator) extends TileStore {
+  val tiles: mutable.Map[(Long, Long), Array[Any]] = mutable.Map.empty
+
+  var cachedSmallWindowIr: Array[Any] = windowedAgg.init
+  var largeTodayIr: Array[Any] = windowedAgg.init
+  var largeYesterdayIr: Array[Any] = windowedAgg.init
+  var currentDayStart: Long = -1L
+  var earliestTileStart: Long = Long.MaxValue
+
+  override def getTile(hopSize: Long, tileStart: Long): Array[Any] = tiles.getOrElse((hopSize, tileStart), null)
+  override def putTile(hopSize: Long, tileStart: Long, ir: Array[Any]): Unit = tiles((hopSize, tileStart)) = ir
+  override def removeTile(hopSize: Long, tileStart: Long): Unit = tiles.remove((hopSize, tileStart))
+  override def tileIterator: Iterator[(Long, Long, Array[Any])] =
+    tiles.iterator.map { case ((h, t), ir) => (h, t, ir) }
+
+  override def getCachedSmallWindowIr: Array[Any] = cachedSmallWindowIr
+  override def putCachedSmallWindowIr(ir: Array[Any]): Unit = cachedSmallWindowIr = ir
+
+  override def getLargeTodayIr: Array[Any] = largeTodayIr
+  override def putLargeTodayIr(ir: Array[Any]): Unit = largeTodayIr = ir
+
+  override def getLargeYesterdayIr: Array[Any] = largeYesterdayIr
+  override def putLargeYesterdayIr(ir: Array[Any]): Unit = largeYesterdayIr = ir
+
+  override def getCurrentDayStart: Long = currentDayStart
+  override def putCurrentDayStart(ts: Long): Unit = currentDayStart = ts
+
+  override def getEarliestTileStart: Long = earliestTileStart
+  override def putEarliestTileStart(ts: Long): Unit = earliestTileStart = ts
+}

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileAggregator.scala
@@ -129,13 +129,14 @@ class MegaTileAggregator(aggregations: Seq[Aggregation],
       if (window != null && window.millis > tailBufferMillis) {
         val hopIndex = tailHopIndices(i)
         val queryTail = TsUtils.round(queryTs - windowMillis, hopSizes(hopIndex))
+        val alignedCollapsed = alignedCollapsedBoundary(batchEndTs - windowMillis, i)
         val hopIrs = batchIr.tailHops(hopIndex)
         val relevantHops = mutable.ArrayBuffer[Any](ir(i))
         var idx: Int = 0
         while (idx < hopIrs.length) {
           val hopIr = hopIrs(idx)
           val hopStart = hopIr.last.asInstanceOf[Long]
-          if ((batchEndTs - windowMillis) + tailBufferMillis > hopStart && hopStart >= queryTail) {
+          if (alignedCollapsed > hopStart && hopStart >= queryTail) {
             relevantHops += hopIr(baseIrIndices(i))
           }
           idx += 1

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileAggregator.scala
@@ -118,7 +118,7 @@ class MegaTileAggregator(aggregations: Seq[Aggregation],
   }
 
   // Like mergeTailHops but skips NO BATCH columns (window <= tailBuffer)
-  private def mergeTailHopsForBatchColumns(ir: Array[Any],
+  private[windowing] def mergeTailHopsForBatchColumns(ir: Array[Any],
                                            queryTs: Long,
                                            batchEndTs: Long,
                                            batchIr: FinalBatchIr): Array[Any] = {

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileAggregator.scala
@@ -133,7 +133,13 @@ class MegaTileAggregator(aggregations: Seq[Aggregation],
           val hopIr = hopIrs(idx)
           val hopStart = hopIr.last.asInstanceOf[Long]
           if (alignedCollapsed > hopStart && hopStart >= queryTail) {
-            relevantHops += hopIr(baseIrIndices(i))
+            val hopVal = hopIr(baseIrIndices(i))
+            if (relevantHops(0) == null) {
+              // bulkMerge may mutate its first non-null IR; clone cached tail-hop state on that path.
+              relevantHops += windowedAggregator(i).clone(hopVal)
+            } else {
+              relevantHops += hopVal
+            }
           }
           idx += 1
         }

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileAggregator.scala
@@ -65,9 +65,7 @@ class MegaTileAggregator(aggregations: Seq[Aggregation],
   }
 
   // Build windowed mega tile IR from small tiles
-  def buildMegaTileIr(tiles: Map[Long, collection.Map[Long, Array[Any]]],
-                      now: Long,
-                      batchEnd: Long): Array[Any] = {
+  def buildMegaTileIr(tiles: Map[Long, collection.Map[Long, Array[Any]]], now: Long, batchEnd: Long): Array[Any] = {
     val megaTileIr = windowedAggregator.init
     var col = 0
     while (col < windowedAggregator.length) {
@@ -89,10 +87,7 @@ class MegaTileAggregator(aggregations: Seq[Aggregation],
   }
 
   // Merge mega tile with batch IR to produce finalized result
-  def serveMegaTile(batchIr: FinalBatchIr,
-                    megaTileIr: Array[Any],
-                    queryTs: Long,
-                    batchEnd: Long): Array[Any] = {
+  def serveMegaTile(batchIr: FinalBatchIr, megaTileIr: Array[Any], queryTs: Long, batchEnd: Long): Array[Any] = {
     // Start from batch collapsed (normalized) — same as lambdaAggregateIrTiled
     val resultIr = if (batchIr != null) windowedAggregator.clone(batchIr.collapsed) else windowedAggregator.init
     var col = 0
@@ -119,9 +114,9 @@ class MegaTileAggregator(aggregations: Seq[Aggregation],
 
   // Like mergeTailHops but skips NO BATCH columns (window <= tailBuffer)
   private[windowing] def mergeTailHopsForBatchColumns(ir: Array[Any],
-                                           queryTs: Long,
-                                           batchEndTs: Long,
-                                           batchIr: FinalBatchIr): Array[Any] = {
+                                                      queryTs: Long,
+                                                      batchEndTs: Long,
+                                                      batchIr: FinalBatchIr): Array[Any] = {
     var i: Int = 0
     while (i < windowedAggregator.length) {
       val windowMillis = windowMappings(i).millis

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileAggregator.scala
@@ -45,9 +45,10 @@ class MegaTileAggregator(aggregations: Seq[Aggregation],
     }
   }
 
-  // Compute tile start timestamps for an event across all active tiers
-  def tileStartsForEvent(eventTs: Long): Map[Long, Long] =
-    activeTiers.iterator.map(hopSize => hopSize -> TsUtils.round(eventTs, hopSize)).toMap
+  // Compute tile start timestamps for an event across all active tiers.
+  // Returns an Array to avoid Map allocation on every event.
+  def tileStartsForEvent(eventTs: Long): Array[(Long, Long)] =
+    activeTiers.map(hopSize => (hopSize, TsUtils.round(eventTs, hopSize)))
 
   // Per-tier retention floor: the earliest tile we must keep
   def retentionFloor(hopSize: Long, now: Long, batchEnd: Long): Long = {

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileAggregator.scala
@@ -1,0 +1,150 @@
+package ai.chronon.aggregator.windowing
+
+import ai.chronon.api._
+import ai.chronon.api.Extensions.WindowOps
+
+import scala.collection.mutable
+
+class MegaTileAggregator(aggregations: Seq[Aggregation],
+                         inputSchema: Seq[(String, DataType)],
+                         resolution: Resolution = FiveMinuteResolution,
+                         override val tailBufferMillis: Long = new Window(2, TimeUnit.DAYS).millis)
+    extends SawtoothMutationAggregator(aggregations, inputSchema, resolution, tailBufferMillis) {
+
+  // Per-column hop size: maps windowed column index → hop size in millis
+  val columnHopSize: Array[Long] = windowMappings.map { mapping =>
+    Option(mapping.aggregationPart.window) match {
+      case Some(w) => resolution.calculateTailHop(w)
+      case None    => hopSizes.head // unwindowed uses largest hop
+    }
+  }
+
+  // Distinct hop sizes that have at least one column mapped to them
+  val activeTiers: Array[Long] = columnHopSize.distinct.sorted
+
+  // Per-column: is this a NO BATCH column (window <= tailBuffer)?
+  val isNoBatch: Array[Boolean] = windowMappings.map { mapping =>
+    Option(mapping.aggregationPart.window) match {
+      case Some(w) => w.millis <= tailBufferMillis
+      case None    => false // unwindowed always needs batch
+    }
+  }
+
+  def effectiveStart(col: Int, now: Long, batchEnd: Long): Long = {
+    val window = windowMappings(col).aggregationPart.window
+    if (window == null) {
+      // unwindowed: need all streaming data from batchEnd
+      batchEnd
+    } else if (window.millis <= tailBufferMillis) {
+      // NO BATCH: mega tile covers full window, rounded to hop boundary (sawtooth tail)
+      val hopSize = columnHopSize(col)
+      TsUtils.round(now - window.millis, hopSize)
+    } else {
+      // BATCH: mega tile covers [batchEnd, now)
+      batchEnd
+    }
+  }
+
+  // Compute tile start timestamps for an event across all active tiers
+  def tileStartsForEvent(eventTs: Long): Map[Long, Long] =
+    activeTiers.iterator.map(hopSize => hopSize -> TsUtils.round(eventTs, hopSize)).toMap
+
+  // Per-tier retention floor: the earliest tile we must keep
+  def retentionFloor(hopSize: Long, now: Long, batchEnd: Long): Long = {
+    var minStart = Long.MaxValue
+    var col = 0
+    while (col < windowedAggregator.length) {
+      if (columnHopSize(col) == hopSize) {
+        val effStart = effectiveStart(col, now, batchEnd)
+        if (effStart < minStart) minStart = effStart
+      }
+      col += 1
+    }
+    // one buffer tile before the floor
+    minStart - hopSize
+  }
+
+  // Build windowed mega tile IR from small tiles
+  def buildMegaTileIr(tiles: Map[Long, collection.Map[Long, Array[Any]]],
+                      now: Long,
+                      batchEnd: Long): Array[Any] = {
+    val megaTileIr = windowedAggregator.init
+    var col = 0
+    while (col < windowedAggregator.length) {
+      val hopSize = columnHopSize(col)
+      val effStart = effectiveStart(col, now, batchEnd)
+      val bucketIdx = baseIrIndices(col)
+      val tierTiles = tiles.get(hopSize)
+
+      tierTiles.foreach { tm =>
+        tm.foreach { case (tileStart, tileIr) =>
+          if (tileStart >= effStart && tileStart < now) {
+            megaTileIr(col) = windowedAggregator.columnAggregators(col).merge(megaTileIr(col), tileIr(bucketIdx))
+          }
+        }
+      }
+      col += 1
+    }
+    megaTileIr
+  }
+
+  // Merge mega tile with batch IR to produce finalized result
+  def serveMegaTile(batchIr: FinalBatchIr,
+                    megaTileIr: Array[Any],
+                    queryTs: Long,
+                    batchEnd: Long): Array[Any] = {
+    // Start from batch collapsed (normalized) — same as lambdaAggregateIrTiled
+    val resultIr = if (batchIr != null) windowedAggregator.clone(batchIr.collapsed) else windowedAggregator.init
+    var col = 0
+    while (col < windowedAggregator.length) {
+      val window = windowMappings(col).aggregationPart.window
+      if (window != null && window.millis <= tailBufferMillis) {
+        // NO BATCH: mega tile is self-contained, replace batch value
+        resultIr(col) = megaTileIr(col)
+      } else if (megaTileIr(col) != null) {
+        // BATCH or unwindowed: merge mega tile into batch collapsed
+        resultIr(col) = windowedAggregator.columnAggregators(col).merge(resultIr(col), megaTileIr(col))
+      }
+      col += 1
+    }
+
+    // Tail hops ONLY for BATCH columns (window > tailBuffer).
+    // NO BATCH columns are fully covered by the mega tile — adding tail hops would double-count.
+    if (batchIr != null) {
+      mergeTailHopsForBatchColumns(resultIr, queryTs, batchEnd, batchIr)
+    }
+
+    windowedAggregator.finalize(resultIr)
+  }
+
+  // Like mergeTailHops but skips NO BATCH columns (window <= tailBuffer)
+  private def mergeTailHopsForBatchColumns(ir: Array[Any],
+                                           queryTs: Long,
+                                           batchEndTs: Long,
+                                           batchIr: FinalBatchIr): Array[Any] = {
+    var i: Int = 0
+    while (i < windowedAggregator.length) {
+      val windowMillis = windowMappings(i).millis
+      val window = windowMappings(i).aggregationPart.window
+      if (window != null && window.millis > tailBufferMillis) {
+        val hopIndex = tailHopIndices(i)
+        val queryTail = TsUtils.round(queryTs - windowMillis, hopSizes(hopIndex))
+        val hopIrs = batchIr.tailHops(hopIndex)
+        val relevantHops = mutable.ArrayBuffer[Any](ir(i))
+        var idx: Int = 0
+        while (idx < hopIrs.length) {
+          val hopIr = hopIrs(idx)
+          val hopStart = hopIr.last.asInstanceOf[Long]
+          if ((batchEndTs - windowMillis) + tailBufferMillis > hopStart && hopStart >= queryTail) {
+            relevantHops += hopIr(baseIrIndices(i))
+          }
+          idx += 1
+        }
+        val merged = windowedAggregator(i).bulkMerge(relevantHops.iterator)
+        ir.update(i, merged)
+      }
+      i += 1
+    }
+    ir
+  }
+}

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileMerger.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileMerger.scala
@@ -15,7 +15,6 @@ import ai.chronon.api.TsUtils
 class MegaTileMerger(megaTileAgg: MegaTileAggregator) {
 
   private val windowedAggregator = megaTileAgg.windowedAggregator
-  private val windowMappings = megaTileAgg.windowMappings
   private val isNoBatch = megaTileAgg.isNoBatch
 
   val DayMillis: Long = 24 * 3600 * 1000L

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileMerger.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileMerger.scala
@@ -4,8 +4,9 @@ import ai.chronon.api.TsUtils
 
 /** Fetcher-side merge logic for the per-day MegaTile KV scheme.
   *
-  * Flink writes at most 2 entries per entity per day: (key, today_midnight) and (key, yesterday_midnight).
-  * The fetcher reads both entries plus the batch IR and this class combines them into a finalized result.
+  * Flink writes one entry per entity/day key and may also update yesterday's key for late events.
+  * The fetcher reads the day keys needed to bridge batchEnd -> queryTs plus one fallback key for
+  * no-batch windows, then combines them with batch IR into a finalized result.
   *
   * Per-column merge semantics:
   *   - Small windows (≤ tailBuffer): self-contained in daily entry. Pick today, fall back to yesterday.
@@ -25,7 +26,24 @@ class MegaTileMerger(megaTileAgg: MegaTileAggregator) {
     (todayStart, todayStart - DayMillis)
   }
 
-  /** Merge batch IR + up to 2 daily streaming entries into a finalized result.
+  /** Returns the day keys that must be fetched to merge stream and batch exactly.
+    *
+    * Batch-backed columns need every daily entry from the batch day through today.
+    * No-batch columns still need one extra previous-day fallback key when today's row is missing.
+    * Keys are returned newest-first so callers preserve fallback order for no-batch columns.
+    */
+  def streamingDayKeys(queryTs: Long, batchEnd: Long): Seq[Long] = {
+    val todayStart = TsUtils.round(queryTs, DayMillis)
+    val batchDayStart = TsUtils.round(batchEnd, DayMillis)
+    val oldestDayStart = Math.min(batchDayStart, todayStart - DayMillis)
+
+    Iterator
+      .iterate(todayStart)(_ - DayMillis)
+      .takeWhile(_ >= oldestDayStart)
+      .toSeq
+  }
+
+  /** Merge batch IR + today's and yesterday's daily streaming entries into a finalized result.
     *
     * @param batchIr     Finalized batch IR (collapsed + tail hops). May be null.
     * @param todayIr     Today's daily entry from stream KV. May be null.
@@ -41,30 +59,43 @@ class MegaTileMerger(megaTileAgg: MegaTileAggregator) {
             todayStart: Long,
             queryTs: Long,
             batchEnd: Long): Array[Any] = {
+    merge(batchIr, Seq(todayStart -> todayIr, (todayStart - DayMillis) -> yesterdayIr), queryTs, batchEnd)
+  }
+
+  /** Merge batch IR + N daily streaming entries into a finalized result.
+    *
+    * @param batchIr      Finalized batch IR (collapsed + tail hops). May be null.
+    * @param dailyTileIrs Daily streaming entries keyed by day start, newest-first preferred. Null IRs are allowed.
+    * @param queryTs      The query timestamp (wall-clock now).
+    * @param batchEnd     The batch upload boundary timestamp.
+    * @return Finalized feature values.
+    */
+  def merge(batchIr: FinalBatchIr, dailyTileIrs: Seq[(Long, Array[Any])], queryTs: Long, batchEnd: Long): Array[Any] = {
 
     val resultIr =
       if (batchIr != null) windowedAggregator.clone(batchIr.collapsed)
       else windowedAggregator.init
+    val oldestNoBatchDayStart = TsUtils.round(queryTs, DayMillis) - DayMillis
+    val batchDayStart = TsUtils.round(batchEnd, DayMillis)
+    val nonNullDailyTileIrs = dailyTileIrs.filter(_._2 != null).sortBy(_._1).reverse
 
     var col = 0
     while (col < windowedAggregator.length) {
       if (isNoBatch(col)) {
         // Small window: self-contained in daily entry, ignore batch.
-        // Fall back to yesterday only if today's ENTRY is missing (null array),
-        // not if today exists but the column value is null (no events in window).
-        if (todayIr != null) {
-          resultIr(col) = todayIr(col)
-        } else if (yesterdayIr != null) {
-          resultIr(col) = yesterdayIr(col)
-        }
+        // Fall back to an older day only if the newer entry is missing entirely,
+        // not if a newer entry exists but this column value is null.
+        val newestAvailableIr = nonNullDailyTileIrs.collectFirst {
+          case (dayStart, dayIr) if dayStart >= oldestNoBatchDayStart => dayIr
+        }.orNull
+        resultIr(col) = if (newestAvailableIr != null) newestAvailableIr(col) else null
       } else {
         // Large window / unwindowed: batch collapsed + streaming daily aggregates
         // resultIr(col) already has batchIr.collapsed(col) from clone
-        if (todayIr != null && todayIr(col) != null) {
-          resultIr(col) = windowedAggregator.columnAggregators(col).merge(resultIr(col), todayIr(col))
-        }
-        if (batchEnd < todayStart && yesterdayIr != null && yesterdayIr(col) != null) {
-          resultIr(col) = windowedAggregator.columnAggregators(col).merge(resultIr(col), yesterdayIr(col))
+        nonNullDailyTileIrs.reverseIterator.foreach { case (dayStart, dayIr) =>
+          if (dayStart >= batchDayStart && dayIr(col) != null) {
+            resultIr(col) = windowedAggregator.columnAggregators(col).merge(resultIr(col), dayIr(col))
+          }
         }
       }
       col += 1

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileMerger.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileMerger.scala
@@ -2,8 +2,7 @@ package ai.chronon.aggregator.windowing
 
 import ai.chronon.api.TsUtils
 
-/**
-  * Fetcher-side merge logic for the per-day MegaTile KV scheme.
+/** Fetcher-side merge logic for the per-day MegaTile KV scheme.
   *
   * Flink writes at most 2 entries per entity per day: (key, today_midnight) and (key, yesterday_midnight).
   * The fetcher reads both entries plus the batch IR and this class combines them into a finalized result.
@@ -26,8 +25,7 @@ class MegaTileMerger(megaTileAgg: MegaTileAggregator) {
     (todayStart, todayStart - DayMillis)
   }
 
-  /**
-    * Merge batch IR + up to 2 daily streaming entries into a finalized result.
+  /** Merge batch IR + up to 2 daily streaming entries into a finalized result.
     *
     * @param batchIr     Finalized batch IR (collapsed + tail hops). May be null.
     * @param todayIr     Today's daily entry from stream KV. May be null.
@@ -44,8 +42,9 @@ class MegaTileMerger(megaTileAgg: MegaTileAggregator) {
             queryTs: Long,
             batchEnd: Long): Array[Any] = {
 
-    val resultIr = if (batchIr != null) windowedAggregator.clone(batchIr.collapsed)
-                   else windowedAggregator.init
+    val resultIr =
+      if (batchIr != null) windowedAggregator.clone(batchIr.collapsed)
+      else windowedAggregator.init
 
     var col = 0
     while (col < windowedAggregator.length) {

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileMerger.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileMerger.scala
@@ -10,7 +10,8 @@ import ai.chronon.api.TsUtils
   *
   * Per-column merge semantics:
   *   - Small windows (≤ tailBuffer): self-contained in daily entry. Pick today, fall back to yesterday.
-  *   - Large windows (> tailBuffer) + unwindowed: batch collapsed + streaming daily aggregates + tail hops.
+  *   - Large windows (> tailBuffer): batch collapsed + streaming daily aggregates + tail hops.
+  *   - Unwindowed: batch collapsed + streaming daily aggregates (no tail hops).
   */
 class MegaTileMerger(megaTileAgg: MegaTileAggregator) {
 

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileMerger.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileMerger.scala
@@ -1,0 +1,81 @@
+package ai.chronon.aggregator.windowing
+
+import ai.chronon.api.TsUtils
+
+/**
+  * Fetcher-side merge logic for the per-day MegaTile KV scheme.
+  *
+  * Flink writes at most 2 entries per entity per day: (key, today_midnight) and (key, yesterday_midnight).
+  * The fetcher reads both entries plus the batch IR and this class combines them into a finalized result.
+  *
+  * Per-column merge semantics:
+  *   - Small windows (≤ tailBuffer): self-contained in daily entry. Pick today, fall back to yesterday.
+  *   - Large windows (> tailBuffer) + unwindowed: batch collapsed + streaming daily aggregates + tail hops.
+  */
+class MegaTileMerger(megaTileAgg: MegaTileAggregator) {
+
+  private val windowedAggregator = megaTileAgg.windowedAggregator
+  private val windowMappings = megaTileAgg.windowMappings
+  private val isNoBatch = megaTileAgg.isNoBatch
+
+  val DayMillis: Long = 24 * 3600 * 1000L
+
+  /** Returns (todayStart, yesterdayStart) aligned to day boundaries. */
+  def streamingDayKeys(now: Long): (Long, Long) = {
+    val todayStart = TsUtils.round(now, DayMillis)
+    (todayStart, todayStart - DayMillis)
+  }
+
+  /**
+    * Merge batch IR + up to 2 daily streaming entries into a finalized result.
+    *
+    * @param batchIr     Finalized batch IR (collapsed + tail hops). May be null.
+    * @param todayIr     Today's daily entry from stream KV. May be null.
+    * @param yesterdayIr Yesterday's daily entry from stream KV. May be null.
+    * @param todayStart  Midnight timestamp for today (the KV key timestamp).
+    * @param queryTs     The query timestamp (wall-clock now).
+    * @param batchEnd    The batch upload boundary timestamp.
+    * @return Finalized feature values.
+    */
+  def merge(batchIr: FinalBatchIr,
+            todayIr: Array[Any],
+            yesterdayIr: Array[Any],
+            todayStart: Long,
+            queryTs: Long,
+            batchEnd: Long): Array[Any] = {
+
+    val resultIr = if (batchIr != null) windowedAggregator.clone(batchIr.collapsed)
+                   else windowedAggregator.init
+
+    var col = 0
+    while (col < windowedAggregator.length) {
+      if (isNoBatch(col)) {
+        // Small window: self-contained in daily entry, ignore batch.
+        // Fall back to yesterday only if today's ENTRY is missing (null array),
+        // not if today exists but the column value is null (no events in window).
+        if (todayIr != null) {
+          resultIr(col) = todayIr(col)
+        } else if (yesterdayIr != null) {
+          resultIr(col) = yesterdayIr(col)
+        }
+      } else {
+        // Large window / unwindowed: batch collapsed + streaming daily aggregates
+        // resultIr(col) already has batchIr.collapsed(col) from clone
+        if (todayIr != null && todayIr(col) != null) {
+          resultIr(col) = windowedAggregator.columnAggregators(col).merge(resultIr(col), todayIr(col))
+        }
+        if (batchEnd < todayStart && yesterdayIr != null && yesterdayIr(col) != null) {
+          resultIr(col) = windowedAggregator.columnAggregators(col).merge(resultIr(col), yesterdayIr(col))
+        }
+      }
+      col += 1
+    }
+
+    // Tail hops for large windowed columns (skips small + unwindowed)
+    if (batchIr != null) {
+      megaTileAgg.mergeTailHopsForBatchColumns(resultIr, queryTs, batchEnd, batchIr)
+    }
+
+    windowedAggregator.finalize(resultIr)
+  }
+}

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileStreamProcessor.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileStreamProcessor.scala
@@ -58,6 +58,18 @@ class MegaTileStreamProcessor(val megaTileAgg: MegaTileAggregator) {
   var currentDayStart: Long = -1L
   var earliestTileStart: Long = Long.MaxValue
 
+  /** Clear all mutable state to defaults. Used by Flink wrapper on key switch
+    * to avoid allocating a new processor instance per event.
+    */
+  def reset(): Unit = {
+    tiles.values.foreach(_.clear())
+    cachedSmallWindowIr = windowedAgg.init
+    largeTodayIr = windowedAgg.init
+    largeYesterdayIr = windowedAgg.init
+    currentDayStart = -1L
+    earliestTileStart = Long.MaxValue
+  }
+
   /** Process a new event. Returns an EmitResult describing what should be
     * written to KV store (today and/or yesterday entries).
     */

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileStreamProcessor.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileStreamProcessor.scala
@@ -13,7 +13,8 @@ import scala.collection.mutable
   * State layout:
   *   - Small window tiles: per-tier base IRs. Source of truth for eviction rebuilds.
   *   - cachedSmallWindowIr: sawtooth running sum, corrected on eviction.
-  *   - Large window today/yesterday IRs: per-day accumulators.
+  *   - Large window today IR and previous-day IR: large columns are per-day accumulators;
+  *     no-batch columns in previous-day IR are frozen at adjacent day rollover.
   *   - Day transitions are watermark-driven (advanceWatermark), not event-driven.
   */
 class MegaTileStreamProcessor(val megaTileAgg: MegaTileAggregator, val store: TileStore) {
@@ -38,7 +39,10 @@ class MegaTileStreamProcessor(val megaTileAgg: MegaTileAggregator, val store: Ti
   val hasSmallWindows: Boolean = smallWindowTiers.nonEmpty
   val minSmallWindowTileSize: Long = if (hasSmallWindows) smallWindowTiers.min else DayMillis
 
-  def onEvent(row: Row, eventTs: Long): EmitResult = {
+  /** Ingest an event at eventTs, but bound cached small-window emission as of smallWindowAsOfTs.
+    * Base tile state still uses eventTs so retained late events remain available for future rebuilds.
+    */
+  def onEvent(row: Row, eventTs: Long, smallWindowAsOfTs: Long): EmitResult = {
     var currentDayStart = store.getCurrentDayStart
     if (currentDayStart == -1L) {
       currentDayStart = TsUtils.round(eventTs, DayMillis)
@@ -50,7 +54,7 @@ class MegaTileStreamProcessor(val megaTileAgg: MegaTileAggregator, val store: Ti
 
     // Update tiles + cachedSmallWindowIr for small-window tiers
     if (hasSmallWindows) {
-      var tilesUpdated = false
+      val acceptedTileStarts = mutable.Map.empty[Long, Long]
       val tileStarts = megaTileAgg.tileStartsForEvent(eventTs)
       for ((hopSize, tileStart) <- tileStarts) {
         if (smallWindowTiers.contains(hopSize)) {
@@ -63,23 +67,38 @@ class MegaTileStreamProcessor(val megaTileAgg: MegaTileAggregator, val store: Ti
             store.putTile(hopSize, tileStart, ir)
             val earliest = store.getEarliestTileStart
             if (tileStart < earliest) store.putEarliestTileStart(tileStart)
-            tilesUpdated = true
+            acceptedTileStarts(hopSize) = tileStart
           }
         }
       }
 
-      // Sawtooth: merge event into running IR for all small-window columns.
-      if (tilesUpdated) {
-        val cachedIr = store.getCachedSmallWindowIr
+      // Sawtooth: merge event into the running IR only for columns whose tile belongs
+      // in the as-of window being emitted. The base tile remains retained even when
+      // a late event is outside a smaller current serving horizon.
+      if (acceptedTileStarts.nonEmpty) {
+        var cachedIr: Array[Any] = null
+        var cachedIrUpdated = false
         var col = 0
         while (col < windowedAgg.length) {
           if (isNoBatch(col)) {
-            windowedAgg.columnAggregators(col).update(cachedIr, row)
+            val hopSize = columnHopSize(col)
+            acceptedTileStarts.get(hopSize).foreach { tileStart =>
+              val effectiveStart = megaTileAgg.effectiveStart(col, smallWindowAsOfTs, currentDayStart)
+              // The retained base tile can accept older late events, but the sawtooth cache represents
+              // the value emitted as of smallWindowAsOfTs.
+              if (tileStart >= effectiveStart && tileStart < smallWindowAsOfTs) {
+                if (cachedIr == null) cachedIr = store.getCachedSmallWindowIr
+                windowedAgg.columnAggregators(col).update(cachedIr, row)
+                cachedIrUpdated = true
+              }
+            }
           }
           col += 1
         }
-        store.putCachedSmallWindowIr(cachedIr)
-        todayDirty = true
+        if (cachedIrUpdated) {
+          store.putCachedSmallWindowIr(cachedIr)
+          todayDirty = true
+        }
       }
     }
 
@@ -121,11 +140,14 @@ class MegaTileStreamProcessor(val megaTileAgg: MegaTileAggregator, val store: Ti
     val wmDay = TsUtils.round(watermarkTs, DayMillis)
     if (wmDay > currentDayStart) {
       val newYesterday =
-        if (wmDay == currentDayStart + DayMillis) store.getLargeTodayIr
+        if (wmDay == currentDayStart + DayMillis) previousDayIrForAdjacentRollover()
         else windowedAgg.init
       store.putLargeYesterdayIr(newYesterday)
       store.putLargeTodayIr(windowedAgg.init)
       store.putCurrentDayStart(wmDay)
+      // cachedSmallWindowIr is as-of sensitive. Day rollover changes each small window's
+      // effective start, so rebuild from retained tiles instead of carrying yesterday's cache forward.
+      rebuildCachedSmallWindowIr(watermarkTs, wmDay)
     }
   }
 
@@ -138,32 +160,7 @@ class MegaTileStreamProcessor(val megaTileAgg: MegaTileAggregator, val store: Ti
 
     val todayStart = currentDayStart
 
-    // Evict stale tiles
-    val staleEntries = mutable.ArrayBuffer.empty[(Long, Long)]
-    val iter = store.tileIterator
-    while (iter.hasNext) {
-      val (hopSize, tileStart, _) = iter.next()
-      if (smallWindowTiers.contains(hopSize)) {
-        val floor = megaTileAgg.retentionFloor(hopSize, timerTs, todayStart)
-        if (tileStart < floor) staleEntries += ((hopSize, tileStart))
-      }
-    }
-    staleEntries.foreach { case (h, t) => store.removeTile(h, t) }
-
-    // Rebuild cachedSmallWindowIr from remaining tiles
-    val tiles: Map[Long, mutable.Map[Long, Array[Any]]] =
-      smallWindowTiers.map(hop => hop -> mutable.Map.empty[Long, Array[Any]]).toMap
-    var newEarliest = Long.MaxValue
-    val rebuildIter = store.tileIterator
-    while (rebuildIter.hasNext) {
-      val (hopSize, tileStart, ir) = rebuildIter.next()
-      tiles.get(hopSize).foreach(_(tileStart) = ir)
-      if (tileStart < newEarliest) newEarliest = tileStart
-    }
-    store.putEarliestTileStart(newEarliest)
-
-    val rebuiltIr = megaTileAgg.buildMegaTileIr(tiles, now = timerTs, batchEnd = todayStart)
-    store.putCachedSmallWindowIr(rebuiltIr)
+    rebuildCachedSmallWindowIr(timerTs, todayStart)
 
     EmitResult(
       todayEntry = packTodayEntry(),
@@ -186,14 +183,27 @@ class MegaTileStreamProcessor(val megaTileAgg: MegaTileAggregator, val store: Ti
   }
 
   def packYesterdayEntry(): Array[Any] = {
-    val largeIr = store.getLargeYesterdayIr
+    val yesterdayIr = store.getLargeYesterdayIr
     val entry = new Array[Any](windowedAgg.length)
     var col = 0
     while (col < windowedAgg.length) {
-      entry(col) = if (isNoBatch(col)) null else largeIr(col)
+      entry(col) = yesterdayIr(col)
       col += 1
     }
     entry
+  }
+
+  private def previousDayIrForAdjacentRollover(): Array[Any] = {
+    val previousDayIr = windowedAgg.clone(store.getLargeTodayIr)
+    val cachedSmallIr = store.getCachedSmallWindowIr
+    var col = 0
+    while (col < windowedAgg.length) {
+      if (isNoBatch(col)) {
+        previousDayIr(col) = windowedAgg.columnAggregators(col).clone(cachedSmallIr(col))
+      }
+      col += 1
+    }
+    previousDayIr
   }
 
   private def updateLargeWindowColumns(ir: Array[Any], row: Row): Unit = {
@@ -204,6 +214,35 @@ class MegaTileStreamProcessor(val megaTileAgg: MegaTileAggregator, val store: Ti
       }
       col += 1
     }
+  }
+
+  private def rebuildCachedSmallWindowIr(asOfTs: Long, todayStart: Long): Unit = {
+    if (!hasSmallWindows) return
+
+    // Classify stale vs retained tiles in one iterator pass. Flink-backed TileStore decodes values
+    // during iteration, so a second full scan would deserialize every retained tile again.
+    val staleEntries = mutable.ArrayBuffer.empty[(Long, Long)]
+    val tiles: Map[Long, mutable.Map[Long, Array[Any]]] =
+      smallWindowTiers.map(hop => hop -> mutable.Map.empty[Long, Array[Any]]).toMap
+    var newEarliest = Long.MaxValue
+    val iter = store.tileIterator
+    while (iter.hasNext) {
+      val (hopSize, tileStart, ir) = iter.next()
+      if (smallWindowTiers.contains(hopSize)) {
+        val floor = megaTileAgg.retentionFloor(hopSize, asOfTs, todayStart)
+        if (tileStart < floor) {
+          staleEntries += ((hopSize, tileStart))
+        } else {
+          tiles(hopSize)(tileStart) = ir
+          if (tileStart < newEarliest) newEarliest = tileStart
+        }
+      }
+    }
+    staleEntries.foreach { case (h, t) => store.removeTile(h, t) }
+    store.putEarliestTileStart(newEarliest)
+
+    val rebuiltIr = megaTileAgg.buildMegaTileIr(tiles, now = asOfTs, batchEnd = todayStart)
+    store.putCachedSmallWindowIr(rebuiltIr)
   }
 }
 

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileStreamProcessor.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileStreamProcessor.scala
@@ -140,7 +140,10 @@ class MegaTileStreamProcessor(val megaTileAgg: MegaTileAggregator) {
     if (currentDayStart == -1L) return
     val wmDay = TsUtils.round(watermarkTs, DayMillis)
     if (wmDay > currentDayStart) {
-      largeYesterdayIr = largeTodayIr
+      // Single-day hop: today's aggregate becomes yesterday's.
+      // Multi-day hop (e.g., after long idle/restart): today's data is stale beyond
+      // the 2d tolerance, so yesterday starts fresh.
+      largeYesterdayIr = if (wmDay == currentDayStart + DayMillis) largeTodayIr else windowedAgg.init
       largeTodayIr = windowedAgg.init
       currentDayStart = wmDay
     }

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileStreamProcessor.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileStreamProcessor.scala
@@ -11,10 +11,11 @@ import scala.collection.mutable
   * eviction, and IR packing. No Flink imports — testable in isolation.
   *
   * State layout:
-  *   - Small window tiles: per-tier Map[tileStart -> base IR], only for tiers with isNoBatch columns.
-  *     On emission, small-window columns are built from tiles via buildMegaTileIr (correct per-column scoping).
+  *   - Small window tiles: per-tier Map[tileStart -> base IR]. Source of truth.
+  *   - cachedSmallWindowIr: running sawtooth approximation of small-window columns.
+  *     Updated incrementally on each event (over-inclusive at the tail).
+  *     Rebuilt from tiles on eviction to correct the tail (shed aged-out data).
   *   - Large window today/yesterday IRs: per-day accumulators for large/unwindowed columns.
-  *     Incremental update on each event.
   *   - Day transitions are watermark-driven (advanceWatermark), not event-driven,
   *     to prevent future-timestamped events from prematurely rotating state.
   */
@@ -43,9 +44,13 @@ class MegaTileStreamProcessor(val megaTileAgg: MegaTileAggregator) {
 
   // ---- Mutable state ----
 
-  // Small window tiles: per small-window tier only
+  // Small window tiles: per small-window tier only. Source of truth for eviction rebuilds.
   val tiles: Map[Long, mutable.Map[Long, Array[Any]]] =
     smallWindowTiers.map(hop => hop -> mutable.Map.empty[Long, Array[Any]]).toMap
+
+  // Sawtooth running sum for small-window columns. Updated on every event (over-inclusive).
+  // Rebuilt from tiles on eviction to correct the tail.
+  var cachedSmallWindowIr: Array[Any] = windowedAgg.init
 
   // Large window per-day accumulators (only large/unwindowed column positions populated)
   var largeTodayIr: Array[Any] = windowedAgg.init
@@ -67,10 +72,9 @@ class MegaTileStreamProcessor(val megaTileAgg: MegaTileAggregator) {
     var todayDirty = false
     var yesterdayDirty = false
 
-    // Update tiles for small-window tiers.
-    // Tiles are the source of truth for small-window columns; on emission,
-    // buildMegaTileIr scopes each column to its effective window.
+    // Update tiles + cachedSmallWindowIr for small-window tiers
     if (hasSmallWindows) {
+      var tilesUpdated = false
       val tileStarts = megaTileAgg.tileStartsForEvent(eventTs)
       for ((hopSize, tileStart) <- tileStarts) {
         if (smallWindowTiers.contains(hopSize)) {
@@ -81,9 +85,23 @@ class MegaTileStreamProcessor(val megaTileAgg: MegaTileAggregator) {
             val ir = tierTiles.getOrElseUpdate(tileStart, baseAgg.init)
             baseAgg.update(ir, row)
             if (tileStart < earliestTileStart) earliestTileStart = tileStart
-            todayDirty = true
+            tilesUpdated = true
           }
         }
+      }
+
+      // Sawtooth: merge event into running IR for all small-window columns.
+      // Over-inclusive at the tail (6h col accumulates same events as 2d col).
+      // Eviction rebuilds from tiles to correct per-column scoping.
+      if (tilesUpdated) {
+        var col = 0
+        while (col < windowedAgg.length) {
+          if (isNoBatch(col)) {
+            windowedAgg.columnAggregators(col).update(cachedSmallWindowIr, row)
+          }
+          col += 1
+        }
+        todayDirty = true
       }
     }
 
@@ -107,7 +125,7 @@ class MegaTileStreamProcessor(val megaTileAgg: MegaTileAggregator) {
     // else: > 2 days late → dropped for large windows (tiles may still capture it above)
 
     EmitResult(
-      todayEntry = if (todayDirty) packTodayEntry(eventTs) else null,
+      todayEntry = if (todayDirty) packTodayEntry() else null,
       todayStart = todayStart,
       yesterdayEntry = if (yesterdayDirty) packYesterdayEntry() else null,
       yesterdayStart = yesterdayStart
@@ -129,8 +147,10 @@ class MegaTileStreamProcessor(val megaTileAgg: MegaTileAggregator) {
   }
 
   /**
-    * Evict stale tiles. Called on timer (watermark-driven interval = minSmallWindowTileSize).
-    * Returns an EmitResult with updated today entry.
+    * Evict stale tiles and rebuild cachedSmallWindowIr from remaining tiles.
+    * Called on timer at every minSmallWindowTileSize interval (watermark-driven).
+    * The rebuild corrects the sawtooth over-inclusiveness by scoping each
+    * column to its effectiveStart via buildMegaTileIr.
     */
   def onEviction(timerTs: Long): EmitResult = {
     if (!hasSmallWindows || earliestTileStart == Long.MaxValue) {
@@ -147,6 +167,10 @@ class MegaTileStreamProcessor(val megaTileAgg: MegaTileAggregator) {
       staleKeys.foreach(tierTiles.remove)
     }
 
+    // Rebuild cachedSmallWindowIr from tiles — corrects sawtooth tail.
+    // buildMegaTileIr scopes each column to its effectiveStart.
+    cachedSmallWindowIr = megaTileAgg.buildMegaTileIr(tiles, now = timerTs, batchEnd = todayStart)
+
     // Update earliestTileStart from remaining tiles
     earliestTileStart = Long.MaxValue
     for ((_, tierTiles) <- tiles; ts <- tierTiles.keys) {
@@ -154,7 +178,7 @@ class MegaTileStreamProcessor(val megaTileAgg: MegaTileAggregator) {
     }
 
     EmitResult(
-      todayEntry = packTodayEntry(timerTs),
+      todayEntry = packTodayEntry(),
       todayStart = todayStart,
       yesterdayEntry = null,
       yesterdayStart = todayStart - DayMillis
@@ -162,23 +186,15 @@ class MegaTileStreamProcessor(val megaTileAgg: MegaTileAggregator) {
   }
 
   /**
-    * Pack today's KV entry.
-    * Small-window columns are built from tiles via buildMegaTileIr (correct per-column scoping).
-    * Large-window columns come from the running daily accumulator.
+    * Pack today's KV entry from cached state.
+    * Small-window columns: cachedSmallWindowIr (sawtooth, corrected on eviction).
+    * Large-window columns: largeTodayIr (always fresh).
     */
-  def packTodayEntry(now: Long): Array[Any] = {
-    val todayStart = currentDayStart
-    // Build small-window columns from tiles (correct per-column effective window)
-    val smallIr = if (hasSmallWindows) megaTileAgg.buildMegaTileIr(tiles, now, batchEnd = todayStart) else null
-
+  def packTodayEntry(): Array[Any] = {
     val entry = new Array[Any](windowedAgg.length)
     var col = 0
     while (col < windowedAgg.length) {
-      if (isNoBatch(col)) {
-        entry(col) = if (smallIr != null) smallIr(col) else null
-      } else {
-        entry(col) = largeTodayIr(col)
-      }
+      entry(col) = if (isNoBatch(col)) cachedSmallWindowIr(col) else largeTodayIr(col)
       col += 1
     }
     entry

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileStreamProcessor.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileStreamProcessor.scala
@@ -5,8 +5,7 @@ import ai.chronon.api.TsUtils
 
 import scala.collection.mutable
 
-/**
-  * Pure Scala state manager for the MegaTile streaming pipeline.
+/** Pure Scala state manager for the MegaTile streaming pipeline.
   * Contains ALL logic for tile updates, day transitions, late event routing,
   * eviction, and IR packing. No Flink imports — testable in isolation.
   *
@@ -59,8 +58,7 @@ class MegaTileStreamProcessor(val megaTileAgg: MegaTileAggregator) {
   var currentDayStart: Long = -1L
   var earliestTileStart: Long = Long.MaxValue
 
-  /**
-    * Process a new event. Returns an EmitResult describing what should be
+  /** Process a new event. Returns an EmitResult describing what should be
     * written to KV store (today and/or yesterday entries).
     */
   def onEvent(row: Row, eventTs: Long): EmitResult = {
@@ -132,8 +130,7 @@ class MegaTileStreamProcessor(val megaTileAgg: MegaTileAggregator) {
     )
   }
 
-  /**
-    * Advance the watermark. Day transitions happen ONLY here, never in onEvent.
+  /** Advance the watermark. Day transitions happen ONLY here, never in onEvent.
     * This prevents future-timestamped events from prematurely rotating state.
     */
   def advanceWatermark(watermarkTs: Long): Unit = {
@@ -149,8 +146,7 @@ class MegaTileStreamProcessor(val megaTileAgg: MegaTileAggregator) {
     }
   }
 
-  /**
-    * Evict stale tiles and rebuild cachedSmallWindowIr from remaining tiles.
+  /** Evict stale tiles and rebuild cachedSmallWindowIr from remaining tiles.
     * Called on timer at every minSmallWindowTileSize interval (watermark-driven).
     * The rebuild corrects the sawtooth over-inclusiveness by scoping each
     * column to its effectiveStart via buildMegaTileIr.
@@ -188,8 +184,7 @@ class MegaTileStreamProcessor(val megaTileAgg: MegaTileAggregator) {
     )
   }
 
-  /**
-    * Pack today's KV entry from cached state.
+  /** Pack today's KV entry from cached state.
     * Small-window columns: cachedSmallWindowIr (sawtooth, corrected on eviction).
     * Large-window columns: largeTodayIr (always fresh).
     */

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileStreamProcessor.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileStreamProcessor.scala
@@ -6,19 +6,17 @@ import ai.chronon.api.TsUtils
 import scala.collection.mutable
 
 /** Pure Scala state manager for the MegaTile streaming pipeline.
-  * Contains ALL logic for tile updates, day transitions, late event routing,
-  * eviction, and IR packing. No Flink imports — testable in isolation.
+  * All state access goes through a TileStore — Flink backs it with MapState/ValueState + codec,
+  * tests back it with InMemoryTileStore. No bulk restore/persist cycle; reads are lazy,
+  * writes are immediate to the touched entries only.
   *
   * State layout:
-  *   - Small window tiles: per-tier Map[tileStart -> base IR]. Source of truth.
-  *   - cachedSmallWindowIr: running sawtooth approximation of small-window columns.
-  *     Updated incrementally on each event (over-inclusive at the tail).
-  *     Rebuilt from tiles on eviction to correct the tail (shed aged-out data).
-  *   - Large window today/yesterday IRs: per-day accumulators for large/unwindowed columns.
-  *   - Day transitions are watermark-driven (advanceWatermark), not event-driven,
-  *     to prevent future-timestamped events from prematurely rotating state.
+  *   - Small window tiles: per-tier base IRs. Source of truth for eviction rebuilds.
+  *   - cachedSmallWindowIr: sawtooth running sum, corrected on eviction.
+  *   - Large window today/yesterday IRs: per-day accumulators.
+  *   - Day transitions are watermark-driven (advanceWatermark), not event-driven.
   */
-class MegaTileStreamProcessor(val megaTileAgg: MegaTileAggregator) {
+class MegaTileStreamProcessor(val megaTileAgg: MegaTileAggregator, val store: TileStore) {
 
   val DayMillis: Long = 24 * 3600 * 1000L
 
@@ -27,7 +25,6 @@ class MegaTileStreamProcessor(val megaTileAgg: MegaTileAggregator) {
   private val isNoBatch = megaTileAgg.isNoBatch
   private val columnHopSize = megaTileAgg.columnHopSize
 
-  // Tiers that have at least one small-window column (tiles only needed for these)
   val smallWindowTiers: Set[Long] = {
     val tiers = mutable.Set.empty[Long]
     var col = 0
@@ -41,42 +38,11 @@ class MegaTileStreamProcessor(val megaTileAgg: MegaTileAggregator) {
   val hasSmallWindows: Boolean = smallWindowTiers.nonEmpty
   val minSmallWindowTileSize: Long = if (hasSmallWindows) smallWindowTiers.min else DayMillis
 
-  // ---- Mutable state ----
-
-  // Small window tiles: per small-window tier only. Source of truth for eviction rebuilds.
-  val tiles: Map[Long, mutable.Map[Long, Array[Any]]] =
-    smallWindowTiers.map(hop => hop -> mutable.Map.empty[Long, Array[Any]]).toMap
-
-  // Sawtooth running sum for small-window columns. Updated on every event (over-inclusive).
-  // Rebuilt from tiles on eviction to correct the tail.
-  var cachedSmallWindowIr: Array[Any] = windowedAgg.init
-
-  // Large window per-day accumulators (only large/unwindowed column positions populated)
-  var largeTodayIr: Array[Any] = windowedAgg.init
-  var largeYesterdayIr: Array[Any] = windowedAgg.init
-
-  var currentDayStart: Long = -1L
-  var earliestTileStart: Long = Long.MaxValue
-
-  /** Clear all mutable state to defaults. Used by Flink wrapper on key switch
-    * to avoid allocating a new processor instance per event.
-    */
-  def reset(): Unit = {
-    tiles.values.foreach(_.clear())
-    cachedSmallWindowIr = windowedAgg.init
-    largeTodayIr = windowedAgg.init
-    largeYesterdayIr = windowedAgg.init
-    currentDayStart = -1L
-    earliestTileStart = Long.MaxValue
-  }
-
-  /** Process a new event. Returns an EmitResult describing what should be
-    * written to KV store (today and/or yesterday entries).
-    */
   def onEvent(row: Row, eventTs: Long): EmitResult = {
-    // Lazy init currentDayStart from first event
+    var currentDayStart = store.getCurrentDayStart
     if (currentDayStart == -1L) {
       currentDayStart = TsUtils.round(eventTs, DayMillis)
+      store.putCurrentDayStart(currentDayStart)
     }
 
     var todayDirty = false
@@ -89,28 +55,30 @@ class MegaTileStreamProcessor(val megaTileAgg: MegaTileAggregator) {
       for ((hopSize, tileStart) <- tileStarts) {
         if (smallWindowTiers.contains(hopSize)) {
           val floor = megaTileAgg.retentionFloor(hopSize, eventTs, currentDayStart)
-          val ceiling = currentDayStart + 2 * DayMillis // reject tiles >= 2 days ahead (state leak guard)
+          val ceiling = currentDayStart + 2 * DayMillis
           if (tileStart >= floor && tileStart < ceiling) {
-            val tierTiles = tiles(hopSize)
-            val ir = tierTiles.getOrElseUpdate(tileStart, baseAgg.init)
+            val existing = store.getTile(hopSize, tileStart)
+            val ir = if (existing != null) existing else baseAgg.init
             baseAgg.update(ir, row)
-            if (tileStart < earliestTileStart) earliestTileStart = tileStart
+            store.putTile(hopSize, tileStart, ir)
+            val earliest = store.getEarliestTileStart
+            if (tileStart < earliest) store.putEarliestTileStart(tileStart)
             tilesUpdated = true
           }
         }
       }
 
       // Sawtooth: merge event into running IR for all small-window columns.
-      // Over-inclusive at the tail (6h col accumulates same events as 2d col).
-      // Eviction rebuilds from tiles to correct per-column scoping.
       if (tilesUpdated) {
+        val cachedIr = store.getCachedSmallWindowIr
         var col = 0
         while (col < windowedAgg.length) {
           if (isNoBatch(col)) {
-            windowedAgg.columnAggregators(col).update(cachedSmallWindowIr, row)
+            windowedAgg.columnAggregators(col).update(cachedIr, row)
           }
           col += 1
         }
+        store.putCachedSmallWindowIr(cachedIr)
         todayDirty = true
       }
     }
@@ -122,17 +90,22 @@ class MegaTileStreamProcessor(val megaTileAgg: MegaTileAggregator) {
 
     if (eventTs >= nextDayStart) {
       // Future event — clamp to today. Day transitions are watermark-driven.
-      updateLargeWindowColumns(largeTodayIr, row)
+      val ir = store.getLargeTodayIr
+      updateLargeWindowColumns(ir, row)
+      store.putLargeTodayIr(ir)
       todayDirty = true
     } else if (eventTs >= todayStart) {
-      updateLargeWindowColumns(largeTodayIr, row)
+      val ir = store.getLargeTodayIr
+      updateLargeWindowColumns(ir, row)
+      store.putLargeTodayIr(ir)
       todayDirty = true
     } else if (eventTs >= yesterdayStart) {
       // Late event from yesterday — within 2d tolerance
-      updateLargeWindowColumns(largeYesterdayIr, row)
+      val ir = store.getLargeYesterdayIr
+      updateLargeWindowColumns(ir, row)
+      store.putLargeYesterdayIr(ir)
       yesterdayDirty = true
     }
-    // else: > 2 days late → dropped for large windows (tiles may still capture it above)
 
     EmitResult(
       todayEntry = if (todayDirty) packTodayEntry() else null,
@@ -142,51 +115,55 @@ class MegaTileStreamProcessor(val megaTileAgg: MegaTileAggregator) {
     )
   }
 
-  /** Advance the watermark. Day transitions happen ONLY here, never in onEvent.
-    * This prevents future-timestamped events from prematurely rotating state.
-    */
   def advanceWatermark(watermarkTs: Long): Unit = {
+    val currentDayStart = store.getCurrentDayStart
     if (currentDayStart == -1L) return
     val wmDay = TsUtils.round(watermarkTs, DayMillis)
     if (wmDay > currentDayStart) {
-      // Single-day hop: today's aggregate becomes yesterday's.
-      // Multi-day hop (e.g., after long idle/restart): today's data is stale beyond
-      // the 2d tolerance, so yesterday starts fresh.
-      largeYesterdayIr = if (wmDay == currentDayStart + DayMillis) largeTodayIr else windowedAgg.init
-      largeTodayIr = windowedAgg.init
-      currentDayStart = wmDay
+      val newYesterday =
+        if (wmDay == currentDayStart + DayMillis) store.getLargeTodayIr
+        else windowedAgg.init
+      store.putLargeYesterdayIr(newYesterday)
+      store.putLargeTodayIr(windowedAgg.init)
+      store.putCurrentDayStart(wmDay)
     }
   }
 
-  /** Evict stale tiles and rebuild cachedSmallWindowIr from remaining tiles.
-    * Called on timer at every minSmallWindowTileSize interval (watermark-driven).
-    * The rebuild corrects the sawtooth over-inclusiveness by scoping each
-    * column to its effectiveStart via buildMegaTileIr.
-    */
   def onEviction(timerTs: Long): EmitResult = {
-    if (!hasSmallWindows || earliestTileStart == Long.MaxValue) {
+    val earliest = store.getEarliestTileStart
+    val currentDayStart = store.getCurrentDayStart
+    if (!hasSmallWindows || earliest == Long.MaxValue) {
       return EmitResult(null, currentDayStart, null, currentDayStart - DayMillis)
     }
 
     val todayStart = currentDayStart
 
-    // Evict stale tiles per tier
-    for (hopSize <- smallWindowTiers) {
-      val floor = megaTileAgg.retentionFloor(hopSize, timerTs, todayStart)
-      val tierTiles = tiles(hopSize)
-      val staleKeys = tierTiles.keys.filter(_ < floor).toSeq
-      staleKeys.foreach(tierTiles.remove)
+    // Evict stale tiles
+    val staleEntries = mutable.ArrayBuffer.empty[(Long, Long)]
+    val iter = store.tileIterator
+    while (iter.hasNext) {
+      val (hopSize, tileStart, _) = iter.next()
+      if (smallWindowTiers.contains(hopSize)) {
+        val floor = megaTileAgg.retentionFloor(hopSize, timerTs, todayStart)
+        if (tileStart < floor) staleEntries += ((hopSize, tileStart))
+      }
     }
+    staleEntries.foreach { case (h, t) => store.removeTile(h, t) }
 
-    // Rebuild cachedSmallWindowIr from tiles — corrects sawtooth tail.
-    // buildMegaTileIr scopes each column to its effectiveStart.
-    cachedSmallWindowIr = megaTileAgg.buildMegaTileIr(tiles, now = timerTs, batchEnd = todayStart)
-
-    // Update earliestTileStart from remaining tiles
-    earliestTileStart = Long.MaxValue
-    for ((_, tierTiles) <- tiles; ts <- tierTiles.keys) {
-      if (ts < earliestTileStart) earliestTileStart = ts
+    // Rebuild cachedSmallWindowIr from remaining tiles
+    val tiles: Map[Long, mutable.Map[Long, Array[Any]]] =
+      smallWindowTiers.map(hop => hop -> mutable.Map.empty[Long, Array[Any]]).toMap
+    var newEarliest = Long.MaxValue
+    val rebuildIter = store.tileIterator
+    while (rebuildIter.hasNext) {
+      val (hopSize, tileStart, ir) = rebuildIter.next()
+      tiles.get(hopSize).foreach(_(tileStart) = ir)
+      if (tileStart < newEarliest) newEarliest = tileStart
     }
+    store.putEarliestTileStart(newEarliest)
+
+    val rebuiltIr = megaTileAgg.buildMegaTileIr(tiles, now = timerTs, batchEnd = todayStart)
+    store.putCachedSmallWindowIr(rebuiltIr)
 
     EmitResult(
       todayEntry = packTodayEntry(),
@@ -196,26 +173,24 @@ class MegaTileStreamProcessor(val megaTileAgg: MegaTileAggregator) {
     )
   }
 
-  /** Pack today's KV entry from cached state.
-    * Small-window columns: cachedSmallWindowIr (sawtooth, corrected on eviction).
-    * Large-window columns: largeTodayIr (always fresh).
-    */
   def packTodayEntry(): Array[Any] = {
+    val cachedIr = store.getCachedSmallWindowIr
+    val largeIr = store.getLargeTodayIr
     val entry = new Array[Any](windowedAgg.length)
     var col = 0
     while (col < windowedAgg.length) {
-      entry(col) = if (isNoBatch(col)) cachedSmallWindowIr(col) else largeTodayIr(col)
+      entry(col) = if (isNoBatch(col)) cachedIr(col) else largeIr(col)
       col += 1
     }
     entry
   }
 
-  /** Pack yesterday's KV entry: null for small-window cols, large-yesterday for large cols. */
   def packYesterdayEntry(): Array[Any] = {
+    val largeIr = store.getLargeYesterdayIr
     val entry = new Array[Any](windowedAgg.length)
     var col = 0
     while (col < windowedAgg.length) {
-      entry(col) = if (isNoBatch(col)) null else largeYesterdayIr(col)
+      entry(col) = if (isNoBatch(col)) null else largeIr(col)
       col += 1
     }
     entry

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileStreamProcessor.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileStreamProcessor.scala
@@ -1,0 +1,214 @@
+package ai.chronon.aggregator.windowing
+
+import ai.chronon.api.Row
+import ai.chronon.api.TsUtils
+
+import scala.collection.mutable
+
+/**
+  * Pure Scala state manager for the MegaTile streaming pipeline.
+  * Contains ALL logic for tile updates, day transitions, late event routing,
+  * eviction, and IR packing. No Flink imports — testable in isolation.
+  *
+  * State layout:
+  *   - Small window tiles: per-tier Map[tileStart -> base IR], only for tiers with isNoBatch columns.
+  *     On emission, small-window columns are built from tiles via buildMegaTileIr (correct per-column scoping).
+  *   - Large window today/yesterday IRs: per-day accumulators for large/unwindowed columns.
+  *     Incremental update on each event.
+  *   - Day transitions are watermark-driven (advanceWatermark), not event-driven,
+  *     to prevent future-timestamped events from prematurely rotating state.
+  */
+class MegaTileStreamProcessor(val megaTileAgg: MegaTileAggregator) {
+
+  val DayMillis: Long = 24 * 3600 * 1000L
+
+  private val windowedAgg = megaTileAgg.windowedAggregator
+  private val baseAgg = megaTileAgg.baseAggregator
+  private val isNoBatch = megaTileAgg.isNoBatch
+  private val columnHopSize = megaTileAgg.columnHopSize
+
+  // Tiers that have at least one small-window column (tiles only needed for these)
+  val smallWindowTiers: Set[Long] = {
+    val tiers = mutable.Set.empty[Long]
+    var col = 0
+    while (col < windowedAgg.length) {
+      if (isNoBatch(col)) tiers += columnHopSize(col)
+      col += 1
+    }
+    tiers.toSet
+  }
+
+  val hasSmallWindows: Boolean = smallWindowTiers.nonEmpty
+  val minSmallWindowTileSize: Long = if (hasSmallWindows) smallWindowTiers.min else DayMillis
+
+  // ---- Mutable state ----
+
+  // Small window tiles: per small-window tier only
+  val tiles: Map[Long, mutable.Map[Long, Array[Any]]] =
+    smallWindowTiers.map(hop => hop -> mutable.Map.empty[Long, Array[Any]]).toMap
+
+  // Large window per-day accumulators (only large/unwindowed column positions populated)
+  var largeTodayIr: Array[Any] = windowedAgg.init
+  var largeYesterdayIr: Array[Any] = windowedAgg.init
+
+  var currentDayStart: Long = -1L
+  var earliestTileStart: Long = Long.MaxValue
+
+  /**
+    * Process a new event. Returns an EmitResult describing what should be
+    * written to KV store (today and/or yesterday entries).
+    */
+  def onEvent(row: Row, eventTs: Long): EmitResult = {
+    // Lazy init currentDayStart from first event
+    if (currentDayStart == -1L) {
+      currentDayStart = TsUtils.round(eventTs, DayMillis)
+    }
+
+    var todayDirty = false
+    var yesterdayDirty = false
+
+    // Update tiles for small-window tiers.
+    // Tiles are the source of truth for small-window columns; on emission,
+    // buildMegaTileIr scopes each column to its effective window.
+    if (hasSmallWindows) {
+      val tileStarts = megaTileAgg.tileStartsForEvent(eventTs)
+      for ((hopSize, tileStart) <- tileStarts) {
+        if (smallWindowTiers.contains(hopSize)) {
+          val floor = megaTileAgg.retentionFloor(hopSize, eventTs, currentDayStart)
+          val ceiling = currentDayStart + 2 * DayMillis // reject tiles >= 2 days ahead (state leak guard)
+          if (tileStart >= floor && tileStart < ceiling) {
+            val tierTiles = tiles(hopSize)
+            val ir = tierTiles.getOrElseUpdate(tileStart, baseAgg.init)
+            baseAgg.update(ir, row)
+            if (tileStart < earliestTileStart) earliestTileStart = tileStart
+            todayDirty = true
+          }
+        }
+      }
+    }
+
+    // Update large window IR — route by event day
+    val todayStart = currentDayStart
+    val nextDayStart = todayStart + DayMillis
+    val yesterdayStart = todayStart - DayMillis
+
+    if (eventTs >= nextDayStart) {
+      // Future event — clamp to today. Day transitions are watermark-driven.
+      updateLargeWindowColumns(largeTodayIr, row)
+      todayDirty = true
+    } else if (eventTs >= todayStart) {
+      updateLargeWindowColumns(largeTodayIr, row)
+      todayDirty = true
+    } else if (eventTs >= yesterdayStart) {
+      // Late event from yesterday — within 2d tolerance
+      updateLargeWindowColumns(largeYesterdayIr, row)
+      yesterdayDirty = true
+    }
+    // else: > 2 days late → dropped for large windows (tiles may still capture it above)
+
+    EmitResult(
+      todayEntry = if (todayDirty) packTodayEntry(eventTs) else null,
+      todayStart = todayStart,
+      yesterdayEntry = if (yesterdayDirty) packYesterdayEntry() else null,
+      yesterdayStart = yesterdayStart
+    )
+  }
+
+  /**
+    * Advance the watermark. Day transitions happen ONLY here, never in onEvent.
+    * This prevents future-timestamped events from prematurely rotating state.
+    */
+  def advanceWatermark(watermarkTs: Long): Unit = {
+    if (currentDayStart == -1L) return
+    val wmDay = TsUtils.round(watermarkTs, DayMillis)
+    if (wmDay > currentDayStart) {
+      largeYesterdayIr = largeTodayIr
+      largeTodayIr = windowedAgg.init
+      currentDayStart = wmDay
+    }
+  }
+
+  /**
+    * Evict stale tiles. Called on timer (watermark-driven interval = minSmallWindowTileSize).
+    * Returns an EmitResult with updated today entry.
+    */
+  def onEviction(timerTs: Long): EmitResult = {
+    if (!hasSmallWindows || earliestTileStart == Long.MaxValue) {
+      return EmitResult(null, currentDayStart, null, currentDayStart - DayMillis)
+    }
+
+    val todayStart = currentDayStart
+
+    // Evict stale tiles per tier
+    for (hopSize <- smallWindowTiers) {
+      val floor = megaTileAgg.retentionFloor(hopSize, timerTs, todayStart)
+      val tierTiles = tiles(hopSize)
+      val staleKeys = tierTiles.keys.filter(_ < floor).toSeq
+      staleKeys.foreach(tierTiles.remove)
+    }
+
+    // Update earliestTileStart from remaining tiles
+    earliestTileStart = Long.MaxValue
+    for ((_, tierTiles) <- tiles; ts <- tierTiles.keys) {
+      if (ts < earliestTileStart) earliestTileStart = ts
+    }
+
+    EmitResult(
+      todayEntry = packTodayEntry(timerTs),
+      todayStart = todayStart,
+      yesterdayEntry = null,
+      yesterdayStart = todayStart - DayMillis
+    )
+  }
+
+  /**
+    * Pack today's KV entry.
+    * Small-window columns are built from tiles via buildMegaTileIr (correct per-column scoping).
+    * Large-window columns come from the running daily accumulator.
+    */
+  def packTodayEntry(now: Long): Array[Any] = {
+    val todayStart = currentDayStart
+    // Build small-window columns from tiles (correct per-column effective window)
+    val smallIr = if (hasSmallWindows) megaTileAgg.buildMegaTileIr(tiles, now, batchEnd = todayStart) else null
+
+    val entry = new Array[Any](windowedAgg.length)
+    var col = 0
+    while (col < windowedAgg.length) {
+      if (isNoBatch(col)) {
+        entry(col) = if (smallIr != null) smallIr(col) else null
+      } else {
+        entry(col) = largeTodayIr(col)
+      }
+      col += 1
+    }
+    entry
+  }
+
+  /** Pack yesterday's KV entry: null for small-window cols, large-yesterday for large cols. */
+  def packYesterdayEntry(): Array[Any] = {
+    val entry = new Array[Any](windowedAgg.length)
+    var col = 0
+    while (col < windowedAgg.length) {
+      entry(col) = if (isNoBatch(col)) null else largeYesterdayIr(col)
+      col += 1
+    }
+    entry
+  }
+
+  private def updateLargeWindowColumns(ir: Array[Any], row: Row): Unit = {
+    var col = 0
+    while (col < windowedAgg.length) {
+      if (!isNoBatch(col)) {
+        windowedAgg.columnAggregators(col).update(ir, row)
+      }
+      col += 1
+    }
+  }
+}
+
+case class EmitResult(
+    todayEntry: Array[Any],
+    todayStart: Long,
+    yesterdayEntry: Array[Any],
+    yesterdayStart: Long
+)

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/SawtoothMutationAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/SawtoothMutationAggregator.scala
@@ -75,6 +75,15 @@ class SawtoothMutationAggregator(aggregations: Seq[Aggregation],
     update(batchEndTs: Long, batchIr: BatchIr, row: Row, batchTails)
   }
 
+  // Align the collapsed boundary to the next hop boundary so that no hop bucket
+  // straddles the collapsed/tail split. Without this, shared tail hops across windows
+  // with different collapsed boundaries can cause double-counting.
+  protected def alignedCollapsedBoundary(batchTail: Long, colIndex: Int): Long = {
+    val hopSize = hopSizes(tailHopIndices(colIndex))
+    val start = batchTail + tailBufferMillis
+    ((start + hopSize - 1) / hopSize) * hopSize
+  }
+
   // downstream assumption: this needs to mutate batchIr in place.
   def update(batchEndTs: Long, batchIr: BatchIr, row: Row, batchTails: Array[Option[Long]]): BatchIr = {
     val rowTs = row.ts
@@ -90,7 +99,7 @@ class SawtoothMutationAggregator(aggregations: Seq[Aggregation],
     var i = 0
     while (i < windowedAggregator.length) {
       if (batchEndTs > rowTs && batchTails(i).forall(rowTs > _)) { // relevant for the window
-        if (batchTails(i).forall(rowTs >= _ + tailBufferMillis)) { // update collapsed part
+        if (batchTails(i).forall(tail => rowTs >= alignedCollapsedBoundary(tail, i))) { // update collapsed part
           windowedAggregator.columnAggregators(i).update(batchIr.collapsed, row)
         } else { // update tailHops part
           val hopIndex = tailHopIndices(i)
@@ -164,13 +173,14 @@ class SawtoothMutationAggregator(aggregations: Seq[Aggregation],
       if (window != null) { // no hops for unwindowed
         val hopIndex = tailHopIndices(i)
         val queryTail = TsUtils.round(queryTs - windowMillis, hopSizes(hopIndex))
+        val alignedCollapsed = alignedCollapsedBoundary(batchEndTs - windowMillis, i)
         val hopIrs = batchIr.tailHops(hopIndex)
         val relevantHops = mutable.ArrayBuffer[Any](ir(i))
         var idx: Int = 0
         while (idx < hopIrs.length) {
           val hopIr = hopIrs(idx)
           val hopStart = hopIr.last.asInstanceOf[Long]
-          if ((batchEndTs - windowMillis) + tailBufferMillis > hopStart && hopStart >= queryTail) {
+          if (alignedCollapsed > hopStart && hopStart >= queryTail) {
             relevantHops += hopIr(baseIrIndices(i))
           }
           idx += 1

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/SawtoothOnlineAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/SawtoothOnlineAggregator.scala
@@ -212,7 +212,8 @@ class SawtoothOnlineAggregator(val batchEndTs: Long,
             val hopStartTimeStamp = hopIr.getTs
 
             // Only want to inspect tail hops that fall within the tailBuffer (default 2d), and after the queryTail
-            if ((batchEndTs - windowMillis) + tailBufferMillis > hopStartTimeStamp && hopStartTimeStamp >= queryTail) {
+            val alignedCollapsed = alignedCollapsedBoundary(batchEndTs - windowMillis, i)
+            if (alignedCollapsed > hopStartTimeStamp && hopStartTimeStamp >= queryTail) {
               val tailHop = hopIr(baseIrIndices(i))
               if (tailHop != null) {
                 hasNonNullTailHop_ = true

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/TileStore.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/TileStore.scala
@@ -1,0 +1,29 @@
+package ai.chronon.aggregator.windowing
+
+/** Abstraction over tile and IR state storage for MegaTileStreamProcessor.
+  *
+  * Flink implements this with MapState/ValueState + codec (serde on access).
+  * Tests implement with mutable.Map (in-memory, no serde).
+  * The processor calls these inline — no bulk restore/persist cycle.
+  */
+trait TileStore {
+  def getTile(hopSize: Long, tileStart: Long): Array[Any]
+  def putTile(hopSize: Long, tileStart: Long, ir: Array[Any]): Unit
+  def removeTile(hopSize: Long, tileStart: Long): Unit
+  def tileIterator: Iterator[(Long, Long, Array[Any])]
+
+  def getCachedSmallWindowIr: Array[Any]
+  def putCachedSmallWindowIr(ir: Array[Any]): Unit
+
+  def getLargeTodayIr: Array[Any]
+  def putLargeTodayIr(ir: Array[Any]): Unit
+
+  def getLargeYesterdayIr: Array[Any]
+  def putLargeYesterdayIr(ir: Array[Any]): Unit
+
+  def getCurrentDayStart: Long
+  def putCurrentDayStart(ts: Long): Unit
+
+  def getEarliestTileStart: Long
+  def putEarliestTileStart(ts: Long): Unit
+}

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/MegaTileAggregatorTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/MegaTileAggregatorTest.scala
@@ -42,7 +42,7 @@ class MegaTileAggregatorTest extends AnyFlatSpec {
       new SawtoothOnlineAggregator(batchEnd, aggregations, schema, tailBufferMillis = TailBufferMillis)
     var batchIr = onlineAgg.init
     batchEvents.foreach(row => batchIr = onlineAgg.update(batchIr, row))
-    val finalBatchIr = onlineAgg.normalizeBatchIr(batchIr)
+    val finalBatchIr = onlineAgg.finalizeSnapshot(batchIr)
 
     // 2. Simulate Flink: bucket ALL events into small tiles per tier
     //    (In production Flink sees all events; eviction handles retention)
@@ -271,7 +271,9 @@ class MegaTileAggregatorTest extends AnyFlatSpec {
       Builders.Aggregation(Operation.COUNT, "num", AllWindows),
       Builders.Aggregation(Operation.AVERAGE, "amount", AllWindows),
       Builders.Aggregation(Operation.MIN, "num", AllWindows),
-      Builders.Aggregation(Operation.MAX, "num", AllWindows)
+      Builders.Aggregation(Operation.MAX, "num", AllWindows),
+      Builders.Aggregation(Operation.LAST, "num", AllWindows),
+      Builders.Aggregation(Operation.FIRST, "num", AllWindows)
     )
 
     val queryTimes = Array(batchEnd + 14 * 3600 * 1000L).filter(_ <= maxTs)

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/MegaTileAggregatorTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/MegaTileAggregatorTest.scala
@@ -1,0 +1,283 @@
+package ai.chronon.aggregator.test
+
+import ai.chronon.aggregator.row.RowAggregator
+import ai.chronon.aggregator.windowing._
+import ai.chronon.api._
+import ai.chronon.api.Extensions.{AggregationOps, WindowOps}
+import com.google.gson.Gson
+import org.junit.Assert._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.slf4j.LoggerFactory
+
+import scala.collection.mutable
+
+class MegaTileAggregatorTest extends AnyFlatSpec {
+  @transient lazy val logger = LoggerFactory.getLogger(getClass)
+  val gson = new Gson
+
+  val AllWindows: Seq[Window] = Seq(
+    new Window(6, TimeUnit.HOURS),  // 6h - NO BATCH, 5min tier
+    new Window(1, TimeUnit.DAYS),   // 1d - NO BATCH, 1hr tier
+    new Window(47, TimeUnit.HOURS), // 47h - NO BATCH, 1hr tier, just under tailBuffer
+    new Window(2, TimeUnit.DAYS),   // 2d - NO BATCH, 1hr tier, exactly tailBuffer
+    new Window(49, TimeUnit.HOURS), // 49h - BATCH, 1hr tier, just over tailBuffer
+    new Window(3, TimeUnit.DAYS),   // 3d - BATCH, 1hr tier, 1d collapsed
+    new Window(7, TimeUnit.DAYS)    // 7d - BATCH, 1hr tier, 5d collapsed
+  )
+
+  val TailBufferMillis: Long = new Window(2, TimeUnit.DAYS).millis
+
+  // Simulate the full mega tile pipeline and compare against naive aggregation
+  def megaTileAggregate(allEvents: Array[TestRow],
+                        queryTimes: Array[Long],
+                        aggregations: Seq[Aggregation],
+                        schema: Seq[(String, DataType)],
+                        batchEnd: Long): Array[Array[Any]] = {
+
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+
+    // 1. Build batch IR from pre-batchEnd events
+    val batchEvents = allEvents.filter(_.ts < batchEnd)
+    val onlineAgg =
+      new SawtoothOnlineAggregator(batchEnd, aggregations, schema, tailBufferMillis = TailBufferMillis)
+    var batchIr = onlineAgg.init
+    batchEvents.foreach(row => batchIr = onlineAgg.update(batchIr, row))
+    val finalBatchIr = onlineAgg.normalizeBatchIr(batchIr)
+
+    // 2. Simulate Flink: bucket ALL events into small tiles per tier
+    //    (In production Flink sees all events; eviction handles retention)
+    val tiles: Map[Long, mutable.Map[Long, Array[Any]]] =
+      megaTileAgg.activeTiers.map(hop => hop -> mutable.Map.empty[Long, Array[Any]]).toMap
+
+    // Simulate Flink: incrementally add events, query at correct times
+    // Events only enter tiles when ts <= queryTs (real-time arrival)
+    val sortedEvents = allEvents.sortBy(_.ts)
+    val sortedQueries = queryTimes.sorted
+    var eventIdx = 0
+    val resultsByQueryTs = mutable.Map[Long, Array[Any]]()
+
+    for (queryTs <- sortedQueries) {
+      // Add events that have arrived by queryTs
+      while (eventIdx < sortedEvents.length && sortedEvents(eventIdx).ts <= queryTs) {
+        val event = sortedEvents(eventIdx)
+        val tileStarts = megaTileAgg.tileStartsForEvent(event.ts)
+        for ((hopSize, tileStart) <- tileStarts) {
+          val tierTiles = tiles(hopSize)
+          val ir = tierTiles.getOrElseUpdate(tileStart, megaTileAgg.baseAggregator.init)
+          megaTileAgg.baseAggregator.update(ir, event)
+        }
+        eventIdx += 1
+      }
+
+      // Evict stale tiles
+      for ((hopSize, tierTiles) <- tiles) {
+        val floor = megaTileAgg.retentionFloor(hopSize, queryTs, batchEnd)
+        tierTiles.keys.filter(_ < floor).foreach(tierTiles.remove)
+      }
+
+      val megaTileIr = megaTileAgg.buildMegaTileIr(tiles, queryTs, batchEnd)
+      resultsByQueryTs(queryTs) = megaTileAgg.serveMegaTile(finalBatchIr, megaTileIr, queryTs, batchEnd)
+    }
+
+    // Return results in original query order
+    queryTimes.map(resultsByQueryTs)
+  }
+
+  def naiveAggregate(allEvents: Array[TestRow],
+                     queryTimes: Array[Long],
+                     aggregations: Seq[Aggregation],
+                     schema: Seq[(String, DataType)]): Array[Array[Any]] = {
+    import scala.collection.JavaConverters._
+    val unpackedParts = aggregations.flatMap(_.unpack)
+    val unpacked = unpackedParts.map(_.window).toArray
+    val tailHops = unpacked.map(w => FiveMinuteResolution.calculateTailHop(w))
+    val rowAgg = new RowAggregator(schema, unpackedParts)
+    val naiveAgg = new NaiveAggregator(rowAgg, unpacked, tailHops)
+    val rawResults = naiveAgg.aggregate(allEvents, queryTimes)
+    // Finalize to match serveMegaTile output
+    rawResults.map(ir => rowAgg.finalize(ir))
+  }
+
+  val Epsilon = 1e-6
+
+  def approxEqual(a: Any, b: Any): Boolean = (a, b) match {
+    case (null, null)                         => true
+    case (null, _) | (_, null)                => false
+    case (x: Double, y: Double)               => Math.abs(x - y) <= Epsilon * Math.max(1.0, Math.max(Math.abs(x), Math.abs(y)))
+    case (x: Float, y: Float)                 => Math.abs(x - y) <= Epsilon.toFloat * Math.max(1.0f, Math.max(Math.abs(x), Math.abs(y)))
+    case (x: java.util.List[_], y: java.util.List[_]) =>
+      x.size() == y.size() && (0 until x.size()).forall(i => approxEqual(x.get(i), y.get(i)))
+    case (x: Array[_], y: Array[_])           =>
+      x.length == y.length && x.zip(y).forall { case (a, b) => approxEqual(a, b) }
+    case _                                    => a == b
+  }
+
+  def compareResults(megaTileResults: Array[Array[Any]],
+                     naiveResults: Array[Array[Any]],
+                     queryTimes: Array[Long],
+                     label: String): Unit = {
+    assertEquals(s"$label: result count mismatch", naiveResults.length, megaTileResults.length)
+    for (i <- queryTimes.indices) {
+      if (!approxEqual(megaTileResults(i), naiveResults(i))) {
+        val naiveStr = gson.toJson(naiveResults(i))
+        val megaStr = gson.toJson(megaTileResults(i))
+        fail(s"$label: mismatch at query ${queryTimes(i)} (index $i)\n  expected: $naiveStr\n  got:      $megaStr")
+      }
+    }
+  }
+
+  // Generate events spanning a time range
+  def generateEvents(windowDays: Int, count: Int): (Array[TestRow], Seq[(String, DataType)]) = {
+    val columns = Seq(
+      Column("ts", LongType, windowDays),
+      Column("num", LongType, 1000),
+      Column("amount", DoubleType, 500)
+    )
+    val data = CStream.gen(columns, count)
+    (data.rows, columns.map(_.schema))
+  }
+
+  it should "match naive aggregation with batch fresh" in {
+    val (events, schema) = generateEvents(10, 10000)
+    val maxTs = events.map(_.ts).max
+    val minTs = events.map(_.ts).min
+
+    // batchEnd = roughly 1 day before maxTs, rounded to day boundary
+    val dayMillis = new Window(1, TimeUnit.DAYS).millis
+    val batchEnd = TsUtils.round(maxTs - dayMillis, dayMillis)
+
+    val aggregations: Seq[Aggregation] = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows),
+      Builders.Aggregation(Operation.AVERAGE, "amount", AllWindows)
+    )
+
+    // Query at multiple points after batchEnd
+    val queryTimes = Array(
+      batchEnd + 6 * 3600 * 1000L,  // 6h after batch
+      batchEnd + 14 * 3600 * 1000L, // 14h after batch (mid-day)
+      batchEnd + 23 * 3600 * 1000L  // 23h after batch (near midnight)
+    ).filter(_ <= maxTs)
+
+    val megaResults = megaTileAggregate(events, queryTimes, aggregations, schema, batchEnd)
+    val naiveResults = naiveAggregate(events, queryTimes, aggregations, schema)
+    compareResults(megaResults, naiveResults, queryTimes, "batch_fresh")
+  }
+
+  it should "match naive aggregation with batch delayed" in {
+    val (events, schema) = generateEvents(10, 10000)
+    val maxTs = events.map(_.ts).max
+    val dayMillis = new Window(1, TimeUnit.DAYS).millis
+
+    // Simulate batch delay: batchEnd is 2 days before maxTs (stale)
+    val batchEnd = TsUtils.round(maxTs - 2 * dayMillis, dayMillis)
+
+    val aggregations: Seq[Aggregation] = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows)
+    )
+
+    // Query at early morning (simulates batch delay scenario)
+    val queryTimes = Array(
+      batchEnd + dayMillis + 2 * 3600 * 1000L, // 26h after batchEnd (02:00 next day)
+      batchEnd + dayMillis + 5 * 3600 * 1000L  // 29h after batchEnd (05:00 next day)
+    ).filter(_ <= maxTs)
+
+    val megaResults = megaTileAggregate(events, queryTimes, aggregations, schema, batchEnd)
+    val naiveResults = naiveAggregate(events, queryTimes, aggregations, schema)
+    compareResults(megaResults, naiveResults, queryTimes, "batch_delayed")
+  }
+
+  it should "handle idle entities with no streaming events" in {
+    val (events, schema) = generateEvents(10, 5000)
+    val maxTs = events.map(_.ts).max
+    val dayMillis = new Window(1, TimeUnit.DAYS).millis
+
+    // batchEnd AFTER all events — no streaming data
+    val batchEnd = maxTs + dayMillis
+
+    val aggregations: Seq[Aggregation] = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows)
+    )
+
+    val queryTimes = Array(batchEnd + 14 * 3600 * 1000L)
+
+    val megaResults = megaTileAggregate(events, queryTimes, aggregations, schema, batchEnd)
+    val naiveResults = naiveAggregate(events, queryTimes, aggregations, schema)
+    compareResults(megaResults, naiveResults, queryTimes, "idle_entity")
+  }
+
+  it should "handle eviction correctly at window boundaries" in {
+    val (events, schema) = generateEvents(10, 10000)
+    val maxTs = events.map(_.ts).max
+    val dayMillis = new Window(1, TimeUnit.DAYS).millis
+    val batchEnd = TsUtils.round(maxTs - dayMillis, dayMillis)
+
+    val aggregations: Seq[Aggregation] = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows)
+    )
+
+    // Query at exact hop boundaries to stress eviction
+    val fiveMin = 5 * 60 * 1000L
+    val oneHour = 3600 * 1000L
+    val queryTimes = Array(
+      TsUtils.round(batchEnd + 14 * oneHour, fiveMin),        // aligned to 5min
+      TsUtils.round(batchEnd + 14 * oneHour, oneHour),        // aligned to 1hr
+      TsUtils.round(batchEnd + 14 * oneHour + fiveMin, fiveMin) // one hop after
+    ).filter(_ <= maxTs).distinct
+
+    val megaResults = megaTileAggregate(events, queryTimes, aggregations, schema, batchEnd)
+    val naiveResults = naiveAggregate(events, queryTimes, aggregations, schema)
+    compareResults(megaResults, naiveResults, queryTimes, "eviction_boundary")
+  }
+
+  it should "match naive with events at exact batchEnd boundary" in {
+    val baseTs = 1700000000000L
+    val dayMillis = new Window(1, TimeUnit.DAYS).millis
+    val batchEnd = TsUtils.round(baseTs, dayMillis)
+
+    val schema: Seq[(String, DataType)] = Seq("ts" -> LongType, "num" -> LongType)
+
+    // Events at and around batchEnd
+    val events = Array(
+      new TestRow(batchEnd - 1L, 10L)(0),    // just before batchEnd → batch
+      new TestRow(batchEnd, 20L)(0),          // exactly at batchEnd → streaming
+      new TestRow(batchEnd + 1L, 30L)(0),     // just after batchEnd → streaming
+      new TestRow(batchEnd + dayMillis / 2, 40L)(0) // mid-day → streaming
+    )
+
+    val aggregations: Seq[Aggregation] = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows)
+    )
+
+    val queryTimes = Array(batchEnd + dayMillis / 2 + 1L)
+
+    val megaResults = megaTileAggregate(events, queryTimes, aggregations, schema, batchEnd)
+    val naiveResults = naiveAggregate(events, queryTimes, aggregations, schema)
+    compareResults(megaResults, naiveResults, queryTimes, "batchEnd_boundary")
+  }
+
+  it should "match naive with multiple aggregation types" in {
+    val (events, schema) = generateEvents(10, 10000)
+    val maxTs = events.map(_.ts).max
+    val dayMillis = new Window(1, TimeUnit.DAYS).millis
+    val batchEnd = TsUtils.round(maxTs - dayMillis, dayMillis)
+
+    val aggregations: Seq[Aggregation] = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows),
+      Builders.Aggregation(Operation.AVERAGE, "amount", AllWindows),
+      Builders.Aggregation(Operation.MIN, "num", AllWindows),
+      Builders.Aggregation(Operation.MAX, "num", AllWindows)
+    )
+
+    val queryTimes = Array(batchEnd + 14 * 3600 * 1000L).filter(_ <= maxTs)
+
+    val megaResults = megaTileAggregate(events, queryTimes, aggregations, schema, batchEnd)
+    val naiveResults = naiveAggregate(events, queryTimes, aggregations, schema)
+    compareResults(megaResults, naiveResults, queryTimes, "multi_agg_types")
+  }
+}

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/MegaTileAggregatorTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/MegaTileAggregatorTest.scala
@@ -260,6 +260,32 @@ class MegaTileAggregatorTest extends AnyFlatSpec {
     compareResults(megaResults, naiveResults, queryTimes, "batchEnd_boundary")
   }
 
+  it should "not mutate batch tail hops across repeated serves" in {
+    val batchEnd = TsUtils.round(1700000000000L, new Window(1, TimeUnit.DAYS).millis)
+    val queryTs = batchEnd + 3600 * 1000L
+    val schema: Seq[(String, DataType)] = Seq("ts" -> LongType, "amount" -> DoubleType)
+    val aggregations: Seq[Aggregation] = Seq(
+      Builders.Aggregation(Operation.AVERAGE, "amount", Seq(new Window(3, TimeUnit.DAYS)))
+    )
+
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val onlineAgg =
+      new SawtoothOnlineAggregator(batchEnd, aggregations, schema, tailBufferMillis = TailBufferMillis)
+    var batchIr = onlineAgg.init
+    batchIr = onlineAgg.update(batchIr, new TestRow(batchEnd - 26 * 3600 * 1000L, 2.0)(0))
+    batchIr = onlineAgg.update(batchIr, new TestRow(batchEnd - 25 * 3600 * 1000L, 4.0)(0))
+    val finalBatchIr = onlineAgg.finalizeSnapshot(batchIr)
+
+    val megaTileIr = megaTileAgg.buildMegaTileIr(Map.empty[Long, collection.Map[Long, Array[Any]]],
+                                                now = queryTs,
+                                                batchEnd = batchEnd)
+    val firstServe = megaTileAgg.serveMegaTile(finalBatchIr, megaTileIr, queryTs, batchEnd)
+    val secondServe = megaTileAgg.serveMegaTile(finalBatchIr, megaTileIr, queryTs, batchEnd)
+
+    assertEquals(3.0, firstServe.head.asInstanceOf[Double], Epsilon)
+    assertTrue(approxEqual(firstServe, secondServe))
+  }
+
   it should "match naive with multiple aggregation types" in {
     val (events, schema) = generateEvents(10, 10000)
     val maxTs = events.map(_.ts).max

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/MegaTileMergerTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/MegaTileMergerTest.scala
@@ -1,0 +1,258 @@
+package ai.chronon.aggregator.test
+
+import ai.chronon.aggregator.row.RowAggregator
+import ai.chronon.aggregator.windowing._
+import ai.chronon.api._
+import ai.chronon.api.Extensions.{AggregationOps, WindowOps}
+import com.google.gson.Gson
+import org.junit.Assert._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.slf4j.LoggerFactory
+
+import scala.collection.mutable
+
+class MegaTileMergerTest extends AnyFlatSpec {
+  @transient lazy val logger = LoggerFactory.getLogger(getClass)
+  val gson = new Gson
+
+  val AllWindows: Seq[Window] = Seq(
+    new Window(6, TimeUnit.HOURS),   // 6h  - NO BATCH, 5min tier
+    new Window(1, TimeUnit.DAYS),    // 1d  - NO BATCH, 1hr tier
+    new Window(47, TimeUnit.HOURS),  // 47h - NO BATCH, 1hr tier, just under tailBuffer
+    new Window(2, TimeUnit.DAYS),    // 2d  - NO BATCH, 1hr tier, exactly tailBuffer
+    new Window(49, TimeUnit.HOURS),  // 49h - BATCH, 1hr tier, just over tailBuffer
+    new Window(3, TimeUnit.DAYS),    // 3d  - BATCH, 1hr tier
+    new Window(7, TimeUnit.DAYS)     // 7d  - BATCH, 1hr tier
+  )
+
+  val TailBufferMillis: Long = new Window(2, TimeUnit.DAYS).millis
+  val DayMillis: Long = new Window(1, TimeUnit.DAYS).millis
+
+  val Epsilon = 1e-6
+
+  def approxEqual(a: Any, b: Any): Boolean = (a, b) match {
+    case (null, null)                         => true
+    case (null, _) | (_, null)                => false
+    case (x: Double, y: Double)               => Math.abs(x - y) <= Epsilon * Math.max(1.0, Math.max(Math.abs(x), Math.abs(y)))
+    case (x: Float, y: Float)                 => Math.abs(x - y) <= Epsilon.toFloat * Math.max(1.0f, Math.max(Math.abs(x), Math.abs(y)))
+    case (x: java.util.List[_], y: java.util.List[_]) =>
+      x.size() == y.size() && (0 until x.size()).forall(i => approxEqual(x.get(i), y.get(i)))
+    case (x: Array[_], y: Array[_])           =>
+      x.length == y.length && x.zip(y).forall { case (a, b) => approxEqual(a, b) }
+    case _                                    => a == b
+  }
+
+  def compareResults(mergerResults: Array[Array[Any]],
+                     naiveResults: Array[Array[Any]],
+                     queryTimes: Array[Long],
+                     label: String): Unit = {
+    assertEquals(s"$label: result count mismatch", naiveResults.length, mergerResults.length)
+    for (i <- queryTimes.indices) {
+      if (!approxEqual(mergerResults(i), naiveResults(i))) {
+        val naiveStr = gson.toJson(naiveResults(i))
+        val mergerStr = gson.toJson(mergerResults(i))
+        fail(s"$label: mismatch at query ${queryTimes(i)} (index $i)\n  expected: $naiveStr\n  got:      $mergerStr")
+      }
+    }
+  }
+
+  def generateEvents(windowDays: Int, count: Int): (Array[TestRow], Seq[(String, DataType)]) = {
+    val columns = Seq(
+      Column("ts", LongType, windowDays),
+      Column("num", LongType, 1000),
+      Column("amount", DoubleType, 500)
+    )
+    val data = CStream.gen(columns, count)
+    (data.rows, columns.map(_.schema))
+  }
+
+  def naiveAggregate(allEvents: Array[TestRow],
+                     queryTimes: Array[Long],
+                     aggregations: Seq[Aggregation],
+                     schema: Seq[(String, DataType)]): Array[Array[Any]] = {
+    import scala.collection.JavaConverters._
+    val unpackedParts = aggregations.flatMap(_.unpack)
+    val unpacked = unpackedParts.map(_.window).toArray
+    val tailHops = unpacked.map(w => FiveMinuteResolution.calculateTailHop(w))
+    val rowAgg = new RowAggregator(schema, unpackedParts)
+    val naiveAgg = new NaiveAggregator(rowAgg, unpacked, tailHops)
+    val rawResults = naiveAgg.aggregate(allEvents, queryTimes)
+    rawResults.map(ir => rowAgg.finalize(ir))
+  }
+
+  /**
+    * Simulate the full Flink -> KV -> Fetcher pipeline using per-day entries.
+    *
+    * 1. Build batch IR from pre-batchEnd events (SawtoothOnlineAggregator)
+    * 2. Maintain tiles in memory (same as MegaTileAggregatorTest)
+    * 3. At each query time:
+    *    - Ingest events up to queryTs into tiles
+    *    - On day transition: freeze yesterday via buildMegaTileIr(tiles, todayStart, yesterdayStart)
+    *    - Build today's live entry via buildMegaTileIr(tiles, queryTs, todayStart)
+    *    - Call merger.merge(batchIr, todayIr, yesterdayIr, todayStart, queryTs, batchEnd)
+    * 4. Compare with naive
+    */
+  def megaTileMergerAggregate(allEvents: Array[TestRow],
+                              queryTimes: Array[Long],
+                              aggregations: Seq[Aggregation],
+                              schema: Seq[(String, DataType)],
+                              batchEnd: Long): Array[Array[Any]] = {
+
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val merger = new MegaTileMerger(megaTileAgg)
+
+    // 1. Build batch IR from pre-batchEnd events
+    val batchEvents = allEvents.filter(_.ts < batchEnd)
+    val onlineAgg =
+      new SawtoothOnlineAggregator(batchEnd, aggregations, schema, tailBufferMillis = TailBufferMillis)
+    var batchIr = onlineAgg.init
+    batchEvents.foreach(row => batchIr = onlineAgg.update(batchIr, row))
+    val finalBatchIr = onlineAgg.finalizeSnapshot(batchIr)
+
+    // 2. Simulate Flink: bucket ALL events into small tiles per tier
+    val tiles: Map[Long, mutable.Map[Long, Array[Any]]] =
+      megaTileAgg.activeTiers.map(hop => hop -> mutable.Map.empty[Long, Array[Any]]).toMap
+
+    val sortedEvents = allEvents.sortBy(_.ts)
+    val sortedQueries = queryTimes.sorted
+    var eventIdx = 0
+    val resultsByQueryTs = mutable.Map[Long, Array[Any]]()
+
+    for (queryTs <- sortedQueries) {
+      val (todayStart, yesterdayStart) = merger.streamingDayKeys(queryTs)
+
+      // Ingest events that have arrived by queryTs
+      while (eventIdx < sortedEvents.length && sortedEvents(eventIdx).ts <= queryTs) {
+        val event = sortedEvents(eventIdx)
+        val tileStarts = megaTileAgg.tileStartsForEvent(event.ts)
+        for ((hopSize, tileStart) <- tileStarts) {
+          val tierTiles = tiles(hopSize)
+          val ir = tierTiles.getOrElseUpdate(tileStart, megaTileAgg.baseAggregator.init)
+          megaTileAgg.baseAggregator.update(ir, event)
+        }
+        eventIdx += 1
+      }
+
+      // Build today's live entry: small windows scope to [queryTs-window, queryTs),
+      // large windows scope to [todayStart, queryTs)
+      val todayIr = megaTileAgg.buildMegaTileIr(tiles, now = queryTs, batchEnd = todayStart)
+
+      // Build yesterday's entry: small windows scope to [todayStart-window, todayStart),
+      // large windows scope to [yesterdayStart, todayStart).
+      // Safe to build on-the-fly because buildMegaTileIr only considers tiles with
+      // tileStart < now (=todayStart), so today's events don't leak into yesterday.
+      val yesterdayIr = megaTileAgg.buildMegaTileIr(tiles, now = todayStart, batchEnd = yesterdayStart)
+
+      // Merge using the fetcher logic
+      resultsByQueryTs(queryTs) = merger.merge(finalBatchIr, todayIr, yesterdayIr, todayStart, queryTs, batchEnd)
+    }
+
+    // Return results in original query order
+    queryTimes.map(resultsByQueryTs)
+  }
+
+  it should "match naive aggregation with batch fresh" in {
+    val (events, schema) = generateEvents(10, 10000)
+    val maxTs = events.map(_.ts).max
+    val batchEnd = TsUtils.round(maxTs - DayMillis, DayMillis)
+
+    val aggregations: Seq[Aggregation] = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows),
+      Builders.Aggregation(Operation.AVERAGE, "amount", AllWindows)
+    )
+
+    val queryTimes = Array(
+      batchEnd + 6 * 3600 * 1000L,
+      batchEnd + 14 * 3600 * 1000L,
+      batchEnd + 23 * 3600 * 1000L
+    ).filter(_ <= maxTs)
+
+    val mergerResults = megaTileMergerAggregate(events, queryTimes, aggregations, schema, batchEnd)
+    val naiveResults = naiveAggregate(events, queryTimes, aggregations, schema)
+    compareResults(mergerResults, naiveResults, queryTimes, "batch_fresh")
+  }
+
+  it should "match naive aggregation with batch delayed" in {
+    val (events, schema) = generateEvents(10, 10000)
+    val maxTs = events.map(_.ts).max
+    val batchEnd = TsUtils.round(maxTs - 2 * DayMillis, DayMillis)
+
+    val aggregations: Seq[Aggregation] = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows)
+    )
+
+    val queryTimes = Array(
+      batchEnd + DayMillis + 2 * 3600 * 1000L,
+      batchEnd + DayMillis + 5 * 3600 * 1000L
+    ).filter(_ <= maxTs)
+
+    val mergerResults = megaTileMergerAggregate(events, queryTimes, aggregations, schema, batchEnd)
+    val naiveResults = naiveAggregate(events, queryTimes, aggregations, schema)
+    compareResults(mergerResults, naiveResults, queryTimes, "batch_delayed")
+  }
+
+  it should "handle idle entities with no streaming events" in {
+    val (events, schema) = generateEvents(10, 5000)
+    val maxTs = events.map(_.ts).max
+    val batchEnd = maxTs + DayMillis
+
+    val aggregations: Seq[Aggregation] = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows)
+    )
+
+    val queryTimes = Array(batchEnd + 14 * 3600 * 1000L)
+
+    val mergerResults = megaTileMergerAggregate(events, queryTimes, aggregations, schema, batchEnd)
+    val naiveResults = naiveAggregate(events, queryTimes, aggregations, schema)
+    compareResults(mergerResults, naiveResults, queryTimes, "idle_entity")
+  }
+
+  it should "match naive with multiple aggregation types" in {
+    val (events, schema) = generateEvents(10, 10000)
+    val maxTs = events.map(_.ts).max
+    val batchEnd = TsUtils.round(maxTs - DayMillis, DayMillis)
+
+    val aggregations: Seq[Aggregation] = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows),
+      Builders.Aggregation(Operation.AVERAGE, "amount", AllWindows),
+      Builders.Aggregation(Operation.MIN, "num", AllWindows),
+      Builders.Aggregation(Operation.MAX, "num", AllWindows),
+      Builders.Aggregation(Operation.LAST, "num", AllWindows),
+      Builders.Aggregation(Operation.FIRST, "num", AllWindows)
+    )
+
+    val queryTimes = Array(batchEnd + 14 * 3600 * 1000L).filter(_ <= maxTs)
+
+    val mergerResults = megaTileMergerAggregate(events, queryTimes, aggregations, schema, batchEnd)
+    val naiveResults = naiveAggregate(events, queryTimes, aggregations, schema)
+    compareResults(mergerResults, naiveResults, queryTimes, "multi_agg_types")
+  }
+
+  it should "handle day boundary transitions" in {
+    val (events, schema) = generateEvents(10, 10000)
+    val maxTs = events.map(_.ts).max
+    val batchEnd = TsUtils.round(maxTs - 2 * DayMillis, DayMillis)
+
+    val aggregations: Seq[Aggregation] = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows),
+      Builders.Aggregation(Operation.AVERAGE, "amount", AllWindows)
+    )
+
+    // Queries spanning 2 days after batchEnd
+    val queryTimes = Array(
+      batchEnd + 6 * 3600 * 1000L,   // day 1 morning
+      batchEnd + 18 * 3600 * 1000L,  // day 1 evening
+      batchEnd + 30 * 3600 * 1000L,  // day 2 morning
+      batchEnd + 42 * 3600 * 1000L   // day 2 evening
+    ).filter(_ <= maxTs)
+
+    val mergerResults = megaTileMergerAggregate(events, queryTimes, aggregations, schema, batchEnd)
+    val naiveResults = naiveAggregate(events, queryTimes, aggregations, schema)
+    compareResults(mergerResults, naiveResults, queryTimes, "day_boundary")
+  }
+}

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/MegaTileMergerTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/MegaTileMergerTest.scala
@@ -66,6 +66,68 @@ class MegaTileMergerTest extends AnyFlatSpec {
     (data.rows, columns.map(_.schema))
   }
 
+  it should "fetch day keys from batch day through today plus one no-batch fallback day" in {
+    val aggregations: Seq[Aggregation] = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows)
+    )
+    val schema: Seq[(String, DataType)] = Seq("ts" -> LongType, "num" -> LongType)
+    val merger = new MegaTileMerger(new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis))
+
+    val todayStart = 1712275200000L // 2024-04-05T00:00:00Z
+    val queryTs = todayStart + 90 * 60 * 1000L
+    val batchEnd = 1711929600000L // 2024-04-01T00:00:00Z
+
+    assertEquals(
+      Seq(
+        todayStart,
+        1712188800000L,
+        1712102400000L,
+        1712016000000L,
+        1711929600000L
+      ),
+      merger.streamingDayKeys(queryTs, batchEnd)
+    )
+
+    assertEquals(
+      Seq(
+        todayStart,
+        1712188800000L
+      ),
+      merger.streamingDayKeys(queryTs, todayStart)
+    )
+  }
+
+  it should "clear no-batch columns when no daily rows exist" in {
+    val aggregations: Seq[Aggregation] = Seq(
+      Builders.Aggregation(Operation.SUM, "num", Seq(new Window(6, TimeUnit.HOURS))),
+      Builders.Aggregation(Operation.SUM, "num", Seq(new Window(7, TimeUnit.DAYS)))
+    )
+    val schema: Seq[(String, DataType)] = Seq("ts" -> LongType, "num" -> LongType)
+    val batchEnd = 1712275200000L // 2024-04-05T00:00:00Z
+    val queryTs = batchEnd + 6 * 3600 * 1000L
+
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val merger = new MegaTileMerger(megaTileAgg)
+    val onlineAgg = new SawtoothOnlineAggregator(batchEnd, aggregations, schema, tailBufferMillis = TailBufferMillis)
+
+    var batchIr = onlineAgg.init
+    batchIr = onlineAgg.update(batchIr, new TestRow(batchEnd - 3600 * 1000L, 5L)(0))
+    val finalBatchIr = onlineAgg.finalizeSnapshot(batchIr)
+
+    val merged = merger.merge(
+      finalBatchIr,
+      Seq(
+        TsUtils.round(queryTs, DayMillis) -> null,
+        (TsUtils.round(queryTs, DayMillis) - DayMillis) -> null
+      ),
+      queryTs,
+      batchEnd
+    )
+
+    assertNull(merged(0))
+    assertEquals(5L, merged(1))
+  }
+
   def naiveAggregate(allEvents: Array[TestRow],
                      queryTimes: Array[Long],
                      aggregations: Seq[Aggregation],

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/MegaTileStreamProcessorTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/MegaTileStreamProcessorTest.scala
@@ -9,6 +9,7 @@ import org.junit.Assert._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.slf4j.LoggerFactory
 
+import java.time.Instant
 import scala.collection.mutable
 
 /**
@@ -83,6 +84,11 @@ class MegaTileStreamProcessorTest extends AnyFlatSpec {
     (data.rows, columns.map(_.schema))
   }
 
+  def toMillis(instant: String): Long = Instant.parse(instant).toEpochMilli
+
+  def finalizeEntry(megaTileAgg: MegaTileAggregator, entry: Array[Any]): Array[Any] =
+    megaTileAgg.windowedAggregator.finalize(entry.clone())
+
   def naiveAggregate(allEvents: Array[TestRow], queryTimes: Array[Long], aggregations: Seq[Aggregation], schema: Seq[(String, DataType)]): Array[Array[Any]] = {
     val unpackedParts = aggregations.flatMap(_.unpack)
     val unpacked = unpackedParts.map(_.window).toArray
@@ -154,7 +160,7 @@ class MegaTileStreamProcessorTest extends AnyFlatSpec {
         processor.advanceWatermark(event.ts)
 
         // Process event
-        val result = processor.onEvent(event, event.ts)
+        val result = processor.onEvent(event, event.ts, queryTs)
         if (result.todayEntry != null) kvStore(result.todayStart) = result.todayEntry
         if (result.yesterdayEntry != null) kvStore(result.yesterdayStart) = result.yesterdayEntry
 
@@ -315,6 +321,141 @@ class MegaTileStreamProcessorTest extends AnyFlatSpec {
     val results = streamProcessorAggregate(events, queryTimes, aggregations, schema, batchEnd)
     val naive = naiveAggregate(events, queryTimes, aggregations, schema)
     compareResults(results, naive, queryTimes, "stream_multi_day_gap")
+  }
+
+  it should "not update cached small windows for a retained late event outside the as-of horizon" in {
+    val oneHour = new Window(1, TimeUnit.HOURS)
+    val oneDay = new Window(1, TimeUnit.DAYS)
+    val threeDays = new Window(3, TimeUnit.DAYS)
+    val aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(oneHour, oneDay, threeDays)))
+    val schema: Seq[(String, DataType)] = Seq("ts" -> LongType, "num" -> LongType)
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val processor = new MegaTileStreamProcessor(megaTileAgg, new InMemoryTileStore(megaTileAgg.windowedAggregator))
+
+    val todayStart = toMillis("2025-07-22T00:00:00Z")
+    val asOfTs = toMillis("2025-07-22T00:10:00Z")
+
+    val currentEvent = TestRow(todayStart, 1L)
+    val currentResult = processor.onEvent(currentEvent, currentEvent.ts, asOfTs)
+    val currentFinalized = finalizeEntry(megaTileAgg, currentResult.todayEntry)
+    assertEquals("1h sum after current event", 1L, currentFinalized(0))
+    assertEquals("1d sum after current event", 1L, currentFinalized(1))
+
+    val retainedButOutsideOneHour = TestRow(toMillis("2025-07-21T00:00:00Z"), 1L)
+    val lateResult = processor.onEvent(retainedButOutsideOneHour, retainedButOutsideOneHour.ts, asOfTs)
+    val lateFinalized = finalizeEntry(megaTileAgg, lateResult.todayEntry)
+
+    assertEquals("1h sum should exclude stale retained late event", 1L, lateFinalized(0))
+    assertEquals("1d sum should still include retained late event", 2L, lateFinalized(1))
+    assertNotNull("large-window yesterday entry should still be emitted", lateResult.yesterdayEntry)
+  }
+
+  it should "update cached small windows for a retained late event inside the as-of horizon" in {
+    val oneHour = new Window(1, TimeUnit.HOURS)
+    val oneDay = new Window(1, TimeUnit.DAYS)
+    val threeDays = new Window(3, TimeUnit.DAYS)
+    val aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(oneHour, oneDay, threeDays)))
+    val schema: Seq[(String, DataType)] = Seq("ts" -> LongType, "num" -> LongType)
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val processor = new MegaTileStreamProcessor(megaTileAgg, new InMemoryTileStore(megaTileAgg.windowedAggregator))
+
+    val todayStart = toMillis("2025-07-22T00:00:00Z")
+    val asOfTs = toMillis("2025-07-22T00:10:00Z")
+
+    val currentEvent = TestRow(todayStart, 1L)
+    processor.onEvent(currentEvent, currentEvent.ts, asOfTs)
+
+    val retainedInsideOneHour = TestRow(toMillis("2025-07-21T23:30:00Z"), 1L)
+    val lateResult = processor.onEvent(retainedInsideOneHour, retainedInsideOneHour.ts, asOfTs)
+    val lateFinalized = finalizeEntry(megaTileAgg, lateResult.todayEntry)
+
+    assertEquals("1h sum should include retained late event inside as-of horizon", 2L, lateFinalized(0))
+    assertEquals("1d sum should include retained late event", 2L, lateFinalized(1))
+    assertNotNull("large-window yesterday entry should still be emitted", lateResult.yesterdayEntry)
+  }
+
+  it should "rebuild cached small windows when watermark advances into a new day" in {
+    val oneHour = new Window(1, TimeUnit.HOURS)
+    val oneDay = new Window(1, TimeUnit.DAYS)
+    val aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(oneHour, oneDay)))
+    val schema: Seq[(String, DataType)] = Seq("ts" -> LongType, "num" -> LongType)
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val processor = new MegaTileStreamProcessor(megaTileAgg, new InMemoryTileStore(megaTileAgg.windowedAggregator))
+
+    // Before midnight, this event is inside both the 1h and 1d small-window caches.
+    val yesterdayEvent = TestRow(toMillis("2025-07-22T22:00:00Z"), 10L)
+    val yesterdayAsOfTs = toMillis("2025-07-22T23:00:00Z")
+    val yesterdayResult = processor.onEvent(yesterdayEvent, yesterdayEvent.ts, yesterdayAsOfTs)
+    val yesterdayFinalized = finalizeEntry(megaTileAgg, yesterdayResult.todayEntry)
+
+    assertEquals("sanity: previous-day 1h cache contains the event before rollover", 10L, yesterdayFinalized(0))
+    assertEquals("sanity: previous-day 1d cache contains the event before rollover", 10L, yesterdayFinalized(1))
+
+    // Day rollover advances the as-of time without a new event, so cachedSmallWindowIr
+    // must be rebuilt here instead of waiting for the next eviction.
+    processor.advanceWatermark(toMillis("2025-07-23T00:00:00Z"))
+    val todayFinalized = finalizeEntry(megaTileAgg, processor.packTodayEntry())
+
+    // After midnight, the 1h window no longer includes 22:00, but the 1d window still does.
+    assertNull("new-day 1h cache should not carry stale previous-day value", todayFinalized(0))
+    assertEquals("new-day 1d cache should be rebuilt from retained tiles", 10L, todayFinalized(1))
+  }
+
+  it should "preserve no-batch values when packing yesterday after rollover" in {
+    val oneHour = new Window(1, TimeUnit.HOURS)
+    val threeDays = new Window(3, TimeUnit.DAYS)
+    val aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(oneHour, threeDays)))
+    val schema: Seq[(String, DataType)] = Seq("ts" -> LongType, "num" -> LongType)
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val processor = new MegaTileStreamProcessor(megaTileAgg, new InMemoryTileStore(megaTileAgg.windowedAggregator))
+
+    val midnight = toMillis("2025-07-23T00:00:00Z")
+    val beforeRollover = TestRow(toMillis("2025-07-22T23:30:00Z"), 10L)
+    processor.onEvent(beforeRollover, beforeRollover.ts, midnight)
+    processor.advanceWatermark(midnight)
+
+    val latePreviousDay = TestRow(toMillis("2025-07-22T22:00:00Z"), 5L)
+    val result = processor.onEvent(latePreviousDay, latePreviousDay.ts, midnight + 5 * 60 * 1000L)
+    val yesterdayFinalized = finalizeEntry(megaTileAgg, result.yesterdayEntry)
+
+    // Late previous-day events must update yesterday's batch-backed columns because serving merges
+    // daily contributions across N days. No-batch columns are not merged: serving picks the newest
+    // available daily row, so small-window updates for the query path belong to today's row instead.
+    assertEquals("yesterday 1h no-batch snapshot should survive the late-row overwrite", 10L, yesterdayFinalized(0))
+    assertEquals("yesterday 3d batch-backed column should include the late event", 15L, yesterdayFinalized(1))
+  }
+
+  it should "not update previous-day no-batch columns for late events when serving picks today" in {
+    val oneHour = new Window(1, TimeUnit.HOURS)
+    val threeDays = new Window(3, TimeUnit.DAYS)
+    val aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(oneHour, threeDays)))
+    val schema: Seq[(String, DataType)] = Seq("ts" -> LongType, "num" -> LongType)
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val processor = new MegaTileStreamProcessor(megaTileAgg, new InMemoryTileStore(megaTileAgg.windowedAggregator))
+    val merger = new MegaTileMerger(megaTileAgg)
+
+    val yesterdayStart = toMillis("2025-07-22T00:00:00Z")
+    val todayStart = yesterdayStart + DayMillis
+    val queryTs = toMillis("2025-07-23T00:10:00Z")
+
+    val beforeRollover = TestRow(toMillis("2025-07-22T23:30:00Z"), 10L)
+    processor.onEvent(beforeRollover, beforeRollover.ts, todayStart)
+    processor.advanceWatermark(todayStart)
+
+    val todayEvent = TestRow(toMillis("2025-07-23T00:01:00Z"), 7L)
+    processor.onEvent(todayEvent, todayEvent.ts, queryTs)
+
+    val latePreviousDay = TestRow(toMillis("2025-07-22T22:00:00Z"), 5L)
+    val lateResult = processor.onEvent(latePreviousDay, latePreviousDay.ts, queryTs)
+    val yesterdayFinalized = finalizeEntry(megaTileAgg, lateResult.yesterdayEntry)
+    assertEquals("late event should not mutate frozen previous-day 1h snapshot", 10L, yesterdayFinalized(0))
+    assertEquals("late event should still update previous-day 3d contribution", 15L, yesterdayFinalized(1))
+
+    val served =
+      merger.merge(null, Seq(todayStart -> processor.packTodayEntry(), yesterdayStart -> lateResult.yesterdayEntry),
+                   queryTs, yesterdayStart)
+    assertEquals("serving should choose today's self-contained 1h row, not merge yesterday", 17L, served(0))
+    assertEquals("batch-backed column should merge today and yesterday daily contributions", 22L, served(1))
   }
 
   it should "match naive with complex aggregations (buckets, approx_unique, histogram, last_k)" in {

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/MegaTileStreamProcessorTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/MegaTileStreamProcessorTest.scala
@@ -36,20 +36,29 @@ class MegaTileStreamProcessorTest extends AnyFlatSpec {
   val DayMillis: Long = new Window(1, TimeUnit.DAYS).millis
   val Epsilon = 1e-6
 
-  def approxEqual(a: Any, b: Any): Boolean = (a, b) match {
-    case (null, null)                                  => true
-    case (null, _) | (_, null)                         => false
-    case (x: Double, y: Double)                        => Math.abs(x - y) <= Epsilon * Math.max(1.0, Math.max(Math.abs(x), Math.abs(y)))
-    case (x: Float, y: Float)                          => Math.abs(x - y) <= Epsilon.toFloat * Math.max(1.0f, Math.max(Math.abs(x), Math.abs(y)))
-    case (x: java.util.List[_], y: java.util.List[_]) => x.size() == y.size() && (0 until x.size()).forall(i => approxEqual(x.get(i), y.get(i)))
-    case (x: Array[_], y: Array[_])                    => x.length == y.length && x.zip(y).forall { case (a, b) => approxEqual(a, b) }
-    case _                                             => a == b
+  // sketchTolerance: relative tolerance for Long values (sketch-based aggs like APPROX_UNIQUE_COUNT
+  // produce slightly different results when merging partial sketches vs building one sketch).
+  def approxEqual(a: Any, b: Any, sketchTolerance: Double = 0.0): Boolean = (a, b) match {
+    case (null, null)                         => true
+    case (null, _) | (_, null)                => false
+    case (x: Double, y: Double)               => Math.abs(x - y) <= Epsilon * Math.max(1.0, Math.max(Math.abs(x), Math.abs(y)))
+    case (x: Float, y: Float)                 => Math.abs(x - y) <= Epsilon.toFloat * Math.max(1.0f, Math.max(Math.abs(x), Math.abs(y)))
+    case (x: Long, y: Long) if sketchTolerance > 0 =>
+      x == y || Math.abs(x - y).toDouble <= sketchTolerance * Math.max(1.0, Math.max(Math.abs(x), Math.abs(y)).toDouble)
+    case (x: java.util.List[_], y: java.util.List[_]) =>
+      x.size() == y.size() && (0 until x.size()).forall(i => approxEqual(x.get(i), y.get(i), sketchTolerance))
+    case (x: java.util.Map[_, _], y: java.util.Map[_, _]) =>
+      x.size() == y.size() && x.keySet().toArray.forall(k => approxEqual(x.get(k), y.get(k), sketchTolerance))
+    case (x: Array[_], y: Array[_]) =>
+      x.length == y.length && x.zip(y).forall { case (a, b) => approxEqual(a, b, sketchTolerance) }
+    case _ => a == b
   }
 
-  def compareResults(actual: Array[Array[Any]], expected: Array[Array[Any]], queryTimes: Array[Long], label: String): Unit = {
+  def compareResults(actual: Array[Array[Any]], expected: Array[Array[Any]], queryTimes: Array[Long],
+                     label: String, sketchTolerance: Double = 0.0): Unit = {
     assertEquals(s"$label: result count mismatch", expected.length, actual.length)
     for (i <- queryTimes.indices) {
-      if (!approxEqual(actual(i), expected(i))) {
+      if (!approxEqual(actual(i), expected(i), sketchTolerance)) {
         val expStr = gson.toJson(expected(i))
         val actStr = gson.toJson(actual(i))
         fail(s"$label: mismatch at query ${queryTimes(i)} (index $i)\n  expected: $expStr\n  got:      $actStr")
@@ -59,6 +68,17 @@ class MegaTileStreamProcessorTest extends AnyFlatSpec {
 
   def generateEvents(windowDays: Int, count: Int): (Array[TestRow], Seq[(String, DataType)]) = {
     val columns = Seq(Column("ts", LongType, windowDays), Column("num", LongType, 1000), Column("amount", DoubleType, 500))
+    val data = CStream.gen(columns, count)
+    (data.rows, columns.map(_.schema))
+  }
+
+  def generateEventsWithCategory(windowDays: Int, count: Int): (Array[TestRow], Seq[(String, DataType)]) = {
+    val columns = Seq(
+      Column("ts", LongType, windowDays),
+      Column("num", LongType, 1000),
+      Column("amount", DoubleType, 500),
+      Column("category", StringType, 5)
+    )
     val data = CStream.gen(columns, count)
     (data.rows, columns.map(_.schema))
   }
@@ -295,5 +315,30 @@ class MegaTileStreamProcessorTest extends AnyFlatSpec {
     val results = streamProcessorAggregate(events, queryTimes, aggregations, schema, batchEnd)
     val naive = naiveAggregate(events, queryTimes, aggregations, schema)
     compareResults(results, naive, queryTimes, "stream_multi_day_gap")
+  }
+
+  it should "match naive with complex aggregations (buckets, approx_unique, histogram, last_k)" in {
+    val (events, schema) = generateEventsWithCategory(14, 20000)
+    val maxTs = events.map(_.ts).max
+    val batchEnd = TsUtils.round(maxTs - DayMillis, DayMillis)
+
+    val aggregations = Seq(
+      // Bucketed: produces MapType(StringType, irType) IR
+      Builders.Aggregation(Operation.SUM, "num", AllWindows, buckets = Seq("category")),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows, buckets = Seq("category")),
+      // Sketch-based: BinaryType IR (CPC sketch serde)
+      Builders.Aggregation(Operation.APPROX_UNIQUE_COUNT, "num", AllWindows),
+      // Map IR: MapType(StringType, IntType)
+      Builders.Aggregation(Operation.HISTOGRAM, "category", AllWindows),
+      // Collection IR: ListType
+      Builders.Aggregation(Operation.LAST_K, "num", AllWindows, argMap = Map("k" -> "3"))
+    )
+
+    val queryTimes = Array(batchEnd + 14 * 3600 * 1000L).filter(_ <= maxTs)
+
+    val results = streamProcessorAggregate(events, queryTimes, aggregations, schema, batchEnd)
+    val naive = naiveAggregate(events, queryTimes, aggregations, schema)
+    // 5% tolerance for APPROX_UNIQUE_COUNT (CPC sketch merge imprecision)
+    compareResults(results, naive, queryTimes, "stream_complex_aggs", sketchTolerance = 0.05)
   }
 }

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/MegaTileStreamProcessorTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/MegaTileStreamProcessorTest.scala
@@ -102,18 +102,32 @@ class MegaTileStreamProcessorTest extends AnyFlatSpec {
     val streamingEvents = allEvents.sortBy(_.ts)
     val sortedQueries = queryTimes.sorted
 
-    // Track last eviction time and KV store state
-    var lastEvictionTs = 0L
     val evictionInterval = processor.minSmallWindowTileSize
+    // Next eviction fires at the next tile boundary after the first event
+    var nextEvictionTs = Long.MaxValue
     val kvStore = mutable.Map[Long, Array[Any]]() // dayStart -> mega tile entry
 
     var eventIdx = 0
     val resultsByQueryTs = mutable.Map[Long, Array[Any]]()
 
+    // Helper: fire all pending evictions up to a given timestamp
+    def firePendingEvictions(upToTs: Long): Unit = {
+      if (!processor.hasSmallWindows) return
+      while (nextEvictionTs <= upToTs) {
+        processor.advanceWatermark(nextEvictionTs)
+        val evictResult = processor.onEviction(nextEvictionTs)
+        if (evictResult.todayEntry != null) kvStore(evictResult.todayStart) = evictResult.todayEntry
+        nextEvictionTs += evictionInterval
+      }
+    }
+
     for (queryTs <- sortedQueries) {
       // Process all streaming events up to queryTs
       while (eventIdx < streamingEvents.length && streamingEvents(eventIdx).ts <= queryTs) {
         val event = streamingEvents(eventIdx)
+
+        // Fire eviction timers that should have fired before this event
+        firePendingEvictions(event.ts)
 
         // Advance watermark to event time (simulating in-order processing)
         processor.advanceWatermark(event.ts)
@@ -123,29 +137,23 @@ class MegaTileStreamProcessorTest extends AnyFlatSpec {
         if (result.todayEntry != null) kvStore(result.todayStart) = result.todayEntry
         if (result.yesterdayEntry != null) kvStore(result.yesterdayStart) = result.yesterdayEntry
 
-        // Simulate eviction timer at regular intervals
-        if (processor.hasSmallWindows && event.ts - lastEvictionTs >= evictionInterval) {
-          val evictResult = processor.onEviction(event.ts)
-          if (evictResult.todayEntry != null) kvStore(evictResult.todayStart) = evictResult.todayEntry
-          lastEvictionTs = event.ts
+        // Initialize eviction schedule from first event
+        if (nextEvictionTs == Long.MaxValue && processor.hasSmallWindows) {
+          nextEvictionTs = TsUtils.round(event.ts, evictionInterval) + evictionInterval
         }
 
         eventIdx += 1
       }
 
+      // Fire pending evictions up to query time
+      firePendingEvictions(queryTs)
+
       // Advance watermark to query time (may trigger day transition for idle periods)
       processor.advanceWatermark(queryTs)
 
-      // Final eviction at query time for consistency
-      if (processor.hasSmallWindows) {
-        val evictResult = processor.onEviction(queryTs)
-        if (evictResult.todayEntry != null) kvStore(evictResult.todayStart) = evictResult.todayEntry
-      }
-
-      // Snapshot current state for the query
+      // Read today's entry from processor cached state (sawtooth-corrected by eviction)
       val (todayStart, yesterdayStart) = merger.streamingDayKeys(queryTs)
-      // Always get fresh today entry from processor state (not stale KV cache)
-      val todayIr = processor.packTodayEntry(queryTs)
+      val todayIr = processor.packTodayEntry()
       val yesterdayIr = kvStore.getOrElse(yesterdayStart, null)
 
       resultsByQueryTs(queryTs) = merger.merge(finalBatchIr, todayIr, yesterdayIr, todayStart, queryTs, batchEnd)

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/MegaTileStreamProcessorTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/MegaTileStreamProcessorTest.scala
@@ -87,7 +87,8 @@ class MegaTileStreamProcessorTest extends AnyFlatSpec {
                                 batchEnd: Long): Array[Array[Any]] = {
 
     val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
-    val processor = new MegaTileStreamProcessor(megaTileAgg)
+    val store = new InMemoryTileStore(megaTileAgg.windowedAggregator)
+    val processor = new MegaTileStreamProcessor(megaTileAgg, store)
     val merger = new MegaTileMerger(megaTileAgg)
 
     // Build batch IR from pre-batchEnd events

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/MegaTileStreamProcessorTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/MegaTileStreamProcessorTest.scala
@@ -265,4 +265,34 @@ class MegaTileStreamProcessorTest extends AnyFlatSpec {
     val naive = naiveAggregate(events, queryTimes, aggregations, schema)
     compareResults(results, naive, queryTimes, "stream_day_boundary")
   }
+
+  it should "handle multi-day watermark gap (3+ day idle then resume)" in {
+    // Events span 14 days with a 3-day gap. Tests that advanceWatermark handles
+    // multi-day jumps correctly (clears largeYesterdayIr instead of carrying stale data).
+    // Batch is set fresh (1 day before query) so we stay within 2d staleness tolerance.
+    val (allEvents, schema) = generateEvents(14, 20000)
+    val maxTs = allEvents.map(_.ts).max
+    val gapEnd = TsUtils.round(maxTs - 2 * DayMillis, DayMillis)
+    val gapStart = gapEnd - 3 * DayMillis
+
+    // Remove events in the gap to simulate idle entity
+    val events = allEvents.filter(e => e.ts < gapStart || e.ts >= gapEnd)
+
+    // Batch is fresh: 1 day before query time
+    val batchEnd = TsUtils.round(maxTs - DayMillis, DayMillis)
+
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows)
+    )
+
+    val queryTimes = Array(
+      batchEnd + 6 * 3600 * 1000L,
+      batchEnd + 14 * 3600 * 1000L
+    ).filter(_ <= maxTs)
+
+    val results = streamProcessorAggregate(events, queryTimes, aggregations, schema, batchEnd)
+    val naive = naiveAggregate(events, queryTimes, aggregations, schema)
+    compareResults(results, naive, queryTimes, "stream_multi_day_gap")
+  }
 }

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/MegaTileStreamProcessorTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/MegaTileStreamProcessorTest.scala
@@ -1,0 +1,260 @@
+package ai.chronon.aggregator.test
+
+import ai.chronon.aggregator.row.RowAggregator
+import ai.chronon.aggregator.windowing._
+import ai.chronon.api._
+import ai.chronon.api.Extensions.{AggregationOps, WindowOps}
+import com.google.gson.Gson
+import org.junit.Assert._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.slf4j.LoggerFactory
+
+import scala.collection.mutable
+
+/**
+  * Tests the full MegaTile streaming pipeline:
+  * MegaTileStreamProcessor (Flink state management) + MegaTileMerger (fetcher merge).
+  *
+  * Replays events through the processor, simulates watermark advancement and eviction,
+  * then merges streaming entries with batch IR and compares against NaiveAggregator.
+  */
+class MegaTileStreamProcessorTest extends AnyFlatSpec {
+  @transient lazy val logger = LoggerFactory.getLogger(getClass)
+  val gson = new Gson
+
+  val AllWindows: Seq[Window] = Seq(
+    new Window(6, TimeUnit.HOURS),
+    new Window(1, TimeUnit.DAYS),
+    new Window(47, TimeUnit.HOURS),
+    new Window(2, TimeUnit.DAYS),
+    new Window(49, TimeUnit.HOURS),
+    new Window(3, TimeUnit.DAYS),
+    new Window(7, TimeUnit.DAYS)
+  )
+
+  val TailBufferMillis: Long = new Window(2, TimeUnit.DAYS).millis
+  val DayMillis: Long = new Window(1, TimeUnit.DAYS).millis
+  val Epsilon = 1e-6
+
+  def approxEqual(a: Any, b: Any): Boolean = (a, b) match {
+    case (null, null)                                  => true
+    case (null, _) | (_, null)                         => false
+    case (x: Double, y: Double)                        => Math.abs(x - y) <= Epsilon * Math.max(1.0, Math.max(Math.abs(x), Math.abs(y)))
+    case (x: Float, y: Float)                          => Math.abs(x - y) <= Epsilon.toFloat * Math.max(1.0f, Math.max(Math.abs(x), Math.abs(y)))
+    case (x: java.util.List[_], y: java.util.List[_]) => x.size() == y.size() && (0 until x.size()).forall(i => approxEqual(x.get(i), y.get(i)))
+    case (x: Array[_], y: Array[_])                    => x.length == y.length && x.zip(y).forall { case (a, b) => approxEqual(a, b) }
+    case _                                             => a == b
+  }
+
+  def compareResults(actual: Array[Array[Any]], expected: Array[Array[Any]], queryTimes: Array[Long], label: String): Unit = {
+    assertEquals(s"$label: result count mismatch", expected.length, actual.length)
+    for (i <- queryTimes.indices) {
+      if (!approxEqual(actual(i), expected(i))) {
+        val expStr = gson.toJson(expected(i))
+        val actStr = gson.toJson(actual(i))
+        fail(s"$label: mismatch at query ${queryTimes(i)} (index $i)\n  expected: $expStr\n  got:      $actStr")
+      }
+    }
+  }
+
+  def generateEvents(windowDays: Int, count: Int): (Array[TestRow], Seq[(String, DataType)]) = {
+    val columns = Seq(Column("ts", LongType, windowDays), Column("num", LongType, 1000), Column("amount", DoubleType, 500))
+    val data = CStream.gen(columns, count)
+    (data.rows, columns.map(_.schema))
+  }
+
+  def naiveAggregate(allEvents: Array[TestRow], queryTimes: Array[Long], aggregations: Seq[Aggregation], schema: Seq[(String, DataType)]): Array[Array[Any]] = {
+    val unpackedParts = aggregations.flatMap(_.unpack)
+    val unpacked = unpackedParts.map(_.window).toArray
+    val tailHops = unpacked.map(w => FiveMinuteResolution.calculateTailHop(w))
+    val rowAgg = new RowAggregator(schema, unpackedParts)
+    val naiveAgg = new NaiveAggregator(rowAgg, unpacked, tailHops)
+    naiveAgg.aggregate(allEvents, queryTimes).map(ir => rowAgg.finalize(ir))
+  }
+
+  /**
+    * Full pipeline simulation:
+    * 1. Build batch IR from pre-batchEnd events
+    * 2. Create MegaTileStreamProcessor, replay streaming events through onEvent()
+    * 3. Simulate watermark advancement + eviction at regular intervals
+    * 4. At each query: pack today/yesterday from processor, merge with batch via MegaTileMerger
+    * 5. Compare with naive
+    */
+  def streamProcessorAggregate(allEvents: Array[TestRow],
+                                queryTimes: Array[Long],
+                                aggregations: Seq[Aggregation],
+                                schema: Seq[(String, DataType)],
+                                batchEnd: Long): Array[Array[Any]] = {
+
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val processor = new MegaTileStreamProcessor(megaTileAgg)
+    val merger = new MegaTileMerger(megaTileAgg)
+
+    // Build batch IR from pre-batchEnd events
+    val batchEvents = allEvents.filter(_.ts < batchEnd)
+    val onlineAgg = new SawtoothOnlineAggregator(batchEnd, aggregations, schema, tailBufferMillis = TailBufferMillis)
+    var batchIr = onlineAgg.init
+    batchEvents.foreach(row => batchIr = onlineAgg.update(batchIr, row))
+    val finalBatchIr = onlineAgg.finalizeSnapshot(batchIr)
+
+    // Flink processes ALL events (it doesn't know about batchEnd).
+    // batchEnd is a fetcher-side concept — the merge logic handles the split.
+    val streamingEvents = allEvents.sortBy(_.ts)
+    val sortedQueries = queryTimes.sorted
+
+    // Track last eviction time and KV store state
+    var lastEvictionTs = 0L
+    val evictionInterval = processor.minSmallWindowTileSize
+    val kvStore = mutable.Map[Long, Array[Any]]() // dayStart -> mega tile entry
+
+    var eventIdx = 0
+    val resultsByQueryTs = mutable.Map[Long, Array[Any]]()
+
+    for (queryTs <- sortedQueries) {
+      // Process all streaming events up to queryTs
+      while (eventIdx < streamingEvents.length && streamingEvents(eventIdx).ts <= queryTs) {
+        val event = streamingEvents(eventIdx)
+
+        // Advance watermark to event time (simulating in-order processing)
+        processor.advanceWatermark(event.ts)
+
+        // Process event
+        val result = processor.onEvent(event, event.ts)
+        if (result.todayEntry != null) kvStore(result.todayStart) = result.todayEntry
+        if (result.yesterdayEntry != null) kvStore(result.yesterdayStart) = result.yesterdayEntry
+
+        // Simulate eviction timer at regular intervals
+        if (processor.hasSmallWindows && event.ts - lastEvictionTs >= evictionInterval) {
+          val evictResult = processor.onEviction(event.ts)
+          if (evictResult.todayEntry != null) kvStore(evictResult.todayStart) = evictResult.todayEntry
+          lastEvictionTs = event.ts
+        }
+
+        eventIdx += 1
+      }
+
+      // Advance watermark to query time (may trigger day transition for idle periods)
+      processor.advanceWatermark(queryTs)
+
+      // Final eviction at query time for consistency
+      if (processor.hasSmallWindows) {
+        val evictResult = processor.onEviction(queryTs)
+        if (evictResult.todayEntry != null) kvStore(evictResult.todayStart) = evictResult.todayEntry
+      }
+
+      // Snapshot current state for the query
+      val (todayStart, yesterdayStart) = merger.streamingDayKeys(queryTs)
+      // Always get fresh today entry from processor state (not stale KV cache)
+      val todayIr = processor.packTodayEntry(queryTs)
+      val yesterdayIr = kvStore.getOrElse(yesterdayStart, null)
+
+      resultsByQueryTs(queryTs) = merger.merge(finalBatchIr, todayIr, yesterdayIr, todayStart, queryTs, batchEnd)
+    }
+
+    queryTimes.map(resultsByQueryTs)
+  }
+
+  it should "match naive with batch fresh (14 day sim)" in {
+    val (events, schema) = generateEvents(14, 20000)
+    val maxTs = events.map(_.ts).max
+    val batchEnd = TsUtils.round(maxTs - DayMillis, DayMillis)
+
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows),
+      Builders.Aggregation(Operation.AVERAGE, "amount", AllWindows)
+    )
+
+    val queryTimes = Array(
+      batchEnd + 6 * 3600 * 1000L,
+      batchEnd + 14 * 3600 * 1000L,
+      batchEnd + 23 * 3600 * 1000L
+    ).filter(_ <= maxTs)
+
+    val results = streamProcessorAggregate(events, queryTimes, aggregations, schema, batchEnd)
+    val naive = naiveAggregate(events, queryTimes, aggregations, schema)
+    compareResults(results, naive, queryTimes, "stream_batch_fresh")
+  }
+
+  it should "match naive with batch delayed (14 day sim)" in {
+    val (events, schema) = generateEvents(14, 20000)
+    val maxTs = events.map(_.ts).max
+    val batchEnd = TsUtils.round(maxTs - 2 * DayMillis, DayMillis)
+
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows)
+    )
+
+    val queryTimes = Array(
+      batchEnd + DayMillis + 2 * 3600 * 1000L,
+      batchEnd + DayMillis + 18 * 3600 * 1000L
+    ).filter(_ <= maxTs)
+
+    val results = streamProcessorAggregate(events, queryTimes, aggregations, schema, batchEnd)
+    val naive = naiveAggregate(events, queryTimes, aggregations, schema)
+    compareResults(results, naive, queryTimes, "stream_batch_delayed")
+  }
+
+  it should "handle idle entities" in {
+    val (events, schema) = generateEvents(14, 10000)
+    val maxTs = events.map(_.ts).max
+    val batchEnd = maxTs + DayMillis
+
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows)
+    )
+
+    val queryTimes = Array(batchEnd + 14 * 3600 * 1000L)
+
+    val results = streamProcessorAggregate(events, queryTimes, aggregations, schema, batchEnd)
+    val naive = naiveAggregate(events, queryTimes, aggregations, schema)
+    compareResults(results, naive, queryTimes, "stream_idle")
+  }
+
+  it should "match naive with all aggregation types (14 day sim)" in {
+    val (events, schema) = generateEvents(14, 20000)
+    val maxTs = events.map(_.ts).max
+    val batchEnd = TsUtils.round(maxTs - DayMillis, DayMillis)
+
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows),
+      Builders.Aggregation(Operation.AVERAGE, "amount", AllWindows),
+      Builders.Aggregation(Operation.MIN, "num", AllWindows),
+      Builders.Aggregation(Operation.MAX, "num", AllWindows),
+      Builders.Aggregation(Operation.LAST, "num", AllWindows),
+      Builders.Aggregation(Operation.FIRST, "num", AllWindows)
+    )
+
+    val queryTimes = Array(batchEnd + 14 * 3600 * 1000L).filter(_ <= maxTs)
+
+    val results = streamProcessorAggregate(events, queryTimes, aggregations, schema, batchEnd)
+    val naive = naiveAggregate(events, queryTimes, aggregations, schema)
+    compareResults(results, naive, queryTimes, "stream_multi_agg")
+  }
+
+  it should "handle day boundary transitions across multiple days" in {
+    val (events, schema) = generateEvents(14, 20000)
+    val maxTs = events.map(_.ts).max
+    val batchEnd = TsUtils.round(maxTs - 2 * DayMillis, DayMillis)
+
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows),
+      Builders.Aggregation(Operation.AVERAGE, "amount", AllWindows)
+    )
+
+    val queryTimes = Array(
+      batchEnd + 6 * 3600 * 1000L,
+      batchEnd + 18 * 3600 * 1000L,
+      batchEnd + 30 * 3600 * 1000L,
+      batchEnd + 42 * 3600 * 1000L
+    ).filter(_ <= maxTs)
+
+    val results = streamProcessorAggregate(events, queryTimes, aggregations, schema, batchEnd)
+    val naive = naiveAggregate(events, queryTimes, aggregations, schema)
+    compareResults(results, naive, queryTimes, "stream_day_boundary")
+  }
+}

--- a/api/src/main/scala/ai/chronon/api/Extensions.scala
+++ b/api/src/main/scala/ai/chronon/api/Extensions.scala
@@ -552,9 +552,13 @@ object Extensions {
       }
     }
 
+    def isMegaTilingEnabled: Boolean =
+      groupBy.onlineStrategy == OnlineStrategy.STREAMING_MEGATILES
+
     def semanticHash: String = {
       val newGroupBy = groupBy.deepCopy()
       newGroupBy.unsetMetaData()
+      newGroupBy.unsetOnlineStrategy() // online-only, doesn't affect batch
       ThriftJsonCodec.md5Digest(newGroupBy)
     }
 

--- a/api/src/main/scala/ai/chronon/api/planner/GroupByPlanner.scala
+++ b/api/src/main/scala/ai/chronon/api/planner/GroupByPlanner.scala
@@ -38,7 +38,7 @@ case class GroupByPlanner(groupBy: GroupBy)(implicit outputPartitionSpec: Partit
 
     val node = new GroupByBackfillNode().setGroupBy(eraseExecutionInfo)
 
-    toNode(metaData, _.setGroupByBackfill(node), semanticGroupBy(groupBy))
+    toNode(metaData, _.setGroupByBackfill(node), semanticGroupByForBatch(groupBy))
   }
 
   private def semanticGroupBy(groupBy: GroupBy): GroupBy = {
@@ -55,6 +55,18 @@ case class GroupByPlanner(groupBy: GroupBy)(implicit outputPartitionSpec: Partit
     semanticGroupBy
   }
 
+  /** Variant for batch nodes (backfill, upload, uploadToKV). Batch outputs are byte-identical
+    * across online strategies — the streaming side reads/writes them differently but the
+    * underlying batch artifacts don't change. Without this, flipping `onlineStrategy` (e.g.
+    * DEFAULT ↔ STREAMING_MEGATILES) causes BatchNodeRunner to archive and re-run every batch
+    * job downstream of the GroupBy for no observable change in output data.
+    */
+  private def semanticGroupByForBatch(groupBy: GroupBy): GroupBy = {
+    val gb = semanticGroupBy(groupBy)
+    gb.unsetOnlineStrategy()
+    gb
+  }
+
   def uploadNode: Node = {
     val stepDays = 1 // GBUs write out data per day
     val metaData =
@@ -65,7 +77,7 @@ case class GroupByPlanner(groupBy: GroupBy)(implicit outputPartitionSpec: Partit
                           Some(stepDays))
 
     val node = new GroupByUploadNode().setGroupBy(eraseExecutionInfo)
-    toNode(metaData, _.setGroupByUpload(node), semanticGroupBy(groupBy))
+    toNode(metaData, _.setGroupByUpload(node), semanticGroupByForBatch(groupBy))
   }
 
   def uploadToKVNode: Node = {
@@ -91,7 +103,7 @@ case class GroupByPlanner(groupBy: GroupBy)(implicit outputPartitionSpec: Partit
       )
 
     val node = new GroupByUploadToKVNode().setGroupBy(eraseExecutionInfo)
-    toNode(metaData, _.setGroupByUploadToKV(node), semanticGroupBy(groupBy))
+    toNode(metaData, _.setGroupByUploadToKV(node), semanticGroupByForBatch(groupBy))
   }
 
   def streamingNode: Option[Node] = {

--- a/api/src/test/scala/ai/chronon/api/test/planner/GroupByPlannerTest.scala
+++ b/api/src/test/scala/ai/chronon/api/test/planner/GroupByPlannerTest.scala
@@ -154,6 +154,34 @@ class GroupByPlannerTest extends AnyFlatSpec with Matchers {
     firstSemanticHashes should equal(secondSemanticHashes)
   }
 
+  it should "GB planner batch nodes must keep the same semantic hash when only onlineStrategy flips" in {
+    // Batch outputs (backfill, upload, uploadToKV) are byte-identical regardless of online
+    // strategy — only the streaming side reads/writes them differently. Flipping onlineStrategy
+    // should NOT cause BatchNodeRunner to archive and re-run those batch jobs.
+    import ai.chronon.api.OnlineStrategy
+
+    val defaultGb = buildGroupBy(includeTopic = true)
+    val megatileGb = buildGroupBy(includeTopic = true)
+    megatileGb.setOnlineStrategy(OnlineStrategy.STREAMING_MEGATILES)
+
+    val defaultPlan = new GroupByPlanner(defaultGb).buildPlan
+    val megatilePlan = new GroupByPlanner(megatileGb).buildPlan
+
+    def hashByContent(plan: ConfPlan, predicate: ai.chronon.planner.NodeContent => Boolean): String =
+      plan.nodes.asScala.find(n => predicate(n.content)).get.semanticHash
+
+    hashByContent(defaultPlan, _.isSetGroupByBackfill) should equal(
+      hashByContent(megatilePlan, _.isSetGroupByBackfill))
+    hashByContent(defaultPlan, _.isSetGroupByUpload) should equal(
+      hashByContent(megatilePlan, _.isSetGroupByUpload))
+    hashByContent(defaultPlan, _.isSetGroupByUploadToKV) should equal(
+      hashByContent(megatilePlan, _.isSetGroupByUploadToKV))
+
+    // Streaming node SHOULD differ — the streaming pipeline shape changes with online strategy.
+    hashByContent(defaultPlan, _.isSetGroupByStreaming) should not equal
+      hashByContent(megatilePlan, _.isSetGroupByStreaming)
+  }
+
   it should "GB planner uploadToKV node should have correct table dependencies" in {
     val gb = buildGroupBy()
     val planner = new GroupByPlanner(gb)

--- a/docs/source/megatile.md
+++ b/docs/source/megatile.md
@@ -110,6 +110,11 @@ Important details that are easy to mix up:
   with wall clock.
 - Output buffering is write coalescing only. It uses PT timers to avoid emitting on every event or
   eviction; it does not change event-time mutation or as-of selection.
+- MegaTile buffered emission defaults to `buffering_output_policy=dirty_buffer_with_jitter`, where
+  the first dirty row schedules `processingTs + buffering_output_time_millis` plus optional
+  `buffering_output_jitter_millis`. `wall_clock_cadence` instead uses a stable per-key wall-clock
+  phase in `Live`/`SparseKeyLag`, while `NoWatermark` and `ActiveCatchup` keep the dirty-buffered
+  fallback so startup and replay are bounded by the configured buffer.
 
 The code-order step-by-step walkthrough lives in `MegaTileProcessFunction.scala`.
 
@@ -153,8 +158,9 @@ events from prematurely rotating state.
 - Event ingestion calls `advanceWatermark` with the current Flink watermark before applying the row.
 - Eviction timers call `advanceWatermark` with the selected eviction time: watermark-hop time in
   `ActiveCatchup`, and PT in `NoWatermark`, `SparseKeyLag`, and `Live`.
-- Before an adjacent one-day roll, `MegaTileProcessFunction` emits any dirty today row under the
-  previous day key so buffered small-window state is not lost.
+- Before an adjacent one-day roll, `MegaTileProcessFunction` emits or buffers any dirty today row
+  under the previous day key so buffered small-window state is not lost. With
+  `wall_clock_cadence`, a pending pre-rollover row is preserved until the next cadence emit timer.
 
 ```
 transitionDay = round(dayTransitionTs, DayMillis)
@@ -341,8 +347,8 @@ Tests at five layers, with aggregator/codec tests comparing against NaiveAggrega
    events, and eviction (9 tests)
 4. **MegaTileCodecRoundTripTest** — serde round-trips via SerdeTileStore + key switch (5 tests)
 5. **MegaTileProcessFunctionTest** — Flink keyed process-function lifecycle coverage for Live,
-   ActiveCatchup, SparseKeyLag, buffered emit jitter, timer restore, malformed rows, and UTC day
-   boundaries (22 tests)
+   ActiveCatchup, SparseKeyLag, buffered emit jitter, wall-clock cadence, timer restore, malformed
+   rows, and UTC day boundaries
 
 Windows tested: 6h, 1d, 47h, 2d, 49h, 3d, 7d.
 Aggregation types: SUM, COUNT, AVERAGE, MIN, MAX, LAST, FIRST.

--- a/docs/source/megatile.md
+++ b/docs/source/megatile.md
@@ -10,23 +10,34 @@ amplification and serving latency.
 
 Write **one mega tile per entity per day** to the KV store. The mega tile contains a **windowed IR**
 where each column has the correct aggregate for its specific window. This reduces KV store reads from
-O(N tiles) to 2 point gets: `(entity, today)` + `(entity, yesterday)`.
+O(N tiles) to 3 point gets: `(entity, today)` + `(entity, yesterday)` from stream KV + `(entity)` from batch KV.
+
+## Opt-in
+
+Enabled per GroupBy via the `OnlineStrategy` thrift enum:
+
+```thrift
+enum OnlineStrategy { DEFAULT = 0, STREAMING_MEGATILES = 1 }
+struct GroupBy { ..., 8: optional OnlineStrategy onlineStrategy }
+```
+
+Both Flink and fetcher check `groupByOps.isMegaTilingEnabled`. The field is excluded from
+`semanticHash` — changing the online strategy doesn't trigger batch recomputation.
 
 ## Window Categories
 
 ```
 tailBuffer = 2d (default)
 
-For each windowed column:
-  collapsedRange = max(0, window.millis - tailBufferMillis)
+Small windows (≤ tailBuffer):
+  effectiveStart = now - window.millis
+  Flink covers full window via tiles + sawtooth running IR.
+  Fetcher uses today's mega tile entry directly (self-contained).
 
-  if window.millis <= tailBufferMillis:     → NO BATCH
-      effectiveStart = now - window.millis
-      Flink covers full window. Serving uses mega tile directly.
-
-  else:                                     → BATCH
-      effectiveStart = batchEnd
-      Mega tile covers [batchEnd, now). Serving merges with batch collapsed + tail hops.
+Large windows (> tailBuffer) + unwindowed:
+  effectiveStart = batchEnd (on fetcher side) or dayStart (on Flink side, per-day)
+  Flink accumulates a daily running IR per day (today + yesterday).
+  Fetcher merges batch collapsed + tail hops + streaming daily aggregates.
 ```
 
 ## Tier Assignment
@@ -39,86 +50,161 @@ Each column's hop size comes from `FiveMinuteResolution.calculateTailHop(window)
 | >= 12h, < 12d | 1hr (3,600,000 ms) |
 | >= 12d | 1day (86,400,000 ms) |
 
-## Small Tile Bucketing
+Tiles are only maintained for **small-window tiers** — tiers that have at least one column
+with `isNoBatch=true`. Large window columns don't use tiles; they use daily accumulators directly.
 
-On each event at time T, for each active tier:
-```
-tileStart = TsUtils.round(T, hopSize)
-ir = tiles[hopSize].getOrInit(tileStart, baseAggregator.init)
-baseAggregator.update(ir, row)
-```
+## Flink State Layout (MegaTileStreamProcessor + TileStore)
 
-Each event updates one tile per active tier. The `baseAggregator` is unwindowed
-(one IR slot per aggregation bucket, not per window).
-
-## Eviction
-
-Per tier, the retention floor is the minimum effectiveStart across all columns at that tier:
-```
-for each tier (hopSize):
-  columnsAtTier = columns where calculateTailHop(window) == hopSize
-  retentionFloor = min over columnsAtTier of:
-    if NO BATCH:  now - window.millis
-    if BATCH:     batchEnd
-  evictionCutoff = retentionFloor - hopSize   // one buffer tile
-  remove all tiles in tier where tileStart < evictionCutoff
-```
-
-Eviction fires every `min_tile_size` interval (event-time timer in Flink). When tiles are evicted,
-the mega tile is rebuilt from remaining tiles and written to KV store. This keeps the mega tile
-fresh even for idle entities (timers fire from global watermark advancement).
-
-## Mega Tile Construction (Windowed IR)
+All state access goes through a `TileStore` abstraction. Flink backs it with `MapState`/`ValueState`
++ codec (serde on access, with decode memoization). Tests back it with `InMemoryTileStore`.
 
 ```
-megaTileIr = windowedAggregator.init    // Array of length = #windowed columns
+Small window state:
+  tiles: MapState<"hopSize:tileStart", bytes>    // base (unwindowed) IRs, small-window tiers only
+  cachedSmallWindowIr: ValueState<bytes>          // sawtooth running sum (windowed IR)
+
+Large window state:
+  largeTodayIr: ValueState<bytes>                 // daily accumulator for [todayStart, now)
+  largeYesterdayIr: ValueState<bytes>             // daily accumulator for [yesterdayStart, todayStart)
+
+Bookkeeping:
+  currentDayStart: ValueState<Long>
+  earliestTileStart: ValueState<Long>
+```
+
+### On Event
+
+1. **Update tiles** (small-window tiers only):
+   - Compute `tileStartsForEvent(eventTs)` → one tile per active tier
+   - Guard: only create tiles within `[retentionFloor, currentDayStart + 2*DayMillis)`
+     (rejects both too-old and too-future timestamps)
+   - Read tile from store, update with `baseAggregator.update(ir, row)`, write back
+   - ~2 tile codec ops per event (one per small-window tier)
+
+2. **Update cachedSmallWindowIr** (sawtooth):
+   - Merge event into running IR for all small-window columns (unconditional)
+   - Over-inclusive at the tail — eviction corrects this
+   - 1 windowed IR codec op
+
+3. **Update large window daily IR** — route by event day:
+   - `eventTs >= todayStart` → update `largeTodayIr`
+   - `eventTs >= yesterdayStart` → update `largeYesterdayIr` (late event, within 2d tolerance)
+   - `eventTs >= nextDayStart` → clamp to today (future event; day transitions are watermark-driven)
+   - `eventTs < yesterdayStart` → drop for large windows (> 2d late)
+   - 1 windowed IR codec op
+
+4. **Emit** to KV store (only dirty targets):
+   - Today's entry: pack `cachedSmallWindowIr` + `largeTodayIr` → `(entity, todayStart)`
+   - Yesterday's entry (only if late event touched it): pack `null` + `largeYesterdayIr` → `(entity, yesterdayStart)`
+
+**Total hot-path cost per event: ~6 codec ops** (vs ~102 with bulk restore/persist).
+
+### Day Transitions (advanceWatermark)
+
+Day transitions are **watermark-driven only** — never triggered by event timestamps. This prevents
+future-timestamped events from prematurely rotating state.
+
+```
+wmDay = round(watermarkTs, DayMillis)
+if wmDay > currentDayStart:
+  // Single-day hop: carry today's aggregate to yesterday
+  // Multi-day hop (e.g., after long idle): clear yesterday (stale beyond 2d tolerance)
+  largeYesterdayIr = if (wmDay == currentDayStart + DayMillis) largeTodayIr else init
+  largeTodayIr = init
+  currentDayStart = wmDay
+```
+
+### Eviction (onEviction, fires every minSmallWindowTileSize)
+
+1. Compute `retentionFloor` per small-window tier
+2. Remove tiles below floor
+3. **Rebuild `cachedSmallWindowIr`** from remaining tiles via `buildMegaTileIr(tiles, now, todayStart)`
+   — corrects the sawtooth tail by scoping each column to its `effectiveStart`
+4. Emit updated today entry
+
+Eviction is the only O(tiles) operation and runs at timer cadence (every 5min or 1hr), not per event.
+
+## Mega Tile Construction (buildMegaTileIr)
+
+Used by eviction rebuild and by the MegaTileMergerTest simulation:
+
+```
+megaTileIr = windowedAggregator.init
 
 for col in 0 until windowedAggregator.length:
   hopSize = calculateTailHop(windowMappings(col).window)
   effStart = effectiveStart(col, now, batchEnd)
-  bucketIdx = baseIrIndices(col)    // maps windowed col → unwindowed bucket
+  bucketIdx = baseIrIndices(col)
 
   for (tileStart, tileIr) in tiles[hopSize]:
     if tileStart >= effStart and tileStart < now:
-      megaTileIr(col) = windowedAggregator(col).merge(megaTileIr(col), tileIr(bucketIdx))
+      megaTileIr(col) = merge(megaTileIr(col), tileIr(bucketIdx))
 ```
 
-Multiple windowed columns (e.g., sum_6h, sum_2d) that share the same bucket (sum)
+Multiple windowed columns (e.g., `sum_6h`, `sum_2d`) that share the same bucket (`sum`)
 read from different tiers and different time ranges but the same bucket index in the tile IR.
 
-## Serving Merge
+## Fetcher Merge (MegaTileMerger)
+
+Fetcher reads 3 entries: `(entity, today)`, `(entity, yesterday)` from stream KV + `(entity)` from batch KV.
 
 ```
-def serveMegaTile(batchIr, megaTileIr, queryTs):
-  resultIr = windowedAggregator.init
+def merge(batchIr, todayIr, yesterdayIr, todayStart, queryTs, batchEnd):
+  resultIr = clone(batchIr.collapsed) or init
 
   for col in 0 until windowedAggregator.length:
-    window = windowMappings(col).aggregationPart.window
+    window = windowMappings(col).window
 
-    if window == null:                             // unwindowed
-      resultIr(col) = merge(batchIr.collapsed(col), megaTileIr(col))
+    if window != null and window.millis <= tailBufferMillis:   // SMALL WINDOW
+      // Self-contained in daily entry. Fall back to yesterday only if
+      // today's entire entry is absent (null array), not if column is null.
+      resultIr(col) = if todayIr != null then todayIr(col)
+                       else if yesterdayIr != null then yesterdayIr(col)
 
-    elif window.millis <= tailBufferMillis:         // NO BATCH
-      resultIr(col) = megaTileIr(col)
+    else:                                                       // LARGE WINDOW / UNWINDOWED
+      // Batch collapsed + streaming daily aggregates
+      if todayIr(col) != null: resultIr(col) = merge(resultIr(col), todayIr(col))
+      if batchEnd < todayStart and yesterdayIr(col) != null:
+        resultIr(col) = merge(resultIr(col), yesterdayIr(col))
 
-    else:                                           // BATCH
-      resultIr(col) = merge(batchIr.collapsed(col), megaTileIr(col))
-
-  // Tail hops for BATCH columns (window > tailBuffer)
-  mergeTailHops(resultIr, queryTs, batchEnd, batchIr)
+  // Tail hops for large windowed columns only (not small, not unwindowed)
+  mergeTailHopsForBatchColumns(resultIr, queryTs, batchEnd, batchIr)
 
   return windowedAggregator.finalize(resultIr)
 ```
 
 ## Daily KV Key Scheme
 
-In production (Flink/Fetcher), the mega tile is stored as `(entity, day)`:
-- Flink writes to `(entity, today)` on each event and eviction
-- At midnight, starts writing to `(entity, new_day)` — ≤2d columns immediately correct
-  because Flink state has small tiles spanning midnight
-- Fetcher always reads `(entity, today)` + `(entity, yesterday)`
-- For ≤2d columns: use today's windowed value (kept fresh by eviction timer)
-- For >2d columns: merge daily aggregates from `[batchEnd, now)` + batch
+KV key: `TileKey(streamingDataset, entityKeyBytes, DayMillis, dayStart)` — reuses existing TileKey
+with `tileSizeMs = DayMillis`. Each day is a separate point-get key.
+
+- Flink emits `todayStart` (not raw `eventTs`) as the tile timestamp, so the codec always writes
+  to the correct daily key even for future-timestamped events.
+- Fetcher constructs two explicit `GetRequest`s for today and yesterday using
+  `MegaTileMerger.streamingDayKeys(queryTs)`. Query time is resolved once and propagated to
+  avoid midnight-boundary inconsistency.
+
+## Codec (MegaTileCodec)
+
+Windowed IR (mega tile entries): `encode(ir)` / `decode(bytes)` using the windowed aggregator schema
+(one IR slot per (agg, window) pair).
+
+Base IR (individual tiles in Flink state): `encodeBaseIr(ir)` / `decodeBaseIr(bytes)` using the
+unwindowed base aggregator schema (one IR slot per aggregation bucket).
+
+AvroCodec instances are cached as `@transient lazy val` to avoid schema parsing per decode.
+
+## Constraints
+
+- **Max batch staleness**: 2 days. Beyond that, large windows have a coverage gap between
+  batchEnd and yesterdayStart. Alert if batch is > 2 days stale.
+- **Sawtooth approximation**: Accepted for all aggregation types. Between evictions, small-window
+  columns are over-inclusive by up to one tile interval at the tail.
+- **Late events**: Up to 2 days late are handled (routed to yesterday's large-window IR).
+  Events > 2 days late are dropped for large windows (tiles may still capture them for small windows
+  if within retention).
+- **Future events**: Clamped to today for large windows. Day transitions are watermark-driven,
+  so future timestamps cannot corrupt state.
 
 ## Scenario Tables
 
@@ -126,34 +212,68 @@ All windows, tailBuffer = 2d, batchEnd = Mar 25 00:00.
 
 ### Scenario 1: Batch fresh (now = Mar 25 14:00, batchEnd = Mar 25 00:00)
 
-| window | tier | category | effectiveStart | mega tile range | batch tail hops | batch collapsed | fetcher uses |
-|--------|------|----------|---------------|-----------------|-----------------|-----------------|-------------|
-| 6h | 5min | NO BATCH | Mar 25 08:00 | [08:00, 14:00) = 6h | — | — | mega tile only |
-| 1d | 1hr | NO BATCH | Mar 24 14:00 | [Mar 24 14:00, Mar 25 14:00) = 24h | — | — | mega tile only |
-| 47h | 1hr | NO BATCH | Mar 23 15:00 | [Mar 23 15:00, Mar 25 14:00) = 47h | — | — | mega tile only |
-| 2d | 1hr | NO BATCH | Mar 23 14:00 | [Mar 23 14:00, Mar 25 14:00) = 48h | — | — | mega tile only |
-| 49h | 1hr | BATCH | Mar 25 00:00 | [Mar 25 00:00, Mar 25 14:00) = 14h | [Mar 22 23:00, Mar 24 23:00) = 2d | [Mar 24 23:00, Mar 25 00:00) = 1h | mega + collapsed + tail |
-| 3d | 1hr | BATCH | Mar 25 00:00 | [Mar 25 00:00, Mar 25 14:00) = 14h | [Mar 22 00:00, Mar 24 00:00) = 2d | [Mar 24 00:00, Mar 25 00:00) = 1d | mega + collapsed + tail |
-| 7d | 1hr | BATCH | Mar 25 00:00 | [Mar 25 00:00, Mar 25 14:00) = 14h | [Mar 18 00:00, Mar 20 00:00) = 2d | [Mar 20 00:00, Mar 25 00:00) = 5d | mega + collapsed + tail |
+| window | tier | category | effectiveStart | today entry range | batch tail hops | batch collapsed | fetcher uses |
+|--------|------|----------|---------------|-------------------|-----------------|-----------------|-------------|
+| 6h | 5min | SMALL | Mar 25 08:00 | [08:00, 14:00) = 6h | — | — | today only |
+| 1d | 1hr | SMALL | Mar 24 14:00 | [Mar 24 14:00, Mar 25 14:00) = 24h | — | — | today only |
+| 47h | 1hr | SMALL | Mar 23 15:00 | [Mar 23 15:00, Mar 25 14:00) = 47h | — | — | today only |
+| 2d | 1hr | SMALL | Mar 23 14:00 | [Mar 23 14:00, Mar 25 14:00) = 48h | — | — | today only |
+| 49h | 1hr | LARGE | Mar 25 00:00 | [Mar 25 00:00, Mar 25 14:00) = 14h | [Mar 22 23:00, Mar 24 23:00) = 2d | [Mar 24 23:00, Mar 25 00:00) = 1h | today + collapsed + tail |
+| 3d | 1hr | LARGE | Mar 25 00:00 | [Mar 25 00:00, Mar 25 14:00) = 14h | [Mar 22 00:00, Mar 24 00:00) = 2d | [Mar 24 00:00, Mar 25 00:00) = 1d | today + collapsed + tail |
+| 7d | 1hr | LARGE | Mar 25 00:00 | [Mar 25 00:00, Mar 25 14:00) = 14h | [Mar 18 00:00, Mar 20 00:00) = 2d | [Mar 20 00:00, Mar 25 00:00) = 5d | today + collapsed + tail |
 
 ### Scenario 2: Batch delayed (now = Mar 25 02:00, batchEnd = Mar 24 00:00)
 
-| window | tier | category | effectiveStart | mega tile range | batch tail hops | batch collapsed | fetcher uses |
-|--------|------|----------|---------------|-----------------|-----------------|-----------------|-------------|
-| 6h | 5min | NO BATCH | Mar 24 20:00 | [20:00, 02:00) = 6h | — | — | mega tile only |
-| 1d | 1hr | NO BATCH | Mar 24 02:00 | [Mar 24 02:00, Mar 25 02:00) = 24h | — | — | mega tile only |
-| 47h | 1hr | NO BATCH | Mar 23 03:00 | [Mar 23 03:00, Mar 25 02:00) = 47h | — | — | mega tile only |
-| 2d | 1hr | NO BATCH | Mar 23 02:00 | [Mar 23 02:00, Mar 25 02:00) = 48h | — | — | mega tile only |
-| 49h | 1hr | BATCH | Mar 24 00:00 | [Mar 24 00:00, Mar 25 02:00) = 26h | [Mar 21 23:00, Mar 23 23:00) = 2d | [Mar 23 23:00, Mar 24 00:00) = 1h | mega + collapsed + tail |
-| 3d | 1hr | BATCH | Mar 24 00:00 | [Mar 24 00:00, Mar 25 02:00) = 26h | [Mar 21 00:00, Mar 23 00:00) = 2d | [Mar 23 00:00, Mar 24 00:00) = 1d | mega + collapsed + tail |
-| 7d | 1hr | BATCH | Mar 24 00:00 | [Mar 24 00:00, Mar 25 02:00) = 26h | [Mar 17 00:00, Mar 19 00:00) = 2d | [Mar 19 00:00, Mar 24 00:00) = 5d | mega + collapsed + tail |
+| window | tier | category | effectiveStart | today entry range | yesterday entry range | fetcher uses |
+|--------|------|----------|---------------|-------------------|-----------------------|-------------|
+| 6h | 5min | SMALL | Mar 24 20:00 | [20:00, 02:00) = 6h | (ignored) | today only |
+| 1d | 1hr | SMALL | Mar 24 02:00 | [Mar 24 02:00, Mar 25 02:00) = 24h | (ignored) | today only |
+| 49h | 1hr | LARGE | — | [Mar 25 00:00, Mar 25 02:00) = 2h | [Mar 24 00:00, Mar 25 00:00) = 24h | yesterday + today + collapsed + tail |
+| 3d | 1hr | LARGE | — | [Mar 25 00:00, Mar 25 02:00) = 2h | [Mar 24 00:00, Mar 25 00:00) = 24h | yesterday + today + collapsed + tail |
 
-### Hourly tier state (max tiles across columns at that tier)
+For large windows with stale batch (`batchEnd < todayStart`): fetcher sums yesterday + today
+to cover `[batchEnd, now)`, then merges with batch collapsed + tail hops.
 
-| scenario | 1d | 47h | 2d | 49h | 3d | 7d | **max** |
-|----------|----|-----|----|----|----|----|---------|
-| Batch fresh | 24 | 47 | 48 | 14 | 14 | 14 | **48** (2d) |
-| Batch delayed | 24 | 47 | 48 | 26 | 26 | 26 | **48** (2d) |
+### Flink state size (max tiles per tier)
 
-The 2d NO BATCH column always drives hourly tier state since `now - 2d` extends further back
-than `batchEnd`.
+| tier | driven by | max tiles |
+|------|-----------|-----------|
+| 5min | 6h window (if present) | 72 |
+| 1hr | 2d window (max small) | 48 |
+
+The 2d SMALL column always drives hourly tier state since `now - 2d` extends further back
+than `todayStart`.
+
+## Architecture
+
+```
+Flink write path:
+  source → spark eval → watermarks → keyBy
+    → MegaTileProcessFunction (delegates to MegaTileStreamProcessor via TileStore)
+    → MegaTileAvroCodecFn (TileKey with DayMillis + dayStart)
+    → AsyncKVStoreWriter
+
+Fetcher read path:
+  GroupByFetcher: 2 point-get requests (today + yesterday)
+    → GroupByResponseHandler.mergeMegaTilesFromStreaming
+    → MegaTileCodec.decode (today + yesterday entries)
+    → MegaTileMerger.merge (batch + today + yesterday → finalized result)
+
+Shared pipeline tails (BaseFlinkJob):
+  buildTiledTail: keyBy → window aggregate → TiledAvroCodecFn → KV write
+  buildMegaTiledTail: keyBy → MegaTileProcessFunction → MegaTileAvroCodecFn → KV write
+  Both FlinkGroupByStreamingJob and ChainedGroupByJob use these.
+```
+
+## Test Coverage
+
+Tests at three layers, all comparing against NaiveAggregator:
+
+1. **MegaTileAggregatorTest** — tile building + serveMegaTile merge (6 tests)
+2. **MegaTileMergerTest** — per-day entry split + MegaTileMerger.merge (5 tests)
+3. **MegaTileStreamProcessorTest** — full Flink simulation with sawtooth + eviction (6 tests,
+   including multi-day watermark gap)
+4. **MegaTileCodecRoundTripTest** — serde round-trips via SerdeTileStore + key switch (3 tests)
+
+Windows tested: 6h, 1d, 47h, 2d, 49h, 3d, 7d.
+Aggregation types: SUM, COUNT, AVERAGE, MIN, MAX, LAST, FIRST.

--- a/docs/source/megatile.md
+++ b/docs/source/megatile.md
@@ -10,7 +10,8 @@ amplification and serving latency.
 
 Write **one mega tile per entity per day** to the KV store. The mega tile contains a **windowed IR**
 where each column has the correct aggregate for its specific window. This reduces KV store reads from
-O(N tiles) to 3 point gets: `(entity, today)` + `(entity, yesterday)` from stream KV + `(entity)` from batch KV.
+O(N tiles) to one batch point get plus one stream point get per daily key from query day back to
+the batch day, with one extra previous-day fallback key for no-batch columns.
 
 ## Opt-in
 
@@ -32,12 +33,14 @@ tailBuffer = 2d (default)
 Small windows (≤ tailBuffer):
   effectiveStart = now - window.millis
   Flink covers full window via tiles + sawtooth running IR.
-  Fetcher uses today's mega tile entry directly (self-contained).
+  Fetcher uses the newest available daily mega tile entry at or after yesterdayStart
+  (self-contained).
 
 Large windows (> tailBuffer) + unwindowed:
   effectiveStart = batchEnd (on fetcher side) or dayStart (on Flink side, per-day)
   Flink accumulates a daily running IR per day (today + yesterday).
-  Fetcher merges batch collapsed + tail hops + streaming daily aggregates.
+  Fetcher merges batch collapsed + tail hops + every available daily streaming aggregate from
+  the batch day through query day.
 ```
 
 ## Tier Assignment
@@ -72,6 +75,44 @@ Bookkeeping:
   earliestTileStart: ValueState<Long>
 ```
 
+## Flink ProcessFunction Mental Model
+
+There are two clocks in this operator:
+
+- **event time/watermark**: where Flink believes the stream has progressed in event time.
+- **processing time (PT)**: wall clock in the Flink task.
+
+There are two primary operating modes:
+
+**Live**: watermark is close enough to PT. The small-window cache and eviction use PT as the as-of
+time, matching vanilla tiled serving where reads enumerate tiles for wall-clock query time.
+
+**ActiveCatchup**: watermark is far behind PT for an active key, often because replay is lagged or
+allowed out-of-orderness is intentionally high. Event time is then decoupled from wall clock, so
+event-path cache updates and timer-path eviction both use `nextSmallWindowHop(watermark)` instead
+of PT. This avoids aging out replay tiles that are still current relative to the event-time
+frontier.
+
+Important details that are easy to mix up:
+
+- `processor.onEvent(row, eventTs, smallWindowAsOfTs)` receives `eventTs` separately so the
+  processor can choose the retained tile/day that the input row mutates. Mode does not choose that
+  tile; it chooses the as-of timestamp for cache and eviction behavior.
+- `smallWindowAsOfTs` is the event-path timestamp for deciding whether the touched tile contributes
+  to the cached small-window IR. The small-window cache is the Flink implementation of Chronon's
+  no-batch windows.
+- `evictionTime` is the timer-path timestamp for making state accurate as of that point: it can
+  roll day state, permanently drop expired retained tiles, and rebuild cached small-window IR.
+- `NoWatermark` is startup/bootstrap behavior: the event path uses the row's event hop, while timer
+  callbacks use PT because there is no watermark clock to trust yet.
+- `SparseKeyLag` is the idle-key fallback: the global watermark may lag because of other input, but
+  this key is not actively replaying, so timer callbacks use PT and values decay or roll forward
+  with wall clock.
+- Output buffering is write coalescing only. It uses PT timers to avoid emitting on every event or
+  eviction; it does not change event-time mutation or as-of selection.
+
+The code-order step-by-step walkthrough lives in `MegaTileProcessFunction.scala`.
+
 ### On Event
 
 1. **Update tiles** (small-window tiers only):
@@ -82,43 +123,59 @@ Bookkeeping:
    - ~2 tile codec ops per event (one per small-window tier)
 
 2. **Update cachedSmallWindowIr** (sawtooth):
-   - Merge event into running IR for all small-window columns (unconditional)
-   - Over-inclusive at the tail — eviction corrects this
-   - 1 windowed IR codec op
+   - `MegaTileProcessFunction` passes `smallWindowAsOfTs` separately from `eventTs`
+   - For each no-batch column, merge the event only when its accepted tile falls inside
+     `[effectiveStart(col, smallWindowAsOfTs, currentDayStart), smallWindowAsOfTs)`
+   - The base tile still uses `eventTs`, so retained late events can update wider current windows
+     or future rebuilds without re-inflating a stale small window that is outside the current as-of
+     horizon
+   - Up to 1 windowed IR codec op when a cached column is actually updated
 
 3. **Update large window daily IR** — route by event day:
+   - `eventTs >= nextDayStart` → clamp to today (future event; day transitions are not event-driven)
    - `eventTs >= todayStart` → update `largeTodayIr`
-   - `eventTs >= yesterdayStart` → update `largeYesterdayIr` (late event, within 2d tolerance)
-   - `eventTs >= nextDayStart` → clamp to today (future event; day transitions are watermark-driven)
-   - `eventTs < yesterdayStart` → drop for large windows (> 2d late)
+   - `eventTs >= yesterdayStart` → update `largeYesterdayIr` (retained late event)
+   - `eventTs < yesterdayStart` → no large-window update; Flink drops this before processor mutation
+     once `currentDayStart` is initialized
    - 1 windowed IR codec op
 
 4. **Emit** to KV store (only dirty targets):
    - Today's entry: pack `cachedSmallWindowIr` + `largeTodayIr` → `(entity, todayStart)`
    - Yesterday's entry (only if late event touched it): pack `null` + `largeYesterdayIr` → `(entity, yesterdayStart)`
 
-**Total hot-path cost per event: ~6 codec ops** (vs ~102 with bulk restore/persist).
+**Total hot-path cost per event: up to ~6 codec ops** (vs ~102 with bulk restore/persist).
 
 ### Day Transitions (advanceWatermark)
 
-Day transitions are **watermark-driven only** — never triggered by event timestamps. This prevents
-future-timestamped events from prematurely rotating state.
+Day transitions are never triggered directly by event timestamps. This prevents future-timestamped
+events from prematurely rotating state.
+
+- Event ingestion calls `advanceWatermark` with the current Flink watermark before applying the row.
+- Eviction timers call `advanceWatermark` with the selected eviction time: watermark-hop time in
+  `ActiveCatchup`, and PT in `NoWatermark`, `SparseKeyLag`, and `Live`.
+- Before an adjacent one-day roll, `MegaTileProcessFunction` emits any dirty today row under the
+  previous day key so buffered small-window state is not lost.
 
 ```
-wmDay = round(watermarkTs, DayMillis)
-if wmDay > currentDayStart:
+transitionDay = round(dayTransitionTs, DayMillis)
+if transitionDay > currentDayStart:
   // Single-day hop: carry today's aggregate to yesterday
   // Multi-day hop (e.g., after long idle): clear yesterday (stale beyond 2d tolerance)
-  largeYesterdayIr = if (wmDay == currentDayStart + DayMillis) largeTodayIr else init
+  largeYesterdayIr = if (transitionDay == currentDayStart + DayMillis) largeTodayIr else init
   largeTodayIr = init
-  currentDayStart = wmDay
+  currentDayStart = transitionDay
 ```
 
-### Eviction (onEviction, fires every minSmallWindowTileSize)
+### Eviction (onEviction, triggered by PT timer)
 
-1. Compute `retentionFloor` per small-window tier
+`MegaTileProcessFunction` keeps one PT eviction timer per key at the next min-hop boundary. The
+timer passes a mode-specific eviction time into `processor.onEviction`: watermark-hop time during
+active catchup, otherwise PT.
+
+1. Compute `retentionFloor` per small-window tier using the eviction time
 2. Remove tiles below floor
-3. **Rebuild `cachedSmallWindowIr`** from remaining tiles via `buildMegaTileIr(tiles, now, todayStart)`
+3. **Rebuild `cachedSmallWindowIr`** from remaining tiles via
+   `buildMegaTileIr(tiles, evictionTime, todayStart)`
    — corrects the sawtooth tail by scoping each column to its `effectiveStart`
 4. Emit updated today entry
 
@@ -146,26 +203,28 @@ read from different tiers and different time ranges but the same bucket index in
 
 ## Fetcher Merge (MegaTileMerger)
 
-Fetcher reads 3 entries: `(entity, today)`, `(entity, yesterday)` from stream KV + `(entity)` from batch KV.
+Fetcher reads one stream entry per daily key from query day back to the batch day, plus one extra
+previous-day fallback key for no-batch columns, and one batch entry `(entity)` from batch KV.
 
 ```
-def merge(batchIr, todayIr, yesterdayIr, todayStart, queryTs, batchEnd):
+def merge(batchIr, dailyTileIrs, queryTs, batchEnd):
   resultIr = clone(batchIr.collapsed) or init
+  batchDayStart = round(batchEnd, 1d)
+  noBatchFallbackDayStart = round(queryTs, 1d) - 1d
 
   for col in 0 until windowedAggregator.length:
     window = windowMappings(col).window
 
     if window != null and window.millis <= tailBufferMillis:   // SMALL WINDOW
-      // Self-contained in daily entry. Fall back to yesterday only if
-      // today's entire entry is absent (null array), not if column is null.
-      resultIr(col) = if todayIr != null then todayIr(col)
-                       else if yesterdayIr != null then yesterdayIr(col)
+      // Self-contained in daily entry. Use the newest non-null column value from
+      // query day or fallback day; clear stale batch values when all daily rows are absent.
+      resultIr(col) = newest dailyTileIr(col) where dayStart >= noBatchFallbackDayStart
 
     else:                                                       // LARGE WINDOW / UNWINDOWED
-      // Batch collapsed + streaming daily aggregates
-      if todayIr(col) != null: resultIr(col) = merge(resultIr(col), todayIr(col))
-      if batchEnd < todayStart and yesterdayIr(col) != null:
-        resultIr(col) = merge(resultIr(col), yesterdayIr(col))
+      // Batch collapsed + historical streaming daily aggregates, merged oldest -> newest.
+      for (dayStart, dailyIr) in dailyTileIrs if dayStart >= batchDayStart:
+        if dailyIr != null and dailyIr(col) != null:
+          resultIr(col) = merge(resultIr(col), dailyIr(col))
 
   // Tail hops for large windowed columns only (not small, not unwindowed)
   mergeTailHopsForBatchColumns(resultIr, queryTs, batchEnd, batchIr)
@@ -180,9 +239,9 @@ with `tileSizeMs = DayMillis`. Each day is a separate point-get key.
 
 - Flink emits `todayStart` (not raw `eventTs`) as the tile timestamp, so the codec always writes
   to the correct daily key even for future-timestamped events.
-- Fetcher constructs two explicit `GetRequest`s for today and yesterday using
-  `MegaTileMerger.streamingDayKeys(queryTs)`. Query time is resolved once and propagated to
-  avoid midnight-boundary inconsistency.
+- Fetcher constructs explicit `GetRequest`s for
+  `MegaTileMerger.streamingDayKeys(queryTs, batchEnd)`. Query time is resolved once and
+  propagated to avoid midnight-boundary inconsistency.
 
 ## Codec (MegaTileCodec)
 
@@ -192,19 +251,25 @@ Windowed IR (mega tile entries): `encode(ir)` / `decode(bytes)` using the window
 Base IR (individual tiles in Flink state): `encodeBaseIr(ir)` / `decodeBaseIr(bytes)` using the
 unwindowed base aggregator schema (one IR slot per aggregation bucket).
 
-AvroCodec instances are cached as `@transient lazy val` to avoid schema parsing per decode.
+`AvroCodec.of` internally uses `ThreadLocal`, so `MegaTileCodec` resolves codec instances through
+`def` accessors instead of sharing a single lazy instance across concurrent fetcher requests.
 
 ## Constraints
 
-- **Max batch staleness**: 2 days. Beyond that, large windows have a coverage gap between
-  batchEnd and yesterdayStart. Alert if batch is > 2 days stale.
-- **Sawtooth approximation**: Accepted for all aggregation types. Between evictions, small-window
-  columns are over-inclusive by up to one tile interval at the tail.
-- **Late events**: Up to 2 days late are handled (routed to yesterday's large-window IR).
-  Events > 2 days late are dropped for large windows (tiles may still capture them for small windows
-  if within retention).
-- **Future events**: Clamped to today for large windows. Day transitions are watermark-driven,
-  so future timestamps cannot corrupt state.
+- **Batch staleness**: Fetcher covers every daily stream key from the batch day through query day,
+  so large-window coverage remains continuous even when batch lags by multiple days.
+- **Sawtooth approximation**: Accepted for all aggregation types. Between evictions, cached
+  small-window columns can be over-inclusive by up to one tile interval at the tail. Retained late
+  events outside the current `smallWindowAsOfTs` horizon do not update stale cached columns.
+- **Late events**: Flink admits events with `eventTs >= currentDayStart - 1d`. A retained late
+  event always uses `eventTs` for base tile and large-window day routing, but it updates cached
+  small-window columns only when the touched tile is inside that column's current as-of horizon.
+  Events older than yesterday relative to `currentDayStart` are dropped before mutating state.
+- **Sparse-key lag**: If a key is idle while another input keeps the global watermark stale,
+  `SparseKeyLag` uses PT for eviction. That can roll `currentDayStart` forward and later cause old
+  backlog events to be dropped as older-than-yesterday for that key.
+- **Future events**: Clamped to today for large windows. Day transitions are driven by watermark or
+  timer eviction mode, not directly by event timestamps, so future timestamps cannot corrupt state.
 
 ## Scenario Tables
 
@@ -231,8 +296,9 @@ All windows, tailBuffer = 2d, batchEnd = Mar 25 00:00.
 | 49h | 1hr | LARGE | — | [Mar 25 00:00, Mar 25 02:00) = 2h | [Mar 24 00:00, Mar 25 00:00) = 24h | yesterday + today + collapsed + tail |
 | 3d | 1hr | LARGE | — | [Mar 25 00:00, Mar 25 02:00) = 2h | [Mar 24 00:00, Mar 25 00:00) = 24h | yesterday + today + collapsed + tail |
 
-For large windows with stale batch (`batchEnd < todayStart`): fetcher sums yesterday + today
-to cover `[batchEnd, now)`, then merges with batch collapsed + tail hops.
+For large windows with stale batch (`batchEnd < todayStart`): fetcher sums all daily stream entries
+from `batchDayStart` through `todayStart` to cover `[batchEnd, now)`, then merges with batch
+collapsed + tail hops.
 
 ### Flink state size (max tiles per tier)
 
@@ -254,10 +320,10 @@ Flink write path:
     → AsyncKVStoreWriter
 
 Fetcher read path:
-  GroupByFetcher: 2 point-get requests (today + yesterday)
+  GroupByFetcher: daily stream point gets from query day back to batch day (+ fallback day)
     → GroupByResponseHandler.mergeMegaTilesFromStreaming
-    → MegaTileCodec.decode (today + yesterday entries)
-    → MegaTileMerger.merge (batch + today + yesterday → finalized result)
+    → MegaTileCodec.decode (daily stream entries)
+    → MegaTileMerger.merge (batch + daily stream entries → finalized result)
 
 Shared pipeline tails (BaseFlinkJob):
   buildTiledTail: keyBy → window aggregate → TiledAvroCodecFn → KV write
@@ -267,13 +333,16 @@ Shared pipeline tails (BaseFlinkJob):
 
 ## Test Coverage
 
-Tests at three layers, all comparing against NaiveAggregator:
+Tests at five layers, with aggregator/codec tests comparing against NaiveAggregator:
 
-1. **MegaTileAggregatorTest** — tile building + serveMegaTile merge (6 tests)
-2. **MegaTileMergerTest** — per-day entry split + MegaTileMerger.merge (5 tests)
-3. **MegaTileStreamProcessorTest** — full Flink simulation with sawtooth + eviction (6 tests,
-   including multi-day watermark gap)
-4. **MegaTileCodecRoundTripTest** — serde round-trips via SerdeTileStore + key switch (3 tests)
+1. **MegaTileAggregatorTest** — tile building + serveMegaTile merge (7 tests)
+2. **MegaTileMergerTest** — per-day entry split + MegaTileMerger.merge (7 tests)
+3. **MegaTileStreamProcessorTest** — full processor simulation with sawtooth, as-of bounded late
+   events, and eviction (9 tests)
+4. **MegaTileCodecRoundTripTest** — serde round-trips via SerdeTileStore + key switch (5 tests)
+5. **MegaTileProcessFunctionTest** — Flink keyed process-function lifecycle coverage for Live,
+   ActiveCatchup, SparseKeyLag, buffered emit jitter, timer restore, malformed rows, and UTC day
+   boundaries (22 tests)
 
 Windows tested: 6h, 1d, 47h, 2d, 49h, 3d, 7d.
 Aggregation types: SUM, COUNT, AVERAGE, MIN, MAX, LAST, FIRST.

--- a/docs/source/megatile.md
+++ b/docs/source/megatile.md
@@ -1,0 +1,159 @@
+# Mega Tile Design
+
+## Problem
+
+Current tiling writes many small hop-aligned tiles per entity (up to 288/day at 5-min resolution).
+The serving side fetches all tiles via prefix scan and merges them per-window. This causes read
+amplification and serving latency.
+
+## Solution
+
+Write **one mega tile per entity per day** to the KV store. The mega tile contains a **windowed IR**
+where each column has the correct aggregate for its specific window. This reduces KV store reads from
+O(N tiles) to 2 point gets: `(entity, today)` + `(entity, yesterday)`.
+
+## Window Categories
+
+```
+tailBuffer = 2d (default)
+
+For each windowed column:
+  collapsedRange = max(0, window.millis - tailBufferMillis)
+
+  if window.millis <= tailBufferMillis:     → NO BATCH
+      effectiveStart = now - window.millis
+      Flink covers full window. Serving uses mega tile directly.
+
+  else:                                     → BATCH
+      effectiveStart = batchEnd
+      Mega tile covers [batchEnd, now). Serving merges with batch collapsed + tail hops.
+```
+
+## Tier Assignment
+
+Each column's hop size comes from `FiveMinuteResolution.calculateTailHop(window)`:
+
+| window range | hop size |
+|-------------|----------|
+| < 12h | 5min (300,000 ms) |
+| >= 12h, < 12d | 1hr (3,600,000 ms) |
+| >= 12d | 1day (86,400,000 ms) |
+
+## Small Tile Bucketing
+
+On each event at time T, for each active tier:
+```
+tileStart = TsUtils.round(T, hopSize)
+ir = tiles[hopSize].getOrInit(tileStart, baseAggregator.init)
+baseAggregator.update(ir, row)
+```
+
+Each event updates one tile per active tier. The `baseAggregator` is unwindowed
+(one IR slot per aggregation bucket, not per window).
+
+## Eviction
+
+Per tier, the retention floor is the minimum effectiveStart across all columns at that tier:
+```
+for each tier (hopSize):
+  columnsAtTier = columns where calculateTailHop(window) == hopSize
+  retentionFloor = min over columnsAtTier of:
+    if NO BATCH:  now - window.millis
+    if BATCH:     batchEnd
+  evictionCutoff = retentionFloor - hopSize   // one buffer tile
+  remove all tiles in tier where tileStart < evictionCutoff
+```
+
+Eviction fires every `min_tile_size` interval (event-time timer in Flink). When tiles are evicted,
+the mega tile is rebuilt from remaining tiles and written to KV store. This keeps the mega tile
+fresh even for idle entities (timers fire from global watermark advancement).
+
+## Mega Tile Construction (Windowed IR)
+
+```
+megaTileIr = windowedAggregator.init    // Array of length = #windowed columns
+
+for col in 0 until windowedAggregator.length:
+  hopSize = calculateTailHop(windowMappings(col).window)
+  effStart = effectiveStart(col, now, batchEnd)
+  bucketIdx = baseIrIndices(col)    // maps windowed col → unwindowed bucket
+
+  for (tileStart, tileIr) in tiles[hopSize]:
+    if tileStart >= effStart and tileStart < now:
+      megaTileIr(col) = windowedAggregator(col).merge(megaTileIr(col), tileIr(bucketIdx))
+```
+
+Multiple windowed columns (e.g., sum_6h, sum_2d) that share the same bucket (sum)
+read from different tiers and different time ranges but the same bucket index in the tile IR.
+
+## Serving Merge
+
+```
+def serveMegaTile(batchIr, megaTileIr, queryTs):
+  resultIr = windowedAggregator.init
+
+  for col in 0 until windowedAggregator.length:
+    window = windowMappings(col).aggregationPart.window
+
+    if window == null:                             // unwindowed
+      resultIr(col) = merge(batchIr.collapsed(col), megaTileIr(col))
+
+    elif window.millis <= tailBufferMillis:         // NO BATCH
+      resultIr(col) = megaTileIr(col)
+
+    else:                                           // BATCH
+      resultIr(col) = merge(batchIr.collapsed(col), megaTileIr(col))
+
+  // Tail hops for BATCH columns (window > tailBuffer)
+  mergeTailHops(resultIr, queryTs, batchEnd, batchIr)
+
+  return windowedAggregator.finalize(resultIr)
+```
+
+## Daily KV Key Scheme
+
+In production (Flink/Fetcher), the mega tile is stored as `(entity, day)`:
+- Flink writes to `(entity, today)` on each event and eviction
+- At midnight, starts writing to `(entity, new_day)` — ≤2d columns immediately correct
+  because Flink state has small tiles spanning midnight
+- Fetcher always reads `(entity, today)` + `(entity, yesterday)`
+- For ≤2d columns: use today's windowed value (kept fresh by eviction timer)
+- For >2d columns: merge daily aggregates from `[batchEnd, now)` + batch
+
+## Scenario Tables
+
+All windows, tailBuffer = 2d, batchEnd = Mar 25 00:00.
+
+### Scenario 1: Batch fresh (now = Mar 25 14:00, batchEnd = Mar 25 00:00)
+
+| window | tier | category | effectiveStart | mega tile range | batch tail hops | batch collapsed | fetcher uses |
+|--------|------|----------|---------------|-----------------|-----------------|-----------------|-------------|
+| 6h | 5min | NO BATCH | Mar 25 08:00 | [08:00, 14:00) = 6h | — | — | mega tile only |
+| 1d | 1hr | NO BATCH | Mar 24 14:00 | [Mar 24 14:00, Mar 25 14:00) = 24h | — | — | mega tile only |
+| 47h | 1hr | NO BATCH | Mar 23 15:00 | [Mar 23 15:00, Mar 25 14:00) = 47h | — | — | mega tile only |
+| 2d | 1hr | NO BATCH | Mar 23 14:00 | [Mar 23 14:00, Mar 25 14:00) = 48h | — | — | mega tile only |
+| 49h | 1hr | BATCH | Mar 25 00:00 | [Mar 25 00:00, Mar 25 14:00) = 14h | [Mar 22 23:00, Mar 24 23:00) = 2d | [Mar 24 23:00, Mar 25 00:00) = 1h | mega + collapsed + tail |
+| 3d | 1hr | BATCH | Mar 25 00:00 | [Mar 25 00:00, Mar 25 14:00) = 14h | [Mar 22 00:00, Mar 24 00:00) = 2d | [Mar 24 00:00, Mar 25 00:00) = 1d | mega + collapsed + tail |
+| 7d | 1hr | BATCH | Mar 25 00:00 | [Mar 25 00:00, Mar 25 14:00) = 14h | [Mar 18 00:00, Mar 20 00:00) = 2d | [Mar 20 00:00, Mar 25 00:00) = 5d | mega + collapsed + tail |
+
+### Scenario 2: Batch delayed (now = Mar 25 02:00, batchEnd = Mar 24 00:00)
+
+| window | tier | category | effectiveStart | mega tile range | batch tail hops | batch collapsed | fetcher uses |
+|--------|------|----------|---------------|-----------------|-----------------|-----------------|-------------|
+| 6h | 5min | NO BATCH | Mar 24 20:00 | [20:00, 02:00) = 6h | — | — | mega tile only |
+| 1d | 1hr | NO BATCH | Mar 24 02:00 | [Mar 24 02:00, Mar 25 02:00) = 24h | — | — | mega tile only |
+| 47h | 1hr | NO BATCH | Mar 23 03:00 | [Mar 23 03:00, Mar 25 02:00) = 47h | — | — | mega tile only |
+| 2d | 1hr | NO BATCH | Mar 23 02:00 | [Mar 23 02:00, Mar 25 02:00) = 48h | — | — | mega tile only |
+| 49h | 1hr | BATCH | Mar 24 00:00 | [Mar 24 00:00, Mar 25 02:00) = 26h | [Mar 21 23:00, Mar 23 23:00) = 2d | [Mar 23 23:00, Mar 24 00:00) = 1h | mega + collapsed + tail |
+| 3d | 1hr | BATCH | Mar 24 00:00 | [Mar 24 00:00, Mar 25 02:00) = 26h | [Mar 21 00:00, Mar 23 00:00) = 2d | [Mar 23 00:00, Mar 24 00:00) = 1d | mega + collapsed + tail |
+| 7d | 1hr | BATCH | Mar 24 00:00 | [Mar 24 00:00, Mar 25 02:00) = 26h | [Mar 17 00:00, Mar 19 00:00) = 2d | [Mar 19 00:00, Mar 24 00:00) = 5d | mega + collapsed + tail |
+
+### Hourly tier state (max tiles across columns at that tier)
+
+| scenario | 1d | 47h | 2d | 49h | 3d | 7d | **max** |
+|----------|----|-----|----|----|----|----|---------|
+| Batch fresh | 24 | 47 | 48 | 14 | 14 | 14 | **48** (2d) |
+| Batch delayed | 24 | 47 | 48 | 26 | 26 | 26 | **48** (2d) |
+
+The 2d NO BATCH column always drives hourly tier state since `now - 2d` extends further back
+than `batchEnd`.

--- a/flink/package.mill
+++ b/flink/package.mill
@@ -48,6 +48,7 @@ trait FlinkModule extends Cross.Module[String] with build.BaseModule {
       mvn"org.apache.flink:flink-test-utils:$flinkVersion"
         .exclude("org.apache.logging.log4j" -> "log4j-slf4j-impl")
         .exclude("log4j" -> "log4j"),
+      mvn"org.apache.flink:flink-streaming-java:$flinkVersion;classifier=tests",
       mvn"org.apache.spark::spark-hive:${build.Constants.sparkVersion}",
       mvn"org.apache.spark::spark-core:${build.Constants.sparkVersion}"
         .exclude("com.fasterxml.jackson.core" -> "jackson-core")

--- a/flink/src/main/scala/ai/chronon/flink/FlinkGroupByStreamingJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkGroupByStreamingJob.scala
@@ -6,6 +6,7 @@ import ai.chronon.flink.FlinkJob.watermarkStrategy
 import ai.chronon.flink.deser.ProjectedEvent
 import ai.chronon.flink.source.FlinkSource
 import ai.chronon.flink.types.{AvroCodecOutput, WriteResponse}
+import ai.chronon.flink.window.MegaTileEmissionPolicy
 import ai.chronon.online.{GroupByServingInfoParsed, TopicInfo}
 import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
@@ -49,6 +50,11 @@ class FlinkGroupByStreamingJob(eventSrc: FlinkSource[ProjectedEvent],
     FlinkUtils.getNonNegativeLongProperty("buffering_output_time_millis", props, topicInfo)
   private val bufferingOutputJitterMillis =
     FlinkUtils.getNonNegativeLongProperty("buffering_output_jitter_millis", props, topicInfo)
+  private val bufferingOutputPolicy =
+    FlinkUtils
+      .getProperty("buffering_output_policy", props, topicInfo)
+      .map(MegaTileEmissionPolicy.fromString)
+      .getOrElse(MegaTileEmissionPolicy.Default)
 
   // The source of our Flink application is a  topic
   val topic: String = groupByServingInfoParsed.groupBy.streamingSource.get.topic
@@ -137,7 +143,8 @@ class FlinkGroupByStreamingJob(eventSrc: FlinkSource[ProjectedEvent],
                        kvStoreCapacity,
                        enableDebug,
                        bufferingOutputTimeMillis,
-                       bufferingOutputJitterMillis)
+                       bufferingOutputJitterMillis,
+                       bufferingOutputPolicy)
   }
 
   private def buildSourceStream(env: StreamExecutionEnvironment): DataStream[ProjectedEvent] = {

--- a/flink/src/main/scala/ai/chronon/flink/FlinkGroupByStreamingJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkGroupByStreamingJob.scala
@@ -210,7 +210,7 @@ class FlinkGroupByStreamingJob(eventSrc: FlinkSource[ProjectedEvent],
     )
   }
 
-  def runMegaTiledGroupByJob(env: StreamExecutionEnvironment): DataStream[WriteResponse] = {
+  override def runMegaTiledGroupByJob(env: StreamExecutionEnvironment): DataStream[WriteResponse] = {
     logger.info(
       f"Running Mega Tiled Flink job for groupByName=${groupByName}, Topic=${topic}.")
 

--- a/flink/src/main/scala/ai/chronon/flink/FlinkGroupByStreamingJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkGroupByStreamingJob.scala
@@ -45,6 +45,10 @@ class FlinkGroupByStreamingJob(eventSrc: FlinkSource[ProjectedEvent],
     .getProperty("kv_concurrency", props, topicInfo)
     .map(_.toInt)
     .getOrElse(AsyncKVStoreWriter.kvStoreConcurrency)
+  private val bufferingOutputTimeMillis =
+    FlinkUtils.getNonNegativeLongProperty("buffering_output_time_millis", props, topicInfo)
+  private val bufferingOutputJitterMillis =
+    FlinkUtils.getNonNegativeLongProperty("buffering_output_jitter_millis", props, topicInfo)
 
   // The source of our Flink application is a  topic
   val topic: String = groupByServingInfoParsed.groupBy.streamingSource.get.topic
@@ -126,7 +130,14 @@ class FlinkGroupByStreamingJob(eventSrc: FlinkSource[ProjectedEvent],
   override def runMegaTiledGroupByJob(env: StreamExecutionEnvironment): DataStream[WriteResponse] = {
     logger.info(f"Running Mega Tiled Flink job for groupByName=${groupByName}, Topic=${topic}.")
     val preparedStream = buildSourceStream(env)
-    buildMegaTiledTail(preparedStream, inputSchema, parallelism, sinkFn, kvStoreCapacity, enableDebug)
+    buildMegaTiledTail(preparedStream,
+                       inputSchema,
+                       parallelism,
+                       sinkFn,
+                       kvStoreCapacity,
+                       enableDebug,
+                       bufferingOutputTimeMillis,
+                       bufferingOutputJitterMillis)
   }
 
   private def buildSourceStream(env: StreamExecutionEnvironment): DataStream[ProjectedEvent] = {

--- a/flink/src/main/scala/ai/chronon/flink/FlinkGroupByStreamingJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkGroupByStreamingJob.scala
@@ -1,29 +1,15 @@
 package ai.chronon.flink
 
-import ai.chronon.aggregator.windowing.ResolutionUtils
 import ai.chronon.api.Extensions.{GroupByOps, SourceOps}
 import ai.chronon.api.DataType
 import ai.chronon.flink.FlinkJob.watermarkStrategy
 import ai.chronon.flink.deser.ProjectedEvent
 import ai.chronon.flink.source.FlinkSource
-import ai.chronon.flink.types.{AvroCodecOutput, TimestampedTile, WriteResponse}
-import ai.chronon.flink.window.{
-  AlwaysFireOnElementTrigger,
-  BufferedProcessingTimeTrigger,
-  FlinkRowAggProcessFunction,
-  FlinkRowAggregationFunction,
-  KeySelectorBuilder,
-  MegaTileProcessFunction
-}
+import ai.chronon.flink.types.{AvroCodecOutput, WriteResponse}
 import ai.chronon.online.{GroupByServingInfoParsed, TopicInfo}
-import org.apache.flink.streaming.api.datastream.{DataStream, SingleOutputStreamOperator}
+import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.streaming.api.functions.async.RichAsyncFunction
-import org.apache.flink.streaming.api.windowing.assigners.{TumblingEventTimeWindows, WindowAssigner}
-import org.apache.flink.streaming.api.windowing.time.Time
-import org.apache.flink.streaming.api.windowing.triggers.Trigger
-import org.apache.flink.streaming.api.windowing.windows.TimeWindow
-import org.apache.flink.util.OutputTag
 
 /** Flink job that processes a single streaming GroupBy and writes out the results (in the form of pre-aggregated tiles) to the KV store.
   *
@@ -124,141 +110,28 @@ class FlinkGroupByStreamingJob(eventSrc: FlinkSource[ProjectedEvent],
     *  The window causes a split in the Flink DAG, so there are two nodes, (1+2) and (3+4+5).
     */
   override def runTiledGroupByJob(env: StreamExecutionEnvironment): DataStream[WriteResponse] = {
-    logger.info(
-      f"Running Flink job for groupByName=${groupByName}, Topic=${topic}. " +
-        "Tiling is enabled.")
-
-    val tilingWindowSizeInMillis: Long =
-      ResolutionUtils.getSmallestTailHopMillis(groupByServingInfoParsed.groupBy)
-
-    // we expect parallelism on the source stream to be set by the source provider
-    val sourceSparkProjectedStream: DataStream[ProjectedEvent] =
-      eventSrc
-        .getDataStream(topic, groupByName)(env, parallelism)
-        .uid(s"source-$groupByName")
-        .name(s"Source for $groupByName")
-
-    val sparkExprEvalDSAndWatermarks: DataStream[ProjectedEvent] = sourceSparkProjectedStream
-      .assignTimestampsAndWatermarks(watermarkStrategy)
-      .uid(s"spark-expr-eval-timestamps-$groupByName")
-      .name(s"Spark expression eval with timestamps for $groupByName")
-      .setParallelism(sourceSparkProjectedStream.getParallelism)
-
-    val window = TumblingEventTimeWindows
-      .of(Time.milliseconds(tilingWindowSizeInMillis))
-      .asInstanceOf[WindowAssigner[ProjectedEvent, TimeWindow]]
-
-    // We default to the AlwaysFireOnElementTrigger which will cause the window to "FIRE" on every element.
-    // An alternative is the BufferedProcessingTimeTrigger (trigger=buffered in topic info
-    // or properties) which will buffer writes and only "FIRE" every X milliseconds per GroupBy & key.
-    val trigger = getTrigger()
-
-    // allowedLateness keeps window state open after the watermark passes the window end,
-    // allowing late events to still be processed. Configurable via allowed_lateness_seconds property.
-    // Default: 0 (disabled).
-    val allowedLatenessMs = getAllowedLatenessMs()
-
-    // We use Flink "Side Outputs" to track any late events that aren't computed.
-    val tilingLateEventsTag = new OutputTag[ProjectedEvent]("tiling-late-events") {}
-
-    // The tiling operator works the following way:
-    // 1. Input: Spark expression eval (previous operator)
-    // 2. Key by the entity key(s) defined in the groupby
-    // 3. Window by a tumbling window
-    // 4. Use our custom trigger that will "FIRE" on every element
-    // 5. the AggregationFunction merges each incoming element with the current IRs which are kept in state
-    //    - Each time a "FIRE" is triggered (i.e. on every event), getResult() is called and the current IRs are emitted
-    // 6. A process window function does additional processing each time the AggregationFunction emits results
-    //    - The only purpose of this window function is to mark tiles as closed so we can do client-side caching in SFS
-    // 7. Output: TimestampedTile, containing the current IRs (Avro encoded) and the timestamp of the current element
-
-    val tilingDS: SingleOutputStreamOperator[TimestampedTile] =
-      sparkExprEvalDSAndWatermarks
-        .keyBy(KeySelectorBuilder.build(groupByServingInfoParsed.groupBy))
-        .window(window)
-        .allowedLateness(Time.milliseconds(allowedLatenessMs))
-        .trigger(trigger)
-        .sideOutputLateData(tilingLateEventsTag)
-        .aggregate(
-          // See Flink's "ProcessWindowFunction with Incremental Aggregation"
-          new FlinkRowAggregationFunction(groupByServingInfoParsed.groupBy, inputSchema, enableDebug),
-          new FlinkRowAggProcessFunction(groupByServingInfoParsed.groupBy, inputSchema, enableDebug)
-        )
-        .uid(s"tiling-01-$groupByName")
-        .name(s"Tiling for $groupByName")
-        .setParallelism(sourceSparkProjectedStream.getParallelism)
-
-    // Track late events
-    tilingDS
-      .getSideOutput(tilingLateEventsTag)
-      .flatMap(new LateEventCounter(groupByName))
-      .uid(s"tiling-side-output-01-$groupByName")
-      .name(s"Tiling Side Output Late Data for $groupByName")
-      .setParallelism(sourceSparkProjectedStream.getParallelism)
-
-    val putRecordDS: DataStream[AvroCodecOutput] = tilingDS
-      .flatMap(TiledAvroCodecFn(groupByServingInfoParsed, tilingWindowSizeInMillis, enableDebug))
-      .uid(s"avro-conversion-01-$groupByName")
-      .name(s"Avro conversion for $groupByName")
-      .setParallelism(sourceSparkProjectedStream.getParallelism)
-
-    AsyncKVStoreWriter.withUnorderedWaits(
-      putRecordDS,
-      sinkFn,
-      groupByName,
-      capacity = kvStoreCapacity
-    )
+    logger.info(f"Running Flink job for groupByName=${groupByName}, Topic=${topic}. Tiling is enabled.")
+    val preparedStream = buildSourceStream(env)
+    buildTiledTail(preparedStream, inputSchema, parallelism, sinkFn, kvStoreCapacity, props, topicInfo, enableDebug)
   }
 
   override def runMegaTiledGroupByJob(env: StreamExecutionEnvironment): DataStream[WriteResponse] = {
-    logger.info(
-      f"Running Mega Tiled Flink job for groupByName=${groupByName}, Topic=${topic}.")
+    logger.info(f"Running Mega Tiled Flink job for groupByName=${groupByName}, Topic=${topic}.")
+    val preparedStream = buildSourceStream(env)
+    buildMegaTiledTail(preparedStream, inputSchema, parallelism, sinkFn, kvStoreCapacity, enableDebug)
+  }
 
-    val sourceSparkProjectedStream: DataStream[ProjectedEvent] =
-      eventSrc
-        .getDataStream(topic, groupByName)(env, parallelism)
-        .uid(s"source-$groupByName")
-        .name(s"Source for $groupByName")
+  private def buildSourceStream(env: StreamExecutionEnvironment): DataStream[ProjectedEvent] = {
+    val sourceSparkProjectedStream = eventSrc
+      .getDataStream(topic, groupByName)(env, parallelism)
+      .uid(s"source-$groupByName")
+      .name(s"Source for $groupByName")
 
-    val sparkExprEvalDSAndWatermarks: DataStream[ProjectedEvent] = sourceSparkProjectedStream
+    sourceSparkProjectedStream
       .assignTimestampsAndWatermarks(watermarkStrategy)
       .uid(s"spark-expr-eval-timestamps-$groupByName")
       .name(s"Spark expression eval with timestamps for $groupByName")
       .setParallelism(sourceSparkProjectedStream.getParallelism)
-
-    val megaTileDS: DataStream[TimestampedTile] = sparkExprEvalDSAndWatermarks
-      .keyBy(KeySelectorBuilder.build(groupByServingInfoParsed.groupBy))
-      .process(
-        new MegaTileProcessFunction(groupByServingInfoParsed.groupBy, inputSchema, enableDebug))
-      .uid(s"mega-tiling-$groupByName")
-      .name(s"Mega Tiling for $groupByName")
-      .setParallelism(sourceSparkProjectedStream.getParallelism)
-
-    val putRecordDS: DataStream[AvroCodecOutput] = megaTileDS
-      .flatMap(MegaTileAvroCodecFn(groupByServingInfoParsed, enableDebug))
-      .uid(s"mega-avro-conversion-$groupByName")
-      .name(s"Mega Tile Avro conversion for $groupByName")
-      .setParallelism(sourceSparkProjectedStream.getParallelism)
-
-    AsyncKVStoreWriter.withUnorderedWaits(
-      putRecordDS,
-      sinkFn,
-      groupByName,
-      capacity = kvStoreCapacity
-    )
   }
 
-  private def getTrigger(): Trigger[ProjectedEvent, TimeWindow] = {
-    FlinkUtils
-      .getProperty("trigger", props, topicInfo)
-      .map {
-        case "always_fire" => new AlwaysFireOnElementTrigger()
-        case "buffered"    => new BufferedProcessingTimeTrigger(100L)
-        case t =>
-          throw new IllegalArgumentException(s"Unsupported trigger type: $t. Supported: 'always_fire', 'buffered'")
-      }
-      .getOrElse(new AlwaysFireOnElementTrigger())
-  }
-
-  private def getAllowedLatenessMs(): Long = FlinkUtils.getAllowedLatenessMs(props, topicInfo)
 }

--- a/flink/src/main/scala/ai/chronon/flink/FlinkGroupByStreamingJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkGroupByStreamingJob.scala
@@ -12,7 +12,8 @@ import ai.chronon.flink.window.{
   BufferedProcessingTimeTrigger,
   FlinkRowAggProcessFunction,
   FlinkRowAggregationFunction,
-  KeySelectorBuilder
+  KeySelectorBuilder,
+  MegaTileProcessFunction
 }
 import ai.chronon.online.{GroupByServingInfoParsed, TopicInfo}
 import org.apache.flink.streaming.api.datastream.{DataStream, SingleOutputStreamOperator}
@@ -199,6 +200,44 @@ class FlinkGroupByStreamingJob(eventSrc: FlinkSource[ProjectedEvent],
       .flatMap(TiledAvroCodecFn(groupByServingInfoParsed, tilingWindowSizeInMillis, enableDebug))
       .uid(s"avro-conversion-01-$groupByName")
       .name(s"Avro conversion for $groupByName")
+      .setParallelism(sourceSparkProjectedStream.getParallelism)
+
+    AsyncKVStoreWriter.withUnorderedWaits(
+      putRecordDS,
+      sinkFn,
+      groupByName,
+      capacity = kvStoreCapacity
+    )
+  }
+
+  def runMegaTiledGroupByJob(env: StreamExecutionEnvironment): DataStream[WriteResponse] = {
+    logger.info(
+      f"Running Mega Tiled Flink job for groupByName=${groupByName}, Topic=${topic}.")
+
+    val sourceSparkProjectedStream: DataStream[ProjectedEvent] =
+      eventSrc
+        .getDataStream(topic, groupByName)(env, parallelism)
+        .uid(s"source-$groupByName")
+        .name(s"Source for $groupByName")
+
+    val sparkExprEvalDSAndWatermarks: DataStream[ProjectedEvent] = sourceSparkProjectedStream
+      .assignTimestampsAndWatermarks(watermarkStrategy)
+      .uid(s"spark-expr-eval-timestamps-$groupByName")
+      .name(s"Spark expression eval with timestamps for $groupByName")
+      .setParallelism(sourceSparkProjectedStream.getParallelism)
+
+    val megaTileDS: DataStream[TimestampedTile] = sparkExprEvalDSAndWatermarks
+      .keyBy(KeySelectorBuilder.build(groupByServingInfoParsed.groupBy))
+      .process(
+        new MegaTileProcessFunction(groupByServingInfoParsed.groupBy, inputSchema, enableDebug))
+      .uid(s"mega-tiling-$groupByName")
+      .name(s"Mega Tiling for $groupByName")
+      .setParallelism(sourceSparkProjectedStream.getParallelism)
+
+    val putRecordDS: DataStream[AvroCodecOutput] = megaTileDS
+      .flatMap(MegaTileAvroCodecFn(groupByServingInfoParsed, enableDebug))
+      .uid(s"mega-avro-conversion-$groupByName")
+      .name(s"Mega Tile Avro conversion for $groupByName")
       .setParallelism(sourceSparkProjectedStream.getParallelism)
 
     AsyncKVStoreWriter.withUnorderedWaits(

--- a/flink/src/main/scala/ai/chronon/flink/FlinkGroupByStreamingJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkGroupByStreamingJob.scala
@@ -112,7 +112,15 @@ class FlinkGroupByStreamingJob(eventSrc: FlinkSource[ProjectedEvent],
   override def runTiledGroupByJob(env: StreamExecutionEnvironment): DataStream[WriteResponse] = {
     logger.info(f"Running Flink job for groupByName=${groupByName}, Topic=${topic}. Tiling is enabled.")
     val preparedStream = buildSourceStream(env)
-    buildTiledTail(preparedStream, inputSchema, parallelism, sinkFn, kvStoreCapacity, props, topicInfo, enableDebug)
+    buildTiledTail(preparedStream,
+                   inputSchema,
+                   parallelism,
+                   sinkFn,
+                   kvStoreCapacity,
+                   props,
+                   topicInfo,
+                   enableDebug,
+                   uidSuffix = "-01")
   }
 
   override def runMegaTiledGroupByJob(env: StreamExecutionEnvironment): DataStream[WriteResponse] = {

--- a/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
@@ -17,6 +17,7 @@ import ai.chronon.flink.window.{
   FlinkRowAggProcessFunction,
   FlinkRowAggregationFunction,
   KeySelectorBuilder,
+  MegaTileEmissionPolicy,
   MegaTileProcessFunction
 }
 import ai.chronon.online.fetcher.{FetchContext, MetadataStore}
@@ -137,7 +138,8 @@ abstract class BaseFlinkJob {
       kvStoreCapacity: Int,
       enableDebug: Boolean,
       bufferingOutputTimeMillis: Long,
-      bufferingOutputJitterMillis: Long
+      bufferingOutputJitterMillis: Long,
+      emissionPolicy: MegaTileEmissionPolicy
   ): DataStream[WriteResponse] = {
     val megaTileDS = preparedStream
       .keyBy(KeySelectorBuilder.build(groupByServingInfoParsed.groupBy))
@@ -146,7 +148,8 @@ abstract class BaseFlinkJob {
                                     schema,
                                     enableDebug,
                                     bufferingOutputTimeMillis,
-                                    bufferingOutputJitterMillis))
+                                    bufferingOutputJitterMillis,
+                                    emissionPolicy))
       .uid(s"mega-tiling-$groupByName")
       .name(s"Mega Tiling for $groupByName")
       .setParallelism(parallelism)

--- a/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
@@ -135,11 +135,18 @@ abstract class BaseFlinkJob {
       parallelism: Int,
       sinkFn: RichAsyncFunction[AvroCodecOutput, WriteResponse],
       kvStoreCapacity: Int,
-      enableDebug: Boolean
+      enableDebug: Boolean,
+      bufferingOutputTimeMillis: Long,
+      bufferingOutputJitterMillis: Long
   ): DataStream[WriteResponse] = {
     val megaTileDS = preparedStream
       .keyBy(KeySelectorBuilder.build(groupByServingInfoParsed.groupBy))
-      .process(new MegaTileProcessFunction(groupByServingInfoParsed.groupBy, schema, enableDebug))
+      .process(
+        new MegaTileProcessFunction(groupByServingInfoParsed.groupBy,
+                                    schema,
+                                    enableDebug,
+                                    bufferingOutputTimeMillis,
+                                    bufferingOutputJitterMillis))
       .uid(s"mega-tiling-$groupByName")
       .name(s"Mega Tiling for $groupByName")
       .setParallelism(parallelism)
@@ -206,6 +213,8 @@ object FlinkJob {
   // Keep windows open for a bit longer before closing to ensure we don't lose data due to late arrivals (needed in case of
   // tiling implementation)
   val AllowedOutOfOrderness: Duration = Duration.ofMinutes(5)
+
+  val CatchupWatermarkLagSlackMillis: Long = 30 * 1000L
 
   // Set an idleness timeout to keep time moving in case of very low traffic event streams as well as late events during
   // large backlog catchups

--- a/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
@@ -61,9 +61,22 @@ abstract class BaseFlinkJob {
   def runTiledGroupByJob(env: StreamExecutionEnvironment): DataStream[WriteResponse]
 
   /** Run the streaming job with mega tiling enabled.
-    * Default delegates to buildMegaTiledTail. Subclasses must provide source setup.
+    *
+    * Default implementation throws — opt-in for any subclass that wants MegaTile. Concrete
+    * BaseFlinkJob subclasses in this repo (FlinkGroupByStreamingJob, ChainedGroupByJob)
+    * override and delegate to `buildMegaTiledTail`. Custom subclasses outside this repo
+    * that don't override stay source-compatible (no compile break) but will fail loudly
+    * at job startup if their GroupBy has `onlineStrategy = STREAMING_MEGATILES` — which
+    * matches chronon's serving-correctness model: a misconfigured job should not silently
+    * fall back to DEFAULT-mode output when the user explicitly asked for MegaTile.
     */
-  def runMegaTiledGroupByJob(env: StreamExecutionEnvironment): DataStream[WriteResponse]
+  def runMegaTiledGroupByJob(env: StreamExecutionEnvironment): DataStream[WriteResponse] =
+    throw new UnsupportedOperationException(
+      s"${getClass.getSimpleName} does not implement runMegaTiledGroupByJob. " +
+        s"GroupBy '$groupByName' has onlineStrategy=STREAMING_MEGATILES, but the Flink job " +
+        "subclass dispatched for it doesn't support mega-tiled execution. Override " +
+        "runMegaTiledGroupByJob to opt in, or unset STREAMING_MEGATILES on this GroupBy."
+    )
 
   /** Shared tail for tiled pipeline: keyBy → window aggregate → tile codec → KV write.
     * Both FlinkGroupByStreamingJob and ChainedGroupByJob use this with their respective

--- a/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
@@ -230,7 +230,10 @@ object FlinkJob {
       FlinkJob.runWriteInternalManifestJob(env, jobArgs.streamingManifestPath(), maybeParentJobId.get, groupByName)
     }
 
-    val jobDatastream = flinkJob.runTiledGroupByJob(env)
+    val isMegaTiling = new GroupByOps(flinkJob.groupByServingInfoParsed.groupBy).isMegaTilingEnabled
+    val jobDatastream =
+      if (isMegaTiling) flinkJob.asInstanceOf[FlinkGroupByStreamingJob].runMegaTiledGroupByJob(env)
+      else flinkJob.runTiledGroupByJob(env)
 
     jobDatastream
       .addSink(new MetricsSink(groupByName))

--- a/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
@@ -41,6 +41,13 @@ abstract class BaseFlinkJob {
     * This is the main execution method that should be implemented by subclasses.
     */
   def runTiledGroupByJob(env: StreamExecutionEnvironment): DataStream[WriteResponse]
+
+  /** Run the streaming job with mega tiling enabled.
+    * Subclasses that support mega tiling should override this.
+    */
+  def runMegaTiledGroupByJob(env: StreamExecutionEnvironment): DataStream[WriteResponse] =
+    throw new UnsupportedOperationException(
+      s"Mega tiling is not supported for ${getClass.getSimpleName} (groupBy=$groupByName)")
 }
 
 object FlinkJob {
@@ -232,7 +239,7 @@ object FlinkJob {
 
     val isMegaTiling = new GroupByOps(flinkJob.groupByServingInfoParsed.groupBy).isMegaTilingEnabled
     val jobDatastream =
-      if (isMegaTiling) flinkJob.asInstanceOf[FlinkGroupByStreamingJob].runMegaTiledGroupByJob(env)
+      if (isMegaTiling) flinkJob.runMegaTiledGroupByJob(env)
       else flinkJob.runTiledGroupByJob(env)
 
     jobDatastream

--- a/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
@@ -1,18 +1,28 @@
 package ai.chronon.flink
 
+import ai.chronon.aggregator.windowing.ResolutionUtils
 import ai.chronon.api.Constants.MetadataDataset
+import ai.chronon.api.DataType
 import ai.chronon.api.Extensions.{GroupByOps, SourceOps}
 import ai.chronon.api.{Constants, DataModel}
 import ai.chronon.flink.{AsyncKVStoreWriter, FlinkGroupByStreamingJob}
 import ai.chronon.flink.deser.{DeserializationSchemaBuilder, FlinkSerDeProvider, ProjectedEvent, SourceProjection}
 import ai.chronon.flink.chaining.ChainedGroupByJob
 import ai.chronon.flink.source.FlinkSourceProvider
-import ai.chronon.flink.types.WriteResponse
+import ai.chronon.flink.types.{AvroCodecOutput, TimestampedTile, WriteResponse}
 import ai.chronon.flink.validation.ValidationFlinkJob
+import ai.chronon.flink.window.{AlwaysFireOnElementTrigger, BufferedProcessingTimeTrigger, FlinkRowAggProcessFunction, FlinkRowAggregationFunction, KeySelectorBuilder, MegaTileProcessFunction}
 import ai.chronon.online.fetcher.{FetchContext, MetadataStore}
 import ai.chronon.online.{Api, GroupByServingInfoParsed, TopicInfo}
 import org.apache.flink.api.common.eventtime.{SerializableTimestampAssigner, WatermarkStrategy}
 import org.apache.flink.api.common.functions.RichMapFunction
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator
+import org.apache.flink.streaming.api.functions.async.RichAsyncFunction
+import org.apache.flink.streaming.api.windowing.assigners.{TumblingEventTimeWindows, WindowAssigner}
+import org.apache.flink.streaming.api.windowing.time.Time
+import org.apache.flink.streaming.api.windowing.triggers.Trigger
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow
+import org.apache.flink.util.OutputTag
 import org.apache.flink.api.common.restartstrategy.RestartStrategies
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.core.fs.FileSystem
@@ -43,11 +53,94 @@ abstract class BaseFlinkJob {
   def runTiledGroupByJob(env: StreamExecutionEnvironment): DataStream[WriteResponse]
 
   /** Run the streaming job with mega tiling enabled.
-    * Subclasses that support mega tiling should override this.
+    * Default delegates to buildMegaTiledTail. Subclasses must provide source setup.
     */
-  def runMegaTiledGroupByJob(env: StreamExecutionEnvironment): DataStream[WriteResponse] =
-    throw new UnsupportedOperationException(
-      s"Mega tiling is not supported for ${getClass.getSimpleName} (groupBy=$groupByName)")
+  def runMegaTiledGroupByJob(env: StreamExecutionEnvironment): DataStream[WriteResponse]
+
+  /** Shared tail for tiled pipeline: keyBy → window aggregate → tile codec → KV write.
+    * Both FlinkGroupByStreamingJob and ChainedGroupByJob use this with their respective
+    * prepared streams and schemas.
+    */
+  protected def buildTiledTail(
+      preparedStream: DataStream[ProjectedEvent],
+      schema: Seq[(String, DataType)],
+      parallelism: Int,
+      sinkFn: RichAsyncFunction[AvroCodecOutput, WriteResponse],
+      kvStoreCapacity: Int,
+      props: Map[String, String],
+      topicInfo: TopicInfo,
+      enableDebug: Boolean
+  ): DataStream[WriteResponse] = {
+    val tilingWindowSizeInMillis = ResolutionUtils.getSmallestTailHopMillis(groupByServingInfoParsed.groupBy)
+
+    val window = TumblingEventTimeWindows
+      .of(Time.milliseconds(tilingWindowSizeInMillis))
+      .asInstanceOf[WindowAssigner[ProjectedEvent, TimeWindow]]
+
+    val trigger = FlinkUtils.getProperty("trigger", props, topicInfo).map {
+      case "always_fire" => new AlwaysFireOnElementTrigger(): Trigger[ProjectedEvent, TimeWindow]
+      case "buffered"    => new BufferedProcessingTimeTrigger(100L): Trigger[ProjectedEvent, TimeWindow]
+      case t => throw new IllegalArgumentException(s"Unsupported trigger type: $t")
+    }.getOrElse(new AlwaysFireOnElementTrigger())
+
+    val allowedLatenessMs = FlinkUtils.getAllowedLatenessMs(props, topicInfo)
+    val tilingLateEventsTag = new OutputTag[ProjectedEvent]("tiling-late-events") {}
+
+    val tilingDS: SingleOutputStreamOperator[TimestampedTile] =
+      preparedStream
+        .keyBy(KeySelectorBuilder.build(groupByServingInfoParsed.groupBy))
+        .window(window)
+        .allowedLateness(Time.milliseconds(allowedLatenessMs))
+        .trigger(trigger)
+        .sideOutputLateData(tilingLateEventsTag)
+        .aggregate(
+          new FlinkRowAggregationFunction(groupByServingInfoParsed.groupBy, schema, enableDebug),
+          new FlinkRowAggProcessFunction(groupByServingInfoParsed.groupBy, schema, enableDebug)
+        )
+        .uid(s"tiling-$groupByName")
+        .name(s"Tiling for $groupByName")
+        .setParallelism(parallelism)
+
+    tilingDS
+      .getSideOutput(tilingLateEventsTag)
+      .flatMap(new LateEventCounter(groupByName))
+      .uid(s"tiling-side-output-$groupByName")
+      .name(s"Tiling Side Output Late Data for $groupByName")
+      .setParallelism(parallelism)
+
+    val putRecordDS = tilingDS
+      .flatMap(TiledAvroCodecFn(groupByServingInfoParsed, tilingWindowSizeInMillis, enableDebug))
+      .uid(s"avro-conversion-$groupByName")
+      .name(s"Avro conversion for $groupByName")
+      .setParallelism(parallelism)
+
+    AsyncKVStoreWriter.withUnorderedWaits(putRecordDS, sinkFn, groupByName, capacity = kvStoreCapacity)
+  }
+
+  /** Shared tail for mega tiled pipeline: keyBy → MegaTileProcessFunction → mega tile codec → KV write. */
+  protected def buildMegaTiledTail(
+      preparedStream: DataStream[ProjectedEvent],
+      schema: Seq[(String, DataType)],
+      parallelism: Int,
+      sinkFn: RichAsyncFunction[AvroCodecOutput, WriteResponse],
+      kvStoreCapacity: Int,
+      enableDebug: Boolean
+  ): DataStream[WriteResponse] = {
+    val megaTileDS = preparedStream
+      .keyBy(KeySelectorBuilder.build(groupByServingInfoParsed.groupBy))
+      .process(new MegaTileProcessFunction(groupByServingInfoParsed.groupBy, schema, enableDebug))
+      .uid(s"mega-tiling-$groupByName")
+      .name(s"Mega Tiling for $groupByName")
+      .setParallelism(parallelism)
+
+    val putRecordDS = megaTileDS
+      .flatMap(MegaTileAvroCodecFn(groupByServingInfoParsed, enableDebug))
+      .uid(s"mega-avro-conversion-$groupByName")
+      .name(s"Mega Tile Avro conversion for $groupByName")
+      .setParallelism(parallelism)
+
+    AsyncKVStoreWriter.withUnorderedWaits(putRecordDS, sinkFn, groupByName, capacity = kvStoreCapacity)
+  }
 }
 
 object FlinkJob {

--- a/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
@@ -11,7 +11,14 @@ import ai.chronon.flink.chaining.ChainedGroupByJob
 import ai.chronon.flink.source.FlinkSourceProvider
 import ai.chronon.flink.types.{AvroCodecOutput, TimestampedTile, WriteResponse}
 import ai.chronon.flink.validation.ValidationFlinkJob
-import ai.chronon.flink.window.{AlwaysFireOnElementTrigger, BufferedProcessingTimeTrigger, FlinkRowAggProcessFunction, FlinkRowAggregationFunction, KeySelectorBuilder, MegaTileProcessFunction}
+import ai.chronon.flink.window.{
+  AlwaysFireOnElementTrigger,
+  BufferedProcessingTimeTrigger,
+  FlinkRowAggProcessFunction,
+  FlinkRowAggregationFunction,
+  KeySelectorBuilder,
+  MegaTileProcessFunction
+}
 import ai.chronon.online.fetcher.{FetchContext, MetadataStore}
 import ai.chronon.online.{Api, GroupByServingInfoParsed, TopicInfo}
 import org.apache.flink.api.common.eventtime.{SerializableTimestampAssigner, WatermarkStrategy}
@@ -77,11 +84,14 @@ abstract class BaseFlinkJob {
       .of(Time.milliseconds(tilingWindowSizeInMillis))
       .asInstanceOf[WindowAssigner[ProjectedEvent, TimeWindow]]
 
-    val trigger = FlinkUtils.getProperty("trigger", props, topicInfo).map {
-      case "always_fire" => new AlwaysFireOnElementTrigger(): Trigger[ProjectedEvent, TimeWindow]
-      case "buffered"    => new BufferedProcessingTimeTrigger(100L): Trigger[ProjectedEvent, TimeWindow]
-      case t => throw new IllegalArgumentException(s"Unsupported trigger type: $t")
-    }.getOrElse(new AlwaysFireOnElementTrigger())
+    val trigger = FlinkUtils
+      .getProperty("trigger", props, topicInfo)
+      .map {
+        case "always_fire" => new AlwaysFireOnElementTrigger(): Trigger[ProjectedEvent, TimeWindow]
+        case "buffered"    => new BufferedProcessingTimeTrigger(100L): Trigger[ProjectedEvent, TimeWindow]
+        case t             => throw new IllegalArgumentException(s"Unsupported trigger type: $t")
+      }
+      .getOrElse(new AlwaysFireOnElementTrigger())
 
     val allowedLatenessMs = FlinkUtils.getAllowedLatenessMs(props, topicInfo)
     val tilingLateEventsTag = new OutputTag[ProjectedEvent]("tiling-late-events") {}

--- a/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
@@ -76,7 +76,8 @@ abstract class BaseFlinkJob {
       kvStoreCapacity: Int,
       props: Map[String, String],
       topicInfo: TopicInfo,
-      enableDebug: Boolean
+      enableDebug: Boolean,
+      uidSuffix: String = ""
   ): DataStream[WriteResponse] = {
     val tilingWindowSizeInMillis = ResolutionUtils.getSmallestTailHopMillis(groupByServingInfoParsed.groupBy)
 
@@ -107,20 +108,20 @@ abstract class BaseFlinkJob {
           new FlinkRowAggregationFunction(groupByServingInfoParsed.groupBy, schema, enableDebug),
           new FlinkRowAggProcessFunction(groupByServingInfoParsed.groupBy, schema, enableDebug)
         )
-        .uid(s"tiling-$groupByName")
+        .uid(s"tiling${uidSuffix}-$groupByName")
         .name(s"Tiling for $groupByName")
         .setParallelism(parallelism)
 
     tilingDS
       .getSideOutput(tilingLateEventsTag)
       .flatMap(new LateEventCounter(groupByName))
-      .uid(s"tiling-side-output-$groupByName")
+      .uid(s"tiling-side-output${uidSuffix}-$groupByName")
       .name(s"Tiling Side Output Late Data for $groupByName")
       .setParallelism(parallelism)
 
     val putRecordDS = tilingDS
       .flatMap(TiledAvroCodecFn(groupByServingInfoParsed, tilingWindowSizeInMillis, enableDebug))
-      .uid(s"avro-conversion-$groupByName")
+      .uid(s"avro-conversion${uidSuffix}-$groupByName")
       .name(s"Avro conversion for $groupByName")
       .setParallelism(parallelism)
 

--- a/flink/src/main/scala/ai/chronon/flink/FlinkUtils.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkUtils.scala
@@ -48,6 +48,21 @@ object FlinkUtils {
       }
       .getOrElse(0L)
   }
+
+  def getNonNegativeLongProperty(key: String, props: Map[String, String], topicInfo: TopicInfo): Long = {
+    getProperty(key, props, topicInfo)
+      .map(_.trim)
+      .filter(_.nonEmpty)
+      .map { value =>
+        val parsed = Try(value.toLong).getOrElse {
+          throw new IllegalArgumentException(
+            s"FlinkUtils.getNonNegativeLongProperty: invalid $key value '$value', must be a valid integer"
+          )
+        }
+        if (parsed < 0L) 0L else parsed
+      }
+      .getOrElse(0L)
+  }
 }
 
 /** This was moved to flink-rpc-akka in Flink 1.16 and made private, so we reproduce the direct execution context here

--- a/flink/src/main/scala/ai/chronon/flink/MegaTileAvroCodecFn.scala
+++ b/flink/src/main/scala/ai/chronon/flink/MegaTileAvroCodecFn.scala
@@ -1,0 +1,78 @@
+package ai.chronon.flink
+
+import ai.chronon.api.Extensions.GroupByOps
+import ai.chronon.api.ScalaJavaConversions._
+import ai.chronon.api.{TilingUtils, TsUtils}
+import ai.chronon.api.{StructType => ChrononStructType}
+import ai.chronon.flink.types.{AvroCodecOutput, TimestampedTile}
+import ai.chronon.online.GroupByServingInfoParsed
+import ai.chronon.online.serde.AvroConversions
+import org.apache.flink.api.common.functions.RichFlatMapFunction
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.metrics.Counter
+import org.apache.flink.util.Collector
+import org.slf4j.{Logger, LoggerFactory}
+
+/**
+  * Converts mega tile output (TimestampedTile) to KV PutRequests (AvroCodecOutput).
+  * Key: TileKey(streamingDataset, entityKeyBytes, DayMillis, dayStart).
+  * Value: mega tile IR bytes (passthrough from MegaTileProcessFunction).
+  */
+case class MegaTileAvroCodecFn(groupByServingInfoParsed: GroupByServingInfoParsed,
+                                enableDebug: Boolean = false)
+    extends RichFlatMapFunction[TimestampedTile, AvroCodecOutput] {
+
+  @transient lazy val logger: Logger = LoggerFactory.getLogger(getClass)
+  @transient private var avroConversionErrorCounter: Counter = _
+  @transient private var eventProcessingErrorCounter: Counter = _
+
+  private val DayMillis: Long = 24 * 3600 * 1000L
+  private lazy val streamingDataset: String = groupByServingInfoParsed.groupBy.streamingDataset
+  private lazy val keyColumns: Array[String] =
+    SparkExpressionEval.buildKeyValueEventTimeColumns(groupByServingInfoParsed.groupBy)._1
+  private lazy val keyToBytes: Any => Array[Byte] = {
+    val keyZSchema: ChrononStructType = groupByServingInfoParsed.keyChrononSchema
+    AvroConversions.encodeBytes(keyZSchema, {
+      case x: Map[_, _] if x.keys.forall(_.isInstanceOf[String]) =>
+        x.toArray.flatMap { case (key, value) => Array(key, value) }
+    })
+  }
+
+  override def open(configuration: Configuration): Unit = {
+    super.open(configuration)
+    val metricsGroup = getRuntimeContext.getMetricGroup
+      .addGroup("chronon")
+      .addGroup("feature_group", groupByServingInfoParsed.groupBy.getMetaData.getName)
+    avroConversionErrorCounter = metricsGroup.counter("avro_conversion_errors")
+    eventProcessingErrorCounter = metricsGroup.counter("event_processing_error")
+  }
+
+  override def close(): Unit = super.close()
+
+  override def flatMap(value: TimestampedTile, out: Collector[AvroCodecOutput]): Unit =
+    try {
+      out.collect(avroConvertMegaTileToPutRequest(value))
+    } catch {
+      case e: Exception =>
+        logger.error("Error converting mega tile to PutRequest", e)
+        eventProcessingErrorCounter.inc()
+        avroConversionErrorCounter.inc()
+    }
+
+  def avroConvertMegaTileToPutRequest(in: TimestampedTile): AvroCodecOutput = {
+    val tsMills = in.latestTsMillis
+    val entityKeyBytes = keyToBytes(in.keys.toArray)
+
+    val dayStart = TsUtils.round(tsMills, DayMillis)
+    val tileKey = TilingUtils.buildTileKey(streamingDataset, entityKeyBytes, Some(DayMillis), Some(dayStart))
+    val tileKeyBytes = TilingUtils.serializeTileKey(tileKey)
+
+    if (enableDebug) {
+      logger.info(
+        s"Mega tile PutRequest: groupBy=${groupByServingInfoParsed.groupBy.getMetaData.getName} " +
+          s"tsMills=$tsMills dayStart=$dayStart valueBytes=${in.tileBytes.length} bytes")
+    }
+
+    new AvroCodecOutput(tileKeyBytes, in.tileBytes, streamingDataset, tsMills, in.startProcessingTime)
+  }
+}

--- a/flink/src/main/scala/ai/chronon/flink/MegaTileAvroCodecFn.scala
+++ b/flink/src/main/scala/ai/chronon/flink/MegaTileAvroCodecFn.scala
@@ -13,13 +13,11 @@ import org.apache.flink.metrics.Counter
 import org.apache.flink.util.Collector
 import org.slf4j.{Logger, LoggerFactory}
 
-/**
-  * Converts mega tile output (TimestampedTile) to KV PutRequests (AvroCodecOutput).
+/** Converts mega tile output (TimestampedTile) to KV PutRequests (AvroCodecOutput).
   * Key: TileKey(streamingDataset, entityKeyBytes, DayMillis, dayStart).
   * Value: mega tile IR bytes (passthrough from MegaTileProcessFunction).
   */
-case class MegaTileAvroCodecFn(groupByServingInfoParsed: GroupByServingInfoParsed,
-                                enableDebug: Boolean = false)
+case class MegaTileAvroCodecFn(groupByServingInfoParsed: GroupByServingInfoParsed, enableDebug: Boolean = false)
     extends RichFlatMapFunction[TimestampedTile, AvroCodecOutput] {
 
   @transient lazy val logger: Logger = LoggerFactory.getLogger(getClass)
@@ -32,10 +30,11 @@ case class MegaTileAvroCodecFn(groupByServingInfoParsed: GroupByServingInfoParse
     SparkExpressionEval.buildKeyValueEventTimeColumns(groupByServingInfoParsed.groupBy)._1
   private lazy val keyToBytes: Any => Array[Byte] = {
     val keyZSchema: ChrononStructType = groupByServingInfoParsed.keyChrononSchema
-    AvroConversions.encodeBytes(keyZSchema, {
-      case x: Map[_, _] if x.keys.forall(_.isInstanceOf[String]) =>
-        x.toArray.flatMap { case (key, value) => Array(key, value) }
-    })
+    AvroConversions.encodeBytes(keyZSchema,
+                                {
+                                  case x: Map[_, _] if x.keys.forall(_.isInstanceOf[String]) =>
+                                    x.toArray.flatMap { case (key, value) => Array(key, value) }
+                                })
   }
 
   override def open(configuration: Configuration): Unit = {

--- a/flink/src/main/scala/ai/chronon/flink/chaining/ChainedGroupByJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/chaining/ChainedGroupByJob.scala
@@ -8,6 +8,7 @@ import ai.chronon.flink.FlinkJob.watermarkStrategy
 import ai.chronon.flink.deser.ProjectedEvent
 import ai.chronon.flink.source.FlinkSource
 import ai.chronon.flink.types.{AvroCodecOutput, WriteResponse}
+import ai.chronon.flink.window.MegaTileEmissionPolicy
 import ai.chronon.online.{Api, GroupByServingInfoParsed, TopicInfo}
 
 import java.util.concurrent.TimeUnit
@@ -70,6 +71,11 @@ class ChainedGroupByJob(eventSrc: FlinkSource[ProjectedEvent],
     FlinkUtils.getNonNegativeLongProperty("buffering_output_time_millis", props, topicInfo)
   private val bufferingOutputJitterMillis =
     FlinkUtils.getNonNegativeLongProperty("buffering_output_jitter_millis", props, topicInfo)
+  private val bufferingOutputPolicy =
+    FlinkUtils
+      .getProperty("buffering_output_policy", props, topicInfo)
+      .map(MegaTileEmissionPolicy.fromString)
+      .getOrElse(MegaTileEmissionPolicy.Default)
 
   /** Build the tiled version of the Flink GroupBy job that chains features using a JoinSource.
     *  The operators are structured as follows:
@@ -100,7 +106,8 @@ class ChainedGroupByJob(eventSrc: FlinkSource[ProjectedEvent],
                        kvStoreCapacity,
                        enableDebug,
                        bufferingOutputTimeMillis,
-                       bufferingOutputJitterMillis)
+                       bufferingOutputJitterMillis,
+                       bufferingOutputPolicy)
   }
 
   /** Build the source → watermark → enrichment → query transform pipeline.

--- a/flink/src/main/scala/ai/chronon/flink/chaining/ChainedGroupByJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/chaining/ChainedGroupByJob.scala
@@ -130,8 +130,7 @@ class ChainedGroupByJob(eventSrc: FlinkSource[ProjectedEvent],
     val processedStream =
       if (joinSource.query != null && joinSource.query.selects != null && !joinSource.query.selects.isEmpty) {
         logger.info("Applying join source query transformations")
-        val queryFunction = new JoinSourceQueryFunction(
-          joinSource, inputSchema, groupByName, api, enableDebug)
+        val queryFunction = new JoinSourceQueryFunction(joinSource, inputSchema, groupByName, api, enableDebug)
         enrichedStream
           .flatMap(queryFunction)
           .uid(s"join-source-query-$groupByName")

--- a/flink/src/main/scala/ai/chronon/flink/chaining/ChainedGroupByJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/chaining/ChainedGroupByJob.scala
@@ -1,32 +1,19 @@
 package ai.chronon.flink.chaining
 
-import ai.chronon.aggregator.windowing.ResolutionUtils
 import ai.chronon.api.Extensions.GroupByOps
 import ai.chronon.api.ScalaJavaConversions._
 import ai.chronon.api._
-import ai.chronon.flink.{AsyncKVStoreWriter, BaseFlinkJob, FlinkUtils, LateEventCounter, TiledAvroCodecFn}
+import ai.chronon.flink.{AsyncKVStoreWriter, BaseFlinkJob, FlinkUtils}
 import ai.chronon.flink.FlinkJob.watermarkStrategy
 import ai.chronon.flink.deser.ProjectedEvent
 import ai.chronon.flink.source.FlinkSource
-import ai.chronon.flink.types.{AvroCodecOutput, TimestampedTile, WriteResponse}
-import ai.chronon.flink.window.{
-  AlwaysFireOnElementTrigger,
-  BufferedProcessingTimeTrigger,
-  FlinkRowAggProcessFunction,
-  FlinkRowAggregationFunction,
-  KeySelectorBuilder
-}
+import ai.chronon.flink.types.{AvroCodecOutput, WriteResponse}
 import ai.chronon.online.{Api, GroupByServingInfoParsed, TopicInfo}
 
 import java.util.concurrent.TimeUnit
-import org.apache.flink.streaming.api.datastream.{AsyncDataStream, DataStream, SingleOutputStreamOperator}
+import org.apache.flink.streaming.api.datastream.{AsyncDataStream, DataStream}
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.streaming.api.functions.async.RichAsyncFunction
-import org.apache.flink.streaming.api.windowing.assigners.{TumblingEventTimeWindows, WindowAssigner}
-import org.apache.flink.streaming.api.windowing.time.Time
-import org.apache.flink.streaming.api.windowing.triggers.Trigger
-import org.apache.flink.streaming.api.windowing.windows.TimeWindow
-import org.apache.flink.util.OutputTag
 
 /** Flink job implementation for chaining features using JoinSource GroupBys.
   * The job reads from event source (that has already performed projections/filters), performs async enrichment,
@@ -80,20 +67,6 @@ class ChainedGroupByJob(eventSrc: FlinkSource[ProjectedEvent],
     .map(_.toInt)
     .getOrElse(AsyncKVStoreWriter.kvStoreConcurrency)
 
-  // We default to the AlwaysFireOnElementTrigger which will cause the window to "FIRE" on every element.
-  // An alternative is the BufferedProcessingTimeTrigger (trigger=buffered in topic info
-  // or properties) which will buffer writes and only "FIRE" every X milliseconds per GroupBy & key.
-  private def getTrigger(): Trigger[ProjectedEvent, TimeWindow] = {
-    FlinkUtils.getProperty("trigger", props, topicInfo).getOrElse("always_fire") match {
-      case "always_fire" => new AlwaysFireOnElementTrigger()
-      case "buffered"    => new BufferedProcessingTimeTrigger(100L)
-      case t =>
-        throw new IllegalArgumentException(s"Unsupported trigger type: $t. Supported: 'always_fire', 'buffered'")
-    }
-  }
-
-  private def getAllowedLatenessMs(): Long = FlinkUtils.getAllowedLatenessMs(props, topicInfo)
-
   /** Build the tiled version of the Flink GroupBy job that chains features using a JoinSource.
     *  The operators are structured as follows:
     *  - Source: Read from Kafka topic into ProjectedEvent stream
@@ -105,10 +78,25 @@ class ChainedGroupByJob(eventSrc: FlinkSource[ProjectedEvent],
     */
   override def runTiledGroupByJob(env: StreamExecutionEnvironment): DataStream[WriteResponse] = {
     logger.info(
-      s"Building Flink streaming job for groupBy: $groupByName that chains join: ${joinSource.getJoin.getMetaData.getName}" +
-        s" using topic: $topic")
+      s"Building tiled Flink streaming job for groupBy: $groupByName that chains join: " +
+        s"${joinSource.getJoin.getMetaData.getName} using topic: $topic")
+    val (processedStream, schema) = buildEnrichedStream(env)
+    buildTiledTail(processedStream, schema, parallelism, sinkFn, kvStoreCapacity, props, topicInfo, enableDebug)
+  }
 
-    // we expect parallelism on the source stream to be set by the source provider
+  override def runMegaTiledGroupByJob(env: StreamExecutionEnvironment): DataStream[WriteResponse] = {
+    logger.info(
+      s"Building mega tiled Flink streaming job for groupBy: $groupByName that chains join: " +
+        s"${joinSource.getJoin.getMetaData.getName} using topic: $topic")
+    val (processedStream, schema) = buildEnrichedStream(env)
+    buildMegaTiledTail(processedStream, schema, parallelism, sinkFn, kvStoreCapacity, enableDebug)
+  }
+
+  /** Build the source → watermark → enrichment → query transform pipeline.
+    * Returns the prepared stream and its post-transformation schema.
+    */
+  private def buildEnrichedStream(
+      env: StreamExecutionEnvironment): (DataStream[ProjectedEvent], Seq[(String, DataType)]) = {
     val sourceSparkProjectedStream: DataStream[ProjectedEvent] = eventSrc
       .getDataStream(topic, groupByName)(env, parallelism)
       .uid(s"join-source-$groupByName")
@@ -139,18 +127,11 @@ class ChainedGroupByJob(eventSrc: FlinkSource[ProjectedEvent],
       .name(s"Async Join Enrichment for $groupByName")
       .setParallelism(sourceSparkProjectedStream.getParallelism)
 
-    // Apply join source query transformations only if there are transformations to apply
     val processedStream =
       if (joinSource.query != null && joinSource.query.selects != null && !joinSource.query.selects.isEmpty) {
         logger.info("Applying join source query transformations")
         val queryFunction = new JoinSourceQueryFunction(
-          joinSource,
-          inputSchema,
-          groupByName,
-          api,
-          enableDebug
-        )
-
+          joinSource, inputSchema, groupByName, api, enableDebug)
         enrichedStream
           .flatMap(queryFunction)
           .uid(s"join-source-query-$groupByName")
@@ -161,69 +142,8 @@ class ChainedGroupByJob(eventSrc: FlinkSource[ProjectedEvent],
         enrichedStream
       }
 
-    // Compute the output schema after JoinSourceQueryFunction transformations using Catalyst
     val postTransformationSchema = computePostTransformationSchemaWithCatalyst(joinSource, inputSchema)
-
-    // Calculate tiling window size based on the GroupBy configuration
-    val tilingWindowSizeInMillis: Long =
-      ResolutionUtils.getSmallestTailHopMillis(groupByServingInfoParsed.groupBy)
-
-    // Configure tumbling window for tiled aggregations
-    val window = TumblingEventTimeWindows
-      .of(Time.milliseconds(tilingWindowSizeInMillis))
-      .asInstanceOf[WindowAssigner[ProjectedEvent, TimeWindow]]
-
-    // Configure trigger (default to always fire on element)
-    val trigger = getTrigger()
-
-    // allowedLateness keeps window state open after the watermark passes the window end,
-    // allowing late events to still be processed. Configurable via allowed_lateness_seconds property.
-    // Default: 0 (disabled).
-    val allowedLatenessMs = getAllowedLatenessMs()
-
-    // We use Flink "Side Outputs" to track any late events that aren't computed.
-    val tilingLateEventsTag = new OutputTag[ProjectedEvent]("tiling-late-events") {}
-
-    // Tiled aggregation: key by entity keys, window, and aggregate
-    val tilingDS: SingleOutputStreamOperator[TimestampedTile] =
-      processedStream
-        .keyBy(KeySelectorBuilder.build(groupByServingInfoParsed.groupBy))
-        .window(window)
-        .allowedLateness(Time.milliseconds(allowedLatenessMs))
-        .trigger(trigger)
-        .sideOutputLateData(tilingLateEventsTag)
-        .aggregate(
-          // Aggregation function that maintains incremental IRs in state
-          new FlinkRowAggregationFunction(groupByServingInfoParsed.groupBy, postTransformationSchema, enableDebug),
-          // Process function that marks tiles as closed for client-side caching
-          new FlinkRowAggProcessFunction(groupByServingInfoParsed.groupBy, postTransformationSchema, enableDebug)
-        )
-        .uid(s"tiling-$groupByName")
-        .name(s"Tiling for $groupByName")
-        .setParallelism(sourceSparkProjectedStream.getParallelism)
-
-    // Track late events
-    tilingDS
-      .getSideOutput(tilingLateEventsTag)
-      .flatMap(new LateEventCounter(groupByName))
-      .uid(s"tiling-side-output-$groupByName")
-      .name(s"Tiling Side Output Late Data for $groupByName")
-      .setParallelism(sourceSparkProjectedStream.getParallelism)
-
-    // Convert tiles to AvroCodecOutput format for KV store writing
-    val avroConvertedStream = tilingDS
-      .flatMap(TiledAvroCodecFn(groupByServingInfoParsed, tilingWindowSizeInMillis, enableDebug))
-      .uid(s"avro-conversion-$groupByName")
-      .name(s"Avro Conversion for $groupByName")
-      .setParallelism(sourceSparkProjectedStream.getParallelism)
-
-    // Write to KV store using existing AsyncKVStoreWriter
-    AsyncKVStoreWriter.withUnorderedWaits(
-      avroConvertedStream,
-      sinkFn,
-      groupByName,
-      capacity = kvStoreCapacity
-    )
+    (processedStream, postTransformationSchema)
   }
 
   /** Compute the schema that results after JoinSourceQueryFunction transformations.

--- a/flink/src/main/scala/ai/chronon/flink/chaining/ChainedGroupByJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/chaining/ChainedGroupByJob.scala
@@ -66,6 +66,10 @@ class ChainedGroupByJob(eventSrc: FlinkSource[ProjectedEvent],
     .getProperty("kv_concurrency", props, topicInfo)
     .map(_.toInt)
     .getOrElse(AsyncKVStoreWriter.kvStoreConcurrency)
+  private val bufferingOutputTimeMillis =
+    FlinkUtils.getNonNegativeLongProperty("buffering_output_time_millis", props, topicInfo)
+  private val bufferingOutputJitterMillis =
+    FlinkUtils.getNonNegativeLongProperty("buffering_output_jitter_millis", props, topicInfo)
 
   /** Build the tiled version of the Flink GroupBy job that chains features using a JoinSource.
     *  The operators are structured as follows:
@@ -89,7 +93,14 @@ class ChainedGroupByJob(eventSrc: FlinkSource[ProjectedEvent],
       s"Building mega tiled Flink streaming job for groupBy: $groupByName that chains join: " +
         s"${joinSource.getJoin.getMetaData.getName} using topic: $topic")
     val (processedStream, schema) = buildEnrichedStream(env)
-    buildMegaTiledTail(processedStream, schema, parallelism, sinkFn, kvStoreCapacity, enableDebug)
+    buildMegaTiledTail(processedStream,
+                       schema,
+                       parallelism,
+                       sinkFn,
+                       kvStoreCapacity,
+                       enableDebug,
+                       bufferingOutputTimeMillis,
+                       bufferingOutputJitterMillis)
   }
 
   /** Build the source → watermark → enrichment → query transform pipeline.

--- a/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
@@ -18,6 +18,30 @@ import org.slf4j.{Logger, LoggerFactory}
 
 import scala.util.Try
 
+sealed trait MegaTileEmissionPolicy extends Serializable
+
+object MegaTileEmissionPolicy {
+
+  case object DirtyBufferWithJitter extends MegaTileEmissionPolicy
+
+  case object WallClockCadence extends MegaTileEmissionPolicy
+
+  val DirtyBufferWithJitterName = "dirty_buffer_with_jitter"
+  val WallClockCadenceName = "wall_clock_cadence"
+  val Default: MegaTileEmissionPolicy = DirtyBufferWithJitter
+  val DefaultName: String = DirtyBufferWithJitterName
+
+  def fromString(raw: String): MegaTileEmissionPolicy =
+    Option(raw).map(_.trim.toLowerCase) match {
+      case Some(DirtyBufferWithJitterName) => DirtyBufferWithJitter
+      case Some(WallClockCadenceName)      => WallClockCadence
+      case _ =>
+        throw new IllegalArgumentException(
+          s"Unsupported MegaTile emission policy '$raw'. Expected one of: " +
+            s"$DirtyBufferWithJitterName, $WallClockCadenceName")
+    }
+}
+
 /** Flink KeyedProcessFunction that maintains per-entity mega tile state.
   * Delegates aggregation logic to MegaTileStreamProcessor and uses FlinkTileStore for keyed state.
   * See docs/source/megatile.md for the high-level clock/mode mental model.
@@ -32,8 +56,8 @@ import scala.util.Try
   *      key's state.
   *
   * 2. Roll day state using the Flink watermark, not this event's timestamp or processing time (PT).
-  *    If the watermark crosses midnight while today's row is still buffered, emit the old-day row
-  *    first.
+  *    If the watermark crosses midnight while today's row is still buffered, emit or buffer the
+  *    old-day row first.
   *    - Why watermark: if one bad/future event arrives with `eventTs = tomorrow 00:01` and we
   *      rotated day state from that event timestamp, then later valid events from `today 23:50`
   *      would get misclassified into yesterday or dropped. The watermark means the stream has
@@ -65,16 +89,18 @@ import scala.util.Try
   *    - Emission's job is write coalescing only: if today/yesterday is dirty, serialize the current
   *      row and write it downstream. The first dirty update arms the timer; later updates only set
   *      dirty bits so hot keys do not emit once per event.
-  *    - Example: with `bufferingOutputTimeMillis = 1000`, 100 events in one second produce one emit
-  *      at `processingTs + 1s + stable key jitter`, not 100 downstream writes.
+  *    - `DirtyBufferWithJitter` schedules relative to the first dirty write. `WallClockCadence`
+  *      uses a stable key phase in live-like modes, with dirty-buffered fallback before the first
+  *      watermark and during active catchup.
   *
   * Timer path (`onTimer`)
   * 7. Dispatch each PT callback into exactly one branch: evict+emit collision, evict-only, or
   *    emit-only.
   *
-  * 8. On an eviction timer, choose the eviction as-of timestamp, maybe emit today's pre-rollover
-  *    row, roll day state, drop expired small-window tiles, rebuild today's small-window state,
-  *    mark dirty state, and re-arm the eviction heartbeat while small-window tiles still exist.
+  * 8. On an eviction timer, choose the eviction as-of timestamp, maybe emit or buffer today's
+  *    pre-rollover row, roll day state, drop expired small-window tiles, rebuild today's
+  *    small-window state, mark dirty state, and re-arm the eviction heartbeat while small-window
+  *    tiles still exist.
   *    - During replay lag, eviction uses the next watermark hop while this key is actively receiving
   *      events; otherwise eviction uses PT.
   *    - Example: if PT is Apr 2 11:00 but replayed events are from Mar 31 11:00, eviction should
@@ -85,14 +111,16 @@ import scala.util.Try
   *      like replay. If upstream stops for a key, that same branch keeps PT eviction running so
   *      values still decay with no new events.
   *
-  * 9. On an emit timer, serialize and emit each dirty day row once, then clear its dirty bit.
+  * 9. On an emit timer, live cadence may roll day from PT first. Then emit each pending or dirty
+  *    day row once and clear its dirty bit or pending buffer.
   */
 class MegaTileProcessFunction(
     groupBy: GroupBy,
     inputSchema: Seq[(String, DataType)],
     enableDebug: Boolean = false,
     bufferingOutputTimeMillis: Long = 0L,
-    bufferingOutputJitterMillis: Long = 0L
+    bufferingOutputJitterMillis: Long = 0L,
+    emissionPolicy: MegaTileEmissionPolicy = MegaTileEmissionPolicy.Default
 ) extends KeyedProcessFunction[java.util.List[Any], ProjectedEvent, TimestampedTile] {
 
   @transient lazy val logger: Logger = LoggerFactory.getLogger(getClass)
@@ -114,6 +142,7 @@ class MegaTileProcessFunction(
   private var largeYesterdayIrState: ValueState[Array[Byte]] = _
   private var currentDayStartState: ValueState[java.lang.Long] = _
   private var earliestTileStartState: ValueState[java.lang.Long] = _
+  private var pendingDayRollEmitTileBytesState: MapState[java.lang.Long, Array[Byte]] = _
 
   private var nextEvictPtTimerState: ValueState[java.lang.Long] = _
   private var nextEmitPtTimerState: ValueState[java.lang.Long] = _
@@ -129,6 +158,14 @@ class MegaTileProcessFunction(
       .addGroup("feature_group", groupBy.getMetaData.getName)
     eventProcessingErrorCounter = metricsGroup.counter("event_processing_error")
 
+    if (emissionPolicy == MegaTileEmissionPolicy.WallClockCadence &&
+        bufferingOutputJitterMillis > 0L) {
+      logger.warn(
+        s"MegaTile emission policy ${MegaTileEmissionPolicy.WallClockCadenceName} ignores " +
+          s"bufferingOutputJitterMillis=$bufferingOutputJitterMillis for " +
+          s"groupBy=${groupBy.getMetaData.getName}; cadence spread comes from wall-clock phase")
+    }
+
     tileState = getRuntimeContext.getMapState(
       new MapStateDescriptor[String, Array[Byte]]("mega-tile-tiles", classOf[String], classOf[Array[Byte]]))
     megaTileIrState =
@@ -141,6 +178,11 @@ class MegaTileProcessFunction(
       new ValueStateDescriptor[java.lang.Long]("mega-tile-day-start", classOf[java.lang.Long]))
     earliestTileStartState = getRuntimeContext.getState(
       new ValueStateDescriptor[java.lang.Long]("mega-tile-earliest-tile", classOf[java.lang.Long]))
+    pendingDayRollEmitTileBytesState = getRuntimeContext.getMapState(
+      new MapStateDescriptor[java.lang.Long, Array[Byte]](
+        "mega-tile-pending-emit-tile-bytes",
+        classOf[java.lang.Long],
+        classOf[Array[Byte]]))
     nextEvictPtTimerState = getRuntimeContext.getState(
       new ValueStateDescriptor[java.lang.Long]("mega-tile-next-evict-pt-timer", classOf[java.lang.Long]))
     nextEmitPtTimerState = getRuntimeContext.getState(
@@ -198,10 +240,10 @@ class MegaTileProcessFunction(
 
       // Step 2. Event ingestion rolls day state from watermark, not processing time, so a brief
       // source lag near midnight does not move `currentDayStart` too early.
-      emitTodayIfNeededThenRollDay(watermark, ctx.getCurrentKey, event.startProcessingTimeMillis, out)
+      emitOrBufferTodayThenDayRoll(watermark, ctx.getCurrentKey, event.startProcessingTimeMillis, out)
       if (isOlderThanYesterdayForCurrentDay(tsMills)) {
         scheduleEvictTimerIfNeeded(timerService, processingTs)
-        emitDirtyOrSchedule(event.startProcessingTimeMillis, processingTs, timerService, out)
+        emitDirtyOrSchedule(event.startProcessingTimeMillis, processingTs, watermark, timerService, out)
         return
       }
 
@@ -215,7 +257,7 @@ class MegaTileProcessFunction(
       // Step 5.
       scheduleEvictTimerIfNeeded(timerService, processingTs)
       // Step 6.
-      emitDirtyOrSchedule(event.startProcessingTimeMillis, processingTs, timerService, out)
+      emitDirtyOrSchedule(event.startProcessingTimeMillis, processingTs, watermark, timerService, out)
     } catch {
       case e: Exception =>
         logger.error(s"Error processing mega tile event for groupBy=${groupBy.getMetaData.getName}", e)
@@ -252,15 +294,15 @@ class MegaTileProcessFunction(
         // Step 7 and Step 8.
         runEvictionTimer(ctx.getCurrentKey, timestamp, processingTs, watermark, timerService, out)
         // Step 9: this timestamp is also the buffered emit timer, so emit once after Step 8 rebuilt state.
-        emitDirtyMegaTiles(ctx.getCurrentKey, processingTs, out)
+        runEmitTimer(ctx.getCurrentKey, timerService, processingTs, watermark, out)
       } else if (isEvictTimer) {
         // Step 7 and Step 8.
         runEvictionTimer(ctx.getCurrentKey, timestamp, processingTs, watermark, timerService, out)
         // Step 9: eviction changed state; if buffering is enabled, arm one emit timer.
-        emitDirtyOrSchedule(processingTs, processingTs, timerService, out)
+        emitDirtyOrSchedule(processingTs, processingTs, watermark, timerService, out)
       } else if (isEmitTimer) {
         // Step 7 and Step 9.
-        emitDirtyMegaTiles(ctx.getCurrentKey, processingTs, out)
+        runEmitTimer(ctx.getCurrentKey, timerService, processingTs, watermark, out)
       }
     } catch {
       case e: Exception =>
@@ -287,6 +329,15 @@ class MegaTileProcessFunction(
   private def isYesterdayDirty: Boolean =
     Option(yesterdayDirtyState.value()).exists(_.booleanValue())
 
+  private def hasPendingDayRollEmit: Boolean =
+    !pendingDayRollEmitTileBytesState.isEmpty
+
+  private def hasDirtyEmitState: Boolean =
+    isTodayDirty || isYesterdayDirty || hasPendingDayRollEmit
+
+  private def shouldKeepLiveCadenceTimer: Boolean =
+    hasDirtyEmitState || hasActiveSmallWindowState
+
   private def markDirtyState(hasTodayUpdate: Boolean, hasYesterdayUpdate: Boolean): Unit = {
     if (hasTodayUpdate) todayDirtyState.update(java.lang.Boolean.TRUE)
     if (hasYesterdayUpdate) yesterdayDirtyState.update(java.lang.Boolean.TRUE)
@@ -300,7 +351,7 @@ class MegaTileProcessFunction(
                                out: Collector[TimestampedTile]): Unit = {
     val mode = currentMode(processingTs, watermark)
     val evictionTime = evictionTimeForProcessingTimer(mode, processingTs, watermark)
-    emitTodayIfNeededThenRollDay(evictionTime, currentKey, processingTs, out)
+    emitOrBufferTodayThenDayRoll(evictionTime, currentKey, processingTs, out)
 
     val result = processor.onEviction(evictionTime)
     markDirtyState(result.todayEntry != null, hasYesterdayUpdate = false)
@@ -329,7 +380,7 @@ class MegaTileProcessFunction(
     * Emitting under `previousDayStart` preserves the logical daily key across rollover; `MegaTileAvroCodecFn`
     * uses that day-start timestamp when constructing the external `TileKey`.
     */
-  private def emitTodayIfNeededThenRollDay(dayTransitionTs: Long,
+  private def emitOrBufferTodayThenDayRoll(dayTransitionTs: Long,
                                            keys: java.util.List[Any],
                                            processingTsMillis: Long,
                                            out: Collector[TimestampedTile]): Unit = {
@@ -340,7 +391,7 @@ class MegaTileProcessFunction(
         isTodayDirty &&
         TsUtils.round(dayTransitionTs, processor.DayMillis) == nextDayStart
     if (shouldEmitPreviousTodayRow) {
-      emitMegaTileIfPresent(keys, processor.packTodayEntry(), previousDayStart, processingTsMillis, out)
+      emitOrBufferDayRollMegaTile(keys, processor.packTodayEntry(), previousDayStart, processingTsMillis, out)
       todayDirtyState.clear()
     }
 
@@ -356,6 +407,12 @@ class MegaTileProcessFunction(
   private case object SparseKeyLag extends Mode
 
   private case object Live extends Mode
+
+  sealed private trait EmitTimerScheduling
+
+  private case class DirtyBufferedEmitTimer(maxJitterMillis: Long) extends EmitTimerScheduling
+
+  private case object LiveCadenceEmitTimer extends EmitTimerScheduling
 
   private def currentMode(processingTs: Long, watermark: Long): Mode = {
     val lastEventProcessingTs =
@@ -416,26 +473,76 @@ class MegaTileProcessFunction(
 
   private def emitDirtyOrSchedule(outputProcessingTsMillis: Long,
                                   processingTs: Long,
+                                  watermark: Long,
                                   timerService: TimerService,
                                   out: Collector[TimestampedTile]): Unit = {
     if (!bufferingEnabled) {
       emitDirtyMegaTiles(lastKey, outputProcessingTsMillis, out)
       return
     }
-    scheduleEmitTimerIfNeeded(timerService, processingTs)
+    val scheduling = emitTimerSchedulingFor(currentMode(processingTs, watermark))
+    scheduleEmitTimerIfNeeded(timerService, processingTs, scheduling)
   }
 
-  private def scheduleEmitTimerIfNeeded(timerService: TimerService, processingTs: Long): Unit = {
-    if (!isTodayDirty && !isYesterdayDirty) return
+  private def scheduleEmitTimerIfNeeded(timerService: TimerService,
+                                        processingTs: Long,
+                                        scheduling: EmitTimerScheduling): Unit =
+    scheduling match {
+      case DirtyBufferedEmitTimer(maxJitterMillis) =>
+        scheduleDirtyBufferedEmitTimerIfNeeded(timerService, processingTs, maxJitterMillis)
+      case LiveCadenceEmitTimer =>
+        if (shouldKeepLiveCadenceTimer) {
+          scheduleLiveCadenceTimer(timerService, processingTs)
+        }
+    }
 
+  private def emitTimerSchedulingFor(mode: Mode): EmitTimerScheduling =
+    emissionPolicy match {
+      case MegaTileEmissionPolicy.DirtyBufferWithJitter =>
+        DirtyBufferedEmitTimer(bufferingOutputJitterMillis)
+      case MegaTileEmissionPolicy.WallClockCadence =>
+        mode match {
+          case NoWatermark | ActiveCatchup =>
+            DirtyBufferedEmitTimer(maxJitterMillis = 0L)
+          case SparseKeyLag | Live =>
+            LiveCadenceEmitTimer
+        }
+    }
+
+  private def scheduleLiveCadenceTimer(timerService: TimerService, processingTs: Long): Unit = {
     val current = nextEmitPtTimerState.value()
     if (current == null) {
-      val timestamp =
-        processingTs + bufferingOutputTimeMillis + stableJitterMillis(lastKey, bufferingOutputJitterMillis)
+      val timestamp = nextKeyWallClockEmitTimer(lastKey, processingTs)
       timerService.registerProcessingTimeTimer(timestamp)
       nextEmitPtTimerState.update(timestamp)
     }
   }
+
+  private def scheduleDirtyBufferedEmitTimerIfNeeded(timerService: TimerService,
+                                                     processingTs: Long,
+                                                     maxJitterMillis: Long): Unit = {
+    if (!hasDirtyEmitState) return
+
+    val current = nextEmitPtTimerState.value()
+    if (current == null) {
+      val timestamp =
+        processingTs + bufferingOutputTimeMillis + stableJitterMillis(lastKey, maxJitterMillis)
+      timerService.registerProcessingTimeTimer(timestamp)
+      nextEmitPtTimerState.update(timestamp)
+    }
+  }
+
+  private def nextKeyWallClockEmitTimer(key: java.util.List[Any], processingTs: Long): Long = {
+    val phase = stablePhaseMillis(key, bufferingOutputTimeMillis)
+    val elapsedSincePhase = Math.floorMod(processingTs - phase, bufferingOutputTimeMillis)
+    val delay =
+      if (elapsedSincePhase == 0L) bufferingOutputTimeMillis
+      else bufferingOutputTimeMillis - elapsedSincePhase
+    processingTs + delay
+  }
+
+  private def stablePhaseMillis(key: java.util.List[Any], cadenceMillis: Long): Long =
+    Math.floorMod((groupBy.getMetaData.getName :: key.toScala).hashCode().toLong, cadenceMillis)
 
   private def stableJitterMillis(key: java.util.List[Any], maxJitterMillis: Long): Long =
     if (maxJitterMillis <= 0L) 0L
@@ -459,32 +566,113 @@ class MegaTileProcessFunction(
     current != null && current.longValue() == timestamp
   }
 
+  private def runEmitTimer(keys: java.util.List[Any],
+                           timerService: TimerService,
+                           processingTsMillis: Long,
+                           watermark: Long,
+                           out: Collector[TimestampedTile]): Unit = {
+    val mode = currentMode(processingTsMillis, watermark)
+    val scheduling = emitTimerSchedulingFor(mode)
+    scheduling match {
+      case LiveCadenceEmitTimer =>
+        // Large-window-only groupBys have no eviction timer; live cadence supplies their PT day roll.
+        emitOrBufferTodayThenDayRoll(processingTsMillis, keys, processingTsMillis, out)
+      case DirtyBufferedEmitTimer(_) =>
+    }
+    emitDirtyMegaTiles(keys, processingTsMillis, out)
+    scheduleEmitTimerIfNeeded(timerService, processingTsMillis, scheduling)
+  }
+
   private def emitDirtyMegaTiles(keys: java.util.List[Any],
                                  processingTsMillis: Long,
                                  out: Collector[TimestampedTile]): Unit = {
     val currentDayStart = flinkStore.getCurrentDayStart
+    emitPendingDayRollMegaTile(keys, currentDayStart, processingTsMillis, out)
     if (isTodayDirty) {
-      emitMegaTileIfPresent(keys, processor.packTodayEntry(), currentDayStart, processingTsMillis, out)
+      emitMegaTile(keys, processor.packTodayEntry(), currentDayStart, processingTsMillis, out)
       todayDirtyState.clear()
     }
     if (isYesterdayDirty) {
-      emitMegaTileIfPresent(keys,
-                            processor.packYesterdayEntry(),
-                            currentDayStart - processor.DayMillis,
-                            processingTsMillis,
-                            out)
+      emitMegaTile(keys,
+                   processor.packYesterdayEntry(),
+                   currentDayStart - processor.DayMillis,
+                   processingTsMillis,
+                   out)
       yesterdayDirtyState.clear()
     }
   }
 
-  private def emitMegaTileIfPresent(keys: java.util.List[Any],
-                                    entry: Array[Any],
-                                    dayStartMillis: Long,
-                                    processingTsMillis: Long,
-                                    out: Collector[TimestampedTile]): Unit = {
-    if (entry == null) return
-    out.collect(new TimestampedTile(keys, megaTileCodec.encode(entry), dayStartMillis, processingTsMillis))
+  private def emitPendingDayRollMegaTile(keys: java.util.List[Any],
+                                         currentDayStart: Long,
+                                         processingTsMillis: Long,
+                                         out: Collector[TimestampedTile]): Unit = {
+    val pendingDayRollEmit =
+      if (pendingDayRollEmitTileBytesState.isEmpty) {
+        None
+      } else {
+        val iterator = pendingDayRollEmitTileBytesState.keys().iterator()
+        val dayStartMillis = iterator.next().longValue()
+        if (iterator.hasNext) {
+          logger.warn(
+            s"MegaTile expected at most one pending day-roll emit row for " +
+              s"groupBy=${groupBy.getMetaData.getName}, key=$lastKey; dropping pending rows")
+          None
+        } else {
+          Some(dayStartMillis -> pendingDayRollEmitTileBytesState.get(dayStartMillis))
+        }
+      }
+
+    pendingDayRollEmit match {
+      case Some((pendingDayStart, tileBytes)) =>
+        val todayStart = currentDayStart
+        val yesterdayStart = currentDayStart - processor.DayMillis
+        val pendingIsRetainedDay =
+          pendingDayStart == todayStart || pendingDayStart == yesterdayStart
+        val pendingHasFresherDirtyRow =
+          (pendingDayStart == todayStart && isTodayDirty) ||
+            (pendingDayStart == yesterdayStart && isYesterdayDirty)
+
+        if (pendingIsRetainedDay && !pendingHasFresherDirtyRow) {
+          emitMegaTileBytes(keys, tileBytes, pendingDayStart, processingTsMillis, out)
+        }
+      case None =>
+    }
+    pendingDayRollEmitTileBytesState.clear()
   }
+
+  private def emitOrBufferDayRollMegaTile(keys: java.util.List[Any],
+                                          entry: Array[Any],
+                                          dayStartMillis: Long,
+                                          processingTsMillis: Long,
+                                          out: Collector[TimestampedTile]): Unit = {
+    if (!bufferingEnabled || emissionPolicy == MegaTileEmissionPolicy.DirtyBufferWithJitter) {
+      emitMegaTile(keys, entry, dayStartMillis, processingTsMillis, out)
+      return
+    }
+
+    if (hasPendingDayRollEmit) {
+      emitPendingDayRollMegaTile(keys, dayStartMillis, processingTsMillis, out)
+    }
+    if (entry != null) {
+      pendingDayRollEmitTileBytesState.put(dayStartMillis, megaTileCodec.encode(entry))
+    }
+  }
+
+  private def emitMegaTile(keys: java.util.List[Any],
+                           entry: Array[Any],
+                           dayStartMillis: Long,
+                           processingTsMillis: Long,
+                           out: Collector[TimestampedTile]): Unit = {
+    if (entry == null) return
+    emitMegaTileBytes(keys, megaTileCodec.encode(entry), dayStartMillis, processingTsMillis, out)
+  }
+
+  private def emitMegaTileBytes(keys: java.util.List[Any],
+                                tileBytes: Array[Byte],
+                                dayStartMillis: Long,
+                                processingTsMillis: Long,
+                                out: Collector[TimestampedTile]): Unit =
+    out.collect(new TimestampedTile(keys, tileBytes, dayStartMillis, processingTsMillis))
 }
 
 /** TileStore backed by Flink's keyed MapState/ValueState.

--- a/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
@@ -451,11 +451,17 @@ class MegaTileProcessFunction(
       case NoWatermark =>
         nextSmallWindowHop(eventTs)
       case SparseKeyLag | Live =>
-        nextSmallWindowHop(processingTs)
+        if (processingTs == floorToSmallWindowHop(processingTs)) {
+          // processor.onEvent includes retained tiles with tileStart < smallWindowAsOfTs.
+          processingTs + 1L
+        } else processingTs
     }
 
+  private def floorToSmallWindowHop(ts: Long): Long =
+    TsUtils.round(ts, processor.minSmallWindowTileSize)
+
   private def nextSmallWindowHop(ts: Long): Long =
-    TsUtils.round(ts, processor.minSmallWindowTileSize) + processor.minSmallWindowTileSize
+    floorToSmallWindowHop(ts) + processor.minSmallWindowTileSize
 
   private def scheduleEvictTimerIfNeeded(timerService: TimerService, processingTs: Long): Unit = {
     if (!hasActiveSmallWindowState) {
@@ -466,8 +472,7 @@ class MegaTileProcessFunction(
     val current = nextEvictPtTimerState.value()
     if (current != null) return
 
-    val timestamp =
-      TsUtils.round(processingTs, processor.minSmallWindowTileSize) + processor.minSmallWindowTileSize
+    val timestamp = nextSmallWindowHop(processingTs)
     timerService.registerProcessingTimeTimer(timestamp)
     nextEvictPtTimerState.update(timestamp)
   }

--- a/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
@@ -34,6 +34,10 @@ class MegaTileProcessFunction(
 
   @transient private var eventProcessingErrorCounter: Counter = _
 
+  // Track the current key to avoid reinitializing processor on every event.
+  // Flink reuses this function across keys — only reset when the key changes.
+  @transient private var lastKey: java.util.List[Any] = _
+
   private val valueColumns: Array[String] = inputSchema.map(_._1).toArray
   private val timeColumnAlias: String = Constants.TimeColumn
 
@@ -95,8 +99,8 @@ class MegaTileProcessFunction(
       val values: Array[Any] = valueColumns.map(element(_))
       val row = new ArrayRow(values, tsMills)
 
-      // Restore processor state from Flink state
-      restoreProcessorState()
+      // Restore processor state from Flink state (only resets on key switch)
+      restoreProcessorState(ctx.getCurrentKey)
 
       // Advance watermark (may trigger day transition)
       processor.advanceWatermark(ctx.timerService().currentWatermark())
@@ -146,7 +150,7 @@ class MegaTileProcessFunction(
     try {
       if (processor == null) initializeTransients()
 
-      restoreProcessorState()
+      restoreProcessorState(ctx.getCurrentKey)
       processor.advanceWatermark(ctx.timerService().currentWatermark())
 
       val result = processor.onEviction(timestamp)
@@ -174,10 +178,12 @@ class MegaTileProcessFunction(
   }
 
   // Restore MegaTileStreamProcessor mutable state from Flink managed state.
-  // Reinitialize processor first to clear previous key's state — Flink reuses
-  // the same KeyedProcessFunction instance across keys within a task.
-  private def restoreProcessorState(): Unit = {
-    processor = new MegaTileStreamProcessor(processor.megaTileAgg)
+  // Only resets processor state on key switch to avoid GC pressure from
+  // allocating new objects on every event.
+  private def restoreProcessorState(currentKey: java.util.List[Any]): Unit = {
+    val keyChanged = lastKey == null || !lastKey.equals(currentKey)
+    lastKey = currentKey
+    if (keyChanged) processor.reset()
     val tileIter = tileState.iterator()
     while (tileIter.hasNext) {
       val entry = tileIter.next()

--- a/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
@@ -10,15 +10,24 @@ import ai.chronon.online.serde.ArrayRow
 import org.apache.flink.api.common.state.{MapState, MapStateDescriptor, ValueState, ValueStateDescriptor}
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.metrics.Counter
+import org.apache.flink.streaming.api.TimeDomain
 import org.apache.flink.streaming.api.functions.KeyedProcessFunction
 import org.apache.flink.util.Collector
 import org.slf4j.{Logger, LoggerFactory}
 
-import scala.util.{Failure, Success, Try}
+import scala.util.Try
 
 /** Flink KeyedProcessFunction that maintains per-entity mega tile state.
   * Delegates all aggregation logic to MegaTileStreamProcessor.
   * State access goes through FlinkTileStore — only touched entries are serialized/deserialized.
+  *
+  * Timer strategy:
+  * - During catchup (watermark far behind wall clock): event-time timers only.
+  *   Eviction fires as watermark advances through the backlog at the correct cadence.
+  * - During live operation (watermark near wall clock): processing-time timers aligned
+  *   to hop boundaries. Fires at wall-clock intervals so idle entities get timely
+  *   sawtooth correction without waiting for the next event to advance the watermark.
+  * - Transition is one-way: catchup → live. Once caught up, stays in live mode.
   */
 class MegaTileProcessFunction(
     groupBy: GroupBy,
@@ -45,6 +54,16 @@ class MegaTileProcessFunction(
   private var largeYesterdayIrState: ValueState[Array[Byte]] = _
   private var currentDayStartState: ValueState[java.lang.Long] = _
   private var earliestTileStartState: ValueState[java.lang.Long] = _
+
+  // Tracks whether this entity has a processing-time timer registered.
+  // Not persisted — after checkpoint restore, first event re-registers.
+  @transient private var hasProcessingTimeTimer: Boolean = false
+
+  // Once true, stays true for the lifetime of this subtask.
+  @transient private var isLive: Boolean = false
+
+  // Threshold: watermark within 2× the allowed lateness of wall clock → caught up.
+  private val CatchupThresholdMillis: Long = 2 * 60 * 1000L // 2 minutes
 
   override def open(parameters: Configuration): Unit = {
     super.open(parameters)
@@ -78,6 +97,21 @@ class MegaTileProcessFunction(
     processor = new MegaTileStreamProcessor(megaTileAgg, flinkStore)
   }
 
+  private def ensureStateBound(currentKey: java.util.List[Any]): Unit = {
+    if (lastKey == null || !lastKey.equals(currentKey)) {
+      lastKey = currentKey
+      flinkStore.bindFlinkState(tileState,
+                                megaTileIrState,
+                                largeTodayIrState,
+                                largeYesterdayIrState,
+                                currentDayStartState,
+                                earliestTileStartState)
+    }
+  }
+
+  private def isCaughtUp(watermark: Long, procNow: Long): Boolean =
+    watermark > 0 && (procNow - watermark) <= CatchupThresholdMillis
+
   override def processElement(
       event: ProjectedEvent,
       ctx: KeyedProcessFunction[java.util.List[Any], ProjectedEvent, TimestampedTile]#Context,
@@ -92,18 +126,7 @@ class MegaTileProcessFunction(
       val values: Array[Any] = valueColumns.map(element(_))
       val row = new ArrayRow(values, tsMills)
 
-      // Point FlinkTileStore at current key's Flink state (only resets on key switch)
-      val currentKey = ctx.getCurrentKey
-      if (lastKey == null || !lastKey.equals(currentKey)) {
-        lastKey = currentKey
-        flinkStore.bindFlinkState(tileState,
-                                  megaTileIrState,
-                                  largeTodayIrState,
-                                  largeYesterdayIrState,
-                                  currentDayStartState,
-                                  earliestTileStartState)
-      }
-
+      ensureStateBound(ctx.getCurrentKey)
       processor.advanceWatermark(ctx.timerService().currentWatermark())
       val result = processor.onEvent(row, tsMills)
 
@@ -124,9 +147,30 @@ class MegaTileProcessFunction(
                               event.startProcessingTimeMillis))
       }
 
+      // Schedule eviction timer if small windows exist
       if (processor.hasSmallWindows) {
-        val nextEviction = TsUtils.round(tsMills, processor.minSmallWindowTileSize) + processor.minSmallWindowTileSize
-        ctx.timerService().registerEventTimeTimer(nextEviction)
+        val hopSize = processor.minSmallWindowTileSize
+        val watermark = ctx.timerService().currentWatermark()
+        val procNow = ctx.timerService().currentProcessingTime()
+
+        if (!isLive && isCaughtUp(watermark, procNow)) {
+          isLive = true
+          if (enableDebug) logger.info(s"Transitioning to live mode: watermark=$watermark procNow=$procNow")
+        }
+
+        if (isLive) {
+          // Live: processing-time timer aligned to hop boundary from wall clock.
+          // Fires at wall-clock intervals so idle entities get timely sawtooth correction.
+          if (!hasProcessingTimeTimer) {
+            val nextEviction = TsUtils.round(procNow, hopSize) + hopSize
+            ctx.timerService().registerProcessingTimeTimer(nextEviction)
+            hasProcessingTimeTimer = true
+          }
+        } else {
+          // Catchup: event-time timer. Fires as watermark advances through the backlog.
+          val nextEviction = TsUtils.round(tsMills, hopSize) + hopSize
+          ctx.timerService().registerEventTimeTimer(nextEviction)
+        }
       }
     } catch {
       case e: Exception =>
@@ -143,18 +187,12 @@ class MegaTileProcessFunction(
     try {
       if (processor == null) initializeTransients()
 
-      val currentKey = ctx.getCurrentKey
-      if (lastKey == null || !lastKey.equals(currentKey)) {
-        lastKey = currentKey
-        flinkStore.bindFlinkState(tileState,
-                                  megaTileIrState,
-                                  largeTodayIrState,
-                                  largeYesterdayIrState,
-                                  currentDayStartState,
-                                  earliestTileStartState)
-      }
-
+      ensureStateBound(ctx.getCurrentKey)
       processor.advanceWatermark(ctx.timerService().currentWatermark())
+
+      // Both event-time and processing-time timers run the same eviction logic.
+      // The timerTs is the eviction point — either the event-time boundary (catchup)
+      // or the wall-clock boundary (live).
       val result = processor.onEviction(timestamp)
 
       if (result.todayEntry != null) {
@@ -165,8 +203,17 @@ class MegaTileProcessFunction(
                               System.currentTimeMillis()))
       }
 
+      // Re-register the next timer
       if (processor.hasSmallWindows) {
-        ctx.timerService().registerEventTimeTimer(timestamp + processor.minSmallWindowTileSize)
+        val hopSize = processor.minSmallWindowTileSize
+        if (ctx.timeDomain() == TimeDomain.PROCESSING_TIME) {
+          // Live mode: re-register next processing-time timer at next hop boundary
+          val nextEviction = TsUtils.round(timestamp, hopSize) + hopSize
+          ctx.timerService().registerProcessingTimeTimer(nextEviction)
+        } else {
+          // Catchup mode: re-register next event-time timer
+          ctx.timerService().registerEventTimeTimer(timestamp + hopSize)
+        }
       }
     } catch {
       case e: Exception =>

--- a/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
@@ -158,8 +158,10 @@ class MegaTileProcessFunction(
       .addGroup("feature_group", groupBy.getMetaData.getName)
     eventProcessingErrorCounter = metricsGroup.counter("event_processing_error")
 
-    if (emissionPolicy == MegaTileEmissionPolicy.WallClockCadence &&
-        bufferingOutputJitterMillis > 0L) {
+    if (
+      emissionPolicy == MegaTileEmissionPolicy.WallClockCadence &&
+      bufferingOutputJitterMillis > 0L
+    ) {
       logger.warn(
         s"MegaTile emission policy ${MegaTileEmissionPolicy.WallClockCadenceName} ignores " +
           s"bufferingOutputJitterMillis=$bufferingOutputJitterMillis for " +
@@ -179,10 +181,9 @@ class MegaTileProcessFunction(
     earliestTileStartState = getRuntimeContext.getState(
       new ValueStateDescriptor[java.lang.Long]("mega-tile-earliest-tile", classOf[java.lang.Long]))
     pendingDayRollEmitTileBytesState = getRuntimeContext.getMapState(
-      new MapStateDescriptor[java.lang.Long, Array[Byte]](
-        "mega-tile-pending-emit-tile-bytes",
-        classOf[java.lang.Long],
-        classOf[Array[Byte]]))
+      new MapStateDescriptor[java.lang.Long, Array[Byte]]("mega-tile-pending-emit-tile-bytes",
+                                                          classOf[java.lang.Long],
+                                                          classOf[Array[Byte]]))
     nextEvictPtTimerState = getRuntimeContext.getState(
       new ValueStateDescriptor[java.lang.Long]("mega-tile-next-evict-pt-timer", classOf[java.lang.Long]))
     nextEmitPtTimerState = getRuntimeContext.getState(
@@ -593,11 +594,7 @@ class MegaTileProcessFunction(
       todayDirtyState.clear()
     }
     if (isYesterdayDirty) {
-      emitMegaTile(keys,
-                   processor.packYesterdayEntry(),
-                   currentDayStart - processor.DayMillis,
-                   processingTsMillis,
-                   out)
+      emitMegaTile(keys, processor.packYesterdayEntry(), currentDayStart - processor.DayMillis, processingTsMillis, out)
       yesterdayDirtyState.clear()
     }
   }

--- a/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
@@ -147,6 +147,9 @@ class MegaTileProcessFunction(
   private var nextEvictPtTimerState: ValueState[java.lang.Long] = _
   private var nextEmitPtTimerState: ValueState[java.lang.Long] = _
   private var lastEventProcessingTsState: ValueState[java.lang.Long] = _
+  // The floored as-of marker for the range currently covered by the TileStore's
+  // cachedSmallWindowIr. In Flink, that cached IR is backed by megaTileIrState.
+  private var cachedSmallWindowAsOfTsState: ValueState[java.lang.Long] = _
   private var todayDirtyState: ValueState[java.lang.Boolean] = _
   private var yesterdayDirtyState: ValueState[java.lang.Boolean] = _
 
@@ -190,6 +193,8 @@ class MegaTileProcessFunction(
       new ValueStateDescriptor[java.lang.Long]("mega-tile-next-emit-pt-timer", classOf[java.lang.Long]))
     lastEventProcessingTsState = getRuntimeContext.getState(
       new ValueStateDescriptor[java.lang.Long]("mega-tile-last-event-processing-ts", classOf[java.lang.Long]))
+    cachedSmallWindowAsOfTsState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Long]("mega-tile-cached-small-window-as-of-ts", classOf[java.lang.Long]))
     todayDirtyState = getRuntimeContext.getState(
       new ValueStateDescriptor[java.lang.Boolean]("mega-tile-today-dirty", classOf[java.lang.Boolean]))
     yesterdayDirtyState = getRuntimeContext.getState(
@@ -250,8 +255,10 @@ class MegaTileProcessFunction(
 
       val mode = currentMode(processingTs, watermark)
       val smallWindowAsOfTs = smallWindowAsOfTsForEvent(mode, tsMills, processingTs, watermark)
+      rebuildCachedSmallWindowForEventIfNeeded(smallWindowAsOfTs)
       // Step 3.
       val result = processor.onEvent(row, tsMills, smallWindowAsOfTs)
+      recordCachedSmallWindowAsOfTs(smallWindowAsOfTs)
       // Step 4.
       markDirtyState(result.todayEntry != null, result.yesterdayEntry != null)
 
@@ -344,6 +351,30 @@ class MegaTileProcessFunction(
     if (hasYesterdayUpdate) yesterdayDirtyState.update(java.lang.Boolean.TRUE)
   }
 
+  private def cachedSmallWindowAsOfTs: Option[Long] =
+    Option(cachedSmallWindowAsOfTsState.value()).map(_.longValue())
+
+  private def recordCachedSmallWindowAsOfTs(asOfTs: Long): Unit = {
+    if (processor.hasSmallWindows) {
+      cachedSmallWindowAsOfTsState.update(floorToSmallWindowHop(asOfTs))
+    }
+  }
+
+  private def rebuildCachedSmallWindowForEventIfNeeded(smallWindowAsOfTs: Long): Unit = {
+    if (!processor.hasSmallWindows || !hasActiveSmallWindowState) {
+      return
+    }
+
+    val targetAsOfTs = floorToSmallWindowHop(smallWindowAsOfTs)
+    if (cachedSmallWindowAsOfTs.contains(targetAsOfTs)) {
+      return
+    }
+
+    val result = processor.onEviction(smallWindowAsOfTs)
+    recordCachedSmallWindowAsOfTs(smallWindowAsOfTs)
+    markDirtyState(result.todayEntry != null, hasYesterdayUpdate = false)
+  }
+
   private def runEvictionTimer(currentKey: java.util.List[Any],
                                timestamp: Long,
                                processingTs: Long,
@@ -355,6 +386,7 @@ class MegaTileProcessFunction(
     emitOrBufferTodayThenDayRoll(evictionTime, currentKey, processingTs, out)
 
     val result = processor.onEviction(evictionTime)
+    recordCachedSmallWindowAsOfTs(evictionTime)
     markDirtyState(result.todayEntry != null, hasYesterdayUpdate = false)
     scheduleEvictTimerIfNeeded(timerService, processingTs)
 
@@ -397,6 +429,10 @@ class MegaTileProcessFunction(
     }
 
     processor.advanceWatermark(dayTransitionTs)
+    val currentDayStart = flinkStore.getCurrentDayStart
+    if (currentDayStart != previousDayStart) {
+      recordCachedSmallWindowAsOfTs(dayTransitionTs)
+    }
   }
 
   sealed private trait Mode

--- a/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
@@ -6,7 +6,6 @@ import ai.chronon.api.ScalaJavaConversions.IteratorOps
 import ai.chronon.flink.deser.ProjectedEvent
 import ai.chronon.flink.types.TimestampedTile
 import ai.chronon.online.MegaTileCodec
-import ai.chronon.online.TileCodec
 import ai.chronon.online.serde.ArrayRow
 import org.apache.flink.api.common.state.{MapState, MapStateDescriptor, ValueState, ValueStateDescriptor}
 import org.apache.flink.configuration.Configuration
@@ -33,7 +32,6 @@ class MegaTileProcessFunction(
   // Transient: rebuilt on checkpoint restore
   @transient private var processor: MegaTileStreamProcessor = _
   @transient private var megaTileCodec: MegaTileCodec = _
-  @transient private var tileCodec: TileCodec = _
 
   @transient private var eventProcessingErrorCounter: Counter = _
 
@@ -82,7 +80,6 @@ class MegaTileProcessFunction(
     )
     processor = new MegaTileStreamProcessor(megaTileAgg)
     megaTileCodec = new MegaTileCodec(groupBy, inputCols)
-    tileCodec = new TileCodec(groupBy, inputCols)
   }
 
   override def processElement(
@@ -168,7 +165,7 @@ class MegaTileProcessFunction(
 
   // Restore MegaTileStreamProcessor mutable state from Flink managed state
   private def restoreProcessorState(): Unit = {
-    // Tiles
+    // Tiles: stored as base (unwindowed) IRs via megaTileCodec.encodeBaseIr
     processor.tiles.values.foreach(_.clear())
     val tileIter = tileState.iterator()
     while (tileIter.hasNext) {
@@ -177,15 +174,11 @@ class MegaTileProcessFunction(
       val hopSize = parts(0).toLong
       val tileStart = parts(1).toLong
       processor.tiles.get(hopSize).foreach { tierTiles =>
-        val (ir, _) = tileCodec.decodeTileIr(entry.getValue)
-        // decodeTileIr returns windowed form; we need base form
-        // Use the base aggregator init size to extract base IR
-        tierTiles(tileStart) = processor.megaTileAgg.baseAggregator.denormalize(
-          processor.megaTileAgg.baseAggregator.normalize(ir.take(processor.megaTileAgg.baseAggregator.length)))
+        tierTiles(tileStart) = megaTileCodec.decodeBaseIr(entry.getValue)
       }
     }
 
-    // Cached small window IR + large window IRs
+    // Cached small window IR + large window IRs: stored as windowed IRs
     Option(megaTileIrState.value()).foreach(bytes => processor.cachedSmallWindowIr = megaTileCodec.decode(bytes))
     Option(largeTodayIrState.value()).foreach(bytes => processor.largeTodayIr = megaTileCodec.decode(bytes))
     Option(largeYesterdayIrState.value()).foreach(bytes => processor.largeYesterdayIr = megaTileCodec.decode(bytes))
@@ -195,14 +188,14 @@ class MegaTileProcessFunction(
 
   // Persist MegaTileStreamProcessor mutable state to Flink managed state
   private def persistProcessorState(): Unit = {
-    // Tiles
+    // Tiles: encode as base (unwindowed) IRs
     tileState.clear()
     for ((hopSize, tierTiles) <- processor.tiles; (tileStart, ir) <- tierTiles) {
       val key = s"$hopSize:$tileStart"
-      tileState.put(key, tileCodec.makeTileIr(ir, isComplete = true))
+      tileState.put(key, megaTileCodec.encodeBaseIr(ir))
     }
 
-    // IRs
+    // IRs: encode as windowed IRs
     megaTileIrState.update(megaTileCodec.encode(processor.cachedSmallWindowIr))
     largeTodayIrState.update(megaTileCodec.encode(processor.largeTodayIr))
     largeYesterdayIrState.update(megaTileCodec.encode(processor.largeYesterdayIr))

--- a/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
@@ -1,8 +1,9 @@
 package ai.chronon.flink.window
 
 import ai.chronon.aggregator.windowing.{MegaTileAggregator, MegaTileStreamProcessor, TileStore}
+import ai.chronon.api.ScalaJavaConversions.ListOps
 import ai.chronon.api.{Constants, DataType, GroupBy, TsUtils}
-import ai.chronon.api.ScalaJavaConversions.IteratorOps
+import ai.chronon.flink.FlinkJob
 import ai.chronon.flink.deser.ProjectedEvent
 import ai.chronon.flink.types.TimestampedTile
 import ai.chronon.online.MegaTileCodec
@@ -10,7 +11,7 @@ import ai.chronon.online.serde.ArrayRow
 import org.apache.flink.api.common.state.{MapState, MapStateDescriptor, ValueState, ValueStateDescriptor}
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.metrics.Counter
-import org.apache.flink.streaming.api.TimeDomain
+import org.apache.flink.streaming.api.{TimeDomain, TimerService}
 import org.apache.flink.streaming.api.functions.KeyedProcessFunction
 import org.apache.flink.util.Collector
 import org.slf4j.{Logger, LoggerFactory}
@@ -18,21 +19,80 @@ import org.slf4j.{Logger, LoggerFactory}
 import scala.util.Try
 
 /** Flink KeyedProcessFunction that maintains per-entity mega tile state.
-  * Delegates all aggregation logic to MegaTileStreamProcessor.
-  * State access goes through FlinkTileStore — only touched entries are serialized/deserialized.
+  * Delegates aggregation logic to MegaTileStreamProcessor and uses FlinkTileStore for keyed state.
+  * See docs/source/megatile.md for the high-level clock/mode mental model.
   *
-  * Timer strategy:
-  * - During catchup (watermark far behind wall clock): event-time timers only.
-  *   Eviction fires as watermark advances through the backlog at the correct cadence.
-  * - During live operation (watermark near wall clock): processing-time timers aligned
-  *   to hop boundaries. Fires at wall-clock intervals so idle entities get timely
-  *   sawtooth correction without waiting for the next event to advance the watermark.
-  * - Transition is one-way: catchup → live. Once caught up, stays in live mode.
+  * Step-by-step mental model in code order:
+  *
+  * Event path (`processElement`)
+  * 1. Bind the current Flink key to its private MegaTile state box, then parse the projected event
+  *    into `(eventTs, row)`.
+  *    - Example: `List("user_123")` and `List("user_456")` each have separate tiles, day state,
+  *      dirty bits, and timers. An event with `ts = 11:03:17` becomes one row applied only to that
+  *      key's state.
+  *
+  * 2. Roll day state using the Flink watermark, not this event's timestamp or processing time (PT).
+  *    If the watermark crosses midnight while today's row is still buffered, emit the old-day row
+  *    first.
+  *    - Why watermark: if one bad/future event arrives with `eventTs = tomorrow 00:01` and we
+  *      rotated day state from that event timestamp, then later valid events from `today 23:50`
+  *      would get misclassified into yesterday or dropped. The watermark means the stream has
+  *      progressed past this event-time point, so day rollover only happens when Flink believes the
+  *      whole stream is safely past midnight.
+  *    - Where the watermark comes from: `FlinkJob.watermarkStrategy` assigns event timestamps and
+  *      builds a bounded-out-of-orderness watermark. Each operator subtask sees the minimum
+  *      watermark over its active partitions/input channels, so one input that is still behind can
+  *      hold the watermark back.
+  *
+  * 3. Drop events older than yesterday relative to `currentDayStart`; otherwise call
+  *    `processor.onEvent(row, eventTs, smallWindowAsOfTs)`. The processor uses `eventTs` for the
+  *    base tile and today/yesterday bucket; `smallWindowAsOfTs` is the as-of timestamp for the
+  *    cached small-window IR.
+  *    - Example: with `currentDayStart = Apr 2 00:00`, `Apr 2 11:03` updates today's 11:00-11:05
+  *      tile, `Apr 1 23:59` updates yesterday's large-window bucket, and `Mar 31 23:59` is dropped.
+  *
+  * 4. Mark `todayDirty` / `yesterdayDirty` from the processor result.
+  *    - Why: state mutation and downstream writes are decoupled. Dirty bits remember which day rows
+  *      need to be published later.
+  *
+  * 5. Keep one PT eviction timer per key at the next hop boundary.
+  *    - Eviction's job is correctness of the in-memory state: drop expired 5-minute tiles, rebuild
+  *      the small-window sawtooth IR, and mark today's row dirty if the rebuilt row changed.
+  *    - Example: an 11:03 event lands in the 11:00-11:05 tile; the 11:05 eviction timer rebuilds
+  *      the 1h value from retained 5-minute tiles so old tiles eventually fall out and values decay.
+  *
+  * 6. Emit immediately if buffering is disabled; otherwise keep one PT emit timer per key.
+  *    - Emission's job is write coalescing only: if today/yesterday is dirty, serialize the current
+  *      row and write it downstream. The first dirty update arms the timer; later updates only set
+  *      dirty bits so hot keys do not emit once per event.
+  *    - Example: with `bufferingOutputTimeMillis = 1000`, 100 events in one second produce one emit
+  *      at `processingTs + 1s + stable key jitter`, not 100 downstream writes.
+  *
+  * Timer path (`onTimer`)
+  * 7. Dispatch each PT callback into exactly one branch: evict+emit collision, evict-only, or
+  *    emit-only.
+  *
+  * 8. On an eviction timer, choose the eviction as-of timestamp, maybe emit today's pre-rollover
+  *    row, roll day state, drop expired small-window tiles, rebuild today's small-window state,
+  *    mark dirty state, and re-arm the eviction heartbeat while small-window tiles still exist.
+  *    - During replay lag, eviction uses the next watermark hop while this key is actively receiving
+  *      events; otherwise eviction uses PT.
+  *    - Example: if PT is Apr 2 11:00 but replayed events are from Mar 31 11:00, eviction should
+  *      use Mar 31 watermark time while replay is active; otherwise PT eviction would jump
+  *      `currentDayStart` to Apr 2 and make valid Mar 31 rows look older than yesterday.
+  *    - In a normal live stream, watermark is already close to PT, so the otherwise branch is the
+  *      expected path. A small slack above one hop prevents normal watermark jitter from looking
+  *      like replay. If upstream stops for a key, that same branch keeps PT eviction running so
+  *      values still decay with no new events.
+  *
+  * 9. On an emit timer, serialize and emit each dirty day row once, then clear its dirty bit.
   */
 class MegaTileProcessFunction(
     groupBy: GroupBy,
     inputSchema: Seq[(String, DataType)],
-    enableDebug: Boolean = false
+    enableDebug: Boolean = false,
+    bufferingOutputTimeMillis: Long = 0L,
+    bufferingOutputJitterMillis: Long = 0L
 ) extends KeyedProcessFunction[java.util.List[Any], ProjectedEvent, TimestampedTile] {
 
   @transient lazy val logger: Logger = LoggerFactory.getLogger(getClass)
@@ -55,15 +115,11 @@ class MegaTileProcessFunction(
   private var currentDayStartState: ValueState[java.lang.Long] = _
   private var earliestTileStartState: ValueState[java.lang.Long] = _
 
-  // Tracks whether this entity has a processing-time timer registered.
-  // Not persisted — after checkpoint restore, first event re-registers.
-  @transient private var hasProcessingTimeTimer: Boolean = false
-
-  // Once true, stays true for the lifetime of this subtask.
-  @transient private var isLive: Boolean = false
-
-  // Threshold: watermark within 2× the allowed lateness of wall clock → caught up.
-  private val CatchupThresholdMillis: Long = 2 * 60 * 1000L // 2 minutes
+  private var nextEvictPtTimerState: ValueState[java.lang.Long] = _
+  private var nextEmitPtTimerState: ValueState[java.lang.Long] = _
+  private var lastEventProcessingTsState: ValueState[java.lang.Long] = _
+  private var todayDirtyState: ValueState[java.lang.Boolean] = _
+  private var yesterdayDirtyState: ValueState[java.lang.Boolean] = _
 
   override def open(parameters: Configuration): Unit = {
     super.open(parameters)
@@ -85,19 +141,29 @@ class MegaTileProcessFunction(
       new ValueStateDescriptor[java.lang.Long]("mega-tile-day-start", classOf[java.lang.Long]))
     earliestTileStartState = getRuntimeContext.getState(
       new ValueStateDescriptor[java.lang.Long]("mega-tile-earliest-tile", classOf[java.lang.Long]))
+    nextEvictPtTimerState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Long]("mega-tile-next-evict-pt-timer", classOf[java.lang.Long]))
+    nextEmitPtTimerState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Long]("mega-tile-next-emit-pt-timer", classOf[java.lang.Long]))
+    lastEventProcessingTsState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Long]("mega-tile-last-event-processing-ts", classOf[java.lang.Long]))
+    todayDirtyState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Boolean]("mega-tile-today-dirty", classOf[java.lang.Boolean]))
+    yesterdayDirtyState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Boolean]("mega-tile-yesterday-dirty", classOf[java.lang.Boolean]))
 
     initializeTransients()
   }
 
   private def initializeTransients(): Unit = {
     val inputCols = inputSchema.map { case (name, dt) => (name, dt) }
-    val megaTileAgg = new MegaTileAggregator(groupBy.getAggregations.iterator().toScala.toSeq, inputCols)
+    val megaTileAgg = new MegaTileAggregator(groupBy.getAggregations.toScala.toSeq, inputCols)
     megaTileCodec = new MegaTileCodec(groupBy, inputCols)
     flinkStore = new FlinkTileStore(megaTileAgg, megaTileCodec)
     processor = new MegaTileStreamProcessor(megaTileAgg, flinkStore)
   }
 
-  private def ensureStateBound(currentKey: java.util.List[Any]): Unit = {
+  private def bindCurrentKey(currentKey: java.util.List[Any]): Unit = {
     if (lastKey == null || !lastKey.equals(currentKey)) {
       lastKey = currentKey
       flinkStore.bindFlinkState(tileState,
@@ -109,9 +175,6 @@ class MegaTileProcessFunction(
     }
   }
 
-  private def isCaughtUp(watermark: Long, procNow: Long): Boolean =
-    watermark > 0 && (procNow - watermark) <= CatchupThresholdMillis
-
   override def processElement(
       event: ProjectedEvent,
       ctx: KeyedProcessFunction[java.util.List[Any], ProjectedEvent, TimestampedTile]#Context,
@@ -120,58 +183,39 @@ class MegaTileProcessFunction(
     try {
       if (processor == null) initializeTransients()
 
+      bindCurrentKey(ctx.getCurrentKey)
+
       val element = event.fields
       val tsMills = Try(element(timeColumnAlias).asInstanceOf[Long])
         .getOrElse(element(timeColumnAlias).asInstanceOf[Double].toLong)
       val values: Array[Any] = valueColumns.map(element(_))
       val row = new ArrayRow(values, tsMills)
 
-      ensureStateBound(ctx.getCurrentKey)
-      processor.advanceWatermark(ctx.timerService().currentWatermark())
-      val result = processor.onEvent(row, tsMills)
+      val timerService = ctx.timerService()
+      val watermark = timerService.currentWatermark()
+      val processingTs = timerService.currentProcessingTime()
+      lastEventProcessingTsState.update(processingTs)
 
-      // Emit results
-      val keys = ctx.getCurrentKey
-      if (result.todayEntry != null) {
-        out.collect(
-          new TimestampedTile(keys,
-                              megaTileCodec.encode(result.todayEntry),
-                              result.todayStart,
-                              event.startProcessingTimeMillis))
-      }
-      if (result.yesterdayEntry != null) {
-        out.collect(
-          new TimestampedTile(keys,
-                              megaTileCodec.encode(result.yesterdayEntry),
-                              result.yesterdayStart,
-                              event.startProcessingTimeMillis))
+      // Step 2. Event ingestion rolls day state from watermark, not processing time, so a brief
+      // source lag near midnight does not move `currentDayStart` too early.
+      emitTodayIfNeededThenRollDay(watermark, ctx.getCurrentKey, event.startProcessingTimeMillis, out)
+      if (isOlderThanYesterdayForCurrentDay(tsMills)) {
+        scheduleEvictTimerIfNeeded(timerService, processingTs)
+        emitDirtyOrSchedule(event.startProcessingTimeMillis, processingTs, timerService, out)
+        return
       }
 
-      // Schedule eviction timer if small windows exist
-      if (processor.hasSmallWindows) {
-        val hopSize = processor.minSmallWindowTileSize
-        val watermark = ctx.timerService().currentWatermark()
-        val procNow = ctx.timerService().currentProcessingTime()
+      val mode = currentMode(processingTs, watermark)
+      val smallWindowAsOfTs = smallWindowAsOfTsForEvent(mode, tsMills, processingTs, watermark)
+      // Step 3.
+      val result = processor.onEvent(row, tsMills, smallWindowAsOfTs)
+      // Step 4.
+      markDirtyState(result.todayEntry != null, result.yesterdayEntry != null)
 
-        if (!isLive && isCaughtUp(watermark, procNow)) {
-          isLive = true
-          if (enableDebug) logger.info(s"Transitioning to live mode: watermark=$watermark procNow=$procNow")
-        }
-
-        if (isLive) {
-          // Live: processing-time timer aligned to hop boundary from wall clock.
-          // Fires at wall-clock intervals so idle entities get timely sawtooth correction.
-          if (!hasProcessingTimeTimer) {
-            val nextEviction = TsUtils.round(procNow, hopSize) + hopSize
-            ctx.timerService().registerProcessingTimeTimer(nextEviction)
-            hasProcessingTimeTimer = true
-          }
-        } else {
-          // Catchup: event-time timer. Fires as watermark advances through the backlog.
-          val nextEviction = TsUtils.round(tsMills, hopSize) + hopSize
-          ctx.timerService().registerEventTimeTimer(nextEviction)
-        }
-      }
+      // Step 5.
+      scheduleEvictTimerIfNeeded(timerService, processingTs)
+      // Step 6.
+      emitDirtyOrSchedule(event.startProcessingTimeMillis, processingTs, timerService, out)
     } catch {
       case e: Exception =>
         logger.error(s"Error processing mega tile event for groupBy=${groupBy.getMetaData.getName}", e)
@@ -187,33 +231,36 @@ class MegaTileProcessFunction(
     try {
       if (processor == null) initializeTransients()
 
-      ensureStateBound(ctx.getCurrentKey)
-      processor.advanceWatermark(ctx.timerService().currentWatermark())
-
-      // Both event-time and processing-time timers run the same eviction logic.
-      // The timerTs is the eviction point — either the event-time boundary (catchup)
-      // or the wall-clock boundary (live).
-      val result = processor.onEviction(timestamp)
-
-      if (result.todayEntry != null) {
-        out.collect(
-          new TimestampedTile(ctx.getCurrentKey,
-                              megaTileCodec.encode(result.todayEntry),
-                              result.todayStart,
-                              System.currentTimeMillis()))
+      bindCurrentKey(ctx.getCurrentKey)
+      if (ctx.timeDomain() != TimeDomain.PROCESSING_TIME) {
+        return
       }
 
-      // Re-register the next timer
-      if (processor.hasSmallWindows) {
-        val hopSize = processor.minSmallWindowTileSize
-        if (ctx.timeDomain() == TimeDomain.PROCESSING_TIME) {
-          // Live mode: re-register next processing-time timer at next hop boundary
-          val nextEviction = TsUtils.round(timestamp, hopSize) + hopSize
-          ctx.timerService().registerProcessingTimeTimer(nextEviction)
-        } else {
-          // Catchup mode: re-register next event-time timer
-          ctx.timerService().registerEventTimeTimer(timestamp + hopSize)
-        }
+      val timerService = ctx.timerService()
+      val processingTs = timerService.currentProcessingTime()
+      val watermark = timerService.currentWatermark()
+      val isEmitTimer = isCurrentEmitTimer(timestamp)
+      val isEvictTimer = isCurrentEvictTimer(timestamp)
+      if (isEmitTimer) {
+        nextEmitPtTimerState.clear()
+      }
+      if (isEvictTimer) {
+        nextEvictPtTimerState.clear()
+      }
+
+      if (isEvictTimer && isEmitTimer) {
+        // Step 7 and Step 8.
+        runEvictionTimer(ctx.getCurrentKey, timestamp, processingTs, watermark, timerService, out)
+        // Step 9: this timestamp is also the buffered emit timer, so emit once after Step 8 rebuilt state.
+        emitDirtyMegaTiles(ctx.getCurrentKey, processingTs, out)
+      } else if (isEvictTimer) {
+        // Step 7 and Step 8.
+        runEvictionTimer(ctx.getCurrentKey, timestamp, processingTs, watermark, timerService, out)
+        // Step 9: eviction changed state; if buffering is enabled, arm one emit timer.
+        emitDirtyOrSchedule(processingTs, processingTs, timerService, out)
+      } else if (isEmitTimer) {
+        // Step 7 and Step 9.
+        emitDirtyMegaTiles(ctx.getCurrentKey, processingTs, out)
       }
     } catch {
       case e: Exception =>
@@ -221,10 +268,227 @@ class MegaTileProcessFunction(
         eventProcessingErrorCounter.inc()
     }
   }
+
+  private def hasActiveSmallWindowState: Boolean =
+    processor.hasSmallWindows &&
+      Option(earliestTileStartState.value()).exists(_.longValue() != Long.MaxValue)
+
+  private def isOlderThanYesterdayForCurrentDay(eventTs: Long): Boolean = {
+    val currentDayStart = flinkStore.getCurrentDayStart
+    currentDayStart != -1L && eventTs < currentDayStart - processor.DayMillis
+  }
+
+  private def bufferingEnabled: Boolean =
+    bufferingOutputTimeMillis > 0L
+
+  private def isTodayDirty: Boolean =
+    Option(todayDirtyState.value()).exists(_.booleanValue())
+
+  private def isYesterdayDirty: Boolean =
+    Option(yesterdayDirtyState.value()).exists(_.booleanValue())
+
+  private def markDirtyState(hasTodayUpdate: Boolean, hasYesterdayUpdate: Boolean): Unit = {
+    if (hasTodayUpdate) todayDirtyState.update(java.lang.Boolean.TRUE)
+    if (hasYesterdayUpdate) yesterdayDirtyState.update(java.lang.Boolean.TRUE)
+  }
+
+  private def runEvictionTimer(currentKey: java.util.List[Any],
+                               timestamp: Long,
+                               processingTs: Long,
+                               watermark: Long,
+                               timerService: TimerService,
+                               out: Collector[TimestampedTile]): Unit = {
+    val mode = currentMode(processingTs, watermark)
+    val evictionTime = evictionTimeForProcessingTimer(mode, processingTs, watermark)
+    emitTodayIfNeededThenRollDay(evictionTime, currentKey, processingTs, out)
+
+    val result = processor.onEviction(evictionTime)
+    markDirtyState(result.todayEntry != null, hasYesterdayUpdate = false)
+    scheduleEvictTimerIfNeeded(timerService, processingTs)
+
+    if (enableDebug) {
+      logger.info(
+        s"MegaTile eviction groupBy=${groupBy.getMetaData.getName}, key=$currentKey, " +
+          s"timerTs=$timestamp, evictionTime=$evictionTime, mode=$mode, " +
+          s"watermark=$watermark, processingTs=$processingTs, dayStart=${flinkStore.getCurrentDayStart}, " +
+          s"todayDirty=$isTodayDirty, yesterdayDirty=$isYesterdayDirty")
+    }
+  }
+
+  /** Advance day state at `dayTransitionTs` without losing a buffered pre-rollover today row.
+    *
+    * Both input events and processing-time eviction timers can cross a day boundary:
+    *   - `processElement` uses the current Flink watermark before applying the event.
+    *   - `runEvictionTimer` uses either a watermark-aligned replay timestamp or wall-clock PT.
+    *
+    * If that timestamp moves `currentDayStart` forward by exactly one day and today's row is still
+    * dirty, emit `packTodayEntry()` under the previous day key first. Then advance the processor's
+    * day state. This keeps the final small-window row for the old day from being lost when
+    * `advanceWatermark(...)` rotates `largeTodayIr` into yesterday and resets today.
+    *
+    * Emitting under `previousDayStart` preserves the logical daily key across rollover; `MegaTileAvroCodecFn`
+    * uses that day-start timestamp when constructing the external `TileKey`.
+    */
+  private def emitTodayIfNeededThenRollDay(dayTransitionTs: Long,
+                                           keys: java.util.List[Any],
+                                           processingTsMillis: Long,
+                                           out: Collector[TimestampedTile]): Unit = {
+    val previousDayStart = flinkStore.getCurrentDayStart
+    val nextDayStart = previousDayStart + processor.DayMillis
+    val shouldEmitPreviousTodayRow =
+      previousDayStart != -1L &&
+        isTodayDirty &&
+        TsUtils.round(dayTransitionTs, processor.DayMillis) == nextDayStart
+    if (shouldEmitPreviousTodayRow) {
+      emitMegaTileIfPresent(keys, processor.packTodayEntry(), previousDayStart, processingTsMillis, out)
+      todayDirtyState.clear()
+    }
+
+    processor.advanceWatermark(dayTransitionTs)
+  }
+
+  sealed private trait Mode
+
+  private case object NoWatermark extends Mode
+
+  private case object ActiveCatchup extends Mode
+
+  private case object SparseKeyLag extends Mode
+
+  private case object Live extends Mode
+
+  private def currentMode(processingTs: Long, watermark: Long): Mode = {
+    val lastEventProcessingTs =
+      Option(lastEventProcessingTsState.value()).map(_.longValue()).getOrElse(Long.MinValue)
+    val watermarkLaggingProcessingTime =
+      watermark > Long.MinValue &&
+        processingTs - watermark > processor.minSmallWindowTileSize + FlinkJob.CatchupWatermarkLagSlackMillis
+    val keyRecentlySeenEvent =
+      lastEventProcessingTs > Long.MinValue &&
+        processingTs - lastEventProcessingTs <= processor.minSmallWindowTileSize
+
+    if (watermark == Long.MinValue) {
+      NoWatermark
+    } else if (watermarkLaggingProcessingTime && keyRecentlySeenEvent) {
+      ActiveCatchup
+    } else if (watermarkLaggingProcessingTime && !keyRecentlySeenEvent) {
+      SparseKeyLag
+    } else {
+      Live
+    }
+  }
+
+  private def evictionTimeForProcessingTimer(mode: Mode, processingTs: Long, watermark: Long): Long =
+    mode match {
+      case ActiveCatchup =>
+        nextSmallWindowHop(watermark)
+      case NoWatermark | SparseKeyLag | Live =>
+        processingTs
+    }
+
+  private def smallWindowAsOfTsForEvent(mode: Mode, eventTs: Long, processingTs: Long, watermark: Long): Long =
+    mode match {
+      case ActiveCatchup =>
+        nextSmallWindowHop(watermark)
+      case NoWatermark =>
+        nextSmallWindowHop(eventTs)
+      case SparseKeyLag | Live =>
+        nextSmallWindowHop(processingTs)
+    }
+
+  private def nextSmallWindowHop(ts: Long): Long =
+    TsUtils.round(ts, processor.minSmallWindowTileSize) + processor.minSmallWindowTileSize
+
+  private def scheduleEvictTimerIfNeeded(timerService: TimerService, processingTs: Long): Unit = {
+    if (!hasActiveSmallWindowState) {
+      cancelEvictTimerIfPresent(timerService)
+      return
+    }
+
+    val current = nextEvictPtTimerState.value()
+    if (current != null) return
+
+    val timestamp =
+      TsUtils.round(processingTs, processor.minSmallWindowTileSize) + processor.minSmallWindowTileSize
+    timerService.registerProcessingTimeTimer(timestamp)
+    nextEvictPtTimerState.update(timestamp)
+  }
+
+  private def emitDirtyOrSchedule(outputProcessingTsMillis: Long,
+                                  processingTs: Long,
+                                  timerService: TimerService,
+                                  out: Collector[TimestampedTile]): Unit = {
+    if (!bufferingEnabled) {
+      emitDirtyMegaTiles(lastKey, outputProcessingTsMillis, out)
+      return
+    }
+    scheduleEmitTimerIfNeeded(timerService, processingTs)
+  }
+
+  private def scheduleEmitTimerIfNeeded(timerService: TimerService, processingTs: Long): Unit = {
+    if (!isTodayDirty && !isYesterdayDirty) return
+
+    val current = nextEmitPtTimerState.value()
+    if (current == null) {
+      val timestamp =
+        processingTs + bufferingOutputTimeMillis + stableJitterMillis(lastKey, bufferingOutputJitterMillis)
+      timerService.registerProcessingTimeTimer(timestamp)
+      nextEmitPtTimerState.update(timestamp)
+    }
+  }
+
+  private def stableJitterMillis(key: java.util.List[Any], maxJitterMillis: Long): Long =
+    if (maxJitterMillis <= 0L) 0L
+    else Math.floorMod(key.hashCode().toLong, maxJitterMillis + 1L)
+
+  private def cancelEvictTimerIfPresent(timerService: TimerService): Unit = {
+    val current = nextEvictPtTimerState.value()
+    if (current != null) {
+      timerService.deleteProcessingTimeTimer(current.longValue())
+      nextEvictPtTimerState.clear()
+    }
+  }
+
+  private def isCurrentEmitTimer(timestamp: Long): Boolean = {
+    val current = nextEmitPtTimerState.value()
+    current != null && current.longValue() == timestamp
+  }
+
+  private def isCurrentEvictTimer(timestamp: Long): Boolean = {
+    val current = nextEvictPtTimerState.value()
+    current != null && current.longValue() == timestamp
+  }
+
+  private def emitDirtyMegaTiles(keys: java.util.List[Any],
+                                 processingTsMillis: Long,
+                                 out: Collector[TimestampedTile]): Unit = {
+    val currentDayStart = flinkStore.getCurrentDayStart
+    if (isTodayDirty) {
+      emitMegaTileIfPresent(keys, processor.packTodayEntry(), currentDayStart, processingTsMillis, out)
+      todayDirtyState.clear()
+    }
+    if (isYesterdayDirty) {
+      emitMegaTileIfPresent(keys,
+                            processor.packYesterdayEntry(),
+                            currentDayStart - processor.DayMillis,
+                            processingTsMillis,
+                            out)
+      yesterdayDirtyState.clear()
+    }
+  }
+
+  private def emitMegaTileIfPresent(keys: java.util.List[Any],
+                                    entry: Array[Any],
+                                    dayStartMillis: Long,
+                                    processingTsMillis: Long,
+                                    out: Collector[TimestampedTile]): Unit = {
+    if (entry == null) return
+    out.collect(new TimestampedTile(keys, megaTileCodec.encode(entry), dayStartMillis, processingTsMillis))
+  }
 }
 
 /** TileStore backed by Flink's keyed MapState/ValueState.
-  * Encodes/decodes only the entries actually accessed — no bulk restore/persist.
+  * Encodes/decodes only the entries actually accessed - no bulk restore/persist.
   * Windowed IR get/put is memoized to avoid redundant decodes within the same event
   * (e.g., onEvent reads cachedSmallWindowIr, then packTodayEntry reads it again).
   * Cache is invalidated on key switch via bindFlinkState.
@@ -240,7 +504,7 @@ class FlinkTileStore(megaTileAgg: MegaTileAggregator, codec: MegaTileCodec) exte
   private var earliestTileStartState: ValueState[java.lang.Long] = _
 
   // Per-access decode cache for windowed IRs. Avoids redundant Avro decodes
-  // when the same IR is read multiple times within one event (get → update → pack).
+  // when the same IR is read multiple times within one event (get -> update -> pack).
   // Invalidated on key switch (bindFlinkState) and updated on put.
   private var cachedSmallDecoded: Array[Any] = _
   private var cachedSmallValid: Boolean = false

--- a/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
@@ -163,10 +163,11 @@ class MegaTileProcessFunction(
     }
   }
 
-  // Restore MegaTileStreamProcessor mutable state from Flink managed state
+  // Restore MegaTileStreamProcessor mutable state from Flink managed state.
+  // Reinitialize processor first to clear previous key's state — Flink reuses
+  // the same KeyedProcessFunction instance across keys within a task.
   private def restoreProcessorState(): Unit = {
-    // Tiles: stored as base (unwindowed) IRs via megaTileCodec.encodeBaseIr
-    processor.tiles.values.foreach(_.clear())
+    processor = new MegaTileStreamProcessor(processor.megaTileAgg)
     val tileIter = tileState.iterator()
     while (tileIter.hasNext) {
       val entry = tileIter.next()

--- a/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
@@ -16,8 +16,7 @@ import org.slf4j.{Logger, LoggerFactory}
 
 import scala.util.{Failure, Success, Try}
 
-/**
-  * Flink KeyedProcessFunction that maintains per-entity mega tile state.
+/** Flink KeyedProcessFunction that maintains per-entity mega tile state.
   * Delegates all aggregation logic to MegaTileStreamProcessor (pure Scala, no Flink deps).
   * Handles Flink-specific concerns: state serde, timer registration, output collection.
   */
@@ -58,10 +57,10 @@ class MegaTileProcessFunction(
 
     tileState = getRuntimeContext.getMapState(
       new MapStateDescriptor[String, Array[Byte]]("mega-tile-tiles", classOf[String], classOf[Array[Byte]]))
-    megaTileIrState = getRuntimeContext.getState(
-      new ValueStateDescriptor[Array[Byte]]("mega-tile-ir", classOf[Array[Byte]]))
-    largeTodayIrState = getRuntimeContext.getState(
-      new ValueStateDescriptor[Array[Byte]]("mega-tile-large-today", classOf[Array[Byte]]))
+    megaTileIrState =
+      getRuntimeContext.getState(new ValueStateDescriptor[Array[Byte]]("mega-tile-ir", classOf[Array[Byte]]))
+    largeTodayIrState =
+      getRuntimeContext.getState(new ValueStateDescriptor[Array[Byte]]("mega-tile-large-today", classOf[Array[Byte]]))
     largeYesterdayIrState = getRuntimeContext.getState(
       new ValueStateDescriptor[Array[Byte]]("mega-tile-large-yesterday", classOf[Array[Byte]]))
     currentDayStartState = getRuntimeContext.getState(
@@ -111,12 +110,15 @@ class MegaTileProcessFunction(
       // Emit results
       val keys = ctx.getCurrentKey
       if (result.todayEntry != null) {
-        out.collect(new TimestampedTile(keys, megaTileCodec.encode(result.todayEntry),
-                                        tsMills, event.startProcessingTimeMillis))
+        out.collect(
+          new TimestampedTile(keys, megaTileCodec.encode(result.todayEntry), tsMills, event.startProcessingTimeMillis))
       }
       if (result.yesterdayEntry != null) {
-        out.collect(new TimestampedTile(keys, megaTileCodec.encode(result.yesterdayEntry),
-                                        result.yesterdayStart, event.startProcessingTimeMillis))
+        out.collect(
+          new TimestampedTile(keys,
+                              megaTileCodec.encode(result.yesterdayEntry),
+                              result.yesterdayStart,
+                              event.startProcessingTimeMillis))
       }
 
       // Register eviction timer
@@ -147,8 +149,8 @@ class MegaTileProcessFunction(
 
       if (result.todayEntry != null) {
         val keys = ctx.getCurrentKey
-        out.collect(new TimestampedTile(keys, megaTileCodec.encode(result.todayEntry),
-                                        timestamp, System.currentTimeMillis()))
+        out.collect(
+          new TimestampedTile(keys, megaTileCodec.encode(result.todayEntry), timestamp, System.currentTimeMillis()))
       }
 
       // Register next eviction timer

--- a/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
@@ -1,6 +1,6 @@
 package ai.chronon.flink.window
 
-import ai.chronon.aggregator.windowing.{MegaTileAggregator, MegaTileStreamProcessor}
+import ai.chronon.aggregator.windowing.{MegaTileAggregator, MegaTileStreamProcessor, TileStore}
 import ai.chronon.api.{Constants, DataType, GroupBy, TsUtils}
 import ai.chronon.api.ScalaJavaConversions.IteratorOps
 import ai.chronon.flink.deser.ProjectedEvent
@@ -17,8 +17,8 @@ import org.slf4j.{Logger, LoggerFactory}
 import scala.util.{Failure, Success, Try}
 
 /** Flink KeyedProcessFunction that maintains per-entity mega tile state.
-  * Delegates all aggregation logic to MegaTileStreamProcessor (pure Scala, no Flink deps).
-  * Handles Flink-specific concerns: state serde, timer registration, output collection.
+  * Delegates all aggregation logic to MegaTileStreamProcessor.
+  * State access goes through FlinkTileStore — only touched entries are serialized/deserialized.
   */
 class MegaTileProcessFunction(
     groupBy: GroupBy,
@@ -28,22 +28,17 @@ class MegaTileProcessFunction(
 
   @transient lazy val logger: Logger = LoggerFactory.getLogger(getClass)
 
-  // Transient: rebuilt on checkpoint restore
   @transient private var processor: MegaTileStreamProcessor = _
   @transient private var megaTileCodec: MegaTileCodec = _
+  @transient private var flinkStore: FlinkTileStore = _
 
   @transient private var eventProcessingErrorCounter: Counter = _
-
-  // Track the current key to avoid reinitializing processor on every event.
-  // Flink reuses this function across keys — only reset when the key changes.
   @transient private var lastKey: java.util.List[Any] = _
 
   private val valueColumns: Array[String] = inputSchema.map(_._1).toArray
   private val timeColumnAlias: String = Constants.TimeColumn
 
-  // Flink managed state — survives checkpoints
-  // Tiles are stored as encoded bytes to avoid custom TypeSerializer.
-  // Key format: "hopSize:tileStart"
+  // Flink managed state
   private var tileState: MapState[String, Array[Byte]] = _
   private var megaTileIrState: ValueState[Array[Byte]] = _
   private var largeTodayIrState: ValueState[Array[Byte]] = _
@@ -77,12 +72,10 @@ class MegaTileProcessFunction(
 
   private def initializeTransients(): Unit = {
     val inputCols = inputSchema.map { case (name, dt) => (name, dt) }
-    val megaTileAgg = new MegaTileAggregator(
-      groupBy.getAggregations.iterator().toScala.toSeq,
-      inputCols
-    )
-    processor = new MegaTileStreamProcessor(megaTileAgg)
+    val megaTileAgg = new MegaTileAggregator(groupBy.getAggregations.iterator().toScala.toSeq, inputCols)
     megaTileCodec = new MegaTileCodec(groupBy, inputCols)
+    flinkStore = new FlinkTileStore(megaTileAgg, megaTileCodec)
+    processor = new MegaTileStreamProcessor(megaTileAgg, flinkStore)
   }
 
   override def processElement(
@@ -99,21 +92,22 @@ class MegaTileProcessFunction(
       val values: Array[Any] = valueColumns.map(element(_))
       val row = new ArrayRow(values, tsMills)
 
-      // Restore processor state from Flink state (only resets on key switch)
-      restoreProcessorState(ctx.getCurrentKey)
+      // Point FlinkTileStore at current key's Flink state (only resets on key switch)
+      val currentKey = ctx.getCurrentKey
+      if (lastKey == null || !lastKey.equals(currentKey)) {
+        lastKey = currentKey
+        flinkStore.bindFlinkState(tileState,
+                                  megaTileIrState,
+                                  largeTodayIrState,
+                                  largeYesterdayIrState,
+                                  currentDayStartState,
+                                  earliestTileStartState)
+      }
 
-      // Advance watermark (may trigger day transition)
       processor.advanceWatermark(ctx.timerService().currentWatermark())
-
-      // Process event
       val result = processor.onEvent(row, tsMills)
 
-      // Persist processor state back to Flink state
-      persistProcessorState()
-
-      // Emit results. Use todayStart/yesterdayStart as latestTsMillis so the codec
-      // writes to the correct daily KV key. Using raw eventTs would misroute
-      // future-timestamped events (clamped to today by watermark logic).
+      // Emit results
       val keys = ctx.getCurrentKey
       if (result.todayEntry != null) {
         out.collect(
@@ -130,7 +124,6 @@ class MegaTileProcessFunction(
                               event.startProcessingTimeMillis))
       }
 
-      // Register eviction timer
       if (processor.hasSmallWindows) {
         val nextEviction = TsUtils.round(tsMills, processor.minSmallWindowTileSize) + processor.minSmallWindowTileSize
         ctx.timerService().registerEventTimeTimer(nextEviction)
@@ -150,25 +143,30 @@ class MegaTileProcessFunction(
     try {
       if (processor == null) initializeTransients()
 
-      restoreProcessorState(ctx.getCurrentKey)
-      processor.advanceWatermark(ctx.timerService().currentWatermark())
+      val currentKey = ctx.getCurrentKey
+      if (lastKey == null || !lastKey.equals(currentKey)) {
+        lastKey = currentKey
+        flinkStore.bindFlinkState(tileState,
+                                  megaTileIrState,
+                                  largeTodayIrState,
+                                  largeYesterdayIrState,
+                                  currentDayStartState,
+                                  earliestTileStartState)
+      }
 
+      processor.advanceWatermark(ctx.timerService().currentWatermark())
       val result = processor.onEviction(timestamp)
-      persistProcessorState()
 
       if (result.todayEntry != null) {
-        val keys = ctx.getCurrentKey
         out.collect(
-          new TimestampedTile(keys,
+          new TimestampedTile(ctx.getCurrentKey,
                               megaTileCodec.encode(result.todayEntry),
                               result.todayStart,
                               System.currentTimeMillis()))
       }
 
-      // Register next eviction timer
       if (processor.hasSmallWindows) {
-        val nextEviction = timestamp + processor.minSmallWindowTileSize
-        ctx.timerService().registerEventTimeTimer(nextEviction)
+        ctx.timerService().registerEventTimeTimer(timestamp + processor.minSmallWindowTileSize)
       }
     } catch {
       case e: Exception =>
@@ -176,47 +174,80 @@ class MegaTileProcessFunction(
         eventProcessingErrorCounter.inc()
     }
   }
+}
 
-  // Restore MegaTileStreamProcessor mutable state from Flink managed state.
-  // Only resets processor state on key switch to avoid GC pressure from
-  // allocating new objects on every event.
-  private def restoreProcessorState(currentKey: java.util.List[Any]): Unit = {
-    val keyChanged = lastKey == null || !lastKey.equals(currentKey)
-    lastKey = currentKey
-    if (keyChanged) processor.reset()
-    val tileIter = tileState.iterator()
-    while (tileIter.hasNext) {
-      val entry = tileIter.next()
-      val parts = entry.getKey.split(":")
-      val hopSize = parts(0).toLong
-      val tileStart = parts(1).toLong
-      processor.tiles.get(hopSize).foreach { tierTiles =>
-        tierTiles(tileStart) = megaTileCodec.decodeBaseIr(entry.getValue)
+/** TileStore backed by Flink's keyed MapState/ValueState.
+  * Encodes/decodes only the entries actually accessed — no bulk restore/persist.
+  * Flink's keyed state is automatically scoped to the current key.
+  */
+class FlinkTileStore(megaTileAgg: MegaTileAggregator, codec: MegaTileCodec) extends TileStore {
+  private val windowedAgg = megaTileAgg.windowedAggregator
+
+  // These are set via bindFlinkState when the key changes
+  private var tileState: MapState[String, Array[Byte]] = _
+  private var megaTileIrState: ValueState[Array[Byte]] = _
+  private var largeTodayIrState: ValueState[Array[Byte]] = _
+  private var largeYesterdayIrState: ValueState[Array[Byte]] = _
+  private var currentDayStartState: ValueState[java.lang.Long] = _
+  private var earliestTileStartState: ValueState[java.lang.Long] = _
+
+  def bindFlinkState(tiles: MapState[String, Array[Byte]],
+                     megaTileIr: ValueState[Array[Byte]],
+                     largeToday: ValueState[Array[Byte]],
+                     largeYesterday: ValueState[Array[Byte]],
+                     dayStart: ValueState[java.lang.Long],
+                     earliest: ValueState[java.lang.Long]): Unit = {
+    tileState = tiles
+    megaTileIrState = megaTileIr
+    largeTodayIrState = largeToday
+    largeYesterdayIrState = largeYesterday
+    currentDayStartState = dayStart
+    earliestTileStartState = earliest
+  }
+
+  private def tileKey(hopSize: Long, tileStart: Long): String = s"$hopSize:$tileStart"
+
+  override def getTile(hopSize: Long, tileStart: Long): Array[Any] = {
+    val bytes = tileState.get(tileKey(hopSize, tileStart))
+    if (bytes != null) codec.decodeBaseIr(bytes) else null
+  }
+
+  override def putTile(hopSize: Long, tileStart: Long, ir: Array[Any]): Unit =
+    tileState.put(tileKey(hopSize, tileStart), codec.encodeBaseIr(ir))
+
+  override def removeTile(hopSize: Long, tileStart: Long): Unit =
+    tileState.remove(tileKey(hopSize, tileStart))
+
+  override def tileIterator: Iterator[(Long, Long, Array[Any])] = {
+    val iter = tileState.iterator()
+    new Iterator[(Long, Long, Array[Any])] {
+      override def hasNext: Boolean = iter.hasNext
+      override def next(): (Long, Long, Array[Any]) = {
+        val entry = iter.next()
+        val parts = entry.getKey.split(":")
+        (parts(0).toLong, parts(1).toLong, codec.decodeBaseIr(entry.getValue))
       }
     }
-
-    // Cached small window IR + large window IRs: stored as windowed IRs
-    Option(megaTileIrState.value()).foreach(bytes => processor.cachedSmallWindowIr = megaTileCodec.decode(bytes))
-    Option(largeTodayIrState.value()).foreach(bytes => processor.largeTodayIr = megaTileCodec.decode(bytes))
-    Option(largeYesterdayIrState.value()).foreach(bytes => processor.largeYesterdayIr = megaTileCodec.decode(bytes))
-    Option(currentDayStartState.value()).foreach(v => processor.currentDayStart = v)
-    Option(earliestTileStartState.value()).foreach(v => processor.earliestTileStart = v)
   }
 
-  // Persist MegaTileStreamProcessor mutable state to Flink managed state
-  private def persistProcessorState(): Unit = {
-    // Tiles: encode as base (unwindowed) IRs
-    tileState.clear()
-    for ((hopSize, tierTiles) <- processor.tiles; (tileStart, ir) <- tierTiles) {
-      val key = s"$hopSize:$tileStart"
-      tileState.put(key, megaTileCodec.encodeBaseIr(ir))
-    }
-
-    // IRs: encode as windowed IRs
-    megaTileIrState.update(megaTileCodec.encode(processor.cachedSmallWindowIr))
-    largeTodayIrState.update(megaTileCodec.encode(processor.largeTodayIr))
-    largeYesterdayIrState.update(megaTileCodec.encode(processor.largeYesterdayIr))
-    currentDayStartState.update(processor.currentDayStart)
-    earliestTileStartState.update(processor.earliestTileStart)
+  private def decodeWindowedIr(state: ValueState[Array[Byte]]): Array[Any] = {
+    val bytes = state.value()
+    if (bytes != null) codec.decode(bytes) else windowedAgg.init
   }
+
+  override def getCachedSmallWindowIr: Array[Any] = decodeWindowedIr(megaTileIrState)
+  override def putCachedSmallWindowIr(ir: Array[Any]): Unit = megaTileIrState.update(codec.encode(ir))
+
+  override def getLargeTodayIr: Array[Any] = decodeWindowedIr(largeTodayIrState)
+  override def putLargeTodayIr(ir: Array[Any]): Unit = largeTodayIrState.update(codec.encode(ir))
+
+  override def getLargeYesterdayIr: Array[Any] = decodeWindowedIr(largeYesterdayIrState)
+  override def putLargeYesterdayIr(ir: Array[Any]): Unit = largeYesterdayIrState.update(codec.encode(ir))
+
+  override def getCurrentDayStart: Long = Option(currentDayStartState.value()).map(_.longValue()).getOrElse(-1L)
+  override def putCurrentDayStart(ts: Long): Unit = currentDayStartState.update(ts)
+
+  override def getEarliestTileStart: Long =
+    Option(earliestTileStartState.value()).map(_.longValue()).getOrElse(Long.MaxValue)
+  override def putEarliestTileStart(ts: Long): Unit = earliestTileStartState.update(ts)
 }

--- a/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
@@ -178,18 +178,29 @@ class MegaTileProcessFunction(
 
 /** TileStore backed by Flink's keyed MapState/ValueState.
   * Encodes/decodes only the entries actually accessed — no bulk restore/persist.
-  * Flink's keyed state is automatically scoped to the current key.
+  * Windowed IR get/put is memoized to avoid redundant decodes within the same event
+  * (e.g., onEvent reads cachedSmallWindowIr, then packTodayEntry reads it again).
+  * Cache is invalidated on key switch via bindFlinkState.
   */
 class FlinkTileStore(megaTileAgg: MegaTileAggregator, codec: MegaTileCodec) extends TileStore {
   private val windowedAgg = megaTileAgg.windowedAggregator
 
-  // These are set via bindFlinkState when the key changes
   private var tileState: MapState[String, Array[Byte]] = _
   private var megaTileIrState: ValueState[Array[Byte]] = _
   private var largeTodayIrState: ValueState[Array[Byte]] = _
   private var largeYesterdayIrState: ValueState[Array[Byte]] = _
   private var currentDayStartState: ValueState[java.lang.Long] = _
   private var earliestTileStartState: ValueState[java.lang.Long] = _
+
+  // Per-access decode cache for windowed IRs. Avoids redundant Avro decodes
+  // when the same IR is read multiple times within one event (get → update → pack).
+  // Invalidated on key switch (bindFlinkState) and updated on put.
+  private var cachedSmallDecoded: Array[Any] = _
+  private var cachedSmallValid: Boolean = false
+  private var largeTodayDecoded: Array[Any] = _
+  private var largeTodayValid: Boolean = false
+  private var largeYesterdayDecoded: Array[Any] = _
+  private var largeYesterdayValid: Boolean = false
 
   def bindFlinkState(tiles: MapState[String, Array[Byte]],
                      megaTileIr: ValueState[Array[Byte]],
@@ -203,6 +214,10 @@ class FlinkTileStore(megaTileAgg: MegaTileAggregator, codec: MegaTileCodec) exte
     largeYesterdayIrState = largeYesterday
     currentDayStartState = dayStart
     earliestTileStartState = earliest
+    // Invalidate decode cache on key switch
+    cachedSmallValid = false
+    largeTodayValid = false
+    largeYesterdayValid = false
   }
 
   private def tileKey(hopSize: Long, tileStart: Long): String = s"$hopSize:$tileStart"
@@ -235,14 +250,34 @@ class FlinkTileStore(megaTileAgg: MegaTileAggregator, codec: MegaTileCodec) exte
     if (bytes != null) codec.decode(bytes) else windowedAgg.init
   }
 
-  override def getCachedSmallWindowIr: Array[Any] = decodeWindowedIr(megaTileIrState)
-  override def putCachedSmallWindowIr(ir: Array[Any]): Unit = megaTileIrState.update(codec.encode(ir))
+  override def getCachedSmallWindowIr: Array[Any] = {
+    if (!cachedSmallValid) { cachedSmallDecoded = decodeWindowedIr(megaTileIrState); cachedSmallValid = true }
+    cachedSmallDecoded
+  }
+  override def putCachedSmallWindowIr(ir: Array[Any]): Unit = {
+    megaTileIrState.update(codec.encode(ir))
+    cachedSmallDecoded = ir; cachedSmallValid = true
+  }
 
-  override def getLargeTodayIr: Array[Any] = decodeWindowedIr(largeTodayIrState)
-  override def putLargeTodayIr(ir: Array[Any]): Unit = largeTodayIrState.update(codec.encode(ir))
+  override def getLargeTodayIr: Array[Any] = {
+    if (!largeTodayValid) { largeTodayDecoded = decodeWindowedIr(largeTodayIrState); largeTodayValid = true }
+    largeTodayDecoded
+  }
+  override def putLargeTodayIr(ir: Array[Any]): Unit = {
+    largeTodayIrState.update(codec.encode(ir))
+    largeTodayDecoded = ir; largeTodayValid = true
+  }
 
-  override def getLargeYesterdayIr: Array[Any] = decodeWindowedIr(largeYesterdayIrState)
-  override def putLargeYesterdayIr(ir: Array[Any]): Unit = largeYesterdayIrState.update(codec.encode(ir))
+  override def getLargeYesterdayIr: Array[Any] = {
+    if (!largeYesterdayValid) {
+      largeYesterdayDecoded = decodeWindowedIr(largeYesterdayIrState); largeYesterdayValid = true
+    }
+    largeYesterdayDecoded
+  }
+  override def putLargeYesterdayIr(ir: Array[Any]): Unit = {
+    largeYesterdayIrState.update(codec.encode(ir))
+    largeYesterdayDecoded = ir; largeYesterdayValid = true
+  }
 
   override def getCurrentDayStart: Long = Option(currentDayStartState.value()).map(_.longValue()).getOrElse(-1L)
   override def putCurrentDayStart(ts: Long): Unit = currentDayStartState.update(ts)

--- a/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
@@ -107,11 +107,16 @@ class MegaTileProcessFunction(
       // Persist processor state back to Flink state
       persistProcessorState()
 
-      // Emit results
+      // Emit results. Use todayStart/yesterdayStart as latestTsMillis so the codec
+      // writes to the correct daily KV key. Using raw eventTs would misroute
+      // future-timestamped events (clamped to today by watermark logic).
       val keys = ctx.getCurrentKey
       if (result.todayEntry != null) {
         out.collect(
-          new TimestampedTile(keys, megaTileCodec.encode(result.todayEntry), tsMills, event.startProcessingTimeMillis))
+          new TimestampedTile(keys,
+                              megaTileCodec.encode(result.todayEntry),
+                              result.todayStart,
+                              event.startProcessingTimeMillis))
       }
       if (result.yesterdayEntry != null) {
         out.collect(
@@ -150,7 +155,10 @@ class MegaTileProcessFunction(
       if (result.todayEntry != null) {
         val keys = ctx.getCurrentKey
         out.collect(
-          new TimestampedTile(keys, megaTileCodec.encode(result.todayEntry), timestamp, System.currentTimeMillis()))
+          new TimestampedTile(keys,
+                              megaTileCodec.encode(result.todayEntry),
+                              result.todayStart,
+                              System.currentTimeMillis()))
       }
 
       // Register next eviction timer

--- a/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
@@ -1,0 +1,212 @@
+package ai.chronon.flink.window
+
+import ai.chronon.aggregator.windowing.{MegaTileAggregator, MegaTileStreamProcessor}
+import ai.chronon.api.{Constants, DataType, GroupBy, TsUtils}
+import ai.chronon.api.ScalaJavaConversions.IteratorOps
+import ai.chronon.flink.deser.ProjectedEvent
+import ai.chronon.flink.types.TimestampedTile
+import ai.chronon.online.MegaTileCodec
+import ai.chronon.online.TileCodec
+import ai.chronon.online.serde.ArrayRow
+import org.apache.flink.api.common.state.{MapState, MapStateDescriptor, ValueState, ValueStateDescriptor}
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.metrics.Counter
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction
+import org.apache.flink.util.Collector
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.util.{Failure, Success, Try}
+
+/**
+  * Flink KeyedProcessFunction that maintains per-entity mega tile state.
+  * Delegates all aggregation logic to MegaTileStreamProcessor (pure Scala, no Flink deps).
+  * Handles Flink-specific concerns: state serde, timer registration, output collection.
+  */
+class MegaTileProcessFunction(
+    groupBy: GroupBy,
+    inputSchema: Seq[(String, DataType)],
+    enableDebug: Boolean = false
+) extends KeyedProcessFunction[java.util.List[Any], ProjectedEvent, TimestampedTile] {
+
+  @transient lazy val logger: Logger = LoggerFactory.getLogger(getClass)
+
+  // Transient: rebuilt on checkpoint restore
+  @transient private var processor: MegaTileStreamProcessor = _
+  @transient private var megaTileCodec: MegaTileCodec = _
+  @transient private var tileCodec: TileCodec = _
+
+  @transient private var eventProcessingErrorCounter: Counter = _
+
+  private val valueColumns: Array[String] = inputSchema.map(_._1).toArray
+  private val timeColumnAlias: String = Constants.TimeColumn
+
+  // Flink managed state — survives checkpoints
+  // Tiles are stored as encoded bytes to avoid custom TypeSerializer.
+  // Key format: "hopSize:tileStart"
+  private var tileState: MapState[String, Array[Byte]] = _
+  private var megaTileIrState: ValueState[Array[Byte]] = _
+  private var largeTodayIrState: ValueState[Array[Byte]] = _
+  private var largeYesterdayIrState: ValueState[Array[Byte]] = _
+  private var currentDayStartState: ValueState[java.lang.Long] = _
+  private var earliestTileStartState: ValueState[java.lang.Long] = _
+
+  override def open(parameters: Configuration): Unit = {
+    super.open(parameters)
+
+    val metricsGroup = getRuntimeContext.getMetricGroup
+      .addGroup("chronon")
+      .addGroup("feature_group", groupBy.getMetaData.getName)
+    eventProcessingErrorCounter = metricsGroup.counter("event_processing_error")
+
+    tileState = getRuntimeContext.getMapState(
+      new MapStateDescriptor[String, Array[Byte]]("mega-tile-tiles", classOf[String], classOf[Array[Byte]]))
+    megaTileIrState = getRuntimeContext.getState(
+      new ValueStateDescriptor[Array[Byte]]("mega-tile-ir", classOf[Array[Byte]]))
+    largeTodayIrState = getRuntimeContext.getState(
+      new ValueStateDescriptor[Array[Byte]]("mega-tile-large-today", classOf[Array[Byte]]))
+    largeYesterdayIrState = getRuntimeContext.getState(
+      new ValueStateDescriptor[Array[Byte]]("mega-tile-large-yesterday", classOf[Array[Byte]]))
+    currentDayStartState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Long]("mega-tile-day-start", classOf[java.lang.Long]))
+    earliestTileStartState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Long]("mega-tile-earliest-tile", classOf[java.lang.Long]))
+
+    initializeTransients()
+  }
+
+  private def initializeTransients(): Unit = {
+    val inputCols = inputSchema.map { case (name, dt) => (name, dt) }
+    val megaTileAgg = new MegaTileAggregator(
+      groupBy.getAggregations.iterator().toScala.toSeq,
+      inputCols
+    )
+    processor = new MegaTileStreamProcessor(megaTileAgg)
+    megaTileCodec = new MegaTileCodec(groupBy, inputCols)
+    tileCodec = new TileCodec(groupBy, inputCols)
+  }
+
+  override def processElement(
+      event: ProjectedEvent,
+      ctx: KeyedProcessFunction[java.util.List[Any], ProjectedEvent, TimestampedTile]#Context,
+      out: Collector[TimestampedTile]
+  ): Unit = {
+    try {
+      if (processor == null) initializeTransients()
+
+      val element = event.fields
+      val tsMills = Try(element(timeColumnAlias).asInstanceOf[Long])
+        .getOrElse(element(timeColumnAlias).asInstanceOf[Double].toLong)
+      val values: Array[Any] = valueColumns.map(element(_))
+      val row = new ArrayRow(values, tsMills)
+
+      // Restore processor state from Flink state
+      restoreProcessorState()
+
+      // Advance watermark (may trigger day transition)
+      processor.advanceWatermark(ctx.timerService().currentWatermark())
+
+      // Process event
+      val result = processor.onEvent(row, tsMills)
+
+      // Persist processor state back to Flink state
+      persistProcessorState()
+
+      // Emit results
+      val keys = ctx.getCurrentKey
+      if (result.todayEntry != null) {
+        out.collect(new TimestampedTile(keys, megaTileCodec.encode(result.todayEntry),
+                                        tsMills, event.startProcessingTimeMillis))
+      }
+      if (result.yesterdayEntry != null) {
+        out.collect(new TimestampedTile(keys, megaTileCodec.encode(result.yesterdayEntry),
+                                        result.yesterdayStart, event.startProcessingTimeMillis))
+      }
+
+      // Register eviction timer
+      if (processor.hasSmallWindows) {
+        val nextEviction = TsUtils.round(tsMills, processor.minSmallWindowTileSize) + processor.minSmallWindowTileSize
+        ctx.timerService().registerEventTimeTimer(nextEviction)
+      }
+    } catch {
+      case e: Exception =>
+        logger.error(s"Error processing mega tile event for groupBy=${groupBy.getMetaData.getName}", e)
+        eventProcessingErrorCounter.inc()
+    }
+  }
+
+  override def onTimer(
+      timestamp: Long,
+      ctx: KeyedProcessFunction[java.util.List[Any], ProjectedEvent, TimestampedTile]#OnTimerContext,
+      out: Collector[TimestampedTile]
+  ): Unit = {
+    try {
+      if (processor == null) initializeTransients()
+
+      restoreProcessorState()
+      processor.advanceWatermark(ctx.timerService().currentWatermark())
+
+      val result = processor.onEviction(timestamp)
+      persistProcessorState()
+
+      if (result.todayEntry != null) {
+        val keys = ctx.getCurrentKey
+        out.collect(new TimestampedTile(keys, megaTileCodec.encode(result.todayEntry),
+                                        timestamp, System.currentTimeMillis()))
+      }
+
+      // Register next eviction timer
+      if (processor.hasSmallWindows) {
+        val nextEviction = timestamp + processor.minSmallWindowTileSize
+        ctx.timerService().registerEventTimeTimer(nextEviction)
+      }
+    } catch {
+      case e: Exception =>
+        logger.error(s"Error in mega tile eviction for groupBy=${groupBy.getMetaData.getName}", e)
+        eventProcessingErrorCounter.inc()
+    }
+  }
+
+  // Restore MegaTileStreamProcessor mutable state from Flink managed state
+  private def restoreProcessorState(): Unit = {
+    // Tiles
+    processor.tiles.values.foreach(_.clear())
+    val tileIter = tileState.iterator()
+    while (tileIter.hasNext) {
+      val entry = tileIter.next()
+      val parts = entry.getKey.split(":")
+      val hopSize = parts(0).toLong
+      val tileStart = parts(1).toLong
+      processor.tiles.get(hopSize).foreach { tierTiles =>
+        val (ir, _) = tileCodec.decodeTileIr(entry.getValue)
+        // decodeTileIr returns windowed form; we need base form
+        // Use the base aggregator init size to extract base IR
+        tierTiles(tileStart) = processor.megaTileAgg.baseAggregator.denormalize(
+          processor.megaTileAgg.baseAggregator.normalize(ir.take(processor.megaTileAgg.baseAggregator.length)))
+      }
+    }
+
+    // Cached small window IR + large window IRs
+    Option(megaTileIrState.value()).foreach(bytes => processor.cachedSmallWindowIr = megaTileCodec.decode(bytes))
+    Option(largeTodayIrState.value()).foreach(bytes => processor.largeTodayIr = megaTileCodec.decode(bytes))
+    Option(largeYesterdayIrState.value()).foreach(bytes => processor.largeYesterdayIr = megaTileCodec.decode(bytes))
+    Option(currentDayStartState.value()).foreach(v => processor.currentDayStart = v)
+    Option(earliestTileStartState.value()).foreach(v => processor.earliestTileStart = v)
+  }
+
+  // Persist MegaTileStreamProcessor mutable state to Flink managed state
+  private def persistProcessorState(): Unit = {
+    // Tiles
+    tileState.clear()
+    for ((hopSize, tierTiles) <- processor.tiles; (tileStart, ir) <- tierTiles) {
+      val key = s"$hopSize:$tileStart"
+      tileState.put(key, tileCodec.makeTileIr(ir, isComplete = true))
+    }
+
+    // IRs
+    megaTileIrState.update(megaTileCodec.encode(processor.cachedSmallWindowIr))
+    largeTodayIrState.update(megaTileCodec.encode(processor.largeTodayIr))
+    largeYesterdayIrState.update(megaTileCodec.encode(processor.largeYesterdayIr))
+    currentDayStartState.update(processor.currentDayStart)
+    earliestTileStartState.update(processor.earliestTileStart)
+  }
+}

--- a/flink/src/test/scala/ai/chronon/flink/test/AllowedLatenessConfigTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/AllowedLatenessConfigTest.scala
@@ -117,4 +117,43 @@ class AllowedLatenessConfigTest extends AnyFlatSpec with Matchers {
     }
     exception.getMessage should include("exceeds maximum")
   }
+
+  "buffering output millis config" should "be parsed from props before topicInfo params" in {
+    val props = Map("buffering_output_time_millis" -> "1000")
+    val topicInfo = TopicInfo("test-topic", "kafka", Map("buffering_output_time_millis" -> "2000"))
+
+    FlinkUtils.getNonNegativeLongProperty("buffering_output_time_millis", props, topicInfo) shouldBe 1000L
+  }
+
+  it should "be parsed from topicInfo params when props are absent" in {
+    val topicInfo = TopicInfo("test-topic", "kafka", Map("buffering_output_jitter_millis" -> "250"))
+
+    FlinkUtils.getNonNegativeLongProperty("buffering_output_jitter_millis", Map.empty, topicInfo) shouldBe 250L
+  }
+
+  it should "default missing empty whitespace and negative values to 0" in {
+    val emptyTopicInfo = TopicInfo("test-topic", "kafka", Map("buffering_output_time_millis" -> ""))
+    val whitespaceTopicInfo = TopicInfo("test-topic", "kafka", Map.empty)
+    val negativeTopicInfo = TopicInfo("test-topic", "kafka", Map.empty)
+
+    FlinkUtils.getNonNegativeLongProperty("buffering_output_time_millis", Map.empty, emptyTopicInfo) shouldBe 0L
+    FlinkUtils.getNonNegativeLongProperty(
+      "buffering_output_time_millis",
+      Map("buffering_output_time_millis" -> "   "),
+      whitespaceTopicInfo) shouldBe 0L
+    FlinkUtils.getNonNegativeLongProperty(
+      "buffering_output_time_millis",
+      Map("buffering_output_time_millis" -> "-1"),
+      negativeTopicInfo) shouldBe 0L
+  }
+
+  it should "throw IllegalArgumentException for non-numeric values" in {
+    val props = Map("buffering_output_jitter_millis" -> "nope")
+    val topicInfo = TopicInfo("test-topic", "kafka", Map.empty)
+
+    val exception = the[IllegalArgumentException] thrownBy {
+      FlinkUtils.getNonNegativeLongProperty("buffering_output_jitter_millis", props, topicInfo)
+    }
+    exception.getMessage should include("invalid buffering_output_jitter_millis value")
+  }
 }

--- a/flink/src/test/scala/ai/chronon/flink/test/BaseFlinkJobMegaTileDefaultTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/BaseFlinkJobMegaTileDefaultTest.scala
@@ -1,0 +1,41 @@
+package ai.chronon.flink.test
+
+import ai.chronon.flink.BaseFlinkJob
+import ai.chronon.flink.types.WriteResponse
+import ai.chronon.online.GroupByServingInfoParsed
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/** Custom subclass that only implements runTiledGroupByJob — simulates a vendor / fork
+  * subclass that pre-dates MegaTile and doesn't opt into mega-tiled execution.
+  */
+private class LegacyOnlyFlinkJob(val groupByName: String) extends BaseFlinkJob {
+  override def groupByServingInfoParsed: GroupByServingInfoParsed = null
+  override def runTiledGroupByJob(env: StreamExecutionEnvironment): DataStream[WriteResponse] = null
+}
+
+class BaseFlinkJobMegaTileDefaultTest extends AnyFlatSpec with Matchers {
+
+  it should "default runMegaTiledGroupByJob impl throws so MegaTile opt-in is explicit" in {
+    val job = new LegacyOnlyFlinkJob("legacy_test_groupby")
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+
+    val ex = the[UnsupportedOperationException] thrownBy job.runMegaTiledGroupByJob(env)
+    ex.getMessage should include("LegacyOnlyFlinkJob")
+    ex.getMessage should include("legacy_test_groupby")
+    ex.getMessage should include("STREAMING_MEGATILES")
+  }
+
+  it should "let subclasses that implement runMegaTiledGroupByJob keep working" in {
+    val sentinel: DataStream[WriteResponse] = null
+    val job = new BaseFlinkJob {
+      override def groupByName: String = "implements_megatile"
+      override def groupByServingInfoParsed: GroupByServingInfoParsed = null
+      override def runTiledGroupByJob(env: StreamExecutionEnvironment): DataStream[WriteResponse] = sentinel
+      override def runMegaTiledGroupByJob(env: StreamExecutionEnvironment): DataStream[WriteResponse] = sentinel
+    }
+    noException should be thrownBy job.runMegaTiledGroupByJob(StreamExecutionEnvironment.getExecutionEnvironment)
+  }
+}

--- a/flink/src/test/scala/ai/chronon/flink/test/FlinkJobEventIntegrationTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/FlinkJobEventIntegrationTest.scala
@@ -1,14 +1,18 @@
 package ai.chronon.flink.test
 
-import ai.chronon.api.Extensions.GroupByOps
-import ai.chronon.api.{GroupBy, TilingUtils}
+import ai.chronon.api.Extensions.{GroupByOps, WindowOps}
 import ai.chronon.api.ScalaJavaConversions._
-import ai.chronon.flink.{FlinkGroupByStreamingJob, SparkExpressionEval, SparkExpressionEvalFn}
+import ai.chronon.api.{Accuracy, Builders, Constants, GroupBy, OnlineStrategy, Operation, TilingUtils, TimeUnit, TsUtils, Window}
+import ai.chronon.flink.deser.ProjectedEvent
+import ai.chronon.flink.{FlinkGroupByStreamingJob, FlinkJob, SparkExpressionEval, SparkExpressionEvalFn}
 import ai.chronon.flink.types.TimestampedIR
 import ai.chronon.flink.types.TimestampedTile
 import ai.chronon.flink.types.WriteResponse
 import ai.chronon.online.{Api, GroupByServingInfoParsed, TopicInfo}
 import ai.chronon.online.serde.SparkConversions
+import org.apache.flink.api.common.eventtime.{TimestampAssignerSupplier, Watermark, WatermarkGeneratorSupplier, WatermarkOutput}
+import org.apache.flink.metrics.MetricGroup
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.test.util.MiniClusterWithClientResource
@@ -19,6 +23,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import org.scalatestplus.mockito.MockitoSugar.mock
 
+import java.time.Instant
 
 
 // Flink Job Integration Test for Event-based GroupBys
@@ -155,6 +160,166 @@ class FlinkJobEventIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
     expectedFinalIRsPerKey shouldBe finalIRsPerKey
   }
 
+  it should "mega tiled flink job writes day-start keyed daily snapshots end to end" in {
+    implicit val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setParallelism(1)
+
+    val elements = Seq(
+      E2ETestEvent(id = "id1", int_val = 1, double_val = 1.5, created = 1712277000000L),
+      E2ETestEvent(id = "id1", int_val = 2, double_val = 2.0, created = 1712277900000L)
+    )
+
+    val groupBy = FlinkTestUtils.makeGroupBy(Seq("id"))
+    groupBy.setOnlineStrategy(OnlineStrategy.STREAMING_MEGATILES)
+    val (job, groupByServingInfoParsed) = buildFlinkJob(groupBy, elements)
+    groupByServingInfoParsed.groupBy.isMegaTilingEnabled shouldBe true
+
+    job.runMegaTiledGroupByJob(env).addSink(new CollectSink)
+    env.execute("MegaTiledFlinkJobIntegrationTest")
+
+    val writeResponses = CollectSink.values.toScala
+    writeResponses.nonEmpty shouldBe true
+    writeResponses.forall(_.status) shouldBe true
+    writeResponses.map(_.dataset).distinct shouldBe Seq(groupByServingInfoParsed.groupBy.streamingDataset)
+
+    val dayMillis = new Window(1, TimeUnit.DAYS).millis
+    val dayStart = TsUtils.round(elements.head.created, dayMillis)
+    val decodedTileKeys = writeResponses.map(response => TilingUtils.deserializeTileKey(response.keyBytes))
+    decodedTileKeys.map(_.tileSizeMillis).distinct shouldBe Seq(dayMillis)
+    decodedTileKeys.map(_.tileStartTimestampMillis).contains(dayStart) shouldBe true
+    decodedTileKeys.forall(tileKey => TsUtils.round(tileKey.tileStartTimestampMillis, dayMillis) == tileKey.tileStartTimestampMillis) shouldBe true
+
+    val decodedEntityKeys = decodedTileKeys.map { tileKey =>
+      val keyBytes = tileKey.keyBytes.toScala.toArray.map(_.asInstanceOf[Byte])
+      val record = groupByServingInfoParsed.keyCodec.decode(keyBytes)
+      record.get("id").toString
+    }
+    decodedEntityKeys.distinct shouldBe Seq("id1")
+
+    val decodedSums = writeResponses
+      .zip(decodedTileKeys)
+      .filter { case (_, tileKey) => tileKey.tileStartTimestampMillis == dayStart }
+      .map(_._1)
+      .map(response => groupByServingInfoParsed.megaTileCodec.decode(response.valueBytes))
+      .map(ir => groupByServingInfoParsed.megaTileCodec.rowAggregator.finalize(ir).head.asInstanceOf[Double])
+      .sorted
+
+    decodedSums.head shouldBe 1.5
+    decodedSums.last shouldBe 3.5
+  }
+
+  it should "mega tiled flink job drops events older than yesterday" in {
+    implicit val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setParallelism(1)
+
+    val currentDayEventTs = 1712277000000L // 2024-04-05T00:30:00Z
+    val staleEventTs = currentDayEventTs - 2 * new Window(1, TimeUnit.DAYS).millis
+    val elements = Seq(
+      E2ETestEvent(id = "id1", int_val = 1, double_val = 2.0, created = currentDayEventTs),
+      E2ETestEvent(id = "id1", int_val = 2, double_val = 9.5, created = staleEventTs)
+    )
+
+    val groupBy = FlinkTestUtils.makeGroupBy(Seq("id"))
+    groupBy.setOnlineStrategy(OnlineStrategy.STREAMING_MEGATILES)
+    val (job, groupByServingInfoParsed) = buildFlinkJob(groupBy, elements)
+
+    job.runMegaTiledGroupByJob(env).addSink(new CollectSink)
+    env.execute("MegaTiledFlinkJobDropsStaleEventsTest")
+
+    val dayMillis = new Window(1, TimeUnit.DAYS).millis
+    val currentDayStart = TsUtils.round(currentDayEventTs, dayMillis)
+    val currentDaySums = CollectSink.values.toScala
+      .filter(_.status)
+      .filter { response =>
+        TilingUtils.deserializeTileKey(response.keyBytes).tileStartTimestampMillis == currentDayStart
+      }
+      .map(response => groupByServingInfoParsed.megaTileCodec.decode(response.valueBytes))
+      .map(ir => groupByServingInfoParsed.megaTileCodec.rowAggregator.finalize(ir).head.asInstanceOf[Double])
+      .distinct
+
+    currentDaySums shouldBe Seq(2.0)
+  }
+
+  it should "mega tiled flink job watermark strategy models stale UTC-midnight catchup" in {
+    val strategy = FlinkJob.watermarkStrategy
+    val assigner = strategy.createTimestampAssigner(WatermarkTestContext)
+    val generator = strategy.createWatermarkGenerator(WatermarkTestContext)
+    val output = new RecordingWatermarkOutput
+
+    val beforeMidnight =
+      ProjectedEvent(Map(Constants.TimeColumn -> toMillis("2026-04-11T23:59:00Z")), 0L)
+    val beforeMidnightTs = assigner.extractTimestamp(beforeMidnight, -1L)
+    beforeMidnightTs shouldBe toMillis("2026-04-11T23:59:00Z")
+    generator.onEvent(beforeMidnight, beforeMidnightTs, output)
+    generator.onPeriodicEmit(output)
+
+    output.lastWatermarkTimestamp shouldBe toMillis("2026-04-11T23:54:00Z") - 1L
+
+    val afterMidnight =
+      ProjectedEvent(Map(Constants.TimeColumn -> toMillis("2026-04-12T00:06:00Z")), 0L)
+    val afterMidnightTs = assigner.extractTimestamp(afterMidnight, -1L)
+    afterMidnightTs shouldBe toMillis("2026-04-12T00:06:00Z")
+    generator.onEvent(afterMidnight, afterMidnightTs, output)
+    generator.onPeriodicEmit(output)
+
+    output.lastWatermarkTimestamp shouldBe toMillis("2026-04-12T00:01:00Z") - 1L
+  }
+
+  it should "mega tiled flink job writes mixed small and large window daily snapshots" in {
+    implicit val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setParallelism(1)
+
+    val elements = Seq(
+      E2ETestEvent(id = "id1", int_val = 1, double_val = 1.5, created = 1712277000000L),
+      E2ETestEvent(id = "id1", int_val = 2, double_val = 2.0, created = 1712277900000L)
+    )
+
+    val groupBy = Builders.GroupBy(
+      sources = Seq(
+        Builders.Source.events(
+          table = "events.my_stream_raw",
+          topic = "events.my_stream",
+          query = Builders.Query(
+            selects = Map(
+              "id" -> "id",
+              "int_val" -> "int_val",
+              "double_val" -> "double_val"
+            ),
+            timeColumn = "created",
+            startPartition = "20231106"
+          )
+        )
+      ),
+      keyColumns = Seq("id"),
+      aggregations = Seq(
+        Builders.Aggregation(
+          operation = Operation.SUM,
+          inputColumn = "double_val",
+          windows = Seq(new Window(1, TimeUnit.HOURS), new Window(1, TimeUnit.DAYS), new Window(3, TimeUnit.DAYS))
+        )
+      ),
+      metaData = Builders.MetaData(name = "e2e-mixed-megatile"),
+      accuracy = Accuracy.TEMPORAL
+    )
+    groupBy.setOnlineStrategy(OnlineStrategy.STREAMING_MEGATILES)
+    val (job, groupByServingInfoParsed) = buildFlinkJob(groupBy, elements)
+
+    job.runMegaTiledGroupByJob(env).addSink(new CollectSink)
+    env.execute("MegaTiledFlinkJobMixedWindowsTest")
+
+    val dayMillis = new Window(1, TimeUnit.DAYS).millis
+    val dayStart = TsUtils.round(elements.head.created, dayMillis)
+    val decodedValues = CollectSink.values.toScala
+      .filter(_.status)
+      .filter(response => TilingUtils.deserializeTileKey(response.keyBytes).tileStartTimestampMillis == dayStart)
+      .map(response => groupByServingInfoParsed.megaTileCodec.decode(response.valueBytes))
+      .map(ir => groupByServingInfoParsed.megaTileCodec.rowAggregator.finalize(ir).toSeq)
+      .sortBy(_.head.asInstanceOf[Double])
+
+    decodedValues.head shouldBe Seq(1.5, 1.5, 1.5)
+    decodedValues.last shouldBe Seq(3.5, 3.5, 3.5)
+  }
+
   private def buildFlinkJob(groupBy: GroupBy, elements: Seq[E2ETestEvent]): (FlinkGroupByStreamingJob, GroupByServingInfoParsed) = {
     val query = SparkExpressionEval.queryFromGroupBy(groupBy)
     val sparkExpressionEvalFn = new SparkExpressionEvalFn(Encoders.product[E2ETestEvent], query, groupBy.metaData.name, groupBy.dataModel)
@@ -180,5 +345,29 @@ class FlinkJobEventIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
                   props = Map.empty,
                   topicInfo = topicInfo),
      groupByServingInfoParsed)
+  }
+
+  private def toMillis(iso: String): Long =
+    Instant.parse(iso).toEpochMilli
+
+  private object WatermarkTestContext
+      extends TimestampAssignerSupplier.Context
+      with WatermarkGeneratorSupplier.Context {
+    override def getMetricGroup: MetricGroup =
+      UnregisteredMetricGroups.createUnregisteredOperatorMetricGroup()
+  }
+
+  final private class RecordingWatermarkOutput extends WatermarkOutput {
+    private var emittedWatermarkTimestamps: List[Long] = Nil
+
+    override def emitWatermark(watermark: Watermark): Unit =
+      emittedWatermarkTimestamps = emittedWatermarkTimestamps :+ watermark.getTimestamp
+
+    override def markIdle(): Unit = ()
+
+    override def markActive(): Unit = ()
+
+    def lastWatermarkTimestamp: Long =
+      emittedWatermarkTimestamps.last
   }
 }

--- a/flink/src/test/scala/ai/chronon/flink/test/window/MegaTileProcessFunctionTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/window/MegaTileProcessFunctionTest.scala
@@ -5,7 +5,7 @@ import ai.chronon.api.Extensions.WindowOps
 import ai.chronon.flink.FlinkJob
 import ai.chronon.flink.deser.ProjectedEvent
 import ai.chronon.flink.types.TimestampedTile
-import ai.chronon.flink.window.MegaTileProcessFunction
+import ai.chronon.flink.window.{MegaTileEmissionPolicy, MegaTileProcessFunction}
 import ai.chronon.online.MegaTileCodec
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.functions.KeySelector
@@ -288,11 +288,10 @@ class MegaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
       driver.processEvent("gen_replay", "2025-07-21T10:31:00Z", "user_replay_2")
       driver.drainNewOutputs().last.values shouldEqual windowValues(2L, 2L, 2L)
 
-      // Once the key is idle for more than one hop, sparse-key fallback rolls to the PT day.
+      // Once the key is idle for more than one hop, sparse-key fallback rolls to the PT day in
+      // state. The rebuild does not need to publish a row when the packed value is unchanged.
       driver.setProcessingTime("2025-07-23T10:50:00Z")
-      val idleFallback = driver.drainNewOutputs().last
-      idleFallback.dayStartMillis shouldEqual dayStart("2025-07-23T00:00:00Z")
-      idleFallback.values shouldEqual windowValues(null, null, null)
+      driver.drainNewOutputs() shouldBe empty
     }
   }
 
@@ -374,7 +373,7 @@ class MegaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
       // In replay mode, the small-window as-of timestamp follows the watermark hop: 1d can include
       // the duplicate boundary row, while 1h must not double-count after the Jul23 day roll.
       outputs.find(_.dayStartMillis == dayStart("2025-07-23T00:00:00Z")).map(_.values) shouldEqual
-        Some(windowValues(1L, 2L, null))
+        Some(windowValues(null, 2L, null))
       outputs.find(_.dayStartMillis == dayStart("2025-07-22T00:00:00Z")).map(_.values) shouldEqual
         Some(windowValues(1L, 1L, 2L))
 
@@ -396,13 +395,14 @@ class MegaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
         expectedDayStart = dayStart("2025-07-21T00:00:00Z"),
         expectedValues = windowValues(1L, 1L, 1L))
 
-      // After one idle hop, SparseKeyLag uses PT eviction and rolls currentDayStart to Jul23.
-      driver.setProcessingTime("2025-07-23T10:40:00Z")
-      assertSingleOutput(
-        driver.drainNewOutputs(),
-        expectedKey = "gen_sparse_replay_drop",
-        expectedDayStart = dayStart("2025-07-23T00:00:00Z"),
-        expectedValues = windowValues(null, null, null))
+      // After one idle hop, SparseKeyLag uses PT eviction and rolls currentDayStart to Jul23. The
+      // rebuild can be in-memory-only when the packed value is unchanged.
+      driver.setProcessingTime("2025-07-23T10:40:00.001Z")
+      driver.drainNewOutputs().lastOption.foreach { output =>
+        output.keys shouldEqual List("gen_sparse_replay_drop")
+        output.dayStartMillis shouldEqual dayStart("2025-07-23T00:00:00Z")
+        output.values shouldEqual windowValues(null, null, null)
+      }
 
       // A later Jul21 backlog event would be valid under active replay, but after the PT roll it is
       // older than currentDayStart - 1d and must be dropped permanently.
@@ -579,6 +579,206 @@ class MegaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
       outputs.head.processingTsMillis shouldEqual expectedEmitTs
     }
   }
+
+  it should "wall-clock cadence emissions use stable per-key phase and emit only when dirty" in {
+    val key = "gen_cadence"
+    val baseProcessingTs = toMillis("2025-07-21T10:30:00Z")
+    val cadenceMillis = 60 * 1000L
+    val firstTick = nextCadenceEmitTick(key, baseProcessingTs, cadenceMillis)
+    val secondTick = firstTick + cadenceMillis
+
+    withDriver(bufferingOutputTimeMillis = cadenceMillis,
+               emissionPolicy = MegaTileEmissionPolicy.WallClockCadence) { driver =>
+      driver.processWatermark("2025-07-21T10:25:30Z")
+      driver.setProcessingTimeMillis(baseProcessingTs)
+      driver.processEvent(key, "2025-07-21T10:30:00Z", "user_1")
+      driver.drainNewOutputs() shouldBe empty
+
+      driver.setProcessingTimeMillis(firstTick - 1L)
+      driver.drainNewOutputs() shouldBe empty
+
+      driver.setProcessingTimeMillis(firstTick)
+      val firstOutputs = driver.drainNewOutputs()
+      assertSingleOutput(
+        firstOutputs,
+        expectedKey = key,
+        expectedDayStart = dayStart("2025-07-21T00:00:00Z"),
+        expectedValues = windowValues(1L, 1L, 1L))
+      firstOutputs.head.processingTsMillis shouldEqual firstTick
+
+      driver.setProcessingTimeMillis(secondTick)
+      driver.drainNewOutputs() shouldBe empty
+
+      driver.processWatermark("2025-07-21T10:32:00Z")
+      driver.setProcessingTimeMillis(secondTick + 1L)
+      driver.processEvent(key, "2025-07-21T10:31:00Z", "user_2")
+      driver.drainNewOutputs() shouldBe empty
+
+      driver.setProcessingTimeMillis(secondTick + cadenceMillis)
+      val secondOutputs = driver.drainNewOutputs()
+      assertSingleOutput(
+        secondOutputs,
+        expectedKey = key,
+        expectedDayStart = dayStart("2025-07-21T00:00:00Z"),
+        expectedValues = windowValues(2L, 2L, 2L))
+      secondOutputs.head.processingTsMillis shouldEqual secondTick + cadenceMillis
+    }
+  }
+
+  it should "wall-clock cadence uses dirty-buffered fallback before first watermark" in {
+    val cadenceMillis = 60 * 1000L
+    val beforeMidnightTs = toMillis("2025-07-21T23:59:30Z")
+    val midnight = toMillis("2025-07-22T00:00:00Z")
+    val dirtyBufferedTick = beforeMidnightTs + cadenceMillis
+    val key = keyWithNextCadenceTickBetween(
+      prefix = "gen_cadence_no_watermark",
+      processingTs = beforeMidnightTs,
+      cadenceMillis = cadenceMillis,
+      lowerBound = midnight,
+      upperBound = dirtyBufferedTick,
+      cadenceGroupBy = largeOnlyGroupBy)
+    val cadenceTick = nextCadenceEmitTick(key, beforeMidnightTs, cadenceMillis, largeOnlyGroupBy)
+
+    withDriver(bufferingOutputTimeMillis = cadenceMillis,
+               emissionPolicy = MegaTileEmissionPolicy.WallClockCadence,
+               testGroupBy = largeOnlyGroupBy) { driver =>
+      driver.setProcessingTimeMillis(beforeMidnightTs)
+      driver.processEvent(key, "2025-07-21T23:59:30Z", "user_before_watermark")
+      driver.drainNewOutputs() shouldBe empty
+
+      cadenceTick should be > midnight
+      cadenceTick should be < dirtyBufferedTick
+      driver.setProcessingTimeMillis(cadenceTick)
+      driver.drainNewOutputs() shouldBe empty
+
+      driver.setProcessingTimeMillis(dirtyBufferedTick)
+      val outputs = driver.drainNewOutputs()
+      assertSingleOutput(
+        outputs,
+        expectedKey = key,
+        expectedDayStart = dayStart("2025-07-21T00:00:00Z"),
+        expectedValues = Seq(1L))
+      outputs.head.processingTsMillis shouldEqual dirtyBufferedTick
+    }
+  }
+
+  it should "wall-clock cadence allows one bounded off-phase emit after catchup becomes live" in {
+    val cadenceMillis = 60 * 1000L
+    val catchupProcessingTs = toMillis("2025-07-21T10:30:00Z")
+    val liveTransitionTs = toMillis("2025-07-21T10:30:30Z")
+    val dirtyBufferedTick = catchupProcessingTs + cadenceMillis
+    val key = keyWithNextCadenceTickAfter(
+      prefix = "gen_cadence_catchup_live",
+      processingTs = liveTransitionTs,
+      cadenceMillis = cadenceMillis,
+      lowerBound = dirtyBufferedTick + 1L)
+    val cadenceTick = nextCadenceEmitTick(key, liveTransitionTs, cadenceMillis)
+
+    withDriver(bufferingOutputTimeMillis = cadenceMillis,
+               emissionPolicy = MegaTileEmissionPolicy.WallClockCadence) { driver =>
+      driver.processWatermark("2025-07-21T10:24:00Z")
+      driver.setProcessingTimeMillis(catchupProcessingTs)
+      driver.processEvent(key, "2025-07-21T10:30:00Z", "user_1")
+      driver.drainNewOutputs() shouldBe empty
+
+      driver.processWatermark("2025-07-21T10:25:30Z")
+      driver.setProcessingTimeMillis(liveTransitionTs)
+      driver.processEvent(key, "2025-07-21T10:30:30Z", "user_2")
+      driver.drainNewOutputs() shouldBe empty
+
+      driver.setProcessingTimeMillis(dirtyBufferedTick)
+      val offPhaseOutputs = driver.drainNewOutputs()
+      offPhaseOutputs should have size 1
+      offPhaseOutputs.head.keys shouldEqual List(key)
+      offPhaseOutputs.head.processingTsMillis shouldEqual dirtyBufferedTick
+
+      driver.setProcessingTimeMillis(dirtyBufferedTick + 1L)
+      driver.processEvent(key, "2025-07-21T10:31:00Z", "user_3")
+      driver.drainNewOutputs() shouldBe empty
+
+      driver.setProcessingTimeMillis(cadenceTick)
+      val cadenceOutputs = driver.drainNewOutputs()
+      cadenceOutputs should have size 1
+      cadenceOutputs.head.keys shouldEqual List(key)
+      cadenceOutputs.head.processingTsMillis shouldEqual cadenceTick
+    }
+  }
+
+  it should "wall-clock cadence emit timer rolls large-window-only keys across UTC day" in {
+    val cadenceMillis = 60 * 1000L
+    val midnight = toMillis("2025-07-22T00:00:00Z")
+    val beforeMidnightTs = toMillis("2025-07-21T23:59:30Z")
+    val key = keyWithNextCadenceTickAfter(
+      prefix = "gen_cadence_large_day_roll",
+      processingTs = beforeMidnightTs,
+      cadenceMillis = cadenceMillis,
+      lowerBound = midnight,
+      cadenceGroupBy = largeOnlyGroupBy)
+    val firstTick = nextCadenceEmitTick(key, beforeMidnightTs, cadenceMillis, largeOnlyGroupBy)
+    val secondTick = firstTick + cadenceMillis
+
+    withDriver(bufferingOutputTimeMillis = cadenceMillis,
+               emissionPolicy = MegaTileEmissionPolicy.WallClockCadence,
+               testGroupBy = largeOnlyGroupBy) { driver =>
+      driver.processWatermark("2025-07-21T23:59:30Z")
+      driver.setProcessingTimeMillis(beforeMidnightTs)
+      driver.processEvent(key, "2025-07-21T23:59:30Z", "user_before_midnight")
+      driver.drainNewOutputs() shouldBe empty
+
+      firstTick should be > midnight
+      driver.setProcessingTimeMillis(firstTick - 1L)
+      driver.drainNewOutputs() shouldBe empty
+
+      driver.setProcessingTimeMillis(firstTick)
+      val dayRollOutputs = driver.drainNewOutputs()
+      assertSingleOutput(
+        dayRollOutputs,
+        expectedKey = key,
+        expectedDayStart = dayStart("2025-07-21T00:00:00Z"),
+        expectedValues = Seq(1L))
+      dayRollOutputs.head.processingTsMillis shouldEqual firstTick
+
+      driver.setProcessingTimeMillis(firstTick + 1L)
+      driver.processEvent(key, "2025-07-22T00:00:30Z", "user_after_midnight")
+      driver.drainNewOutputs() shouldBe empty
+
+      driver.setProcessingTimeMillis(secondTick)
+      val afterMidnightOutputs = driver.drainNewOutputs()
+      assertSingleOutput(
+        afterMidnightOutputs,
+        expectedKey = key,
+        expectedDayStart = dayStart("2025-07-22T00:00:00Z"),
+        expectedValues = Seq(1L))
+      afterMidnightOutputs.head.processingTsMillis shouldEqual secondTick
+    }
+  }
+
+  it should "wall-clock cadence preserves pending day-roll output when watermark outruns PT emit" in {
+    val cadenceMillis = 5 * 60 * 1000L
+    val processingTs = toMillis("2025-07-23T10:00:00Z")
+    val key = "gen_cadence_pending_day_roll"
+
+    withDriver(bufferingOutputTimeMillis = cadenceMillis,
+               emissionPolicy = MegaTileEmissionPolicy.WallClockCadence,
+               testGroupBy = largeOnlyGroupBy) { driver =>
+      driver.processWatermark("2025-07-21T23:50:00Z")
+      driver.setProcessingTimeMillis(processingTs)
+      driver.processEvent(key, "2025-07-21T23:50:00Z", "user_day_1")
+      driver.drainNewOutputs() shouldBe empty
+
+      driver.processWatermark("2025-07-22T00:00:01Z")
+      driver.processEvent(key, "2025-07-22T00:00:00Z", "user_day_2")
+      driver.drainNewOutputs() shouldBe empty
+
+      driver.processWatermark("2025-07-23T00:00:01Z")
+      driver.processEvent(key, "2025-07-23T00:00:00Z", "user_day_3")
+      assertSingleOutput(
+        driver.drainNewOutputs(),
+        expectedKey = key,
+        expectedDayStart = dayStart("2025-07-21T00:00:00Z"),
+        expectedValues = Seq(1L))
+    }
+  }
 }
 
 object MegaTileProcessFunctionTest extends Matchers {
@@ -609,6 +809,34 @@ object MegaTileProcessFunctionTest extends Matchers {
         )
       ),
       metaData = Builders.MetaData(name = "mega_tile_process_function_test"),
+      accuracy = Accuracy.TEMPORAL
+    )
+    gb.setOnlineStrategy(OnlineStrategy.STREAMING_MEGATILES)
+    gb
+  }
+
+  private val largeOnlyGroupBy: GroupBy = {
+    val gb = Builders.GroupBy(
+      sources = Seq(
+        Builders.Source.events(
+          table = "events.test_stream",
+          topic = "events.test_stream",
+          query = Builders.Query(
+            selects = Map("id" -> "id", "view_by" -> "view_by"),
+            timeColumn = Constants.TimeColumn,
+            startPartition = "20250101"
+          )
+        )
+      ),
+      keyColumns = Seq("id"),
+      aggregations = Seq(
+        Builders.Aggregation(
+          operation = Operation.COUNT,
+          inputColumn = "view_by",
+          windows = Seq(new Window(3, TimeUnit.DAYS))
+        )
+      ),
+      metaData = Builders.MetaData(name = "mega_tile_process_function_large_only_test"),
       accuracy = Accuracy.TEMPORAL
     )
     gb.setOnlineStrategy(OnlineStrategy.STREAMING_MEGATILES)
@@ -722,8 +950,15 @@ object MegaTileProcessFunctionTest extends Matchers {
       processingTsMillis: Long,
       values: Seq[Any])
 
-  final private class Driver(bufferingOutputTimeMillis: Long, bufferingOutputJitterMillis: Long) {
-    private val testHarness = harness(bufferingOutputTimeMillis, bufferingOutputJitterMillis)
+  final private class Driver(bufferingOutputTimeMillis: Long,
+                             bufferingOutputJitterMillis: Long,
+                             emissionPolicy: MegaTileEmissionPolicy,
+                             testGroupBy: GroupBy) {
+    private val outputCodec = new MegaTileCodec(testGroupBy, inputSchema)
+    private val testHarness = harness(bufferingOutputTimeMillis,
+                                      bufferingOutputJitterMillis,
+                                      emissionPolicy,
+                                      testGroupBy)
     private var emittedCount = 0
     private var currentProcessingTs = 0L
 
@@ -749,7 +984,7 @@ object MegaTileProcessFunctionTest extends Matchers {
         0L)
 
     def drainNewOutputs(): List[DecodedOutput] = {
-      val allOutputs = testHarness.extractOutputValues().asScala.toList.map(decodeOutput)
+      val allOutputs = testHarness.extractOutputValues().asScala.toList.map(decodeOutput(_, outputCodec))
       val newOutputs = allOutputs.drop(emittedCount)
       emittedCount = allOutputs.size
       newOutputs
@@ -759,9 +994,12 @@ object MegaTileProcessFunctionTest extends Matchers {
       testHarness.close()
   }
 
-  private def withDriver(bufferingOutputTimeMillis: Long, bufferingOutputJitterMillis: Long = 0L)(
+  private def withDriver(bufferingOutputTimeMillis: Long,
+                         bufferingOutputJitterMillis: Long = 0L,
+                         emissionPolicy: MegaTileEmissionPolicy = MegaTileEmissionPolicy.Default,
+                         testGroupBy: GroupBy = groupBy)(
       fn: Driver => Unit): Unit = {
-    val driver = new Driver(bufferingOutputTimeMillis, bufferingOutputJitterMillis)
+    val driver = new Driver(bufferingOutputTimeMillis, bufferingOutputJitterMillis, emissionPolicy, testGroupBy)
     try {
       fn(driver)
     } finally {
@@ -770,15 +1008,18 @@ object MegaTileProcessFunctionTest extends Matchers {
   }
 
   private def harness(bufferingOutputTimeMillis: Long,
-                      bufferingOutputJitterMillis: Long = 0L)
+                      bufferingOutputJitterMillis: Long = 0L,
+                      emissionPolicy: MegaTileEmissionPolicy = MegaTileEmissionPolicy.Default,
+                      testGroupBy: GroupBy = groupBy)
       : KeyedOneInputStreamOperatorTestHarness[java.util.List[Any], ProjectedEvent, TimestampedTile] = {
     new KeyedOneInputStreamOperatorTestHarness[java.util.List[Any], ProjectedEvent, TimestampedTile](
       new KeyedProcessOperator[java.util.List[Any], ProjectedEvent, TimestampedTile](
         new MegaTileProcessFunction(
-          groupBy,
+          testGroupBy,
           inputSchema,
           bufferingOutputTimeMillis = bufferingOutputTimeMillis,
-          bufferingOutputJitterMillis = bufferingOutputJitterMillis
+          bufferingOutputJitterMillis = bufferingOutputJitterMillis,
+          emissionPolicy = emissionPolicy
         )),
       new KeySelector[ProjectedEvent, java.util.List[Any]] {
         override def getKey(value: ProjectedEvent): java.util.List[Any] =
@@ -812,12 +1053,15 @@ object MegaTileProcessFunctionTest extends Matchers {
   }
 
   private def decodeOutput(tile: TimestampedTile): DecodedOutput =
+    decodeOutput(tile, megaTileCodec)
+
+  private def decodeOutput(tile: TimestampedTile, codec: MegaTileCodec): DecodedOutput =
     DecodedOutput(
       keys = tile.keys.asScala.toList,
       dayStartMillis = tile.latestTsMillis,
       processingTsMillis = tile.startProcessingTime,
-      values = megaTileCodec.rowAggregator
-        .finalize(megaTileCodec.decode(tile.tileBytes))
+      values = codec.rowAggregator
+        .finalize(codec.decode(tile.tileBytes))
         .toSeq
     )
 
@@ -826,4 +1070,43 @@ object MegaTileProcessFunctionTest extends Matchers {
 
   private def toMillis(iso: String): Long =
     Instant.parse(iso).toEpochMilli
+
+  private def nextCadenceEmitTick(key: String,
+                                  processingTs: Long,
+                                  cadenceMillis: Long,
+                                  cadenceGroupBy: GroupBy = groupBy): Long = {
+    val phase = Math.floorMod(
+      (cadenceGroupBy.getMetaData.getName :: List(key)).hashCode().toLong,
+      cadenceMillis)
+    val elapsedSincePhase = Math.floorMod(processingTs - phase, cadenceMillis)
+    val delay = if (elapsedSincePhase == 0L) cadenceMillis else cadenceMillis - elapsedSincePhase
+    processingTs + delay
+  }
+
+  private def keyWithNextCadenceTickAfter(prefix: String,
+                                          processingTs: Long,
+                                          cadenceMillis: Long,
+                                          lowerBound: Long,
+                                          cadenceGroupBy: GroupBy = groupBy): String =
+    Iterator
+      .from(0)
+      .map(index => s"${prefix}_$index")
+      .find(key => nextCadenceEmitTick(key, processingTs, cadenceMillis, cadenceGroupBy) > lowerBound)
+      .getOrElse(throw new IllegalStateException(s"No cadence key found for prefix=$prefix"))
+
+  private def keyWithNextCadenceTickBetween(prefix: String,
+                                            processingTs: Long,
+                                            cadenceMillis: Long,
+                                            lowerBound: Long,
+                                            upperBound: Long,
+                                            cadenceGroupBy: GroupBy = groupBy): String =
+    Iterator
+      .from(0)
+      .map(index => s"${prefix}_$index")
+      .find { key =>
+        val tick = nextCadenceEmitTick(key, processingTs, cadenceMillis, cadenceGroupBy)
+        tick > lowerBound && tick < upperBound
+      }
+      .getOrElse(throw new IllegalStateException(
+        s"No cadence key found for prefix=$prefix between $lowerBound and $upperBound"))
 }

--- a/flink/src/test/scala/ai/chronon/flink/test/window/MegaTileProcessFunctionTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/window/MegaTileProcessFunctionTest.scala
@@ -78,6 +78,17 @@ class MegaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
         expectedKey = "gen_catchup",
         expectedDayStart = dayStart("2025-07-21T00:00:00Z"),
         expectedValues = windowValues(2L, 3L, 3L))
+
+      // When the watermark catches up enough for Live mode, the event path must rebuild from the
+      // current live range before applying the incremental update.
+      driver.processWatermark("2025-07-21T11:29:40Z")
+      driver.setProcessingTime("2025-07-21T11:35:09Z")
+      driver.processEvent("gen_catchup", "2025-07-21T11:35:09Z", "user_after_transition")
+      assertSingleOutput(
+        driver.drainNewOutputs(),
+        expectedKey = "gen_catchup",
+        expectedDayStart = dayStart("2025-07-21T00:00:00Z"),
+        expectedValues = windowValues(2L, 4L, 4L))
     }
   }
 

--- a/flink/src/test/scala/ai/chronon/flink/test/window/MegaTileProcessFunctionTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/window/MegaTileProcessFunctionTest.scala
@@ -1,0 +1,829 @@
+package ai.chronon.flink.test.window
+
+import ai.chronon.api._
+import ai.chronon.api.Extensions.WindowOps
+import ai.chronon.flink.FlinkJob
+import ai.chronon.flink.deser.ProjectedEvent
+import ai.chronon.flink.types.TimestampedTile
+import ai.chronon.flink.window.MegaTileProcessFunction
+import ai.chronon.online.MegaTileCodec
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.functions.KeySelector
+import org.apache.flink.streaming.api.operators.KeyedProcessOperator
+import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.time.Instant
+import java.util
+import scala.collection.JavaConverters._
+
+class MegaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
+  import MegaTileProcessFunctionTest._
+
+  /*
+   * Output values use the order from the test GroupBy:
+   *   windowValues(oneHour, oneDay, threeDay)
+   *
+   * Each value is the count of view_by rows for that window. null means that window has no
+   * aggregate value after eviction.
+   */
+
+  "MegaTileProcessFunction" should "watermark constants stay aligned with MegaTile eviction lifecycle" in {
+    // With a 5-minute hop, a 5-minute bounded-out-of-orderness watermark keeps late events near the
+    // hop boundary available until the processor has a chance to rebuild cached small-window state.
+    FlinkJob.AllowedOutOfOrderness.toMillis shouldEqual 5 * 60 * 1000L
+    // Idleness keeps watermarks moving when an upstream partition or low-volume key goes quiet.
+    FlinkJob.IdlenessTimeout.toMillis shouldEqual 30 * 1000L
+    // The extra slack prevents normal one-hop watermark jitter from being treated as active catchup.
+    FlinkJob.CatchupWatermarkLagSlackMillis shouldEqual 30 * 1000L
+  }
+
+  it should "Live vs ActiveCatchup boundary: one-hop watermark lag plus slack still uses PT eviction" in {
+    withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      seedOldTileBeforeLiveCatchupBoundary(driver, "gen_live_slack")
+
+      // The watermark is 5m15s behind PT, which is still inside one hop plus the 30s slack. The
+      // current event is therefore treated as live and immediately sees the old tile in the cache.
+      driver.processWatermark("2025-07-21T11:29:45Z")
+      driver.setProcessingTime("2025-07-21T11:34:00Z")
+      driver.processEvent("gen_live_slack", "2025-07-21T11:34:00Z", "user_current")
+      driver.drainNewOutputs().last.values shouldEqual windowValues(3L, 3L, 3L)
+
+      // The 11:35 PT eviction rebuilds 1h over [10:35, 11:35), so the old 10:30 tile falls out.
+      driver.setProcessingTime("2025-07-21T11:35:00Z")
+      assertSingleOutput(
+        driver.drainNewOutputs(),
+        expectedKey = "gen_live_slack",
+        expectedDayStart = dayStart("2025-07-21T00:00:00Z"),
+        expectedValues = windowValues(1L, 3L, 3L))
+    }
+  }
+
+  it should "Live vs ActiveCatchup boundary: active catchup beyond slack uses watermark-time eviction" in {
+    withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      seedOldTileBeforeLiveCatchupBoundary(driver, "gen_catchup")
+
+      // This watermark is 5m31s behind PT, just beyond one hop plus slack. A recently active key
+      // stays in ActiveCatchup, so eviction follows the next watermark hop instead of wall-clock PT.
+      driver.processWatermark("2025-07-21T11:29:29Z")
+      driver.setProcessingTime("2025-07-21T11:34:00Z")
+      driver.processEvent("gen_catchup", "2025-07-21T11:34:00Z", "user_current")
+      driver.drainNewOutputs().last.values shouldEqual windowValues(3L, 3L, 3L)
+
+      // The watermark-aligned rebuild is as of 11:30, so the old 10:30 tile is still inside 1h.
+      driver.setProcessingTime("2025-07-21T11:35:00Z")
+      assertSingleOutput(
+        driver.drainNewOutputs(),
+        expectedKey = "gen_catchup",
+        expectedDayStart = dayStart("2025-07-21T00:00:00Z"),
+        expectedValues = windowValues(2L, 3L, 3L))
+    }
+  }
+
+  it should "Live mode lifecycle: continuous events before, during, and after day transition" in {
+    withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      // Seed the final Jul21 tile before either PT or watermark day rollover occurs.
+      driver.setProcessingTime("2025-07-21T23:59:00Z")
+      driver.processEvent("gen_steady", "2025-07-21T23:59:00Z", "user_before_roll")
+      assertSingleOutput(
+        driver.drainNewOutputs(),
+        expectedKey = "gen_steady",
+        expectedDayStart = dayStart("2025-07-21T00:00:00Z"),
+        expectedValues = windowValues(1L, 1L, 1L))
+
+      // PT eviction can fire first; it should not rely on the watermark crossing midnight.
+      driver.setProcessingTime("2025-07-22T00:00:01Z")
+      driver.drainNewOutputs() should not be empty
+
+      // Once the watermark crosses midnight, the processor emits the old day before applying Jul22.
+      driver.processWatermark("2025-07-22T00:00:00Z")
+      driver.processEvent("gen_steady", "2025-07-22T00:00:00Z", "user_after_roll")
+      val rolloverOutputs = driver.drainNewOutputs()
+      assertSingleOutput(
+        rolloverOutputs,
+        expectedKey = "gen_steady",
+        expectedDayStart = dayStart("2025-07-22T00:00:00Z"),
+        expectedValues = windowValues(2L, 2L, 1L))
+
+      // After the first Jul22 hop boundary, an exact-hop Jul22 event updates both no-batch windows.
+      driver.setProcessingTime("2025-07-22T00:05:01Z")
+      driver.drainNewOutputs() should not be empty
+
+      driver.processEvent("gen_steady", "2025-07-22T00:05:00Z", "user_exact_hop")
+      val todayOutputs = driver.drainNewOutputs()
+      todayOutputs.last.dayStartMillis shouldEqual dayStart("2025-07-22T00:00:00Z")
+      todayOutputs.last.values shouldEqual windowValues(3L, 3L, 2L)
+    }
+  }
+
+  it should "Live mode lifecycle: PT midnight roll before watermark routes late previous-day events to both day rows" in {
+    withDriver(bufferingOutputTimeMillis = 1000L) { driver =>
+      // Keep watermark just before midnight but close enough to PT that this key remains Live.
+      driver.processWatermark("2025-07-21T23:54:55.999Z")
+      driver.setProcessingTime("2025-07-21T23:59:56.900Z")
+      driver.processEvent("gen_midnight_live", "2025-07-21T23:59:56Z", "user_before_midnight")
+      driver.drainNewOutputs() shouldBe empty
+
+      // Buffered emit publishes the Jul21 row once the 1s delay expires.
+      driver.setProcessingTime("2025-07-21T23:59:57.900Z")
+      assertSingleOutput(
+        driver.drainNewOutputs(),
+        expectedKey = "gen_midnight_live",
+        expectedDayStart = dayStart("2025-07-21T00:00:00Z"),
+        expectedValues = windowValues(1L, 1L, 1L))
+
+      // PT reaches midnight before the watermark. The buffered new-day row should not emit yet.
+      driver.setProcessingTime("2025-07-22T00:00:00.001Z")
+      driver.drainNewOutputs() shouldBe empty
+
+      // A pre-midnight event arriving after the PT roll is still admissible. It belongs to Jul22
+      // small windows because it is inside [23:05, 00:05), and to Jul21 large-window yesterday IR.
+      driver.setProcessingTime("2025-07-22T00:00:00.006Z")
+      driver.processEvent("gen_midnight_live", "2025-07-21T23:59:58Z", "user_previous_day_after_roll")
+      driver.drainNewOutputs() shouldBe empty
+
+      // The delayed callback emits both affected day rows: current small windows for Jul22 and
+      // a complete previous-day row for Jul21.
+      driver.setProcessingTime("2025-07-22T00:00:01.001Z")
+      val boundaryOutputs = driver.drainNewOutputs()
+      boundaryOutputs should have size 2
+      boundaryOutputs.find(_.dayStartMillis == dayStart("2025-07-22T00:00:00Z")).map(_.values) shouldEqual
+        Some(windowValues(2L, 2L, null))
+      boundaryOutputs.find(_.dayStartMillis == dayStart("2025-07-21T00:00:00Z")).map(_.values) shouldEqual
+        Some(windowValues(1L, 1L, 2L))
+    }
+  }
+
+  it should "Live mode: retained yesterdayStart updates 1d without incrementing stale 1h" in {
+    withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      // Anchor the current-day cache at Jul22 start.
+      driver.setProcessingTime("2025-07-22T00:10:00Z")
+      driver.processEvent("gen_boundary", "2025-07-22T00:00:00Z", "user_today_start")
+      driver.drainNewOutputs() should have size 1
+
+      // The exact Jul21 boundary is retained as yesterday, but as of Jul22 00:15 the 1h horizon is
+      // [Jul21 23:15, Jul22 00:15), so only 1d and 3d may include it.
+      driver.processWatermark("2025-07-22T00:05:00Z")
+      driver.processEvent("gen_boundary", "2025-07-21T00:00:00Z", "user_yesterday_start")
+      val outputs = driver.drainNewOutputs()
+      outputs should have size 2
+      // Current-day packed row keeps 1h at one event while 1d includes the retained boundary event.
+      outputs.find(_.dayStartMillis == dayStart("2025-07-22T00:00:00Z")).map(_.values) shouldEqual
+        Some(windowValues(1L, 2L, 1L))
+      // Without a prior rollover, there is no frozen no-batch snapshot for the previous day.
+      outputs.find(_.dayStartMillis == dayStart("2025-07-21T00:00:00Z")).map(_.values) shouldEqual
+        Some(windowValues(null, null, 1L))
+    }
+  }
+
+  it should "Live mode lifecycle: PT eviction decays during a short stop and recovers on resume" in {
+    withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      // Initial event starts all three windows in Live mode.
+      driver.processWatermark("2025-07-21T10:25:00Z")
+      driver.setProcessingTime("2025-07-21T10:30:00Z")
+      driver.processEvent("gen_stop_short", "2025-07-21T10:30:00Z", "user_initial")
+      driver.drainNewOutputs().last.values shouldEqual windowValues(1L, 1L, 1L)
+
+      // Keep the watermark close enough that the next two PT timers remain Live.
+      driver.processWatermark("2025-07-21T11:25:00Z")
+      // At 11:30 the 10:30 tile is still inside the 1h window.
+      driver.setProcessingTime("2025-07-21T11:30:00Z")
+      driver.drainNewOutputs().last.values shouldEqual windowValues(1L, 1L, 1L)
+
+      driver.processWatermark("2025-07-21T11:29:30Z")
+      // At 11:35 the 1h window starts at 10:35, so only the stopped key's 1h value decays.
+      driver.setProcessingTime("2025-07-21T11:35:00Z")
+      driver.drainNewOutputs().last.values shouldEqual windowValues(null, 1L, 1L)
+
+      // A live resume event restarts 1h and increments the longer windows.
+      driver.processEvent("gen_stop_short", "2025-07-21T11:36:00Z", "user_resume")
+      driver.drainNewOutputs().last.values shouldEqual windowValues(1L, 2L, 2L)
+    }
+  }
+
+  it should "Live mode lifecycle: late retained tile outside smallWindowAsOfTs does not re-inflate 1h" in {
+    withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      // 10:30 lands in the 10:30-10:35 tile in Live mode and starts every window.
+      driver.processWatermark("2025-07-21T10:25:00Z")
+      driver.setProcessingTime("2025-07-21T10:30:00Z")
+      driver.processEvent("gen_late_same_day", "2025-07-21T10:30:00Z", "user_on_time")
+      driver.drainNewOutputs().last.values shouldEqual windowValues(1L, 1L, 1L)
+
+      // PT eviction at 11:35 rebuilds 1h over [10:35, 11:35), so the 10:30 tile falls out.
+      driver.processWatermark("2025-07-21T11:29:30Z")
+      driver.setProcessingTime("2025-07-21T11:35:00Z")
+      driver.drainNewOutputs().last.values shouldEqual windowValues(null, 1L, 1L)
+
+      // A late 10:32 event still updates the retained base tile and longer windows, but its tile is
+      // outside the current 1h as-of horizon and must not re-inflate cached 1h.
+      driver.setProcessingTime("2025-07-21T11:36:00Z")
+      driver.processWatermark("2025-07-21T11:30:00Z")
+      driver.processEvent("gen_late_same_day", "2025-07-21T10:32:00Z", "user_late_expired_hop")
+      driver.drainNewOutputs().last.values shouldEqual windowValues(null, 2L, 2L)
+    }
+  }
+
+  it should "SparseKeyLag lifecycle: long idle stop expires 1d, then Live resume restarts all windows" in {
+    withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      // Seed the key, then let PT move more than one day ahead with no new events.
+      driver.processWatermark("2025-07-21T10:25:00Z")
+      driver.setProcessingTime("2025-07-21T10:30:00Z")
+      driver.processEvent("gen_stop_long", "2025-07-21T10:30:00Z", "user_initial")
+      driver.drainNewOutputs() should have size 1
+
+      // The key is idle while the watermark is stale, so SparseKeyLag uses PT for eviction. The
+      // timer rolls to Jul22 and rebuilds an empty current-day row for no-batch windows.
+      driver.setProcessingTime("2025-07-22T11:35:00Z")
+      driver.drainNewOutputs().last.values shouldEqual windowValues(null, null, null)
+
+      // A fresh Jul22 event restarts every current serving window once the watermark catches up
+      // enough for Live mode.
+      driver.processWatermark("2025-07-22T11:31:00Z")
+      driver.processEvent("gen_stop_long", "2025-07-22T11:36:00Z", "user_resume")
+      driver.drainNewOutputs().last.values shouldEqual windowValues(1L, 1L, 1L)
+    }
+  }
+
+  it should "Live mode after idle eviction: retained yesterdayStart updates 1d without incrementing stale 1h" in {
+    withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      // Anchor current-day state, then let one PT hop eviction run while the key is otherwise idle.
+      driver.processWatermark("2025-07-22T00:05:00Z")
+      driver.setProcessingTime("2025-07-22T00:10:00Z")
+      driver.processEvent("gen_stop_boundary", "2025-07-22T00:10:00Z", "user_anchor")
+      driver.drainNewOutputs() should have size 1
+
+      driver.processWatermark("2025-07-22T00:09:30Z")
+      driver.setProcessingTime("2025-07-22T00:15:00Z")
+      driver.drainNewOutputs() should not be empty
+
+      // The retained Jul21 boundary updates Jul22 1d, but remains outside Jul22 1h after the idle
+      // PT eviction has already advanced the processor.
+      driver.processEvent("gen_stop_boundary", "2025-07-21T00:00:00Z", "user_yesterday_start")
+      val outputs = driver.drainNewOutputs()
+      outputs should have size 2
+      // Current day sees the retained boundary in 1d only.
+      outputs.find(_.dayStartMillis == dayStart("2025-07-22T00:00:00Z")).map(_.values) shouldEqual
+        Some(windowValues(1L, 2L, 1L))
+      // Yesterday row carries only the batch-backed 3d contribution.
+      outputs.find(_.dayStartMillis == dayStart("2025-07-21T00:00:00Z")).map(_.values) shouldEqual
+        Some(windowValues(null, null, 1L))
+
+      // Just older than retained yesterday is dropped before it can mutate tile or large-window state.
+      driver.processEvent("gen_stop_boundary", "2025-07-20T23:59:59.999Z", "user_too_old")
+      driver.drainNewOutputs() shouldBe empty
+    }
+  }
+
+  it should "ActiveCatchup lifecycle: active backlog uses watermark-time eviction, then SparseKeyLag fallback uses PT" in {
+    withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      // Replay starts two days behind PT; active per-key traffic keeps eviction on watermark time.
+      driver.setProcessingTime("2025-07-23T10:30:00Z")
+      driver.processWatermark("2025-07-21T10:30:00Z")
+      driver.processEvent("gen_replay", "2025-07-21T10:30:00Z", "user_replay_1")
+      driver.drainNewOutputs().last.dayStartMillis shouldEqual dayStart("2025-07-21T00:00:00Z")
+
+      // The second replayed event stays in the Jul21 day because the key is still active.
+      driver.setProcessingTime("2025-07-23T10:35:00Z")
+      driver.processEvent("gen_replay", "2025-07-21T10:31:00Z", "user_replay_2")
+      driver.drainNewOutputs().last.values shouldEqual windowValues(2L, 2L, 2L)
+
+      // Once the key is idle for more than one hop, sparse-key fallback rolls to the PT day.
+      driver.setProcessingTime("2025-07-23T10:50:00Z")
+      val idleFallback = driver.drainNewOutputs().last
+      idleFallback.dayStartMillis shouldEqual dayStart("2025-07-23T00:00:00Z")
+      idleFallback.values shouldEqual windowValues(null, null, null)
+    }
+  }
+
+  it should "ActiveCatchup lifecycle: event ahead of stale watermark is retained, then appears after rebuild catches up" in {
+    withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      driver.processWatermark("2025-07-21T22:31:23.999Z")
+      driver.setProcessingTime("2025-07-21T23:40:01Z")
+      // ActiveCatchup evaluates no-batch cache as of the next watermark hop, so the current 23:40
+      // event is retained but not immediately visible in 1h/1d.
+      driver.processEvent("gen_resume_stale_watermark", "2025-07-21T23:40:00Z", "user_resume")
+      driver.drainNewOutputs().last.values shouldEqual windowValues(null, null, 1L)
+
+      // Once the watermark reaches the event-time frontier, the scheduled eviction rebuild includes
+      // the retained 23:40 tile.
+      driver.processWatermark("2025-07-21T23:40:00Z")
+      driver.setProcessingTime("2025-07-21T23:45:00Z")
+      driver.drainNewOutputs().last.values shouldEqual windowValues(1L, 1L, 1L)
+    }
+  }
+
+  it should "catchup UTC day-boundary scenario matrix documents the four branch-driving axes" in {
+    /*
+     * These scenarios cover four independent axes that drive admission and rebuild behavior:
+     *
+     * 1. Resume timing: PT crosses UTC midnight before, near, or long after the stream watermark.
+     * 2. Watermark state: watermark may be close enough for Live mode or stale enough for catchup.
+     * 3. Key activity: an active key uses ActiveCatchup, while an idle key falls back to SparseKeyLag.
+     * 4. Event age: exact yesterday-start rows are still retained, while one millisecond older rows
+     *    are rejected before they can mutate state.
+     */
+    val scenarios = Seq(
+      activeKeyResumesAfterUtcMidnightWithStaleWatermarkThenCatchesUp _,
+      sparseKeyResumesAfterUtcMidnightWithStaleWatermark _,
+      yesterdayBoundaryEventAfterResumeIsAdmitted _,
+      olderThanYesterdayEventAfterResumeIsDropped _
+    )
+
+    scenarios.foreach { scenario =>
+      withDriver(bufferingOutputTimeMillis = 0L)(scenario)
+    }
+  }
+
+  it should "catchup UTC day-boundary: multi-day downtime jump does not emit old dirty day as adjacent rollover" in {
+    withDriver(bufferingOutputTimeMillis = 3L * DayMillis) { driver =>
+      // Buffer an Apr11 dirty row, but do not let its long delayed emit fire yet.
+      driver.setProcessingTime("2026-04-11T23:50:00Z")
+      driver.processEvent("axis_multi_day_jump", "2026-04-11T23:50:00Z", "user_seed")
+      driver.drainNewOutputs() shouldBe empty
+
+      // A PT jump to Apr13 is not an adjacent Apr11->Apr12 rollover. The guarded rollover emit
+      // must not publish the old Apr11 row at the Apr13 boundary.
+      driver.setProcessingTime("2026-04-13T00:10:00Z")
+      driver.drainNewOutputs() shouldBe empty
+
+      // After the PT day roll, Apr11 backlog is older than the retained yesterday boundary and is
+      // dropped before mutating state.
+      driver.processEvent("axis_multi_day_jump", "2026-04-11T23:59:00Z", "user_backlog_too_old_after_jump")
+      driver.drainNewOutputs() shouldBe empty
+    }
+  }
+
+  it should "ActiveCatchup lifecycle: replayed yesterdayStart updates 1d but not stale 1h" in {
+    withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      // Start replay on Jul22 event time while PT is already Jul24.
+      driver.setProcessingTime("2025-07-24T10:00:00Z")
+      driver.processWatermark("2025-07-22T00:00:00Z")
+      driver.processEvent("gen_replay_boundary", "2025-07-22T00:00:00Z", "user_today_start")
+      assertSingleOutput(
+        driver.drainNewOutputs(),
+        expectedKey = "gen_replay_boundary",
+        expectedDayStart = dayStart("2025-07-22T00:00:00Z"),
+        expectedValues = windowValues(1L, 1L, 1L))
+
+      // Watermark rollover makes the duplicate Jul22 row a retained yesterday row for Jul23 output.
+      driver.processWatermark("2025-07-23T00:00:00Z")
+      driver.processEvent("gen_replay_boundary", "2025-07-22T00:00:00Z", "user_yesterday_start")
+      val outputs = driver.drainNewOutputs()
+      outputs should have size 2
+      // In replay mode, the small-window as-of timestamp follows the watermark hop: 1d can include
+      // the duplicate boundary row, while 1h must not double-count after the Jul23 day roll.
+      outputs.find(_.dayStartMillis == dayStart("2025-07-23T00:00:00Z")).map(_.values) shouldEqual
+        Some(windowValues(1L, 2L, null))
+      outputs.find(_.dayStartMillis == dayStart("2025-07-22T00:00:00Z")).map(_.values) shouldEqual
+        Some(windowValues(1L, 1L, 2L))
+
+      // Older-than-yesterday replay data is dropped relative to the post-roll currentDayStart.
+      driver.processEvent("gen_replay_boundary", "2025-07-21T23:59:59.999Z", "user_too_old")
+      driver.drainNewOutputs() shouldBe empty
+    }
+  }
+
+  it should "SparseKeyLag lifecycle: sparse-key PT fallback can permanently drop backlog events older than yesterday after day roll" in {
+    withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      // Seed a sparse key during replay; the key then goes idle while the global watermark remains behind.
+      driver.setProcessingTime("2025-07-23T10:30:00Z")
+      driver.processWatermark("2025-07-21T10:30:00Z")
+      driver.processEvent("gen_sparse_replay_drop", "2025-07-21T10:30:00Z", "user_seed")
+      assertSingleOutput(
+        driver.drainNewOutputs(),
+        expectedKey = "gen_sparse_replay_drop",
+        expectedDayStart = dayStart("2025-07-21T00:00:00Z"),
+        expectedValues = windowValues(1L, 1L, 1L))
+
+      // After one idle hop, SparseKeyLag uses PT eviction and rolls currentDayStart to Jul23.
+      driver.setProcessingTime("2025-07-23T10:40:00Z")
+      assertSingleOutput(
+        driver.drainNewOutputs(),
+        expectedKey = "gen_sparse_replay_drop",
+        expectedDayStart = dayStart("2025-07-23T00:00:00Z"),
+        expectedValues = windowValues(null, null, null))
+
+      // A later Jul21 backlog event would be valid under active replay, but after the PT roll it is
+      // older than currentDayStart - 1d and must be dropped permanently.
+      driver.setProcessingTime("2025-07-23T10:41:00Z")
+      driver.processEvent("gen_sparse_replay_drop", "2025-07-21T23:59:00Z", "user_backlog_too_late")
+      driver.drainNewOutputs() shouldBe empty
+    }
+  }
+
+  it should "Cold start backlog lifecycle: stream starts 2d behind and rolls old-day rows without dropping valid events" in {
+    withDriver(bufferingOutputTimeMillis = 120000L) { driver =>
+      // Cold start begins with PT on Jul23 but watermark/event time on Jul21.
+      driver.setProcessingTime("2025-07-23T10:30:00Z")
+      driver.processWatermark("2025-07-21T23:59:00Z")
+      driver.processEvent("gen_cold_start", "2025-07-21T23:59:00Z", "user_day_1")
+      driver.drainNewOutputs() shouldBe empty
+
+      // Crossing the Jul22 watermark emits the buffered Jul21 row before applying the Jul22 event.
+      driver.processWatermark("2025-07-22T00:00:01Z")
+      driver.processEvent("gen_cold_start", "2025-07-22T00:00:00Z", "user_day_2")
+      assertSingleOutput(
+        driver.drainNewOutputs(),
+        expectedKey = "gen_cold_start",
+        expectedDayStart = dayStart("2025-07-21T00:00:00Z"),
+        expectedValues = windowValues(1L, 1L, 1L))
+
+      // Add rows around the Jul22 00:05 hop, plus one retained previous-day row and one too-old row.
+      driver.processEvent("gen_cold_start", "2025-07-22T00:05:00Z", "user_exact_hop")
+      driver.processEvent("gen_cold_start", "2025-07-22T00:05:01Z", "user_after_hop")
+      driver.processEvent("gen_cold_start", "2025-07-21T00:00:00Z", "user_prev_day")
+      driver.processEvent("gen_cold_start", "2025-07-20T23:59:59.999Z", "user_too_old")
+      driver.drainNewOutputs() shouldBe empty
+
+      // Buffered emit fires before the first watermark-aligned eviction rebuild.
+      driver.setProcessingTime("2025-07-23T10:32:00Z")
+      val preEvictionOutputs = driver.drainNewOutputs()
+      preEvictionOutputs should have size 2
+      // The retained Jul21 daily row keeps its frozen no-batch snapshot when later yesterday
+      // updates republish the same day key.
+      preEvictionOutputs.find(_.dayStartMillis == dayStart("2025-07-21T00:00:00Z")).map(_.values) shouldEqual
+        Some(windowValues(1L, 1L, 2L))
+      // Before the rebuild, cached 1h is bounded by watermark-hop smallWindowAsOfTs: Jul21 23:59
+      // and Jul22 00:00 count for 1h; Jul21 00:00 is retained only for 1d/3d.
+      preEvictionOutputs.find(_.dayStartMillis == dayStart("2025-07-22T00:00:00Z")).map(_.values) shouldEqual
+        Some(windowValues(2L, 5L, 3L))
+
+      // The 10:35 PT callback is the eviction timer; output remains buffered until 10:37.
+      driver.setProcessingTime("2025-07-23T10:35:00Z")
+      driver.drainNewOutputs() shouldBe empty
+
+      // Buffered output after eviction reflects the watermark-aligned rebuild.
+      driver.setProcessingTime("2025-07-23T10:37:00Z")
+      assertSingleOutput(
+        driver.drainNewOutputs(),
+        expectedKey = "gen_cold_start",
+        expectedDayStart = dayStart("2025-07-22T00:00:00Z"),
+        expectedValues = windowValues(2L, 5L, 3L))
+    }
+  }
+
+  it should "Stale event lifecycle: events older than yesterday are dropped before mutating state" in {
+    withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      // Anchor currentDayStart at Apr12.
+      driver.processWatermark("2026-04-12T00:05:00Z")
+      driver.setProcessingTime("2026-04-12T00:10:00Z")
+      driver.processEvent("gen_stale", "2026-04-12T00:10:00Z", "user_anchor")
+      driver.drainNewOutputs() should have size 1
+
+      // Apr10 23:59:59.999 is one millisecond older than retained yesterday and should not dirty state.
+      driver.processEvent("gen_stale", "2026-04-10T23:59:59.999Z", "user_too_old")
+      driver.drainNewOutputs() shouldBe empty
+    }
+  }
+
+  it should "Failure/recovery lifecycle: checkpoint restore preserves pending timers, dirty bits, and key isolation" in {
+    val originalHarness = harness(bufferingOutputTimeMillis = 10 * 60 * 1000L)
+    originalHarness.open()
+    val baseProcessingTs = toMillis("2025-07-21T10:30:00Z")
+    // Buffer two dirty keys, then snapshot before either key's emit timer fires.
+    originalHarness.setProcessingTime(baseProcessingTs)
+    originalHarness.processElement(event("gen_restore_a", "2025-07-21T10:30:00Z", "user_a_1", baseProcessingTs), 0L)
+    originalHarness.processElement(event("gen_restore_b", "2025-07-21T10:31:00Z", "user_b_1", baseProcessingTs), 0L)
+    originalHarness.extractOutputValues().asScala.toList shouldBe empty
+
+    // Snapshot must capture dirty bits, pending timers, and per-key MegaTile state.
+    val snapshot = originalHarness.snapshot(7L, baseProcessingTs + 1000L)
+    originalHarness.close()
+
+    val restoredHarness = harness(bufferingOutputTimeMillis = 10 * 60 * 1000L)
+    restoredHarness.setup()
+    restoredHarness.initializeState(snapshot)
+    restoredHarness.open()
+
+    // Pending timers survive restore but are not due yet.
+    restoredHarness.setProcessingTime(toMillis("2025-07-21T10:35:00Z"))
+    restoredHarness.extractOutputValues().asScala.toList shouldBe empty
+
+    // The original dirty rows emit once their restored timers become due.
+    restoredHarness.setProcessingTime(toMillis("2025-07-21T10:40:00Z"))
+    val outputs = restoredHarness.extractOutputValues().asScala.toList.map(decodeOutput)
+    outputs should have size 2
+    outputs.find(_.keys == List("gen_restore_a")).map(_.values) shouldEqual Some(windowValues(1L, 1L, 1L))
+    outputs.find(_.keys == List("gen_restore_b")).map(_.values) shouldEqual Some(windowValues(1L, 1L, 1L))
+
+    // A post-restore event for key A must not mutate key B's restored state.
+    restoredHarness.processElement(
+      event("gen_restore_a", "2025-07-21T10:41:00Z", "user_a_2", toMillis("2025-07-21T10:40:00Z")),
+      0L)
+    restoredHarness.setProcessingTime(toMillis("2025-07-21T10:51:00Z"))
+    val postRestore = restoredHarness.extractOutputValues().asScala.toList.map(decodeOutput)
+    postRestore.filter(_.keys == List("gen_restore_a")).last.values shouldEqual windowValues(2L, 2L, 2L)
+    postRestore.filter(_.keys == List("gen_restore_b")).last.values shouldEqual windowValues(1L, 1L, 1L)
+    restoredHarness.close()
+  }
+
+  it should "Failure/recovery lifecycle: malformed timestamp rows are skipped without corrupting later valid rows" in {
+    withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      // Bad timestamp rows should increment error handling and leave keyed state untouched.
+      driver.setProcessingTime("2025-07-21T10:30:00Z")
+      driver.processMalformedTimestamp("gen_bad", "bad_ts", "user_bad")
+      driver.drainNewOutputs() shouldBe empty
+
+      // A later valid row for the same key should behave like the first accepted event.
+      driver.processEvent("gen_bad", "2025-07-21T10:31:00Z", "user_good")
+      driver.drainNewOutputs().last.values shouldEqual windowValues(1L, 1L, 1L)
+    }
+  }
+
+  it should "Failure/recovery lifecycle: emit and eviction timers at the same PT instant coalesce into one row" in {
+    withDriver(bufferingOutputTimeMillis = 5 * 60 * 1000L) { driver =>
+      // The event arms both an eviction timer and a buffered emit timer for 10:35.
+      driver.setProcessingTime("2025-07-21T10:30:00Z")
+      driver.processEvent("gen_collision", "2025-07-21T10:30:00Z", "user_1")
+      driver.drainNewOutputs() shouldBe empty
+
+      // A shared callback timestamp should rebuild and emit once, not duplicate the dirty row.
+      driver.setProcessingTime("2025-07-21T10:35:00Z")
+      assertSingleOutput(
+        driver.drainNewOutputs(),
+        expectedKey = "gen_collision",
+        expectedDayStart = dayStart("2025-07-21T00:00:00Z"),
+        expectedValues = windowValues(1L, 1L, 1L))
+    }
+  }
+
+  it should "buffered emissions add stable per-key jitter" in {
+    val key = "gen_jitter"
+    val baseProcessingTs = toMillis("2025-07-21T10:30:00Z")
+    val bufferMillis = 1000L
+    val maxJitterMillis = 1000L
+    val expectedJitter = Math.floorMod(keyList(key).hashCode().toLong, maxJitterMillis + 1L)
+    val expectedEmitTs = baseProcessingTs + bufferMillis + expectedJitter
+
+    withDriver(bufferingOutputTimeMillis = bufferMillis, bufferingOutputJitterMillis = maxJitterMillis) { driver =>
+      // The first dirty row schedules an emit at base delay plus stable key jitter.
+      driver.setProcessingTimeMillis(baseProcessingTs)
+      driver.processEvent(key, "2025-07-21T10:30:00Z", "user_1")
+      driver.drainNewOutputs() shouldBe empty
+
+      // Nothing should emit before the jittered timestamp.
+      if (expectedEmitTs > baseProcessingTs) {
+        driver.setProcessingTimeMillis(expectedEmitTs - 1L)
+        driver.drainNewOutputs() shouldBe empty
+      }
+
+      // At the jittered timestamp exactly one buffered output is emitted.
+      driver.setProcessingTimeMillis(expectedEmitTs)
+      val outputs = driver.drainNewOutputs()
+      assertSingleOutput(
+        outputs,
+        expectedKey = key,
+        expectedDayStart = dayStart("2025-07-21T00:00:00Z"),
+        expectedValues = windowValues(1L, 1L, 1L))
+      outputs.head.processingTsMillis shouldEqual expectedEmitTs
+    }
+  }
+}
+
+object MegaTileProcessFunctionTest extends Matchers {
+  private val DayMillis = new Window(1, TimeUnit.DAYS).millis
+
+  private val inputSchema: Seq[(String, DataType)] =
+    Seq("view_by" -> StringType, Constants.TimeColumn -> LongType)
+
+  private val groupBy: GroupBy = {
+    val gb = Builders.GroupBy(
+      sources = Seq(
+        Builders.Source.events(
+          table = "events.test_stream",
+          topic = "events.test_stream",
+          query = Builders.Query(
+            selects = Map("id" -> "id", "view_by" -> "view_by"),
+            timeColumn = Constants.TimeColumn,
+            startPartition = "20250101"
+          )
+        )
+      ),
+      keyColumns = Seq("id"),
+      aggregations = Seq(
+        Builders.Aggregation(
+          operation = Operation.COUNT,
+          inputColumn = "view_by",
+          windows = Seq(new Window(1, TimeUnit.HOURS), new Window(1, TimeUnit.DAYS), new Window(3, TimeUnit.DAYS))
+        )
+      ),
+      metaData = Builders.MetaData(name = "mega_tile_process_function_test"),
+      accuracy = Accuracy.TEMPORAL
+    )
+    gb.setOnlineStrategy(OnlineStrategy.STREAMING_MEGATILES)
+    gb
+  }
+
+  private val megaTileCodec = new MegaTileCodec(groupBy, inputSchema)
+
+  private def windowValues(oneHour: Any, oneDay: Any, threeDay: Any): Seq[Any] =
+    Seq(oneHour, oneDay, threeDay)
+
+  // Shared setup for the live/catchup boundary tests: create an old 10:30-10:35 tile, then
+  // advance PT so the 11:35 callback decides whether that tile is still in 1h.
+  private def seedOldTileBeforeLiveCatchupBoundary(driver: Driver, key: String): Unit = {
+    driver.setProcessingTime("2025-07-21T10:30:00Z")
+    driver.processEvent(key, "2025-07-21T10:30:00Z", "user_old_1")
+    driver.processEvent(key, "2025-07-21T10:31:00Z", "user_old_2")
+    driver.drainNewOutputs().last.values shouldEqual windowValues(2L, 2L, 2L)
+
+    driver.setProcessingTime("2025-07-21T11:30:00Z")
+    driver.drainNewOutputs().last.values shouldEqual windowValues(2L, 2L, 2L)
+  }
+
+  private def activeKeyResumesAfterUtcMidnightWithStaleWatermarkThenCatchesUp(driver: Driver): Unit = {
+    val key = "axis_active_after_midnight"
+    driver.processWatermark("2026-04-11T23:54:00Z")
+    driver.setProcessingTime("2026-04-12T00:01:00Z")
+
+    // The key is active and watermark is more than one hop plus slack behind PT, so the 00:00:30
+    // tile is retained but not merged into no-batch windows as of the 23:55 watermark hop.
+    driver.processEvent(key, "2026-04-12T00:00:30Z", "user_after_midnight")
+    assertSingleOutput(
+      driver.drainNewOutputs(),
+      expectedKey = key,
+      expectedDayStart = dayStart("2026-04-12T00:00:00Z"),
+      expectedValues = windowValues(null, null, 1L))
+
+    // Once watermark crosses midnight and is close enough to PT, the next PT eviction rebuilds the
+    // small-window cache as live time and the retained 00:00 tile appears.
+    driver.processWatermark("2026-04-12T00:00:30Z")
+    driver.setProcessingTime("2026-04-12T00:05:00Z")
+    assertSingleOutput(
+      driver.drainNewOutputs(),
+      expectedKey = key,
+      expectedDayStart = dayStart("2026-04-12T00:00:00Z"),
+      expectedValues = windowValues(1L, 1L, 1L))
+  }
+
+  private def sparseKeyResumesAfterUtcMidnightWithStaleWatermark(driver: Driver): Unit = {
+    val key = "axis_sparse_after_midnight"
+    driver.processWatermark("2026-04-11T23:49:00Z")
+    driver.setProcessingTime("2026-04-11T23:50:00Z")
+    driver.processEvent(key, "2026-04-11T23:50:00Z", "user_seed")
+    assertSingleOutput(
+      driver.drainNewOutputs(),
+      expectedKey = key,
+      expectedDayStart = dayStart("2026-04-11T00:00:00Z"),
+      expectedValues = windowValues(1L, 1L, 1L))
+
+    // At 00:10 the key has been idle for more than one hop, so stale-watermark mode is SparseKeyLag.
+    // The overdue PT eviction rolls currentDayStart to Apr12 and rebuilds small windows as of PT.
+    driver.processWatermark("2026-04-11T23:54:00Z")
+    driver.setProcessingTime("2026-04-12T00:10:00Z")
+    assertSingleOutput(
+      driver.drainNewOutputs(),
+      expectedKey = key,
+      expectedDayStart = dayStart("2026-04-12T00:00:00Z"),
+      expectedValues = windowValues(1L, 1L, null))
+  }
+
+  private def yesterdayBoundaryEventAfterResumeIsAdmitted(driver: Driver): Unit = {
+    val key = "axis_yesterday_boundary"
+    driver.processWatermark("2026-04-12T00:05:00Z")
+    driver.setProcessingTime("2026-04-12T00:10:00Z")
+    driver.processEvent(key, "2026-04-12T00:10:00Z", "user_anchor")
+    assertSingleOutput(
+      driver.drainNewOutputs(),
+      expectedKey = key,
+      expectedDayStart = dayStart("2026-04-12T00:00:00Z"),
+      expectedValues = windowValues(1L, 1L, 1L))
+
+    // Exact yesterday-start is admissible. It updates current 1d/3d state, but not current 1h.
+    driver.processEvent(key, "2026-04-11T00:00:00Z", "user_yesterday_start")
+    val outputs = driver.drainNewOutputs()
+    outputs should have size 2
+    outputs.find(_.dayStartMillis == dayStart("2026-04-12T00:00:00Z")).map(_.values) shouldEqual
+      Some(windowValues(1L, 2L, 1L))
+    outputs.find(_.dayStartMillis == dayStart("2026-04-11T00:00:00Z")).map(_.values) shouldEqual
+      Some(windowValues(null, null, 1L))
+  }
+
+  private def olderThanYesterdayEventAfterResumeIsDropped(driver: Driver): Unit = {
+    val key = "axis_older_than_yesterday"
+    driver.processWatermark("2026-04-12T00:05:00Z")
+    driver.setProcessingTime("2026-04-12T00:10:00Z")
+    driver.processEvent(key, "2026-04-12T00:10:00Z", "user_anchor")
+    assertSingleOutput(
+      driver.drainNewOutputs(),
+      expectedKey = key,
+      expectedDayStart = dayStart("2026-04-12T00:00:00Z"),
+      expectedValues = windowValues(1L, 1L, 1L))
+
+    // One millisecond older than yesterday is rejected before processor.onEvent can mutate state.
+    driver.processEvent(key, "2026-04-10T23:59:59.999Z", "user_too_old")
+    driver.drainNewOutputs() shouldBe empty
+  }
+
+  private case class DecodedOutput(
+      keys: List[Any],
+      dayStartMillis: Long,
+      processingTsMillis: Long,
+      values: Seq[Any])
+
+  final private class Driver(bufferingOutputTimeMillis: Long, bufferingOutputJitterMillis: Long) {
+    private val testHarness = harness(bufferingOutputTimeMillis, bufferingOutputJitterMillis)
+    private var emittedCount = 0
+    private var currentProcessingTs = 0L
+
+    testHarness.open()
+
+    def setProcessingTime(iso: String): Unit =
+      setProcessingTimeMillis(toMillis(iso))
+
+    def setProcessingTimeMillis(ts: Long): Unit = {
+      currentProcessingTs = ts
+      testHarness.setProcessingTime(ts)
+    }
+
+    def processWatermark(iso: String): Unit =
+      testHarness.processWatermark(toMillis(iso))
+
+    def processEvent(id: String, eventIso: String, viewBy: String): Unit =
+      testHarness.processElement(event(id, eventIso, viewBy, currentProcessingTs), 0L)
+
+    def processMalformedTimestamp(id: String, malformedTs: String, viewBy: String): Unit =
+      testHarness.processElement(
+        ProjectedEvent(Map("id" -> id, "view_by" -> viewBy, Constants.TimeColumn -> malformedTs), currentProcessingTs),
+        0L)
+
+    def drainNewOutputs(): List[DecodedOutput] = {
+      val allOutputs = testHarness.extractOutputValues().asScala.toList.map(decodeOutput)
+      val newOutputs = allOutputs.drop(emittedCount)
+      emittedCount = allOutputs.size
+      newOutputs
+    }
+
+    def close(): Unit =
+      testHarness.close()
+  }
+
+  private def withDriver(bufferingOutputTimeMillis: Long, bufferingOutputJitterMillis: Long = 0L)(
+      fn: Driver => Unit): Unit = {
+    val driver = new Driver(bufferingOutputTimeMillis, bufferingOutputJitterMillis)
+    try {
+      fn(driver)
+    } finally {
+      driver.close()
+    }
+  }
+
+  private def harness(bufferingOutputTimeMillis: Long,
+                      bufferingOutputJitterMillis: Long = 0L)
+      : KeyedOneInputStreamOperatorTestHarness[java.util.List[Any], ProjectedEvent, TimestampedTile] = {
+    new KeyedOneInputStreamOperatorTestHarness[java.util.List[Any], ProjectedEvent, TimestampedTile](
+      new KeyedProcessOperator[java.util.List[Any], ProjectedEvent, TimestampedTile](
+        new MegaTileProcessFunction(
+          groupBy,
+          inputSchema,
+          bufferingOutputTimeMillis = bufferingOutputTimeMillis,
+          bufferingOutputJitterMillis = bufferingOutputJitterMillis
+        )),
+      new KeySelector[ProjectedEvent, java.util.List[Any]] {
+        override def getKey(value: ProjectedEvent): java.util.List[Any] =
+          keyList(value.fields("id"))
+      },
+      TypeInformation.of(classOf[java.util.List[_]]).asInstanceOf[TypeInformation[java.util.List[Any]]]
+    )
+  }
+
+  private def event(id: String, eventIso: String, viewBy: String, processingTs: Long): ProjectedEvent =
+    ProjectedEvent(
+      Map("id" -> id, "view_by" -> viewBy, Constants.TimeColumn -> toMillis(eventIso)),
+      processingTs
+    )
+
+  private def keyList(key: Any): java.util.List[Any] = {
+    val result = new util.ArrayList[Any](1)
+    result.add(key)
+    result
+  }
+
+  private def assertSingleOutput(
+      outputs: List[DecodedOutput],
+      expectedKey: String,
+      expectedDayStart: Long,
+      expectedValues: Seq[Any]): Unit = {
+    outputs should have size 1
+    outputs.head.keys shouldEqual List(expectedKey)
+    outputs.head.dayStartMillis shouldEqual expectedDayStart
+    outputs.head.values shouldEqual expectedValues
+  }
+
+  private def decodeOutput(tile: TimestampedTile): DecodedOutput =
+    DecodedOutput(
+      keys = tile.keys.asScala.toList,
+      dayStartMillis = tile.latestTsMillis,
+      processingTsMillis = tile.startProcessingTime,
+      values = megaTileCodec.rowAggregator
+        .finalize(megaTileCodec.decode(tile.tileBytes))
+        .toSeq
+    )
+
+  private def dayStart(iso: String): Long =
+    TsUtils.round(toMillis(iso), DayMillis)
+
+  private def toMillis(iso: String): Long =
+    Instant.parse(iso).toEpochMilli
+}

--- a/flink/src/test/scala/ai/chronon/flink/test/window/MegaTileProcessFunctionTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/window/MegaTileProcessFunctionTest.scala
@@ -81,6 +81,51 @@ class MegaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     }
   }
 
+  it should "Live event just after hop does not rebuild small-window cache at next hop" in {
+    withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      val key = "gen_live_after_hop"
+
+      driver.processWatermark("2025-07-21T10:30:00Z")
+      driver.setProcessingTime("2025-07-21T10:35:00Z")
+      driver.processEvent(key, "2025-07-21T10:35:00Z", "user_left_edge")
+      assertSingleOutput(
+        driver.drainNewOutputs(),
+        expectedKey = key,
+        expectedDayStart = dayStart("2025-07-21T00:00:00Z"),
+        expectedValues = windowValues(1L, 1L, 1L))
+
+      driver.processWatermark("2025-07-21T11:30:00Z")
+      driver.setProcessingTime("2025-07-21T11:35:09Z")
+      driver.drainNewOutputs().last.values shouldEqual windowValues(1L, 1L, 1L)
+
+      // If the event path rebuilt at 11:40, the live 1h start would advance to 10:40 and drop the
+      // left-edge 10:35 tile too early.
+      driver.processEvent(key, "2025-07-21T11:35:09Z", "user_current")
+      assertSingleOutput(
+        driver.drainNewOutputs(),
+        expectedKey = key,
+        expectedDayStart = dayStart("2025-07-21T00:00:00Z"),
+        expectedValues = windowValues(2L, 2L, 2L))
+    }
+  }
+
+  it should "Live event exactly on hop updates just-opened small-window tile" in {
+    withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      val key = "gen_live_exact_hop"
+
+      driver.processWatermark("2025-07-21T11:30:00Z")
+      driver.setProcessingTime("2025-07-21T11:35:00Z")
+      driver.processEvent(key, "2025-07-21T11:35:00Z", "user_exact_hop")
+
+      // processor.onEvent includes retained tiles using tileStart < smallWindowAsOfTs.
+      assertSingleOutput(
+        driver.drainNewOutputs(),
+        expectedKey = key,
+        expectedDayStart = dayStart("2025-07-21T00:00:00Z"),
+        expectedValues = windowValues(1L, 1L, 1L))
+    }
+  }
+
   it should "Live mode lifecycle: continuous events before, during, and after day transition" in {
     withDriver(bufferingOutputTimeMillis = 0L) { driver =>
       // Seed the final Jul21 tile before either PT or watermark day rollover occurs.

--- a/online/package.mill
+++ b/online/package.mill
@@ -57,7 +57,7 @@ trait OnlineModule extends Cross.Module[String] with build.BaseModule {
   object test extends build.BaseTestModule {
 
     def scalaVersion = crossValue
-    def moduleDeps = Seq(build.online(crossValue), build.api(crossValue).test)
+    def moduleDeps = Seq(build.online(crossValue), build.api(crossValue).test, build.aggregator(crossValue).test)
     def mvnDeps = super.mvnDeps() ++ build.Constants.testDeps ++ Seq(
       mvn"org.apache.spark::spark-hive:${build.Constants.sparkVersion}"
     )

--- a/online/src/main/scala/ai/chronon/online/GroupByServingInfoParsed.scala
+++ b/online/src/main/scala/ai/chronon/online/GroupByServingInfoParsed.scala
@@ -16,7 +16,7 @@
 
 package ai.chronon.online
 
-import ai.chronon.aggregator.windowing.{ResolutionUtils, SawtoothOnlineAggregator}
+import ai.chronon.aggregator.windowing.{MegaTileAggregator, MegaTileMerger, ResolutionUtils, SawtoothOnlineAggregator}
 import ai.chronon.api.Constants.{ReversalField, TimeField}
 import ai.chronon.api.Extensions.{GroupByOps, MetadataOps, WindowOps, WindowUtils}
 import ai.chronon.api.ScalaJavaConversions.ListOps
@@ -93,6 +93,20 @@ class GroupByServingInfoParsed(val groupByServingInfo: GroupByServingInfo)
   lazy val tiledCodec: TileCodec = new TileCodec(groupBy, valueChrononSchema.fields.map(sf => (sf.name, sf.fieldType)))
 
   // End tiling specific variables
+
+  // Start mega tiling specific variables
+
+  private lazy val valueInputSchema: Seq[(String, DataType)] =
+    valueChrononSchema.fields.map(sf => (sf.name, sf.fieldType))
+
+  lazy val megaTileAggregator: MegaTileAggregator =
+    new MegaTileAggregator(groupByServingInfo.groupBy.aggregations.toScala, valueInputSchema)
+
+  lazy val megaTileMerger: MegaTileMerger = new MegaTileMerger(megaTileAggregator)
+
+  lazy val megaTileCodec: MegaTileCodec = new MegaTileCodec(groupBy, valueInputSchema)
+
+  // End mega tiling specific variables
 
   def outputChrononSchema: StructType =
     if (groupByServingInfo.groupBy.aggregations == null) {

--- a/online/src/main/scala/ai/chronon/online/MegaTileCodec.scala
+++ b/online/src/main/scala/ai/chronon/online/MegaTileCodec.scala
@@ -27,9 +27,10 @@ class MegaTileCodec(groupBy: GroupBy, inputSchema: Seq[(String, DataType)]) {
 
   def encode(ir: Array[Any]): Array[Byte] = encodeFn(rowAggregator.normalize(ir))
 
+  @transient private lazy val avroCodec: AvroCodec = AvroCodec.of(avroSchema)
+
   def decode(bytes: Array[Byte]): Array[Any] = {
-    val codec = AvroCodec.of(avroSchema)
-    val record = codec.decode(bytes).asInstanceOf[GenericData.Record]
+    val record = avroCodec.decode(bytes).asInstanceOf[GenericData.Record]
     val ir = rowConverter(record)
     rowAggregator.denormalize(ir)
   }
@@ -46,9 +47,10 @@ class MegaTileCodec(groupBy: GroupBy, inputSchema: Seq[(String, DataType)]) {
 
   def encodeBaseIr(ir: Array[Any]): Array[Byte] = baseEncodeFn(baseRowAggregator.normalize(ir))
 
+  @transient private lazy val baseAvroCodec: AvroCodec = AvroCodec.of(baseAvroSchema)
+
   def decodeBaseIr(bytes: Array[Byte]): Array[Any] = {
-    val codec = AvroCodec.of(baseAvroSchema)
-    val record = codec.decode(bytes).asInstanceOf[GenericData.Record]
+    val record = baseAvroCodec.decode(bytes).asInstanceOf[GenericData.Record]
     val ir = baseRowConverter(record)
     baseRowAggregator.denormalize(ir)
   }

--- a/online/src/main/scala/ai/chronon/online/MegaTileCodec.scala
+++ b/online/src/main/scala/ai/chronon/online/MegaTileCodec.scala
@@ -6,8 +6,7 @@ import ai.chronon.api.{DataType, GroupBy, StructType}
 import ai.chronon.online.serde.{AvroCodec, AvroConversions}
 import org.apache.avro.generic.GenericData
 
-/**
-  * Encodes/decodes the windowed mega tile IR (Array[Any]) to/from bytes.
+/** Encodes/decodes the windowed mega tile IR (Array[Any]) to/from bytes.
   * Unlike TileCodec which uses the unwindowed base aggregator schema,
   * MegaTileCodec uses the windowed aggregator schema — one IR slot per (agg, window) pair.
   *

--- a/online/src/main/scala/ai/chronon/online/MegaTileCodec.scala
+++ b/online/src/main/scala/ai/chronon/online/MegaTileCodec.scala
@@ -1,0 +1,33 @@
+package ai.chronon.online
+
+import ai.chronon.aggregator.row.RowAggregator
+import ai.chronon.api.Extensions.MetadataOps
+import ai.chronon.api.{DataType, GroupBy, StructType}
+import ai.chronon.online.serde.{AvroCodec, AvroConversions}
+import org.apache.avro.generic.GenericData
+
+/**
+  * Encodes/decodes the windowed mega tile IR (Array[Any]) to/from bytes.
+  * Unlike TileCodec which uses the unwindowed base aggregator schema,
+  * MegaTileCodec uses the windowed aggregator schema — one IR slot per (agg, window) pair.
+  */
+class MegaTileCodec(groupBy: GroupBy, inputSchema: Seq[(String, DataType)]) {
+
+  val rowAggregator: RowAggregator = TileCodec.buildWindowedRowAggregator(groupBy, inputSchema)
+  val irSchema: StructType = StructType.from(s"${groupBy.getMetaData.cleanName}_MEGA_TILE_IR", rowAggregator.irSchema)
+  val avroSchema: String = AvroConversions.fromChrononSchema(irSchema).toString()
+
+  private val encodeFn: Any => Array[Byte] = AvroConversions.encodeBytes(irSchema, null)
+
+  @transient private lazy val rowConverter: Any => Array[Any] =
+    AvroConversions.genericRecordToChrononRowConverter(irSchema)
+
+  def encode(ir: Array[Any]): Array[Byte] = encodeFn(rowAggregator.normalize(ir))
+
+  def decode(bytes: Array[Byte]): Array[Any] = {
+    val codec = AvroCodec.of(avroSchema)
+    val record = codec.decode(bytes).asInstanceOf[GenericData.Record]
+    val ir = rowConverter(record)
+    rowAggregator.denormalize(ir)
+  }
+}

--- a/online/src/main/scala/ai/chronon/online/MegaTileCodec.scala
+++ b/online/src/main/scala/ai/chronon/online/MegaTileCodec.scala
@@ -10,9 +10,13 @@ import org.apache.avro.generic.GenericData
   * Encodes/decodes the windowed mega tile IR (Array[Any]) to/from bytes.
   * Unlike TileCodec which uses the unwindowed base aggregator schema,
   * MegaTileCodec uses the windowed aggregator schema — one IR slot per (agg, window) pair.
+  *
+  * Also provides encodeBaseIr/decodeBaseIr for encoding per-tile base (unwindowed) IRs.
+  * These are used by Flink state persistence where tiles store base IRs, not windowed IRs.
   */
 class MegaTileCodec(groupBy: GroupBy, inputSchema: Seq[(String, DataType)]) {
 
+  // Windowed: one slot per (agg, window) pair — for mega tile entries
   val rowAggregator: RowAggregator = TileCodec.buildWindowedRowAggregator(groupBy, inputSchema)
   val irSchema: StructType = StructType.from(s"${groupBy.getMetaData.cleanName}_MEGA_TILE_IR", rowAggregator.irSchema)
   val avroSchema: String = AvroConversions.fromChrononSchema(irSchema).toString()
@@ -29,5 +33,24 @@ class MegaTileCodec(groupBy: GroupBy, inputSchema: Seq[(String, DataType)]) {
     val record = codec.decode(bytes).asInstanceOf[GenericData.Record]
     val ir = rowConverter(record)
     rowAggregator.denormalize(ir)
+  }
+
+  // Base (unwindowed): one slot per aggregation bucket — for individual tile state
+  val baseRowAggregator: RowAggregator = TileCodec.buildRowAggregator(groupBy, inputSchema)
+  private val baseIrSchema: StructType =
+    StructType.from(s"${groupBy.getMetaData.cleanName}_BASE_TILE_IR", baseRowAggregator.irSchema)
+  private val baseAvroSchema: String = AvroConversions.fromChrononSchema(baseIrSchema).toString()
+  private val baseEncodeFn: Any => Array[Byte] = AvroConversions.encodeBytes(baseIrSchema, null)
+
+  @transient private lazy val baseRowConverter: Any => Array[Any] =
+    AvroConversions.genericRecordToChrononRowConverter(baseIrSchema)
+
+  def encodeBaseIr(ir: Array[Any]): Array[Byte] = baseEncodeFn(baseRowAggregator.normalize(ir))
+
+  def decodeBaseIr(bytes: Array[Byte]): Array[Any] = {
+    val codec = AvroCodec.of(baseAvroSchema)
+    val record = codec.decode(bytes).asInstanceOf[GenericData.Record]
+    val ir = baseRowConverter(record)
+    baseRowAggregator.denormalize(ir)
   }
 }

--- a/online/src/main/scala/ai/chronon/online/MegaTileCodec.scala
+++ b/online/src/main/scala/ai/chronon/online/MegaTileCodec.scala
@@ -27,7 +27,9 @@ class MegaTileCodec(groupBy: GroupBy, inputSchema: Seq[(String, DataType)]) {
 
   def encode(ir: Array[Any]): Array[Byte] = encodeFn(rowAggregator.normalize(ir))
 
-  @transient private lazy val avroCodec: AvroCodec = AvroCodec.of(avroSchema)
+  // AvroCodec.of returns a per-thread cached codec keyed by schema string, so this avoids
+  // cross-thread decoder reuse without reparsing the schema on every decode call.
+  private def avroCodec: AvroCodec = AvroCodec.of(avroSchema)
 
   def decode(bytes: Array[Byte]): Array[Any] = {
     val record = avroCodec.decode(bytes).asInstanceOf[GenericData.Record]
@@ -47,7 +49,8 @@ class MegaTileCodec(groupBy: GroupBy, inputSchema: Seq[(String, DataType)]) {
 
   def encodeBaseIr(ir: Array[Any]): Array[Byte] = baseEncodeFn(baseRowAggregator.normalize(ir))
 
-  @transient private lazy val baseAvroCodec: AvroCodec = AvroCodec.of(baseAvroSchema)
+  // Same per-thread cache behavior as avroCodec above.
+  private def baseAvroCodec: AvroCodec = AvroCodec.of(baseAvroSchema)
 
   def decodeBaseIr(bytes: Array[Byte]): Array[Any] = {
     val record = baseAvroCodec.decode(bytes).asInstanceOf[GenericData.Record]

--- a/online/src/main/scala/ai/chronon/online/fetcher/FetcherCache.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/FetcherCache.scala
@@ -127,7 +127,7 @@ trait FetcherCache {
     groupByRequestToKvRequest
       .map {
 
-        case (request, Success(LambdaKvRequest(servingInfo, _, batchRequest, _, _, _)))
+        case (request, Success(LambdaKvRequest(servingInfo, _, batchRequest, _, _, _, _)))
             if isCachingEnabled(servingInfo.groupBy) =>
           val batchRequestCacheKey =
             BatchIrCache.Key(batchRequest.dataset, request.keys, servingInfo.batchEndTsMillis)

--- a/online/src/main/scala/ai/chronon/online/fetcher/GroupByFetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/GroupByFetcher.scala
@@ -91,14 +91,16 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
 
       val batchRequest = GetRequest(batchKeyBytes, groupByServingInfo.groupByOps.batchDataset)
 
+      // Resolve query time once to avoid inconsistency across midnight boundaries
+      val resolvedQueryTs = request.atMillis.getOrElse(System.currentTimeMillis())
+
       val (streamingRequestOpt, megaTileYesterdayRequestOpt) =
         groupByServingInfo.groupByOps.inferredAccuracy match {
           case Accuracy.TEMPORAL if groupByServingInfo.groupByOps.isMegaTilingEnabled =>
             // Mega tiling: 2 point gets — (key, today) + (key, yesterday)
-            val queryTs = request.atMillis.getOrElse(System.currentTimeMillis())
             val DayMillis = 24 * 3600 * 1000L
             val (todayStart, yesterdayStart) =
-              groupByServingInfo.megaTileMerger.streamingDayKeys(queryTs)
+              groupByServingInfo.megaTileMerger.streamingDayKeys(resolvedQueryTs)
             val dataset = groupByServingInfo.groupByOps.streamingDataset
 
             def megaTileRequest(dayStart: Long): GetRequest = {
@@ -137,7 +139,7 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
                        batchRequest,
                        streamingRequestOpt,
                        megaTileYesterdayRequestOpt,
-                       request.atMillis,
+                       Some(resolvedQueryTs),
                        context)
 
     }
@@ -220,7 +222,7 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
         val responses: Seq[Response] = groupByRequestToKvRequest.iterator.map { case (request, requestMetaTry) =>
           val responseMapTry: Try[Map[String, AnyRef]] = requestMetaTry.map { requestMeta =>
             val LambdaKvRequest(groupByServingInfo, castedRequest, batchRequest, streamingRequestOpt,
-                                megaTileYesterdayOpt, _, context) = requestMeta
+                                megaTileYesterdayOpt, endTs, context) = requestMeta
 
             context.count("multi_get.batch.size", allRequestsToFetch.length)
             context.distribution("multi_get.bytes", totalResponseValueBytes)
@@ -248,7 +250,7 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
             val megaTileYesterdayResponsesOpt =
               megaTileYesterdayOpt.map(responsesMap.getOrElse(_, Success(Seq.empty)).getOrElse(Seq.empty))
 
-            val queryTs = request.atMillis.getOrElse(System.currentTimeMillis())
+            val queryTs = endTs.getOrElse(request.atMillis.getOrElse(System.currentTimeMillis()))
             val requestContext = RequestContext(groupByServingInfo, queryTs, startTimeMs, context, request.keys)
 
             val groupByResponse: Map[String, AnyRef] =

--- a/online/src/main/scala/ai/chronon/online/fetcher/GroupByFetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/GroupByFetcher.scala
@@ -135,12 +135,12 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
 
       val castedRequest = request.copy(keys = groupByServingInfo.keyChrononSchema.cast(request.keys))
       LambdaKvRequest(groupByServingInfo,
-                       castedRequest,
-                       batchRequest,
-                       streamingRequestOpt,
-                       megaTileYesterdayRequestOpt,
-                       Some(resolvedQueryTs),
-                       context)
+                      castedRequest,
+                      batchRequest,
+                      streamingRequestOpt,
+                      megaTileYesterdayRequestOpt,
+                      Some(resolvedQueryTs),
+                      context)
 
     }
 
@@ -221,8 +221,13 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
 
         val responses: Seq[Response] = groupByRequestToKvRequest.iterator.map { case (request, requestMetaTry) =>
           val responseMapTry: Try[Map[String, AnyRef]] = requestMetaTry.map { requestMeta =>
-            val LambdaKvRequest(groupByServingInfo, castedRequest, batchRequest, streamingRequestOpt,
-                                megaTileYesterdayOpt, endTs, context) = requestMeta
+            val LambdaKvRequest(groupByServingInfo,
+                                castedRequest,
+                                batchRequest,
+                                streamingRequestOpt,
+                                megaTileYesterdayOpt,
+                                endTs,
+                                context) = requestMeta
 
             context.count("multi_get.batch.size", allRequestsToFetch.length)
             context.distribution("multi_get.bytes", totalResponseValueBytes)
@@ -260,10 +265,7 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
                     s"Constructing response for groupBy: ${groupByServingInfo.groupByOps.metaData.getName} " +
                       s"for keys: ${request.keys}")
 
-                decodeAndMerge(batchResponses,
-                               streamingResponsesOpt,
-                               megaTileYesterdayResponsesOpt,
-                               requestContext)
+                decodeAndMerge(batchResponses, streamingResponsesOpt, megaTileYesterdayResponsesOpt, requestContext)
 
               } catch {
 

--- a/online/src/main/scala/ai/chronon/online/fetcher/GroupByFetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/GroupByFetcher.scala
@@ -91,37 +91,54 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
 
       val batchRequest = GetRequest(batchKeyBytes, groupByServingInfo.groupByOps.batchDataset)
 
-      val streamingRequestOpt = groupByServingInfo.groupByOps.inferredAccuracy match {
-        // fetch batch(ir) and streaming(input) and aggregate
-        case Accuracy.TEMPORAL =>
-          // Build a tile key for the streaming request
-          // When we build support for layering, we can expand this out into a utility that builds n tile keys for n layers
-          val keyBytes = if (fetchContext.isTilingEnabled) {
+      val (streamingRequestOpt, megaTileYesterdayRequestOpt) =
+        groupByServingInfo.groupByOps.inferredAccuracy match {
+          case Accuracy.TEMPORAL if groupByServingInfo.groupByOps.isMegaTilingEnabled =>
+            // Mega tiling: 2 point gets — (key, today) + (key, yesterday)
+            val queryTs = request.atMillis.getOrElse(System.currentTimeMillis())
+            val DayMillis = 24 * 3600 * 1000L
+            val (todayStart, yesterdayStart) =
+              groupByServingInfo.megaTileMerger.streamingDayKeys(queryTs)
+            val dataset = groupByServingInfo.groupByOps.streamingDataset
 
-            val tileKey = TilingUtils.buildTileKey(
-              groupByServingInfo.groupByOps.streamingDataset,
-              streamingKeyBytes,
-              Some(groupByServingInfo.smallestTailHopMillis),
-              None
-            )
+            def megaTileRequest(dayStart: Long): GetRequest = {
+              val tileKey =
+                TilingUtils.buildTileKey(dataset, streamingKeyBytes, Some(DayMillis), Some(dayStart))
+              GetRequest(TilingUtils.serializeTileKey(tileKey), dataset)
+            }
 
-            TilingUtils.serializeTileKey(tileKey)
-          } else {
-            streamingKeyBytes
-          }
+            (Some(megaTileRequest(todayStart)), Some(megaTileRequest(yesterdayStart)))
 
-          Some(
-            GetRequest(keyBytes,
-                       groupByServingInfo.groupByOps.streamingDataset,
-                       Some(groupByServingInfo.batchEndTsMillis)))
+          case Accuracy.TEMPORAL =>
+            // Standard tiling or raw streaming
+            val keyBytes = if (fetchContext.isTilingEnabled) {
+              val tileKey = TilingUtils.buildTileKey(
+                groupByServingInfo.groupByOps.streamingDataset,
+                streamingKeyBytes,
+                Some(groupByServingInfo.smallestTailHopMillis),
+                None
+              )
+              TilingUtils.serializeTileKey(tileKey)
+            } else {
+              streamingKeyBytes
+            }
+            (Some(
+               GetRequest(keyBytes,
+                          groupByServingInfo.groupByOps.streamingDataset,
+                          Some(groupByServingInfo.batchEndTsMillis))),
+             None)
 
-        // no further aggregation is required - the value in KvStore is good as is
-        case Accuracy.SNAPSHOT => None
-
-      }
+          case Accuracy.SNAPSHOT => (None, None)
+        }
 
       val castedRequest = request.copy(keys = groupByServingInfo.keyChrononSchema.cast(request.keys))
-      LambdaKvRequest(groupByServingInfo, castedRequest, batchRequest, streamingRequestOpt, request.atMillis, context)
+      LambdaKvRequest(groupByServingInfo,
+                       castedRequest,
+                       batchRequest,
+                       streamingRequestOpt,
+                       megaTileYesterdayRequestOpt,
+                       request.atMillis,
+                       context)
 
     }
 
@@ -170,9 +187,10 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
       LRUCache.collectCaffeineCacheMetrics(caffeineMetricsContext, cache.cache, cache.cacheName))
 
     val allRequestsToFetch: Seq[GetRequest] = groupByRequestToKvRequest.flatMap {
-      case (_, Success(LambdaKvRequest(_, _, batchRequest, streamingRequestOpt, _, _))) =>
+      case (_, Success(LambdaKvRequest(_, _, batchRequest, streamingRequestOpt, megaTileYesterdayOpt, _, _))) =>
         // If a batch request is cached, don't include it in the list of requests to fetch because the batch IRs already cached
-        if (cachedRequests.contains(batchRequest)) streamingRequestOpt else Some(batchRequest) ++ streamingRequestOpt
+        val batchReqs = if (cachedRequests.contains(batchRequest)) Seq.empty else Seq(batchRequest)
+        batchReqs ++ streamingRequestOpt ++ megaTileYesterdayOpt
 
       case _ => Seq.empty
     }
@@ -201,8 +219,8 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
 
         val responses: Seq[Response] = groupByRequestToKvRequest.iterator.map { case (request, requestMetaTry) =>
           val responseMapTry: Try[Map[String, AnyRef]] = requestMetaTry.map { requestMeta =>
-            val LambdaKvRequest(groupByServingInfo, castedRequest, batchRequest, streamingRequestOpt, _, context) =
-              requestMeta
+            val LambdaKvRequest(groupByServingInfo, castedRequest, batchRequest, streamingRequestOpt,
+                                megaTileYesterdayOpt, _, context) = requestMeta
 
             context.count("multi_get.batch.size", allRequestsToFetch.length)
             context.distribution("multi_get.bytes", totalResponseValueBytes)
@@ -227,6 +245,8 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
 
             val streamingResponsesOpt =
               streamingRequestOpt.map(responsesMap.getOrElse(_, Success(Seq.empty)).getOrElse(Seq.empty))
+            val megaTileYesterdayResponsesOpt =
+              megaTileYesterdayOpt.map(responsesMap.getOrElse(_, Success(Seq.empty)).getOrElse(Seq.empty))
 
             val queryTs = request.atMillis.getOrElse(System.currentTimeMillis())
             val requestContext = RequestContext(groupByServingInfo, queryTs, startTimeMs, context, request.keys)
@@ -238,7 +258,10 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
                     s"Constructing response for groupBy: ${groupByServingInfo.groupByOps.metaData.getName} " +
                       s"for keys: ${request.keys}")
 
-                decodeAndMerge(batchResponses, streamingResponsesOpt, requestContext)
+                decodeAndMerge(batchResponses,
+                               streamingResponsesOpt,
+                               megaTileYesterdayResponsesOpt,
+                               requestContext)
 
               } catch {
 
@@ -333,5 +356,6 @@ case class LambdaKvRequest(groupByServingInfoParsed: GroupByServingInfoParsed,
                            castedGroupByRequest: Fetcher.Request,
                            batchRequest: GetRequest,
                            streamingRequestOpt: Option[GetRequest],
+                           megaTileYesterdayRequestOpt: Option[GetRequest] = None,
                            endTs: Option[Long],
                            context: metrics.Metrics.Context)

--- a/online/src/main/scala/ai/chronon/online/fetcher/GroupByFetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/GroupByFetcher.scala
@@ -94,13 +94,14 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
       // Resolve query time once to avoid inconsistency across midnight boundaries
       val resolvedQueryTs = request.atMillis.getOrElse(System.currentTimeMillis())
 
-      val (streamingRequestOpt, megaTileYesterdayRequestOpt) =
+      val (streamingRequestOpt, megaTileHistoricalRequestsOpt) =
         groupByServingInfo.groupByOps.inferredAccuracy match {
           case Accuracy.TEMPORAL if groupByServingInfo.groupByOps.isMegaTilingEnabled =>
-            // Mega tiling: 2 point gets — (key, today) + (key, yesterday)
+            // Mega tiling: one daily point get per day from today back to batch day,
+            // plus one extra fallback day for no-batch windows.
             val DayMillis = 24 * 3600 * 1000L
-            val (todayStart, yesterdayStart) =
-              groupByServingInfo.megaTileMerger.streamingDayKeys(resolvedQueryTs)
+            val dayStarts = groupByServingInfo.megaTileMerger
+              .streamingDayKeys(resolvedQueryTs, groupByServingInfo.batchEndTsMillis)
             val dataset = groupByServingInfo.groupByOps.streamingDataset
 
             def megaTileRequest(dayStart: Long): GetRequest = {
@@ -109,7 +110,8 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
               GetRequest(TilingUtils.serializeTileKey(tileKey), dataset)
             }
 
-            (Some(megaTileRequest(todayStart)), Some(megaTileRequest(yesterdayStart)))
+            (dayStarts.headOption.map(megaTileRequest),
+             Some(dayStarts.drop(1).map(dayStart => dayStart -> megaTileRequest(dayStart))))
 
           case Accuracy.TEMPORAL =>
             // Standard tiling or raw streaming
@@ -138,7 +140,7 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
                       castedRequest,
                       batchRequest,
                       streamingRequestOpt,
-                      megaTileYesterdayRequestOpt,
+                      megaTileHistoricalRequestsOpt,
                       Some(resolvedQueryTs),
                       context)
 
@@ -189,10 +191,11 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
       LRUCache.collectCaffeineCacheMetrics(caffeineMetricsContext, cache.cache, cache.cacheName))
 
     val allRequestsToFetch: Seq[GetRequest] = groupByRequestToKvRequest.flatMap {
-      case (_, Success(LambdaKvRequest(_, _, batchRequest, streamingRequestOpt, megaTileYesterdayOpt, _, _))) =>
+      case (_,
+            Success(LambdaKvRequest(_, _, batchRequest, streamingRequestOpt, megaTileHistoricalRequestsOpt, _, _))) =>
         // If a batch request is cached, don't include it in the list of requests to fetch because the batch IRs already cached
         val batchReqs = if (cachedRequests.contains(batchRequest)) Seq.empty else Seq(batchRequest)
-        batchReqs ++ streamingRequestOpt ++ megaTileYesterdayOpt
+        batchReqs ++ streamingRequestOpt.toSeq ++ megaTileHistoricalRequestsOpt.getOrElse(Seq.empty).map(_._2)
 
       case _ => Seq.empty
     }
@@ -225,7 +228,7 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
                                 castedRequest,
                                 batchRequest,
                                 streamingRequestOpt,
-                                megaTileYesterdayOpt,
+                                megaTileHistoricalRequestsOpt,
                                 endTs,
                                 context) = requestMeta
 
@@ -252,8 +255,12 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
 
             val streamingResponsesOpt =
               streamingRequestOpt.map(responsesMap.getOrElse(_, Success(Seq.empty)).getOrElse(Seq.empty))
-            val megaTileYesterdayResponsesOpt =
-              megaTileYesterdayOpt.map(responsesMap.getOrElse(_, Success(Seq.empty)).getOrElse(Seq.empty))
+            val megaTileHistoricalResponses =
+              megaTileHistoricalRequestsOpt
+                .getOrElse(Seq.empty)
+                .map { case (dayStart, historyRequest) =>
+                  dayStart -> responsesMap.getOrElse(historyRequest, Success(Seq.empty)).getOrElse(Seq.empty)
+                }
 
             val queryTs = endTs.getOrElse(request.atMillis.getOrElse(System.currentTimeMillis()))
             val requestContext = RequestContext(groupByServingInfo, queryTs, startTimeMs, context, request.keys)
@@ -265,7 +272,7 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
                     s"Constructing response for groupBy: ${groupByServingInfo.groupByOps.metaData.getName} " +
                       s"for keys: ${request.keys}")
 
-                decodeAndMerge(batchResponses, streamingResponsesOpt, megaTileYesterdayResponsesOpt, requestContext)
+                decodeAndMerge(batchResponses, streamingResponsesOpt, megaTileHistoricalResponses, requestContext)
 
               } catch {
 
@@ -360,6 +367,6 @@ case class LambdaKvRequest(groupByServingInfoParsed: GroupByServingInfoParsed,
                            castedGroupByRequest: Fetcher.Request,
                            batchRequest: GetRequest,
                            streamingRequestOpt: Option[GetRequest],
-                           megaTileYesterdayRequestOpt: Option[GetRequest] = None,
+                           megaTileHistoricalRequestsOpt: Option[Seq[(Long, GetRequest)]] = None,
                            endTs: Option[Long],
                            context: metrics.Metrics.Context)

--- a/online/src/main/scala/ai/chronon/online/fetcher/GroupByResponseHandler.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/GroupByResponseHandler.scala
@@ -30,7 +30,7 @@ class GroupByResponseHandler(fetchContext: FetchContext, metadataStore: Metadata
 
   def decodeAndMerge(batchResponses: BatchResponses,
                      streamingResponsesOpt: Option[Seq[TimedValue]],
-                     megaTileYesterdayResponsesOpt: Option[Seq[TimedValue]] = None,
+                     megaTileHistoricalResponses: Seq[(Long, Seq[TimedValue])] = Seq.empty,
                      requestContext: RequestContext): Map[String, AnyRef] = {
 
     val newServingInfo = getServingInfo(requestContext.servingInfo, batchResponses)
@@ -70,7 +70,7 @@ class GroupByResponseHandler(fetchContext: FetchContext, metadataStore: Metadata
                                         newServingInfo,
                                         batchResponses,
                                         streamingResponses,
-                                        megaTileYesterdayResponsesOpt.getOrElse(Seq.empty),
+                                        megaTileHistoricalResponses,
                                         batchBytes)
           } else {
             mergeWithStreaming(batchResponses, streamingResponses, batchBytes, updatedContext)
@@ -268,24 +268,78 @@ class GroupByResponseHandler(fetchContext: FetchContext, metadataStore: Metadata
                                           servingInfo: GroupByServingInfoParsed,
                                           batchResponses: BatchResponses,
                                           todayResponses: Seq[TimedValue],
-                                          yesterdayResponses: Seq[TimedValue],
+                                          megaTileHistoricalResponses: Seq[(Long, Seq[TimedValue])],
                                           batchBytes: Array[Byte]): Array[Any] = {
+    val hasNoHistoricalData = megaTileHistoricalResponses.forall { case (_, responses) =>
+      responses == null || responses.isEmpty
+    }
+    if (
+      (todayResponses == null || todayResponses.isEmpty) &&
+      hasNoHistoricalData &&
+      batchResponses.isInstanceOf[KvStoreBatchResponse] &&
+      batchBytes == null
+    ) {
+      if (fetchContext.debug) {
+        logger.info("Batch, today's streaming data, and historical streaming data are all null")
+      }
+      return null
+    }
+
+    val allStreamingResponses =
+      Option(todayResponses).getOrElse(Seq.empty) ++
+        megaTileHistoricalResponses.flatMap { case (_, responses) => Option(responses).getOrElse(Seq.empty) }
+    reportKvResponse(requestContext.metricsContext.withSuffix("streaming"),
+                     allStreamingResponses,
+                     requestContext.queryTimeMs)
+
+    val batchIrDecodeStartTime = System.currentTimeMillis()
     val batchIr = getBatchIrFromBatchResponse(batchResponses, batchBytes, servingInfo, toBatchIr, requestContext.keys)
-    val todayIr = decodeLatestMegaTile(todayResponses, servingInfo)
-    val yesterdayIr = decodeLatestMegaTile(yesterdayResponses, servingInfo)
-    val (todayStart, _) = servingInfo.megaTileMerger.streamingDayKeys(requestContext.queryTimeMs)
-    servingInfo.megaTileMerger.merge(batchIr,
-                                     todayIr,
-                                     yesterdayIr,
-                                     todayStart,
-                                     requestContext.queryTimeMs,
-                                     servingInfo.batchEndTsMillis)
+    requestContext.metricsContext.distribution("group_by.batchir_decode.latency.millis",
+                                               System.currentTimeMillis() - batchIrDecodeStartTime)
+
+    val allStreamingIrDecodeStartTime = System.currentTimeMillis()
+    val todayStart = servingInfo.megaTileMerger.streamingDayKeys(requestContext.queryTimeMs)._1
+    val dailyTileIrs =
+      (Seq(todayStart -> todayResponses) ++ megaTileHistoricalResponses).map { case (dayStart, responses) =>
+        dayStart -> decodeLatestMegaTile(responses, servingInfo)
+      }
+    requestContext.metricsContext.distribution("group_by.all_streamingir_decode.latency.millis",
+                                               System.currentTimeMillis() - allStreamingIrDecodeStartTime)
+
+    if (fetchContext.debug) {
+      val gson = new Gson()
+      logger.info(s"""
+                     |batch ir: ${gson.toJson(batchIr)}
+                     |dailyTileIrs: ${gson.toJson(dailyTileIrs)}
+                     |batchEnd in millis: ${servingInfo.batchEndTsMillis}
+                     |queryTime in millis: ${requestContext.queryTimeMs}
+                     |""".stripMargin)
+    }
+
+    val aggregatorStartTime = System.currentTimeMillis()
+    val result =
+      servingInfo.megaTileMerger.merge(batchIr, dailyTileIrs, requestContext.queryTimeMs, servingInfo.batchEndTsMillis)
+    requestContext.metricsContext.distribution("group_by.aggregator.latency.millis",
+                                               System.currentTimeMillis() - aggregatorStartTime)
+    result
   }
 
   private def decodeLatestMegaTile(responses: Seq[TimedValue], servingInfo: GroupByServingInfoParsed): Array[Any] = {
     if (responses == null || responses.isEmpty) return null
     val latest = responses.maxBy(_.millis)
-    servingInfo.megaTileCodec.decode(latest.bytes)
+    Try(servingInfo.megaTileCodec.decode(latest.bytes)) match {
+      case Success(ir) => ir
+      case Failure(_) =>
+        logger.error(
+          s"Failed to decode mega tile ir for groupBy ${servingInfo.groupByOps.metaData.getName}" +
+            "Streaming mega tile IRs will be ignored")
+        if (servingInfo.groupByOps.dontThrowOnDecodeFailFlag) {
+          null
+        } else {
+          throw new RuntimeException(
+            s"Failed to decode mega tile ir for groupBy ${servingInfo.groupByOps.metaData.getName}")
+        }
+    }
   }
 
   private def reportKvResponse(ctx: Metrics.Context, response: Seq[TimedValue], queryTsMillis: Long): Unit = {

--- a/online/src/main/scala/ai/chronon/online/fetcher/GroupByResponseHandler.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/GroupByResponseHandler.scala
@@ -1,7 +1,7 @@
 package ai.chronon.online.fetcher
 import ai.chronon.aggregator.windowing
 import ai.chronon.aggregator.windowing.{FinalBatchIr, SawtoothOnlineAggregator, TiledIr}
-import ai.chronon.api.Extensions.WindowOps
+import ai.chronon.api.Extensions.{GroupByOps, WindowOps}
 import ai.chronon.api.ScalaJavaConversions.{IteratorOps, JMapOps}
 import ai.chronon.api.{DataModel, Row, Window}
 import ai.chronon.online.serde.AvroConversions
@@ -30,6 +30,7 @@ class GroupByResponseHandler(fetchContext: FetchContext, metadataStore: Metadata
 
   def decodeAndMerge(batchResponses: BatchResponses,
                      streamingResponsesOpt: Option[Seq[TimedValue]],
+                     megaTileYesterdayResponsesOpt: Option[Seq[TimedValue]] = None,
                      requestContext: RequestContext): Map[String, AnyRef] = {
 
     val newServingInfo = getServingInfo(requestContext.servingInfo, batchResponses)
@@ -61,11 +62,18 @@ class GroupByResponseHandler(fetchContext: FetchContext, metadataStore: Metadata
 
       } else { // temporal accurate
 
+        val updatedContext = requestContext.copy(servingInfo = newServingInfo)
         val streamingResponses = streamingResponsesOpt.get
-        val output: Array[Any] = mergeWithStreaming(batchResponses,
-                                                    streamingResponses,
-                                                    batchBytes,
-                                                    requestContext.copy(servingInfo = newServingInfo))
+        val output: Array[Any] =
+          if (newServingInfo.groupByOps.isMegaTilingEnabled) {
+            mergeMegaTilesFromStreaming(updatedContext,
+                                        newServingInfo,
+                                        streamingResponses,
+                                        megaTileYesterdayResponsesOpt.getOrElse(Seq.empty),
+                                        batchBytes)
+          } else {
+            mergeWithStreaming(batchResponses, streamingResponses, batchBytes, updatedContext)
+          }
 
         val fieldNames = newServingInfo.outputCodec.fieldNames
         if (output != null) {
@@ -253,6 +261,26 @@ class GroupByResponseHandler(fetchContext: FetchContext, metadataStore: Metadata
     requestContext.metricsContext.distribution("group_by.aggregator.latency.millis",
                                                System.currentTimeMillis() - aggregatorStartTime)
     result
+  }
+
+  private def mergeMegaTilesFromStreaming(requestContext: RequestContext,
+                                          servingInfo: GroupByServingInfoParsed,
+                                          todayResponses: Seq[TimedValue],
+                                          yesterdayResponses: Seq[TimedValue],
+                                          batchBytes: Array[Byte]): Array[Any] = {
+    val batchIr = toBatchIr(batchBytes, servingInfo)
+    val todayIr = decodeLatestMegaTile(todayResponses, servingInfo)
+    val yesterdayIr = decodeLatestMegaTile(yesterdayResponses, servingInfo)
+    val (todayStart, _) = servingInfo.megaTileMerger.streamingDayKeys(requestContext.queryTimeMs)
+    servingInfo.megaTileMerger.merge(batchIr, todayIr, yesterdayIr, todayStart,
+                                     requestContext.queryTimeMs, servingInfo.batchEndTsMillis)
+  }
+
+  private def decodeLatestMegaTile(responses: Seq[TimedValue],
+                                    servingInfo: GroupByServingInfoParsed): Array[Any] = {
+    if (responses == null || responses.isEmpty) return null
+    val latest = responses.maxBy(_.millis)
+    servingInfo.megaTileCodec.decode(latest.bytes)
   }
 
   private def reportKvResponse(ctx: Metrics.Context, response: Seq[TimedValue], queryTsMillis: Long): Unit = {

--- a/online/src/main/scala/ai/chronon/online/fetcher/GroupByResponseHandler.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/GroupByResponseHandler.scala
@@ -274,12 +274,15 @@ class GroupByResponseHandler(fetchContext: FetchContext, metadataStore: Metadata
     val todayIr = decodeLatestMegaTile(todayResponses, servingInfo)
     val yesterdayIr = decodeLatestMegaTile(yesterdayResponses, servingInfo)
     val (todayStart, _) = servingInfo.megaTileMerger.streamingDayKeys(requestContext.queryTimeMs)
-    servingInfo.megaTileMerger.merge(batchIr, todayIr, yesterdayIr, todayStart,
-                                     requestContext.queryTimeMs, servingInfo.batchEndTsMillis)
+    servingInfo.megaTileMerger.merge(batchIr,
+                                     todayIr,
+                                     yesterdayIr,
+                                     todayStart,
+                                     requestContext.queryTimeMs,
+                                     servingInfo.batchEndTsMillis)
   }
 
-  private def decodeLatestMegaTile(responses: Seq[TimedValue],
-                                    servingInfo: GroupByServingInfoParsed): Array[Any] = {
+  private def decodeLatestMegaTile(responses: Seq[TimedValue], servingInfo: GroupByServingInfoParsed): Array[Any] = {
     if (responses == null || responses.isEmpty) return null
     val latest = responses.maxBy(_.millis)
     servingInfo.megaTileCodec.decode(latest.bytes)

--- a/online/src/main/scala/ai/chronon/online/fetcher/GroupByResponseHandler.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/GroupByResponseHandler.scala
@@ -68,6 +68,7 @@ class GroupByResponseHandler(fetchContext: FetchContext, metadataStore: Metadata
           if (newServingInfo.groupByOps.isMegaTilingEnabled) {
             mergeMegaTilesFromStreaming(updatedContext,
                                         newServingInfo,
+                                        batchResponses,
                                         streamingResponses,
                                         megaTileYesterdayResponsesOpt.getOrElse(Seq.empty),
                                         batchBytes)
@@ -265,10 +266,11 @@ class GroupByResponseHandler(fetchContext: FetchContext, metadataStore: Metadata
 
   private def mergeMegaTilesFromStreaming(requestContext: RequestContext,
                                           servingInfo: GroupByServingInfoParsed,
+                                          batchResponses: BatchResponses,
                                           todayResponses: Seq[TimedValue],
                                           yesterdayResponses: Seq[TimedValue],
                                           batchBytes: Array[Byte]): Array[Any] = {
-    val batchIr = toBatchIr(batchBytes, servingInfo)
+    val batchIr = getBatchIrFromBatchResponse(batchResponses, batchBytes, servingInfo, toBatchIr, requestContext.keys)
     val todayIr = decodeLatestMegaTile(todayResponses, servingInfo)
     val yesterdayIr = decodeLatestMegaTile(yesterdayResponses, servingInfo)
     val (todayStart, _) = servingInfo.megaTileMerger.streamingDayKeys(requestContext.queryTimeMs)

--- a/online/src/test/scala/ai/chronon/online/test/FetcherCacheTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/FetcherCacheTest.scala
@@ -121,7 +121,7 @@ class FetcherCacheTest extends AnyFlatSpec with MockitoHelper {
     val request = Request("req_name", keys, Some(eventTs), Some(mock[Context]))
     val getRequest = KVStore.GetRequest("key".getBytes, dataset, Some(eventTs))
     val requestMeta =
-      LambdaKvRequest(mockGroupByServingInfoParsed, request, getRequest, Some(getRequest), Some(eventTs), mockContext)
+      LambdaKvRequest(mockGroupByServingInfoParsed, request, getRequest, Some(getRequest), None, Some(eventTs), mockContext)
     val groupByRequestToKvRequest: Seq[(Request, Try[LambdaKvRequest])] = Seq((request, Success(requestMeta)))
 
     // getCachedRequests should return an empty list when the cache is empty
@@ -156,7 +156,7 @@ class FetcherCacheTest extends AnyFlatSpec with MockitoHelper {
     val request = Request("req_name", keys, Some(eventTs))
     val getRequest = KVStore.GetRequest("key".getBytes, dataset, Some(eventTs))
     val requestMeta =
-      LambdaKvRequest(mockGroupByServingInfoParsed, request, getRequest, Some(getRequest), Some(eventTs), mockContext)
+      LambdaKvRequest(mockGroupByServingInfoParsed, request, getRequest, Some(getRequest), None, Some(eventTs), mockContext)
     val groupByRequestToKvRequest: Seq[(Request, Try[LambdaKvRequest])] = Seq((request, Success(requestMeta)))
 
     val cachedRequests = fetcherCache.getCachedRequests(groupByRequestToKvRequest)

--- a/online/src/test/scala/ai/chronon/online/test/MegaTileCodecRoundTripTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/MegaTileCodecRoundTripTest.scala
@@ -2,7 +2,7 @@ package ai.chronon.online.test
 
 import ai.chronon.aggregator.row.RowAggregator
 import ai.chronon.aggregator.test.NaiveAggregator
-import ai.chronon.aggregator.windowing._
+import ai.chronon.aggregator.windowing.{InMemoryTileStore, TileStore, _}
 import ai.chronon.api._
 import ai.chronon.api.Extensions.{AggregationOps, WindowOps}
 import ai.chronon.online.MegaTileCodec
@@ -81,36 +81,44 @@ class MegaTileCodecRoundTripTest extends AnyFlatSpec {
     gb
   }
 
-  /** Simulate persist → restore: encode state, create fresh processor, decode into it. */
-  def roundTripProcessorState(source: MegaTileStreamProcessor, codec: MegaTileCodec): MegaTileStreamProcessor = {
-    val dest = new MegaTileStreamProcessor(source.megaTileAgg)
+  /** TileStore that encodes/decodes on every access, simulating Flink's MapState/ValueState with codec. */
+  class SerdeTileStore(windowedAgg: RowAggregator, codec: MegaTileCodec) extends TileStore {
+    private val tileBytes = mutable.Map[(Long, Long), Array[Byte]]()
+    private var cachedSmallBytes: Array[Byte] = codec.encode(windowedAgg.init)
+    private var largeTodayBytes: Array[Byte] = codec.encode(windowedAgg.init)
+    private var largeYesterdayBytes: Array[Byte] = codec.encode(windowedAgg.init)
+    private var dayStart: Long = -1L
+    private var earliest: Long = Long.MaxValue
 
-    // Tiles: encode/decode as base IRs
-    dest.tiles.values.foreach(_.clear())
-    for ((hopSize, tierTiles) <- source.tiles; (tileStart, ir) <- tierTiles) {
-      dest.tiles.get(hopSize).foreach(_(tileStart) = codec.decodeBaseIr(codec.encodeBaseIr(ir)))
-    }
+    override def getTile(h: Long, t: Long): Array[Any] = tileBytes.get((h, t)).map(codec.decodeBaseIr).orNull
+    override def putTile(h: Long, t: Long, ir: Array[Any]): Unit = tileBytes((h, t)) = codec.encodeBaseIr(ir)
+    override def removeTile(h: Long, t: Long): Unit = tileBytes.remove((h, t))
+    override def tileIterator: Iterator[(Long, Long, Array[Any])] =
+      tileBytes.iterator.map { case ((h, t), b) => (h, t, codec.decodeBaseIr(b)) }
 
-    // Windowed IRs
-    dest.cachedSmallWindowIr = codec.decode(codec.encode(source.cachedSmallWindowIr))
-    dest.largeTodayIr = codec.decode(codec.encode(source.largeTodayIr))
-    dest.largeYesterdayIr = codec.decode(codec.encode(source.largeYesterdayIr))
-
-    dest.currentDayStart = source.currentDayStart
-    dest.earliestTileStart = source.earliestTileStart
-    dest
+    override def getCachedSmallWindowIr: Array[Any] = codec.decode(cachedSmallBytes)
+    override def putCachedSmallWindowIr(ir: Array[Any]): Unit = cachedSmallBytes = codec.encode(ir)
+    override def getLargeTodayIr: Array[Any] = codec.decode(largeTodayBytes)
+    override def putLargeTodayIr(ir: Array[Any]): Unit = largeTodayBytes = codec.encode(ir)
+    override def getLargeYesterdayIr: Array[Any] = codec.decode(largeYesterdayBytes)
+    override def putLargeYesterdayIr(ir: Array[Any]): Unit = largeYesterdayBytes = codec.encode(ir)
+    override def getCurrentDayStart: Long = dayStart
+    override def putCurrentDayStart(ts: Long): Unit = dayStart = ts
+    override def getEarliestTileStart: Long = earliest
+    override def putEarliestTileStart(ts: Long): Unit = earliest = ts
   }
 
   def streamProcessorWithSerdeAggregate(allEvents: Array[Row],
                                          queryTimes: Array[Long],
                                          aggregations: Seq[Aggregation],
-                                         batchEnd: Long,
-                                         roundTripInterval: Int = 50): Array[Array[Any]] = {
+                                         batchEnd: Long): Array[Array[Any]] = {
 
     val megaTileAgg = new MegaTileAggregator(aggregations, Schema, tailBufferMillis = TailBufferMillis)
-    var processor = new MegaTileStreamProcessor(megaTileAgg)
-    val merger = new MegaTileMerger(megaTileAgg)
     val codec = new MegaTileCodec(buildGroupBy(aggregations), Schema)
+    // SerdeTileStore encodes/decodes on every access — tests the codec round-trip inline
+    val store = new SerdeTileStore(megaTileAgg.windowedAggregator, codec)
+    val processor = new MegaTileStreamProcessor(megaTileAgg, store)
+    val merger = new MegaTileMerger(megaTileAgg)
 
     val batchEvents = allEvents.filter(_.ts < batchEnd)
     val onlineAgg = new SawtoothOnlineAggregator(batchEnd, aggregations, Schema, tailBufferMillis = TailBufferMillis)
@@ -125,9 +133,9 @@ class MegaTileCodecRoundTripTest extends AnyFlatSpec {
     var nextEvictionTs = Long.MaxValue
     val kvStore = mutable.Map[Long, Array[Any]]()
     var eventIdx = 0
-    var eventsSinceRoundTrip = 0
     val resultsByQueryTs = mutable.Map[Long, Array[Any]]()
 
+    // Serde happens on every TileStore access (SerdeTileStore), so no explicit round-trip needed.
     def firePendingEvictions(upToTs: Long): Unit = {
       if (!processor.hasSmallWindows) return
       while (nextEvictionTs <= upToTs) {
@@ -150,13 +158,6 @@ class MegaTileCodecRoundTripTest extends AnyFlatSpec {
 
         if (nextEvictionTs == Long.MaxValue && processor.hasSmallWindows) {
           nextEvictionTs = TsUtils.round(event.ts, evictionInterval) + evictionInterval
-        }
-
-        // Serde round-trip every N events
-        eventsSinceRoundTrip += 1
-        if (eventsSinceRoundTrip >= roundTripInterval) {
-          processor = roundTripProcessorState(processor, codec)
-          eventsSinceRoundTrip = 0
         }
 
         eventIdx += 1
@@ -236,21 +237,23 @@ class MegaTileCodecRoundTripTest extends AnyFlatSpec {
 
     val megaTileAgg = new MegaTileAggregator(aggregations, Schema, tailBufferMillis = TailBufferMillis)
 
-    // Process key A events — accumulate state
-    val processorA = new MegaTileStreamProcessor(megaTileAgg)
+    // Process key A events — accumulate state in a shared store
+    val storeA = new InMemoryTileStore(megaTileAgg.windowedAggregator)
+    val processorA = new MegaTileStreamProcessor(megaTileAgg, storeA)
     for (event <- events.sortBy(_.ts)) {
       processorA.advanceWatermark(event.ts)
       processorA.onEvent(event, event.ts)
     }
     // Verify key A has non-empty state
-    assertTrue("key A should have tiles", processorA.tiles.values.exists(_.nonEmpty))
+    assertTrue("key A should have tiles", storeA.tiles.nonEmpty)
 
-    // Key switch to B: reinitialize (what restoreProcessorState does after our fix)
-    val processorB = new MegaTileStreamProcessor(megaTileAgg)
+    // Key switch to B: fresh store (what Flink's keyed state scoping does)
+    val storeB = new InMemoryTileStore(megaTileAgg.windowedAggregator)
+    val processorB = new MegaTileStreamProcessor(megaTileAgg, storeB)
     // Verify key B state is clean
-    assertTrue("key B tiles should be empty", processorB.tiles.values.forall(_.isEmpty))
-    assertEquals("key B currentDayStart should be -1", -1L, processorB.currentDayStart)
-    assertEquals("key B earliestTileStart should be MaxValue", Long.MaxValue, processorB.earliestTileStart)
+    assertTrue("key B tiles should be empty", storeB.tiles.isEmpty)
+    assertEquals("key B currentDayStart should be -1", -1L, storeB.currentDayStart)
+    assertEquals("key B earliestTileStart should be MaxValue", Long.MaxValue, storeB.earliestTileStart)
 
     // Process same events through B with serde round-trips — should match naive
     val queryTimes = Array(batchEnd + 14 * 3600 * 1000L).filter(_ <= maxTs)

--- a/online/src/test/scala/ai/chronon/online/test/MegaTileCodecRoundTripTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/MegaTileCodecRoundTripTest.scala
@@ -219,4 +219,48 @@ class MegaTileCodecRoundTripTest extends AnyFlatSpec {
                  approxEqual(results(i), naive(i)))
     }
   }
+
+  it should "handle key switching (Flink reuses processor across keys)" in {
+    // Simulates Flink's key reuse: process events for key A, then reinitialize
+    // processor (simulating key switch to B with empty state), verify B's state
+    // is clean by comparing against the normal serde round-trip test for the same data.
+    val events = generateEvents(14, 20000)
+    val maxTs = events.map(_.ts).max
+    val batchEnd = TsUtils.round(maxTs - DayMillis, DayMillis)
+
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows),
+      Builders.Aggregation(Operation.AVERAGE, "amount", AllWindows)
+    )
+
+    val megaTileAgg = new MegaTileAggregator(aggregations, Schema, tailBufferMillis = TailBufferMillis)
+
+    // Process key A events — accumulate state
+    val processorA = new MegaTileStreamProcessor(megaTileAgg)
+    for (event <- events.sortBy(_.ts)) {
+      processorA.advanceWatermark(event.ts)
+      processorA.onEvent(event, event.ts)
+    }
+    // Verify key A has non-empty state
+    assertTrue("key A should have tiles", processorA.tiles.values.exists(_.nonEmpty))
+
+    // Key switch to B: reinitialize (what restoreProcessorState does after our fix)
+    val processorB = new MegaTileStreamProcessor(megaTileAgg)
+    // Verify key B state is clean
+    assertTrue("key B tiles should be empty", processorB.tiles.values.forall(_.isEmpty))
+    assertEquals("key B currentDayStart should be -1", -1L, processorB.currentDayStart)
+    assertEquals("key B earliestTileStart should be MaxValue", Long.MaxValue, processorB.earliestTileStart)
+
+    // Process same events through B with serde round-trips — should match naive
+    val queryTimes = Array(batchEnd + 14 * 3600 * 1000L).filter(_ <= maxTs)
+    val results = streamProcessorWithSerdeAggregate(events, queryTimes, aggregations, batchEnd)
+    val naive = naiveAggregate(events, queryTimes, aggregations)
+    assertEquals("result count", naive.length, results.length)
+    for (i <- queryTimes.indices) {
+      assertTrue(
+        s"key_switch: mismatch at query ${queryTimes(i)}\n  expected: ${gson.toJson(naive(i))}\n  got:      ${gson.toJson(results(i))}",
+        approxEqual(results(i), naive(i)))
+    }
+  }
 }

--- a/online/src/test/scala/ai/chronon/online/test/MegaTileCodecRoundTripTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/MegaTileCodecRoundTripTest.scala
@@ -1,0 +1,222 @@
+package ai.chronon.online.test
+
+import ai.chronon.aggregator.row.RowAggregator
+import ai.chronon.aggregator.test.NaiveAggregator
+import ai.chronon.aggregator.windowing._
+import ai.chronon.api._
+import ai.chronon.api.Extensions.{AggregationOps, WindowOps}
+import ai.chronon.online.MegaTileCodec
+import ai.chronon.online.serde.ArrayRow
+import com.google.gson.Gson
+import org.junit.Assert._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.slf4j.LoggerFactory
+
+import scala.collection.mutable
+import scala.util.Random
+
+/**
+  * Tests MegaTileStreamProcessor with serde round-trips at state boundaries,
+  * simulating what MegaTileProcessFunction does in Flink (persist → restore).
+  * Catches bugs where encode → decode doesn't preserve state.
+  */
+class MegaTileCodecRoundTripTest extends AnyFlatSpec {
+  @transient lazy val logger = LoggerFactory.getLogger(getClass)
+  val gson = new Gson
+
+  val AllWindows: Seq[Window] = Seq(
+    new Window(6, TimeUnit.HOURS),
+    new Window(1, TimeUnit.DAYS),
+    new Window(47, TimeUnit.HOURS),
+    new Window(2, TimeUnit.DAYS),
+    new Window(49, TimeUnit.HOURS),
+    new Window(3, TimeUnit.DAYS),
+    new Window(7, TimeUnit.DAYS)
+  )
+
+  val TailBufferMillis: Long = new Window(2, TimeUnit.DAYS).millis
+  val DayMillis: Long = new Window(1, TimeUnit.DAYS).millis
+  val Epsilon = 1e-6
+
+  val Schema: Seq[(String, DataType)] = Seq("ts" -> LongType, "num" -> LongType, "amount" -> DoubleType)
+
+  def approxEqual(a: Any, b: Any): Boolean = (a, b) match {
+    case (null, null)                                  => true
+    case (null, _) | (_, null)                         => false
+    case (x: Double, y: Double)                        => Math.abs(x - y) <= Epsilon * Math.max(1.0, Math.max(Math.abs(x), Math.abs(y)))
+    case (x: Float, y: Float)                          => Math.abs(x - y) <= Epsilon.toFloat * Math.max(1.0f, Math.max(Math.abs(x), Math.abs(y)))
+    case (x: java.util.List[_], y: java.util.List[_]) => x.size() == y.size() && (0 until x.size()).forall(i => approxEqual(x.get(i), y.get(i)))
+    case (x: Array[_], y: Array[_])                    => x.length == y.length && x.zip(y).forall { case (a, b) => approxEqual(a, b) }
+    case _                                             => a == b
+  }
+
+  def generateEvents(daySpan: Int, count: Int): Array[Row] = {
+    val rng = new Random(42)
+    val baseTs = 1774000000000L
+    val spanMillis = daySpan.toLong * DayMillis
+    (0 until count).map { _ =>
+      val ts = baseTs + (rng.nextDouble() * spanMillis).toLong
+      val num = rng.nextInt(1000).toLong
+      val amount = rng.nextDouble() * 500.0
+      new ArrayRow(Array(ts, num, amount), ts): Row
+    }.toArray
+  }
+
+  def naiveAggregate(allEvents: Array[Row], queryTimes: Array[Long], aggregations: Seq[Aggregation]): Array[Array[Any]] = {
+    val unpackedParts = aggregations.flatMap(_.unpack)
+    val unpacked = unpackedParts.map(_.window).toArray
+    val tailHops = unpacked.map(w => FiveMinuteResolution.calculateTailHop(w))
+    val rowAgg = new RowAggregator(Schema, unpackedParts)
+    val naiveAgg = new NaiveAggregator(rowAgg, unpacked, tailHops)
+    naiveAgg.aggregate(allEvents, queryTimes).map(ir => rowAgg.finalize(ir))
+  }
+
+  def buildGroupBy(aggregations: Seq[Aggregation]): GroupBy = {
+    import scala.collection.JavaConverters._
+    val gb = new GroupBy()
+    gb.setAggregations(aggregations.asJava)
+    val meta = new MetaData()
+    meta.setName("test_mega_tile_codec")
+    gb.setMetaData(meta)
+    gb
+  }
+
+  /** Simulate persist → restore: encode state, create fresh processor, decode into it. */
+  def roundTripProcessorState(source: MegaTileStreamProcessor, codec: MegaTileCodec): MegaTileStreamProcessor = {
+    val dest = new MegaTileStreamProcessor(source.megaTileAgg)
+
+    // Tiles: encode/decode as base IRs
+    dest.tiles.values.foreach(_.clear())
+    for ((hopSize, tierTiles) <- source.tiles; (tileStart, ir) <- tierTiles) {
+      dest.tiles.get(hopSize).foreach(_(tileStart) = codec.decodeBaseIr(codec.encodeBaseIr(ir)))
+    }
+
+    // Windowed IRs
+    dest.cachedSmallWindowIr = codec.decode(codec.encode(source.cachedSmallWindowIr))
+    dest.largeTodayIr = codec.decode(codec.encode(source.largeTodayIr))
+    dest.largeYesterdayIr = codec.decode(codec.encode(source.largeYesterdayIr))
+
+    dest.currentDayStart = source.currentDayStart
+    dest.earliestTileStart = source.earliestTileStart
+    dest
+  }
+
+  def streamProcessorWithSerdeAggregate(allEvents: Array[Row],
+                                         queryTimes: Array[Long],
+                                         aggregations: Seq[Aggregation],
+                                         batchEnd: Long,
+                                         roundTripInterval: Int = 50): Array[Array[Any]] = {
+
+    val megaTileAgg = new MegaTileAggregator(aggregations, Schema, tailBufferMillis = TailBufferMillis)
+    var processor = new MegaTileStreamProcessor(megaTileAgg)
+    val merger = new MegaTileMerger(megaTileAgg)
+    val codec = new MegaTileCodec(buildGroupBy(aggregations), Schema)
+
+    val batchEvents = allEvents.filter(_.ts < batchEnd)
+    val onlineAgg = new SawtoothOnlineAggregator(batchEnd, aggregations, Schema, tailBufferMillis = TailBufferMillis)
+    var batchIr = onlineAgg.init
+    batchEvents.foreach(row => batchIr = onlineAgg.update(batchIr, row))
+    val finalBatchIr = onlineAgg.finalizeSnapshot(batchIr)
+
+    val sortedEvents = allEvents.sortBy(_.ts)
+    val sortedQueries = queryTimes.sorted
+
+    val evictionInterval = processor.minSmallWindowTileSize
+    var nextEvictionTs = Long.MaxValue
+    val kvStore = mutable.Map[Long, Array[Any]]()
+    var eventIdx = 0
+    var eventsSinceRoundTrip = 0
+    val resultsByQueryTs = mutable.Map[Long, Array[Any]]()
+
+    def firePendingEvictions(upToTs: Long): Unit = {
+      if (!processor.hasSmallWindows) return
+      while (nextEvictionTs <= upToTs) {
+        processor.advanceWatermark(nextEvictionTs)
+        val r = processor.onEviction(nextEvictionTs)
+        if (r.todayEntry != null) kvStore(r.todayStart) = r.todayEntry
+        nextEvictionTs += evictionInterval
+      }
+    }
+
+    for (queryTs <- sortedQueries) {
+      while (eventIdx < sortedEvents.length && sortedEvents(eventIdx).ts <= queryTs) {
+        val event = sortedEvents(eventIdx)
+        firePendingEvictions(event.ts)
+        processor.advanceWatermark(event.ts)
+
+        val result = processor.onEvent(event, event.ts)
+        if (result.todayEntry != null) kvStore(result.todayStart) = result.todayEntry
+        if (result.yesterdayEntry != null) kvStore(result.yesterdayStart) = result.yesterdayEntry
+
+        if (nextEvictionTs == Long.MaxValue && processor.hasSmallWindows) {
+          nextEvictionTs = TsUtils.round(event.ts, evictionInterval) + evictionInterval
+        }
+
+        // Serde round-trip every N events
+        eventsSinceRoundTrip += 1
+        if (eventsSinceRoundTrip >= roundTripInterval) {
+          processor = roundTripProcessorState(processor, codec)
+          eventsSinceRoundTrip = 0
+        }
+
+        eventIdx += 1
+      }
+
+      firePendingEvictions(queryTs)
+      processor.advanceWatermark(queryTs)
+
+      val (todayStart, yesterdayStart) = merger.streamingDayKeys(queryTs)
+      val todayIr = processor.packTodayEntry()
+      val yesterdayIr = kvStore.getOrElse(yesterdayStart, null)
+      resultsByQueryTs(queryTs) = merger.merge(finalBatchIr, todayIr, yesterdayIr, todayStart, queryTs, batchEnd)
+    }
+
+    queryTimes.map(resultsByQueryTs)
+  }
+
+  it should "match naive with serde round-trips (batch fresh)" in {
+    val events = generateEvents(14, 20000)
+    val maxTs = events.map(_.ts).max
+    val batchEnd = TsUtils.round(maxTs - DayMillis, DayMillis)
+
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows),
+      Builders.Aggregation(Operation.AVERAGE, "amount", AllWindows)
+    )
+
+    val queryTimes = Array(batchEnd + 6 * 3600 * 1000L, batchEnd + 14 * 3600 * 1000L).filter(_ <= maxTs)
+    val results = streamProcessorWithSerdeAggregate(events, queryTimes, aggregations, batchEnd)
+    val naive = naiveAggregate(events, queryTimes, aggregations)
+    assertEquals("result count", naive.length, results.length)
+    for (i <- queryTimes.indices) {
+      assertTrue(s"serde_fresh: mismatch at query ${queryTimes(i)}\n  expected: ${gson.toJson(naive(i))}\n  got:      ${gson.toJson(results(i))}",
+                 approxEqual(results(i), naive(i)))
+    }
+  }
+
+  it should "match naive with serde round-trips (all agg types)" in {
+    val events = generateEvents(14, 20000)
+    val maxTs = events.map(_.ts).max
+    val batchEnd = TsUtils.round(maxTs - DayMillis, DayMillis)
+
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows),
+      Builders.Aggregation(Operation.AVERAGE, "amount", AllWindows),
+      Builders.Aggregation(Operation.MIN, "num", AllWindows),
+      Builders.Aggregation(Operation.MAX, "num", AllWindows),
+      Builders.Aggregation(Operation.LAST, "num", AllWindows),
+      Builders.Aggregation(Operation.FIRST, "num", AllWindows)
+    )
+
+    val queryTimes = Array(batchEnd + 14 * 3600 * 1000L).filter(_ <= maxTs)
+    val results = streamProcessorWithSerdeAggregate(events, queryTimes, aggregations, batchEnd)
+    val naive = naiveAggregate(events, queryTimes, aggregations)
+    assertEquals("result count", naive.length, results.length)
+    for (i <- queryTimes.indices) {
+      assertTrue(s"serde_all_agg: mismatch at query ${queryTimes(i)}\n  expected: ${gson.toJson(naive(i))}\n  got:      ${gson.toJson(results(i))}",
+                 approxEqual(results(i), naive(i)))
+    }
+  }
+}

--- a/online/src/test/scala/ai/chronon/online/test/MegaTileCodecRoundTripTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/MegaTileCodecRoundTripTest.scala
@@ -39,15 +39,25 @@ class MegaTileCodecRoundTripTest extends AnyFlatSpec {
   val Epsilon = 1e-6
 
   val Schema: Seq[(String, DataType)] = Seq("ts" -> LongType, "num" -> LongType, "amount" -> DoubleType)
+  val SchemaWithCategory: Seq[(String, DataType)] =
+    Seq("ts" -> LongType, "num" -> LongType, "amount" -> DoubleType, "category" -> StringType)
 
-  def approxEqual(a: Any, b: Any): Boolean = (a, b) match {
-    case (null, null)                                  => true
-    case (null, _) | (_, null)                         => false
-    case (x: Double, y: Double)                        => Math.abs(x - y) <= Epsilon * Math.max(1.0, Math.max(Math.abs(x), Math.abs(y)))
-    case (x: Float, y: Float)                          => Math.abs(x - y) <= Epsilon.toFloat * Math.max(1.0f, Math.max(Math.abs(x), Math.abs(y)))
-    case (x: java.util.List[_], y: java.util.List[_]) => x.size() == y.size() && (0 until x.size()).forall(i => approxEqual(x.get(i), y.get(i)))
-    case (x: Array[_], y: Array[_])                    => x.length == y.length && x.zip(y).forall { case (a, b) => approxEqual(a, b) }
-    case _                                             => a == b
+  private val categories = Array("alpha", "beta", "gamma", "delta", "epsilon")
+
+  def approxEqual(a: Any, b: Any, sketchTolerance: Double = 0.0): Boolean = (a, b) match {
+    case (null, null)                         => true
+    case (null, _) | (_, null)                => false
+    case (x: Double, y: Double)               => Math.abs(x - y) <= Epsilon * Math.max(1.0, Math.max(Math.abs(x), Math.abs(y)))
+    case (x: Float, y: Float)                 => Math.abs(x - y) <= Epsilon.toFloat * Math.max(1.0f, Math.max(Math.abs(x), Math.abs(y)))
+    case (x: Long, y: Long) if sketchTolerance > 0 =>
+      x == y || Math.abs(x - y).toDouble <= sketchTolerance * Math.max(1.0, Math.max(Math.abs(x), Math.abs(y)).toDouble)
+    case (x: java.util.List[_], y: java.util.List[_]) =>
+      x.size() == y.size() && (0 until x.size()).forall(i => approxEqual(x.get(i), y.get(i), sketchTolerance))
+    case (x: java.util.Map[_, _], y: java.util.Map[_, _]) =>
+      x.size() == y.size() && x.keySet().toArray.forall(k => approxEqual(x.get(k), y.get(k), sketchTolerance))
+    case (x: Array[_], y: Array[_]) =>
+      x.length == y.length && x.zip(y).forall { case (a, b) => approxEqual(a, b, sketchTolerance) }
+    case _ => a == b
   }
 
   def generateEvents(daySpan: Int, count: Int): Array[Row] = {
@@ -62,11 +72,27 @@ class MegaTileCodecRoundTripTest extends AnyFlatSpec {
     }.toArray
   }
 
-  def naiveAggregate(allEvents: Array[Row], queryTimes: Array[Long], aggregations: Seq[Aggregation]): Array[Array[Any]] = {
+  def generateEventsWithCategory(daySpan: Int, count: Int): Array[Row] = {
+    val rng = new Random(42)
+    val baseTs = 1774000000000L
+    val spanMillis = daySpan.toLong * DayMillis
+    (0 until count).map { _ =>
+      val ts = baseTs + (rng.nextDouble() * spanMillis).toLong
+      val num = rng.nextInt(1000).toLong
+      val amount = rng.nextDouble() * 500.0
+      val cat = categories(rng.nextInt(categories.length))
+      new ArrayRow(Array(ts, num, amount, cat), ts): Row
+    }.toArray
+  }
+
+  def naiveAggregate(allEvents: Array[Row],
+                     queryTimes: Array[Long],
+                     aggregations: Seq[Aggregation],
+                     schema: Seq[(String, DataType)] = Schema): Array[Array[Any]] = {
     val unpackedParts = aggregations.flatMap(_.unpack)
     val unpacked = unpackedParts.map(_.window).toArray
     val tailHops = unpacked.map(w => FiveMinuteResolution.calculateTailHop(w))
-    val rowAgg = new RowAggregator(Schema, unpackedParts)
+    val rowAgg = new RowAggregator(schema, unpackedParts)
     val naiveAgg = new NaiveAggregator(rowAgg, unpacked, tailHops)
     naiveAgg.aggregate(allEvents, queryTimes).map(ir => rowAgg.finalize(ir))
   }
@@ -111,17 +137,18 @@ class MegaTileCodecRoundTripTest extends AnyFlatSpec {
   def streamProcessorWithSerdeAggregate(allEvents: Array[Row],
                                          queryTimes: Array[Long],
                                          aggregations: Seq[Aggregation],
-                                         batchEnd: Long): Array[Array[Any]] = {
+                                         batchEnd: Long,
+                                         schema: Seq[(String, DataType)] = Schema): Array[Array[Any]] = {
 
-    val megaTileAgg = new MegaTileAggregator(aggregations, Schema, tailBufferMillis = TailBufferMillis)
-    val codec = new MegaTileCodec(buildGroupBy(aggregations), Schema)
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val codec = new MegaTileCodec(buildGroupBy(aggregations), schema)
     // SerdeTileStore encodes/decodes on every access — tests the codec round-trip inline
     val store = new SerdeTileStore(megaTileAgg.windowedAggregator, codec)
     val processor = new MegaTileStreamProcessor(megaTileAgg, store)
     val merger = new MegaTileMerger(megaTileAgg)
 
     val batchEvents = allEvents.filter(_.ts < batchEnd)
-    val onlineAgg = new SawtoothOnlineAggregator(batchEnd, aggregations, Schema, tailBufferMillis = TailBufferMillis)
+    val onlineAgg = new SawtoothOnlineAggregator(batchEnd, aggregations, schema, tailBufferMillis = TailBufferMillis)
     var batchIr = onlineAgg.init
     batchEvents.foreach(row => batchIr = onlineAgg.update(batchIr, row))
     val finalBatchIr = onlineAgg.finalizeSnapshot(batchIr)
@@ -264,6 +291,36 @@ class MegaTileCodecRoundTripTest extends AnyFlatSpec {
       assertTrue(
         s"key_switch: mismatch at query ${queryTimes(i)}\n  expected: ${gson.toJson(naive(i))}\n  got:      ${gson.toJson(results(i))}",
         approxEqual(results(i), naive(i)))
+    }
+  }
+
+  it should "match naive with complex aggregations through serde (buckets, approx_unique, histogram, last_k)" in {
+    val events = generateEventsWithCategory(14, 20000)
+    val maxTs = events.map(_.ts).max
+    val batchEnd = TsUtils.round(maxTs - DayMillis, DayMillis)
+
+    val aggregations = Seq(
+      // Bucketed: MapType(StringType, irType) — tests map serde
+      Builders.Aggregation(Operation.SUM, "num", AllWindows, buckets = Seq("category")),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows, buckets = Seq("category")),
+      // Sketch-based: BinaryType IR (CPC sketch) — tests binary serde
+      Builders.Aggregation(Operation.APPROX_UNIQUE_COUNT, "num", AllWindows),
+      // Map IR: MapType(StringType, IntType) — tests map serde
+      Builders.Aggregation(Operation.HISTOGRAM, "category", AllWindows),
+      // Collection IR: ListType — tests list serde
+      Builders.Aggregation(Operation.LAST_K, "num", AllWindows, argMap = Map("k" -> "3"))
+    )
+
+    val queryTimes = Array(batchEnd + 14 * 3600 * 1000L).filter(_ <= maxTs)
+    val results = streamProcessorWithSerdeAggregate(events, queryTimes, aggregations, batchEnd,
+                                                     schema = SchemaWithCategory)
+    val naive = naiveAggregate(events, queryTimes, aggregations, schema = SchemaWithCategory)
+    assertEquals("result count", naive.length, results.length)
+    for (i <- queryTimes.indices) {
+      // 5% tolerance for APPROX_UNIQUE_COUNT (CPC sketch merge imprecision)
+      assertTrue(
+        s"serde_complex_aggs: mismatch at query ${queryTimes(i)}\n  expected: ${gson.toJson(naive(i))}\n  got:      ${gson.toJson(results(i))}",
+        approxEqual(results(i), naive(i), sketchTolerance = 0.05))
     }
   }
 }

--- a/online/src/test/scala/ai/chronon/online/test/MegaTileCodecRoundTripTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/MegaTileCodecRoundTripTest.scala
@@ -12,7 +12,10 @@ import org.junit.Assert._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.slf4j.LoggerFactory
 
+import java.util
 import scala.collection.mutable
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.Random
 
 /**
@@ -179,7 +182,7 @@ class MegaTileCodecRoundTripTest extends AnyFlatSpec {
         firePendingEvictions(event.ts)
         processor.advanceWatermark(event.ts)
 
-        val result = processor.onEvent(event, event.ts)
+        val result = processor.onEvent(event, event.ts, queryTs)
         if (result.todayEntry != null) kvStore(result.todayStart) = result.todayEntry
         if (result.yesterdayEntry != null) kvStore(result.yesterdayStart) = result.yesterdayEntry
 
@@ -269,7 +272,8 @@ class MegaTileCodecRoundTripTest extends AnyFlatSpec {
     val processorA = new MegaTileStreamProcessor(megaTileAgg, storeA)
     for (event <- events.sortBy(_.ts)) {
       processorA.advanceWatermark(event.ts)
-      processorA.onEvent(event, event.ts)
+      val smallWindowAsOfTs = TsUtils.round(event.ts, processorA.minSmallWindowTileSize) + processorA.minSmallWindowTileSize
+      processorA.onEvent(event, event.ts, smallWindowAsOfTs)
     }
     // Verify key A has non-empty state
     assertTrue("key A should have tiles", storeA.tiles.nonEmpty)
@@ -321,6 +325,61 @@ class MegaTileCodecRoundTripTest extends AnyFlatSpec {
       assertTrue(
         s"serde_complex_aggs: mismatch at query ${queryTimes(i)}\n  expected: ${gson.toJson(naive(i))}\n  got:      ${gson.toJson(results(i))}",
         approxEqual(results(i), naive(i), sketchTolerance = 0.05))
+    }
+  }
+
+  it should "decode mega tile bytes safely across threads" in {
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.HISTOGRAM, "category", AllWindows),
+      Builders.Aggregation(Operation.LAST_K, "num", AllWindows, argMap = Map("k" -> "3"))
+    )
+    val codec = new MegaTileCodec(buildGroupBy(aggregations), SchemaWithCategory)
+
+    def histogramIr(): util.HashMap[String, java.lang.Long] = {
+      val ir = new util.HashMap[String, java.lang.Long]()
+      ir.put("alpha", Long.box(1L))
+      ir.put("beta", Long.box(2L))
+      ir
+    }
+
+    def lastKIr(): util.ArrayList[util.ArrayList[Any]] = {
+      val ir = new util.ArrayList[util.ArrayList[Any]]()
+      ir.add(ai.chronon.aggregator.base.TimeTuple.make(1775001000000L, Long.box(10L)))
+      ir.add(ai.chronon.aggregator.base.TimeTuple.make(1775000400000L, Long.box(9L)))
+      ir.add(ai.chronon.aggregator.base.TimeTuple.make(1774999800000L, Long.box(8L)))
+      ir
+    }
+
+    val ir = Array[Any](
+      histogramIr(),
+      histogramIr(),
+      histogramIr(),
+      histogramIr(),
+      histogramIr(),
+      histogramIr(),
+      histogramIr(),
+      lastKIr(),
+      lastKIr(),
+      lastKIr(),
+      lastKIr(),
+      lastKIr(),
+      lastKIr(),
+      lastKIr()
+    )
+
+    val bytes = codec.encode(ir)
+    assertTrue(approxEqual(ir, codec.decode(bytes)))
+
+    val executor = java.util.concurrent.Executors.newFixedThreadPool(8)
+    implicit val ec: ExecutionContext = ExecutionContext.fromExecutorService(executor)
+    try {
+      val decoded = Await.result(
+        Future.sequence((0 until 2000).map(_ => Future(codec.decode(bytes)))),
+        30.seconds
+      )
+      decoded.foreach(result => assertTrue(approxEqual(ir, result)))
+    } finally {
+      executor.shutdownNow()
     }
   }
 }

--- a/thrift/api.thrift
+++ b/thrift/api.thrift
@@ -277,6 +277,11 @@ enum Accuracy {
     SNAPSHOT = 1
 }
 
+enum OnlineStrategy {
+    DEFAULT = 0,
+    STREAMING_MEGATILES = 1
+}
+
 enum EngineType {
     SPARK = 0,
     BIGQUERY = 1,
@@ -377,6 +382,7 @@ struct GroupBy {
     5: optional Accuracy accuracy
     // support for offline only for now
     7: optional list<Derivation> derivations
+    8: optional OnlineStrategy onlineStrategy
 }
 
 struct JoinPart {


### PR DESCRIPTION
## Why

Current tiling writes many small hop-aligned tiles per entity (up to 288/day at 5-min resolution). The fetcher does a prefix scan over all tiles and merges them per-window. This causes **read amplification** and serving latency at scale.

## Approach

Replace the prefix-scan tile scheme with **2 point gets per entity**: `(key, today)` + `(key, yesterday)` from the stream KV store, plus `(key)` from the batch KV store.

### Flink (write side)
- **MegaTileStreamProcessor**: per-entity state manager maintaining small-window tiles (sawtooth running IR corrected by periodic eviction) and large-window per-day accumulators
- Small windows (≤ 2d): tiles per tier + `cachedSmallWindowIr` (rebuilt from tiles on eviction via `buildMegaTileIr`)
- Large windows (> 2d): daily running IR (today + yesterday), routed by event timestamp
- Day transitions driven by watermark (not event timestamps) to prevent future-timestamped events from corrupting state
- Late events (up to 2d) correctly routed to yesterday's accumulator; multi-day watermark jumps clear stale state
- Single packed `Array[Any]` per day: small-window columns + large-window columns emitted to KV store
- **MegaTileProcessFunction**: thin Flink `KeyedProcessFunction` wrapper handling state serde (via `MegaTileCodec.encodeBaseIr`/`decodeBaseIr` for tiles, `encode`/`decode` for windowed IRs), event-time timers for eviction, and key-switch reinitialization
- **MegaTileAvroCodecFn**: packs mega tile output into KV `PutRequest` with `TileKey(dataset, entityKey, DayMillis, dayStart)`
- Shared `buildTiledTail`/`buildMegaTiledTail` in `BaseFlinkJob` — both `FlinkGroupByStreamingJob` and `ChainedGroupByJob` use the same pipeline tail

### Fetcher (read side)
- **MegaTileMerger**: per-column merge of `(today, yesterday, batchIr)` → finalized result
  - Small windows: pick today's entry (self-contained). Fall back to yesterday only if today's entry is entirely absent from KV.
  - Large windows + unwindowed: batch collapsed + streaming daily aggregates (sum yesterday if batch stale) + tail hops
- **MegaTileCodec**: Avro serde for windowed mega tile IRs + base (unwindowed) tile IRs
- **GroupByFetcher**: constructs 2 point-get `GetRequest`s (today + yesterday) when `isMegaTilingEnabled`; resolves `queryTs` once to avoid midnight-boundary inconsistency
- **GroupByResponseHandler**: `mergeMegaTilesFromStreaming` branch using `getBatchIrFromBatchResponse` (handles cached batch correctly)

### Opt-in
- `OnlineStrategy` thrift enum (`DEFAULT`, `STREAMING_MEGATILES`) on `GroupBy` field 8
- `GroupByOps.isMegaTilingEnabled` checks the enum; excluded from `semanticHash` (online-only, doesn't trigger batch recomputation)
- Both Flink and fetcher check the same field

### Boundary fix (original commit)
- `alignedCollapsedBoundary` in `SawtoothMutationAggregator` aligns the collapsed/tail split to hop boundaries, preventing double-counting when shared tail hops span windows with different collapsed boundaries

## Test plan

**3 layers of fuzz tests, all comparing against `NaiveAggregator`:**

- [x] `MegaTileAggregatorTest` (6 tests) — tile building + `serveMegaTile` merge: batch fresh, batch delayed, idle entities, eviction boundaries, batchEnd boundary, multiple agg types (SUM/COUNT/AVG/MIN/MAX/LAST/FIRST)
- [x] `MegaTileMergerTest` (5 tests) — per-day entry split + `MegaTileMerger.merge`: batch fresh, batch delayed, idle entities, multiple agg types, day boundary transitions
- [x] `MegaTileStreamProcessorTest` (6 tests) — full Flink simulation with sawtooth running IR + eviction at tile boundaries: batch fresh, batch delayed, idle entities, all agg types, day boundaries, **multi-day watermark gap** (3-day idle then resume)
- [x] `MegaTileCodecRoundTripTest` (3 tests) — serde round-trips every 50 events through `MegaTileCodec.encode`/`decode` + `encodeBaseIr`/`decodeBaseIr`: batch fresh, all agg types, **key switch verification** (Flink key reuse)

Windows tested: `6h, 1d, 47h, 2d, 49h, 3d, 7d`