### PR TITLE
[ZIP-1340] duplicate conf names cause ambiguous confHashMap

### DIFF
--- a/python/src/ai/chronon/repo/hub_runner.py
+++ b/python/src/ai/chronon/repo/hub_runner.py
@@ -24,7 +24,7 @@ from ai.chronon.cli.theme import (
     status_spinner,
 )
 from ai.chronon.click_helpers import handle_compile, handle_conf_not_found, handle_dry_run_compile
-from ai.chronon.repo import hub_uploader, utils
+from ai.chronon.repo import FOLDER_NAME_TO_CLASS, hub_uploader, utils
 from ai.chronon.repo.auth import get_user_email
 from ai.chronon.repo.constants import VALID_CLOUDS, RunMode
 from ai.chronon.repo.utils import print_possible_confs, upload_to_blob_store
@@ -835,12 +835,20 @@ def eval(
 
     # get conf name
     conf_name = utils.get_metadata_name_from_conf(repo, conf)
+    # Prefix with folder type if we can infer it from the conf path (e.g. "joins#gcp.demo.v1__1").
+    # This matches the prefixed keys in conf_hash_map so the server can resolve the right conf
+    # when same-named confs of different types are present.
+    conf_path_parts = os.path.normpath(conf).split(os.sep)
+    folder_prefix = next(
+        (f for f in FOLDER_NAME_TO_CLASS if f in conf_path_parts), None
+    )
+    typed_conf_name = f"{folder_prefix}#{conf_name}" if folder_prefix else conf_name
     if generate_test_config:
         parameters["generateTestDataSkeleton"] = "true"
     response_json = zipline_hub.call_eval_api(
-        conf_name=conf_name,
+        conf_name=typed_conf_name,
         conf_hash_map={
-            conf.name: conf.hash for conf in conf_name_to_hash_dict.values()
+            key: conf.hash for key, conf in conf_name_to_hash_dict.items()
         },
         parameters=parameters,
     )

--- a/python/src/ai/chronon/repo/hub_runner.py
+++ b/python/src/ai/chronon/repo/hub_runner.py
@@ -394,6 +394,9 @@ def submit_workflow(
 
     # get conf name
     conf_name = utils.get_metadata_name_from_conf(repo, conf)
+    conf_path_parts = os.path.normpath(conf).split(os.sep)
+    folder_prefix = next((f for f in FOLDER_NAME_TO_CLASS if f in conf_path_parts), None)
+    conf_key = f"{folder_prefix}#{conf_name}" if folder_prefix else conf_name
 
     with status_spinner(f"Submitting {mode} workflow...", format=format):
         response_json = zipline_hub.call_workflow_start_api(
@@ -403,7 +406,7 @@ def submit_workflow(
             user=get_user_email(),
             start=start_ds,
             end=end_ds,
-            conf_hash=conf_name_to_hash_dict[conf_name].hash,
+            conf_hash=conf_name_to_hash_dict[conf_key].hash,
             skip_long_running=False,
         )
 
@@ -445,6 +448,9 @@ def submit_schedule(
 
     # get conf name
     conf_name = utils.get_metadata_name_from_conf(repo, conf)
+    conf_path_parts = os.path.normpath(conf).split(os.sep)
+    folder_prefix = next((f for f in FOLDER_NAME_TO_CLASS if f in conf_path_parts), None)
+    conf_key = f"{folder_prefix}#{conf_name}" if folder_prefix else conf_name
     schedule_modes = get_schedule_modes(os.path.join(repo, conf))
     modes = {
         RunMode.BACKFILL.value.upper(): schedule_modes.offline_schedule,
@@ -456,7 +462,7 @@ def submit_schedule(
             modes=modes,
             branch=branch,
             conf_name=conf_name,
-            conf_hash=conf_name_to_obj_dict[conf_name].hash,
+            conf_hash=conf_name_to_obj_dict[conf_key].hash,
         )
 
     if format == Format.JSON:

--- a/python/src/ai/chronon/repo/hub_uploader.py
+++ b/python/src/ai/chronon/repo/hub_uploader.py
@@ -16,7 +16,8 @@ from gen_thrift.api.ttypes import Conf
 
 def build_local_repo_hashmap(root_dir: str):
     compiled_dir = os.path.join(root_dir, "compiled")
-    # Returns a map of name -> (tbinary, file_hash)
+    # Returns a map of (name, confType) -> Conf to avoid collisions when a conf name
+    # is shared across different types (e.g. a join and a model with the same filename).
     results = {}
 
     # Iterate through each object type folder (staging_queries, group_bys, joins etc)
@@ -44,18 +45,15 @@ def build_local_repo_hashmap(root_dir: str):
                 json_obj = json.loads(thrift_json)
                 name = json_obj["metaData"]["name"]
 
-                # Load the json into the appropriate object type based on folder
-                # binary = json2binary(thrift_json, obj_class)
-
+                conf_type = FOLDER_NAME_TO_CONF_TYPE[folder_name]
                 md5_hash = hashlib.md5(thrift_json.encode()).hexdigest()
-                # md5_hash = hashlib.md5(thrift_json.encode()).hexdigest() + "123"
-                # results[name] = (binary, md5_hash, FOLDER_NAME_TO_CONF_TYPE[folder_name])
-                results[name] = Conf(
+                # Key includes the folder name prefix (e.g. "joins#gcp.demo.v1__1") so that
+                # same-named confs of different types can coexist in the map.
+                results[f"{folder_name}#{name}"] = Conf(
                     name=name,
                     hash=md5_hash,
-                    # contents=binary,
                     contents=thrift_json,
-                    confType=FOLDER_NAME_TO_CONF_TYPE[folder_name],
+                    confType=conf_type,
                     localPath=json_file
                 )
 
@@ -70,21 +68,20 @@ def build_local_repo_hashmap(root_dir: str):
                 + "your thrift version before rerunning your command."
             )
             raise RuntimeError(error_msg)
-
     return results
 
 
 def compute_and_upload_diffs(
         branch: str,
         zipline_hub: ZiplineHub,
-        local_repo_confs: dict[str, Conf],
+        local_repo_confs: dict[tuple, Conf],
         format: Format = Format.TEXT,
 ) -> dict[str, Conf]:
-    # Group confs by confType so that diff/sync requests are scoped per type.
-    # This avoids collisions when a GROUP_BY and JOIN share the same compiled name.
+    # Group by confType — within a single type, names are guaranteed unique.
+    # local_repo_confs is keyed by (name, confType) to prevent same-name cross-type collisions.
     confs_by_type = defaultdict(dict)
-    for name, conf in local_repo_confs.items():
-        confs_by_type[conf.confType][name] = conf
+    for key, conf in local_repo_confs.items():
+        confs_by_type[conf.confType][conf.name] = conf
 
     total_count = len(local_repo_confs)
     print_step(f"🧮 Computed hashes for {total_count} local files.", format=format)

--- a/python/src/ai/chronon/repo/hub_uploader.py
+++ b/python/src/ai/chronon/repo/hub_uploader.py
@@ -14,7 +14,7 @@ from ai.chronon.repo.zipline_hub import ZiplineHub
 from gen_thrift.api.ttypes import Conf
 
 
-def build_local_repo_hashmap(root_dir: str):
+def build_local_repo_hashmap(root_dir: str) -> dict[str, Conf]:
     compiled_dir = os.path.join(root_dir, "compiled")
     # Returns a map of (name, confType) -> Conf to avoid collisions when a conf name
     # is shared across different types (e.g. a join and a model with the same filename).
@@ -74,11 +74,11 @@ def build_local_repo_hashmap(root_dir: str):
 def compute_and_upload_diffs(
         branch: str,
         zipline_hub: ZiplineHub,
-        local_repo_confs: dict[tuple, Conf],
+        local_repo_confs: dict[str, Conf],
         format: Format = Format.TEXT,
 ) -> dict[str, Conf]:
     # Group by confType — within a single type, names are guaranteed unique.
-    # local_repo_confs is keyed by (name, confType) to prevent same-name cross-type collisions.
+    # local_repo_confs is keyed by 'confType#name' to prevent same-name cross-type collisions.
     confs_by_type = defaultdict(dict)
     for _key, conf in local_repo_confs.items():
         confs_by_type[conf.confType][conf.name] = conf

--- a/python/src/ai/chronon/repo/hub_uploader.py
+++ b/python/src/ai/chronon/repo/hub_uploader.py
@@ -5,7 +5,7 @@ import os
 from collections import defaultdict
 
 from ai.chronon.cli.formatter import Format, format_print
-from ai.chronon.cli.theme import print_info, print_step, print_success
+from ai.chronon.cli.theme import print_info, print_step, print_success, print_warning
 from ai.chronon.repo import (
     FOLDER_NAME_TO_CLASS,
     FOLDER_NAME_TO_CONF_TYPE,
@@ -91,19 +91,31 @@ def compute_and_upload_diffs(
 
     all_diffed_confs = {}
     names_to_hashes_by_type = {}
+    server_supports_type_scoped = False
 
     for conf_type, type_confs in confs_by_type.items():
         conf_type_name = conf_type.name if hasattr(conf_type, "name") else str(conf_type)
         names_to_hashes = {name: c.hash for name, c in type_confs.items()}
         names_to_hashes_by_type[conf_type] = names_to_hashes
 
-        changed_conf_names: list[str] = zipline_hub.call_diff_api(
-            names_to_hashes, conf_type=conf_type_name
-        )["diff"]
+        diff_response = zipline_hub.call_diff_api(names_to_hashes, conf_type=conf_type_name)
+        # Any truthy value from the server means it supports type-scoped uploads
+        server_supports_type_scoped = server_supports_type_scoped or bool(
+            diff_response.get("supportsTypeScopedUpload")
+        )
 
+        changed_conf_names: list[str] = diff_response["diff"]
         if changed_conf_names:
             diffed = {k: type_confs[k] for k in changed_conf_names}
             all_diffed_confs.update(diffed)
+
+    if not server_supports_type_scoped:
+        print_warning(
+            "The Zipline Hub service does not support type-scoped uploads. "
+            "Upgrade the orchestration service to enable it. "
+            "Falling back to legacy sync — conf name collisions across types may occur.",
+            format=format,
+        )
 
     if not all_diffed_confs:
         print_success(
@@ -125,11 +137,16 @@ def compute_and_upload_diffs(
             f"⬆️ Uploaded {len(all_diffed_confs)} changed confs to branch '{branch}'.", format=format
         )
 
-    # Sync each type separately so the scoped upsert only touches confs of that type
-    for conf_type, names_to_hashes in names_to_hashes_by_type.items():
-        conf_type_name = conf_type.name if hasattr(conf_type, "name") else str(conf_type)
-        zipline_hub.call_sync_api(branch=branch, names_to_hashes=names_to_hashes,
-                                   conf_type=conf_type_name)
+    if server_supports_type_scoped:
+        # Sync per type so the scoped upsert only touches confs of that type
+        for conf_type, names_to_hashes in names_to_hashes_by_type.items():
+            conf_type_name = conf_type.name if hasattr(conf_type, "name") else str(conf_type)
+            zipline_hub.call_sync_api(branch=branch, names_to_hashes=names_to_hashes,
+                                       conf_type=conf_type_name)
+    else:
+        # Legacy path: single sync call with all confs combined
+        all_names_to_hashes = {n: h for m in names_to_hashes_by_type.values() for n, h in m.items()}
+        zipline_hub.call_sync_api(branch=branch, names_to_hashes=all_names_to_hashes)
 
     print_success(f"{total_count} hashes updated on branch '{branch}'.", format=format)
     return all_diffed_confs

--- a/python/src/ai/chronon/repo/hub_uploader.py
+++ b/python/src/ai/chronon/repo/hub_uploader.py
@@ -80,7 +80,7 @@ def compute_and_upload_diffs(
     # Group by confType — within a single type, names are guaranteed unique.
     # local_repo_confs is keyed by (name, confType) to prevent same-name cross-type collisions.
     confs_by_type = defaultdict(dict)
-    for key, conf in local_repo_confs.items():
+    for _key, conf in local_repo_confs.items():
         confs_by_type[conf.confType][conf.name] = conf
 
     total_count = len(local_repo_confs)

--- a/python/src/ai/chronon/repo/hub_uploader.py
+++ b/python/src/ai/chronon/repo/hub_uploader.py
@@ -2,6 +2,7 @@ import glob
 import hashlib
 import json
 import os
+from collections import defaultdict
 
 from ai.chronon.cli.formatter import Format, format_print
 from ai.chronon.cli.theme import print_info, print_step, print_success
@@ -79,42 +80,56 @@ def compute_and_upload_diffs(
         local_repo_confs: dict[str, Conf],
         format: Format = Format.TEXT,
 ) -> dict[str, Conf]:
-    # Determine which confs are different from the ZiplineHub
-    # Call Zipline hub with `names_and_hashes` as the argument to get back
-    names_to_hashes = {name: local_conf.hash for name, local_conf in local_repo_confs.items()}
-    print_step(f"🧮 Computed hashes for {len(names_to_hashes)} local files.", format=format)
+    # Group confs by confType so that diff/sync requests are scoped per type.
+    # This avoids collisions when a GROUP_BY and JOIN share the same compiled name.
+    confs_by_type = defaultdict(dict)
+    for name, conf in local_repo_confs.items():
+        confs_by_type[conf.confType][name] = conf
 
-    changed_conf_names: list[str] = zipline_hub.call_diff_api(names_to_hashes)["diff"]
+    total_count = len(local_repo_confs)
+    print_step(f"🧮 Computed hashes for {total_count} local files.", format=format)
 
-    if not changed_conf_names:
+    all_diffed_confs = {}
+    names_to_hashes_by_type = {}
+
+    for conf_type, type_confs in confs_by_type.items():
+        conf_type_name = conf_type.name if hasattr(conf_type, "name") else str(conf_type)
+        names_to_hashes = {name: c.hash for name, c in type_confs.items()}
+        names_to_hashes_by_type[conf_type] = names_to_hashes
+
+        changed_conf_names: list[str] = zipline_hub.call_diff_api(
+            names_to_hashes, conf_type=conf_type_name
+        )["diff"]
+
+        if changed_conf_names:
+            diffed = {k: type_confs[k] for k in changed_conf_names}
+            all_diffed_confs.update(diffed)
+
+    if not all_diffed_confs:
         print_success(
             f"Remote contains all local files. No need to upload '{branch}'.", format=format
         )
-        diffed_confs = {}
     else:
-        unchanged = len(names_to_hashes) - len(changed_conf_names)
+        unchanged = total_count - len(all_diffed_confs)
         print_info(
-            f"🔍 Detected {len(changed_conf_names)} changes on local branch '{branch}'. {unchanged} unchanged.",
+            f"🔍 Detected {len(all_diffed_confs)} changes on local branch '{branch}'. {unchanged} unchanged.",
             format=format,
         )
 
-        # a list of names for diffed hashes on branch
-        diffed_confs = {k: local_repo_confs[k] for k in changed_conf_names}
-
-        conf_names_str = "\n    - ".join(diffed_confs.keys())
+        conf_names_str = "\n    - ".join(all_diffed_confs.keys())
         format_print(f"    - {conf_names_str}", format=format)
 
-        diff_confs = []
-        for _, conf in diffed_confs.items():
-            diff_confs.append(conf.__dict__)
-
-        # Make PUT request to ZiplineHub
+        diff_confs = [conf.__dict__ for conf in all_diffed_confs.values()]
         zipline_hub.call_upload_api(branch=branch, diff_confs=diff_confs)
         print_step(
-            f"⬆️ Uploaded {len(diffed_confs)} changed confs to branch '{branch}'.", format=format
+            f"⬆️ Uploaded {len(all_diffed_confs)} changed confs to branch '{branch}'.", format=format
         )
 
-    zipline_hub.call_sync_api(branch=branch, names_to_hashes=names_to_hashes)
+    # Sync each type separately so the scoped upsert only touches confs of that type
+    for conf_type, names_to_hashes in names_to_hashes_by_type.items():
+        conf_type_name = conf_type.name if hasattr(conf_type, "name") else str(conf_type)
+        zipline_hub.call_sync_api(branch=branch, names_to_hashes=names_to_hashes,
+                                   conf_type=conf_type_name)
 
-    print_success(f"{len(names_to_hashes)} hashes updated on branch '{branch}'.", format=format)
-    return diffed_confs
+    print_success(f"{total_count} hashes updated on branch '{branch}'.", format=format)
+    return all_diffed_confs

--- a/python/src/ai/chronon/repo/zipline_hub.py
+++ b/python/src/ai/chronon/repo/zipline_hub.py
@@ -304,10 +304,12 @@ class ZiplineHub:
 
         return response.signed_jwt
 
-    def call_diff_api(self, names_to_hashes: dict[str, str]) -> Optional[list[str]]:
+    def call_diff_api(self, names_to_hashes: dict[str, str], conf_type: str = None) -> Optional[list[str]]:
         url = f"{self.base_url}/upload/v2/diff"
 
         diff_request = {"namesToHashes": names_to_hashes}
+        if conf_type:
+            diff_request["confType"] = conf_type
         try:
             response = requests.post(
                 url, json=diff_request, headers=self.additional_headers(self.base_url)
@@ -415,13 +417,15 @@ class ZiplineHub:
             print_error(f"Error calling workflow cancel API: {self._get_error_details(e)}", format=self.format)
             raise e
 
-    def call_sync_api(self, branch: str, names_to_hashes: dict[str, str]) -> Optional[list[str]]:
+    def call_sync_api(self, branch: str, names_to_hashes: dict[str, str], conf_type: str = None) -> Optional[list[str]]:
         url = f"{self.base_url}/upload/v2/sync"
 
         sync_request = {
             "namesToHashes": names_to_hashes,
             "branch": branch,
         }
+        if conf_type:
+            sync_request["confType"] = conf_type
 
         try:
             response = requests.post(


### PR DESCRIPTION
## Summary

  build_local_repo_hashmap keyed confs by plain name (results[name]). If a JOIN and a MODEL shared the same compiled name, one would silently overwrite the other in the map — causing missed uploads and incorrect branch tracking during sync. The same collision applied to
  the confHashMap sent to the eval service.
  
  Requires orchestrator upgrade: https://github.com/zipline-ai/platform/pull/887 to handle confType in upload / diff requests

## Changes

  **hub_uploader.py**
  - build_local_repo_hashmap: keys now use "folder_name#conf_name" (e.g. "joins#gcp.demo.v1__1") so same-named confs of different types coexist without collision
  - compute_and_upload_diffs: groups confs by type and calls diff/sync once per type, passing confType to scope each operation. Detects whether the orchestration service supports type-scoped uploads via supportsTypeScopedUpload in the diff response; falls back to a single
   combined sync call against older servers

  **zipline_hub.py**
  - call_diff_api / call_sync_api: accept optional conf_type kwarg, included in the request body when set

  **hub_runner.py**
  - eval: conf_hash_map now uses the prefixed keys from conf_name_to_hash_dict directly, preserving type context for the eval service to resolve same-named confs correctly

##  Rollout

  - Safe to deploy against the current orchestration service — the supportsTypeScopedUpload flag gates the new sync path; old servers fall back transparently
  - Eval service should be updated before this CLI version is deployed (prefixed confHashMap keys require the updated eval service to resolve correctly)
  
  
## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [x] Integration tested
Copied the listing model into demo.py rename the object to v1 to reproduce.
Now eval works properly for example.
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Uploads support type-scoped processing with automatic server capability detection, enabling per-type diffing and syncing when available.
  * Workflow, schedule and evaluation actions now use type-prefixed configuration identifiers for accurate selection.

* **Improvements**
  * Configuration identifiers are now composite type-based keys for clearer organization.
  * Sync/diff flows aggregate changes across types and report totals and aggregated counts for clearer status and messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->