### PR TITLE
CLI: Add support for multiple conf paths for `eval`

### DIFF
--- a/python/src/ai/chronon/repo/hub_runner.py
+++ b/python/src/ai/chronon/repo/hub_runner.py
@@ -14,7 +14,7 @@ from ai.chronon.cli.formatter import (
     format_print,
     jsonify_exceptions_if_json_format,
 )
-from ai.chronon.cli.git_utils import get_current_branch
+from ai.chronon.cli.git_utils import get_current_branch, get_git_user_email
 from ai.chronon.cli.theme import (
     print_error,
     print_info,
@@ -25,7 +25,6 @@ from ai.chronon.cli.theme import (
 )
 from ai.chronon.click_helpers import handle_compile, handle_conf_not_found, handle_dry_run_compile
 from ai.chronon.repo import hub_uploader, utils
-from ai.chronon.repo.auth import get_user_email
 from ai.chronon.repo.constants import VALID_CLOUDS, RunMode
 from ai.chronon.repo.utils import print_possible_confs, upload_to_blob_store
 from ai.chronon.repo.zipline_hub import ZiplineHub
@@ -176,6 +175,10 @@ def conf_argument(func):
     return click.argument("conf")(func)
 
 
+def confs_argument(func):
+    return click.argument("confs", nargs=-1, required=True)(func)
+
+
 def ds_option(func):
     return click.option(
         "--date",
@@ -229,8 +232,53 @@ def _get_zipline_hub(
         cloud_provider=hub_conf.cloud_provider,
         scope=scope,
         format=format,
+    )
+
+
+def _get_eval_zipline_hub(
+    hub_conf: HubConfig,
+    hub_url: Optional[str],
+    use_auth: bool,
+    eval_url: Optional[str],
+    format: Format,
+):
+    scope = ""
+    if hub_conf.auth_scope is not None:
+        scope = hub_conf.auth_scope
+    elif hub_conf.cloud_provider == "azure" and hub_conf.customer_id is not None:
+        scope = f"api://{hub_conf.customer_id}-zipline-auth"
+    return ZiplineHub(
+        base_url=hub_url or hub_conf.hub_url,
+        sa_name=hub_conf.sa_name,
+        use_auth=use_auth,
+        eval_url=eval_url or hub_conf.eval_url,
+        cloud_provider=hub_conf.cloud_provider,
+        scope=scope,
+        format=format,
         auth_url=hub_conf.frontend_url,
     )
+
+
+def _build_eval_parameters(
+    hub_conf: HubConfig,
+    generate_test_config: bool,
+    test_data_path: Optional[str],
+):
+    parameters = {}
+    if test_data_path:
+        if hub_conf.cloud_provider != "gcp":
+            raise RuntimeError("Test data path is only supported for GCP.")
+        zipline_artifact_prefix = (
+            hub_conf.artifact_prefix.rstrip("/") if hub_conf.artifact_prefix else ""
+        )
+        if not zipline_artifact_prefix:
+            raise click.UsageError("Zipline artifact prefix is not set.")
+        url = f"eval/test_data/{os.path.basename(test_data_path)}"
+        upload_to_blob_store(test_data_path, f"{zipline_artifact_prefix}/{url}")
+        parameters["testDataPath"] = f"{zipline_artifact_prefix}/{url}"
+    if generate_test_config:
+        parameters["generateTestDataSkeleton"] = "true"
+    return parameters
 
 
 def submit_schedule_all(
@@ -400,7 +448,7 @@ def submit_workflow(
             conf_name=conf_name,
             mode=mode,
             branch=branch,
-            user=get_user_email(),
+            user=get_git_user_email(),
             start=start_ds,
             end=end_ds,
             conf_hash=conf_name_to_hash_dict[conf_name].hash,
@@ -757,7 +805,7 @@ def fetch(conf, repo, hub_url, use_auth, format, force, fetcher_url, schema, key
 # zipline hub eval compiled/joins/join
 # localSparkSession evaluation of conf
 @hub.command()
-@conf_argument
+@confs_argument
 @common_options
 @click.option(
     "--eval-url",
@@ -777,11 +825,10 @@ def fetch(conf, repo, hub_url, use_auth, format, force, fetcher_url, schema, key
     type=str,
     default=None,
 )
-@handle_conf_not_found(log_error=True, callback=print_possible_confs)
 @handle_compile
 @jsonify_exceptions_if_json_format
 def eval(
-    conf,
+    confs,
     repo,
     hub_url,
     use_auth,
@@ -794,65 +841,65 @@ def eval(
 ):
     """Validate a conf against source tables and schemas.
 
-    CONF is the path to the compiled conf (e.g. compiled/joins/team/my_join).
+    CONFS are paths to compiled confs (e.g. compiled/joins/team/my_join).
     """
-    parameters = {}
-    hub_conf = get_hub_conf(conf, root_dir=repo)
-    scope = ""
-    if hub_conf.auth_scope is not None:
-        scope = hub_conf.auth_scope
-    elif hub_conf.cloud_provider == "azure" and hub_conf.customer_id is not None:
-        scope = f"api://{hub_conf.customer_id}-zipline-auth"
-    zipline_hub = ZiplineHub(
-        base_url=hub_url or hub_conf.hub_url,
-        sa_name=hub_conf.sa_name,
-        use_auth=use_auth,
-        eval_url=eval_url or hub_conf.eval_url,
-        cloud_provider=hub_conf.cloud_provider,
-        scope=scope,
-        format=format,
-        auth_url=hub_conf.frontend_url,
-    )
     conf_name_to_hash_dict = hub_uploader.build_local_repo_hashmap(root_dir=repo)
     branch = get_current_branch()
-    if test_data_path:
-        # Upload the test data skeleton to the bucket.
-        if hub_conf.cloud_provider != "gcp":
-            raise RuntimeError("Test data path is only supported for GCP.")
-        # import here to avoid dependency for other clouds.
-        zipline_artifact_prefix = (
-            hub_conf.artifact_prefix.rstrip("/") if hub_conf.artifact_prefix else ""
+    conf_hash_map = {conf_obj.name: conf_obj.hash for conf_obj in conf_name_to_hash_dict.values()}
+    multi = len(confs) > 1
+    hub_cache = {}
+    responses = []
+    for conf in confs:
+        try:
+            hub_conf = get_hub_conf(conf, root_dir=repo)
+        except FileNotFoundError as e:
+            print_error(f"File not found in eval: {e}", format=format)
+            print_possible_confs(conf, repo)
+            continue
+
+        parameters = _build_eval_parameters(
+            hub_conf=hub_conf,
+            generate_test_config=generate_test_config,
+            test_data_path=test_data_path,
         )
-        if not zipline_artifact_prefix:
-            raise click.UsageError("Zipline artifact prefix is not set.")
-        url = f"eval/test_data/{os.path.basename(test_data_path)}"
-        upload_to_blob_store(test_data_path, f"{zipline_artifact_prefix}/{url}")
-        parameters["testDataPath"] = f"{zipline_artifact_prefix}/{url}"
+        effective_url = hub_url or hub_conf.hub_url
+        if effective_url not in hub_cache:
+            hub_cache[effective_url] = _get_eval_zipline_hub(
+                hub_conf=hub_conf,
+                hub_url=hub_url,
+                use_auth=use_auth,
+                eval_url=eval_url,
+                format=format,
+            )
+            hub_uploader.compute_and_upload_diffs(
+                branch, zipline_hub=hub_cache[effective_url], local_repo_confs=conf_name_to_hash_dict
+            )
+        zipline_hub = hub_cache[effective_url]
+        conf_name = utils.get_metadata_name_from_conf(repo, conf)
+        response_json = zipline_hub.call_eval_api(
+            conf_name=conf_name,
+            conf_hash_map=conf_hash_map,
+            parameters=parameters,
+        )
+        responses.append({"conf": conf, "response": response_json})
 
-    hub_uploader.compute_and_upload_diffs(
-        branch, zipline_hub=zipline_hub, local_repo_confs=conf_name_to_hash_dict
-    )
+    overall_success = all(result["response"].get("success") for result in responses)
 
-    # get conf name
-    conf_name = utils.get_metadata_name_from_conf(repo, conf)
-    if generate_test_config:
-        parameters["generateTestDataSkeleton"] = "true"
-    response_json = zipline_hub.call_eval_api(
-        conf_name=conf_name,
-        conf_hash_map={
-            conf.name: conf.hash for conf in conf_name_to_hash_dict.values()
-        },
-        parameters=parameters,
-    )
     if format == Format.JSON:
-        print(json.dumps(response_json, indent=4))
-        sys.exit(0 if response_json.get("success") else 1)
-    if response_json.get("success"):
-        print_success("Eval job finished successfully.", format=format)
+        payload = responses[0]["response"] if not multi else {"status": "success" if overall_success else "error", "results": responses}
+        print(json.dumps(payload, indent=4))
+        sys.exit(0 if overall_success else 1)
+
+    for result in responses:
+        response_json = result["response"]
+        label = f" for {result['conf']}" if multi else ""
+        if response_json.get("success"):
+            print_success(f"Eval job finished successfully{label}.", format=format)
+        else:
+            print_error(f"Eval job failed{label}.", format=format)
         format_print(response_json.get("message"), format=format)
-    else:
-        print_error("Eval job failed.", format=format)
-        format_print(response_json.get("message"), format=format)
+
+    if not overall_success:
         sys.exit(1)
 
 
@@ -934,7 +981,6 @@ def eval_table(
         cloud_provider=hub_conf.cloud_provider,
         scope=scope,
         format=format,
-        auth_url=hub_conf.frontend_url,
     )
 
     execution_info = (
@@ -1024,7 +1070,6 @@ def list_tables(schema_name, repo, team, hub_url, use_auth, format, eval_url, en
         cloud_provider=hub_conf.cloud_provider,
         scope=scope,
         format=format,
-        auth_url=hub_conf.frontend_url,
     )
 
     response_json = zipline_hub.call_list_tables_api(

--- a/python/src/ai/chronon/repo/hub_runner.py
+++ b/python/src/ai/chronon/repo/hub_runner.py
@@ -883,6 +883,9 @@ def eval(
         )
         responses.append({"conf": conf, "response": response_json})
 
+    if not responses:
+        sys.exit(1)
+
     overall_success = all(result["response"].get("success") for result in responses)
 
     if format == Format.JSON:

--- a/python/test/test_hub_runner.py
+++ b/python/test/test_hub_runner.py
@@ -11,7 +11,8 @@
 #     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
-from unittest.mock import patch
+import json
+from unittest.mock import Mock, patch
 
 from click.testing import CliRunner
 from rich.text import Text
@@ -52,6 +53,121 @@ class TestHubRunner:
         result = self._run_and_print(runner, hub, ["--help"])
         assert result.exit_code == 0
         assert "Usage:" in result.output
+
+    @patch('ai.chronon.click_helpers.__compile')
+    @patch('ai.chronon.repo.hub_runner.hub_uploader.compute_and_upload_diffs')
+    @patch('ai.chronon.repo.hub_runner.get_current_branch')
+    @patch('ai.chronon.repo.hub_runner.utils.get_metadata_name_from_conf')
+    @patch('ai.chronon.repo.hub_runner.get_hub_conf')
+    @patch('ai.chronon.repo.zipline_hub.requests.post')
+    def test_eval_supports_multiple_confs(
+        self,
+        mock_post,
+        mock_get_hub_conf,
+        mock_get_metadata_name,
+        mock_get_current_branch,
+        mock_compute_and_upload_diffs,
+        mock_compile,
+        canary,
+        online_join_conf,
+    ):
+        """Test eval command supports multiple conf arguments."""
+        mock_compile.return_value = ({}, False, {"added": [], "changed": [], "deleted": []})
+        mock_get_current_branch.return_value = "test-branch"
+        mock_compute_and_upload_diffs.return_value = None
+        mock_get_hub_conf.return_value = Mock(
+            hub_url='http://localhost:3903',
+            frontend_url='http://localhost:3000',
+            eval_url=None,
+            sa_name=None,
+            cloud_provider='gcp',
+            auth_scope=None,
+            customer_id=None,
+            artifact_prefix=None,
+        )
+        mock_get_metadata_name.side_effect = ['gcp.demo.v1', 'gcp.user_activities.v1']
+        mock_post.side_effect = [
+            Mock(json=Mock(return_value={"success": True, "message": "join ok"}), raise_for_status=Mock()),
+            Mock(json=Mock(return_value={"success": True, "message": "group by ok"}), raise_for_status=Mock()),
+        ]
+
+        second_conf = 'compiled/group_bys/gcp/user_activities.v1'
+        runner = CliRunner()
+        result = self._run_and_print(runner, hub, [
+            'eval',
+            online_join_conf,
+            second_conf,
+            '--repo', canary,
+            '--no-use-auth',
+            '--eval-url', 'http://localhost:3904',
+        ])
+
+        assert result.exit_code == 0
+        plain_output = ' '.join(_plain(result.output).split())
+        assert f"Eval job finished successfully for {online_join_conf}." in plain_output
+        assert f"Eval job finished successfully for {second_conf}." in plain_output
+        assert mock_post.call_count == 2
+
+        first_payload = mock_post.call_args_list[0][1]['json']
+        second_payload = mock_post.call_args_list[1][1]['json']
+        assert first_payload['confName'] == 'gcp.demo.v1'
+        assert second_payload['confName'] == 'gcp.user_activities.v1'
+
+    @patch('ai.chronon.click_helpers.__compile')
+    @patch('ai.chronon.repo.hub_runner.hub_uploader.compute_and_upload_diffs')
+    @patch('ai.chronon.repo.hub_runner.get_current_branch')
+    @patch('ai.chronon.repo.hub_runner.utils.get_metadata_name_from_conf')
+    @patch('ai.chronon.repo.hub_runner.get_hub_conf')
+    @patch('ai.chronon.repo.zipline_hub.requests.post')
+    def test_eval_multiple_confs_json_output(
+        self,
+        mock_post,
+        mock_get_hub_conf,
+        mock_get_metadata_name,
+        mock_get_current_branch,
+        mock_compute_and_upload_diffs,
+        mock_compile,
+        canary,
+        online_join_conf,
+    ):
+        """Test eval emits aggregated JSON for multiple conf arguments."""
+        mock_compile.return_value = ({}, False, {"added": [], "changed": [], "deleted": []})
+        mock_get_current_branch.return_value = "test-branch"
+        mock_compute_and_upload_diffs.return_value = None
+        mock_get_hub_conf.return_value = Mock(
+            hub_url='http://localhost:3903',
+            frontend_url='http://localhost:3000',
+            eval_url=None,
+            sa_name=None,
+            cloud_provider='gcp',
+            auth_scope=None,
+            customer_id=None,
+            artifact_prefix=None,
+        )
+        mock_get_metadata_name.side_effect = ['gcp.demo.v1', 'gcp.user_activities.v1']
+        mock_post.side_effect = [
+            Mock(json=Mock(return_value={"success": True, "message": "join ok"}), raise_for_status=Mock()),
+            Mock(json=Mock(return_value={"success": False, "message": "group by failed"}), raise_for_status=Mock()),
+        ]
+
+        second_conf = 'compiled/group_bys/gcp/user_activities.v1'
+        runner = CliRunner()
+        result = self._run_and_print(runner, hub, [
+            'eval',
+            online_join_conf,
+            second_conf,
+            '--repo', canary,
+            '--no-use-auth',
+            '--eval-url', 'http://localhost:3904',
+            '--format', 'json',
+        ])
+
+        assert result.exit_code == 1
+        response_json = json.loads(result.output)
+        assert response_json['status'] == 'error'
+        assert [entry['conf'] for entry in response_json['results']] == [online_join_conf, second_conf]
+        assert response_json['results'][0]['response']['success'] is True
+        assert response_json['results'][1]['response']['success'] is False
 
     @patch('requests.post')
     @patch('ai.chronon.repo.hub_runner.get_current_branch')


### PR DESCRIPTION
## Summary
This PR aims to allow multiple conf paths for an `eval`, mainly for easier use in CI/pre-commit hooks.

Changes:

- eval now takes one or more CONFS arguments instead of a single CONF
- Hub instantiation and diff uploads are deduplicated per hub URL; if multiple `confs` share the same hub, it only connects and uploads once
- Auth/info log lines are suppressed for subsequent confs on the same hub
- Text output labels each result with the conf path when multiple confs are provided
- JSON output wraps results in an aggregated {"status": ..., "results": [...]} envelope for multi-conf runs; single-conf output is unchanged
- Added tests



## Checklist
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update

