### PR TITLE
GigaTile: push-based serving — design doc, core processor, Flink wiring

### DIFF
--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStore.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStore.scala
@@ -1,0 +1,18 @@
+package ai.chronon.aggregator.windowing
+
+/** Extended TileStore for GigaTile: adds batch IR and running large-window IR state.
+  *
+  * GigaTile holds the FinalBatchIr in Flink state (loaded from Iceberg) and maintains
+  * a runningLargeIr that's the fully merged value: batch collapsed + selected tail hops
+  * + streaming daily accumulators.
+  */
+trait GigaTileStore extends TileStore {
+  def getBatchIr: FinalBatchIr
+  def putBatchIr(ir: FinalBatchIr): Unit
+
+  def getBatchEndTs: Long
+  def putBatchEndTs(ts: Long): Unit
+
+  def getRunningLargeIr: Array[Any]
+  def putRunningLargeIr(ir: Array[Any]): Unit
+}

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStore.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStore.scala
@@ -1,10 +1,10 @@
 package ai.chronon.aggregator.windowing
 
-/** Extended TileStore for GigaTile: adds batch IR and running large-window IR state.
+/** Extended TileStore for GigaTile: adds batch IR and per-day large-window IR state.
   *
   * GigaTile holds the FinalBatchIr in Flink state (loaded from Iceberg) and maintains
-  * a runningLargeIr that's the fully merged value: batch collapsed + selected tail hops
-  * + streaming daily accumulators.
+  * one daily large-window IR slot per day with streaming events. recomputeRunningLargeIr
+  * merges batch + every daily slot whose dayStart is at or after batchEndDay.
   */
 trait GigaTileStore extends TileStore {
   def getBatchIr: FinalBatchIr
@@ -15,4 +15,11 @@ trait GigaTileStore extends TileStore {
 
   def getRunningLargeIr: Array[Any]
   def putRunningLargeIr(ir: Array[Any]): Unit
+
+  // Per-day large-window IR state. One slot per day with streaming events between
+  // batchEndDay and the current watermark day; pruned on batch advance.
+  def getDailyLargeIr(dayStart: Long): Array[Any]
+  def putDailyLargeIr(dayStart: Long, ir: Array[Any]): Unit
+  def removeDailyLargeIr(dayStart: Long): Unit
+  def dailyLargeIrIterator: Iterator[(Long, Array[Any])]
 }

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStore.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStore.scala
@@ -16,6 +16,14 @@ trait GigaTileStore extends TileStore {
   def getRunningLargeIr: Array[Any]
   def putRunningLargeIr(ir: Array[Any]): Unit
 
+  /** Hop-aligned as-of timestamp represented by the cached small-window IR. */
+  def getCachedSmallWindowAsOfTs: Long
+  def putCachedSmallWindowAsOfTs(ts: Long): Unit
+
+  /** As-of timestamp used by the last full running-large IR recomputation. */
+  def getLastLargeRecomputeAsOfTs: Long
+  def putLastLargeRecomputeAsOfTs(ts: Long): Unit
+
   // Per-day large-window IR state. One slot per day with streaming events between
   // batchEndDay and the current watermark day; pruned on batch advance.
   def getDailyLargeIr(dayStart: Long): Array[Any]

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStore.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStore.scala
@@ -25,7 +25,7 @@ trait GigaTileStore extends TileStore {
   def putLastLargeRecomputeAsOfTs(ts: Long): Unit
 
   // Per-day large-window IR state. One slot per day with streaming events between
-  // batchEndDay and the current watermark day; pruned on batch advance.
+  // batchEndDay and the current materialized day; pruned on batch advance.
   def getDailyLargeIr(dayStart: Long): Array[Any]
   def putDailyLargeIr(dayStart: Long, ir: Array[Any]): Unit
   def removeDailyLargeIr(dayStart: Long): Unit

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStreamProcessor.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStreamProcessor.scala
@@ -49,6 +49,10 @@ class GigaTileStreamProcessor(
   // Large-window-only GroupBys need eviction for tail hop correction.
   val minEvictionInterval: Long = megaTileAgg.activeTiers.min
 
+  // Tracks the packed IR from the last eviction emit. Used to suppress redundant KV writes
+  // when nothing changed between evictions (idle entities, no tail hop shift).
+  private var lastEvictionPackedIr: Array[Any] = _
+
   // Hop indices only used by small (NO BATCH) windows — stripped from batch IR on load.
   // 5-min tail hops for ≤12h windows are never used by mergeTailHopsForBatchColumns.
   private[windowing] val smallWindowOnlyHopIndices: Set[Int] = {
@@ -201,7 +205,15 @@ class GigaTileStreamProcessor(
     // --- Large windows: recompute runningLargeIr from batch + streaming ---
     recomputeRunningLargeIr(timerTs, currentDayStart)
 
-    GigaEmitResult(packAndFinalize())
+    // Suppress redundant emits: skip if the packed IR hasn't changed since last eviction.
+    // For idle entities with no events and no tail hop shift, this avoids O(entities) KV writes per interval.
+    val packed = pack()
+    if (lastEvictionPackedIr != null && irEqual(lastEvictionPackedIr, packed)) {
+      GigaEmitResult(null)
+    } else {
+      lastEvictionPackedIr = windowedAgg.clone(packed)
+      GigaEmitResult(windowedAgg.finalize(packed))
+    }
   }
 
   /** Process a new batch IR from the Iceberg connected stream.
@@ -295,8 +307,8 @@ class GigaTileStreamProcessor(
     }
   }
 
-  /** Pack small + large window columns into a single IR and finalize to output values. */
-  private[windowing] def packAndFinalize(): Array[Any] = {
+  /** Pack small + large window columns into a single windowed IR (before finalization). */
+  private def pack(): Array[Any] = {
     val cachedIr = store.getCachedSmallWindowIr
     val runningIr = store.getRunningLargeIr
     val packed = new Array[Any](windowedAgg.length)
@@ -305,8 +317,11 @@ class GigaTileStreamProcessor(
       packed(col) = if (isNoBatch(col)) cachedIr(col) else runningIr(col)
       col += 1
     }
-    windowedAgg.finalize(packed)
+    packed
   }
+
+  /** Pack small + large window columns and finalize to output values. */
+  private[windowing] def packAndFinalize(): Array[Any] = windowedAgg.finalize(pack())
 
   /** Strip tail hops that are only used by small windows to reduce state size.
     * 5-min hops for ≤12h windows are never consumed by mergeTailHopsForBatchColumns.

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStreamProcessor.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStreamProcessor.scala
@@ -268,13 +268,27 @@ class GigaTileStreamProcessor(
 
   // --- Private helpers ---
 
-  /** Recompute runningLargeIr from: batch (collapsed + tail hops) + streaming (today + yesterday). */
+  /** Recompute runningLargeIr from: batch (collapsed + tail hops) + streaming (today + yesterday).
+    * For columns where the entire window has moved past batchEndTs, the collapsed value
+    * is stale — zero it out so stale batch data doesn't persist for idle entities.
+    */
   private def recomputeRunningLargeIr(queryTs: Long, currentDayStart: Long): Unit = {
     val batchIr = store.getBatchIr
     val batchEndTs = store.getBatchEndTs
     val runningIr = if (batchIr != null) {
       val ir = windowedAgg.clone(batchIr.collapsed)
       megaTileAgg.mergeTailHopsForBatchColumns(ir, queryTs, batchEndTs, batchIr)
+      // Zero out columns where the window has moved entirely past batch data.
+      // collapsed covers [alignedCollapsedBoundary, batchEnd) — if the window start
+      // (queryTs - windowMillis) is past batchEnd, collapsed is outside the window.
+      var col = 0
+      while (col < windowedAgg.length) {
+        val window = megaTileAgg.windowMappings(col).aggregationPart.window
+        if (!isNoBatch(col) && window != null && queryTs - megaTileAgg.windowMappings(col).millis >= batchEndTs) {
+          ir(col) = null
+        }
+        col += 1
+      }
       ir
     } else {
       windowedAgg.init

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStreamProcessor.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStreamProcessor.scala
@@ -1,0 +1,329 @@
+package ai.chronon.aggregator.windowing
+
+import ai.chronon.api.Row
+import ai.chronon.api.TsUtils
+
+import scala.collection.mutable
+
+/** Pure Scala state manager for the GigaTile streaming pipeline.
+  *
+  * Extends the MegaTile approach: Flink holds batch IR in state (loaded from Iceberg)
+  * and maintains a runningLargeIr that's the fully merged value (batch + streaming).
+  * Emits finalized feature vectors instead of windowed IRs.
+  *
+  * State layout (extends MegaTile):
+  *   - tiles, cachedSmallWindowIr: unchanged (small window sawtooth)
+  *   - largeTodayIr, largeYesterdayIr: unchanged (daily accumulators)
+  *   - batchIr: FinalBatchIr from Iceberg (collapsed + tail hops)
+  *   - batchEndTs: when batch was last computed
+  *   - runningLargeIr: fully merged large window IR (batch + streaming)
+  */
+class GigaTileStreamProcessor(
+    val megaTileAgg: MegaTileAggregator,
+    val store: GigaTileStore,
+    // Returns true if two windowed IRs are equal (for batch update mismatch detection).
+    // Default: always report mismatch (always emit on batch update).
+    val irEqual: (Array[Any], Array[Any]) => Boolean = (_, _) => false
+) {
+
+  val DayMillis: Long = 24 * 3600 * 1000L
+
+  private val windowedAgg = megaTileAgg.windowedAggregator
+  private val baseAgg = megaTileAgg.baseAggregator
+  private val isNoBatch = megaTileAgg.isNoBatch
+  private val columnHopSize = megaTileAgg.columnHopSize
+
+  val smallWindowTiers: Set[Long] = {
+    val tiers = mutable.Set.empty[Long]
+    var col = 0
+    while (col < windowedAgg.length) {
+      if (isNoBatch(col)) tiers += columnHopSize(col)
+      col += 1
+    }
+    tiers.toSet
+  }
+
+  val hasSmallWindows: Boolean = smallWindowTiers.nonEmpty
+
+  // Eviction cadence: smallest hop across ALL windows (not just small).
+  // Large-window-only GroupBys need eviction for tail hop correction.
+  val minEvictionInterval: Long = megaTileAgg.activeTiers.min
+
+  // Hop indices only used by small (NO BATCH) windows — stripped from batch IR on load.
+  // 5-min tail hops for ≤12h windows are never used by mergeTailHopsForBatchColumns.
+  private[windowing] val smallWindowOnlyHopIndices: Set[Int] = {
+    val usedByBatch = mutable.Set.empty[Int]
+    var col = 0
+    while (col < windowedAgg.length) {
+      val window = megaTileAgg.windowMappings(col).aggregationPart.window
+      // Only windowed BATCH columns actually use tail hops
+      if (!isNoBatch(col) && window != null) {
+        usedByBatch += megaTileAgg.tailHopIndicesArray(col)
+      }
+      col += 1
+    }
+    (0 until megaTileAgg.hopSizesArray.length).filterNot(usedByBatch.contains(_)).toSet
+  }
+
+  def onEvent(row: Row, eventTs: Long): GigaEmitResult = {
+    var currentDayStart = store.getCurrentDayStart
+    if (currentDayStart == -1L) {
+      currentDayStart = TsUtils.round(eventTs, DayMillis)
+      store.putCurrentDayStart(currentDayStart)
+    }
+
+    var dirty = false
+
+    // --- Small windows: update tiles + cachedSmallWindowIr ---
+    if (hasSmallWindows) {
+      var tilesUpdated = false
+      val tileStarts = megaTileAgg.tileStartsForEvent(eventTs)
+      for ((hopSize, tileStart) <- tileStarts) {
+        if (smallWindowTiers.contains(hopSize)) {
+          val floor = megaTileAgg.retentionFloor(hopSize, eventTs, currentDayStart)
+          val ceiling = currentDayStart + 2 * DayMillis
+          if (tileStart >= floor && tileStart < ceiling) {
+            val existing = store.getTile(hopSize, tileStart)
+            val ir = if (existing != null) existing else baseAgg.init
+            baseAgg.update(ir, row)
+            store.putTile(hopSize, tileStart, ir)
+            val earliest = store.getEarliestTileStart
+            if (tileStart < earliest) store.putEarliestTileStart(tileStart)
+            tilesUpdated = true
+          }
+        }
+      }
+
+      if (tilesUpdated) {
+        val cachedIr = store.getCachedSmallWindowIr
+        var col = 0
+        while (col < windowedAgg.length) {
+          if (isNoBatch(col)) {
+            windowedAgg.columnAggregators(col).update(cachedIr, row)
+          }
+          col += 1
+        }
+        store.putCachedSmallWindowIr(cachedIr)
+        dirty = true
+      }
+    }
+
+    // --- Large windows: update daily accumulator AND running sum ---
+    val todayStart = currentDayStart
+    val nextDayStart = todayStart + DayMillis
+    val yesterdayStart = todayStart - DayMillis
+
+    if (eventTs >= nextDayStart) {
+      // Future event — clamp to today. Day transitions are watermark-driven.
+      val todayIr = store.getLargeTodayIr
+      updateLargeWindowColumns(todayIr, row)
+      store.putLargeTodayIr(todayIr)
+      val runningIr = store.getRunningLargeIr
+      updateLargeWindowColumns(runningIr, row)
+      store.putRunningLargeIr(runningIr)
+      dirty = true
+    } else if (eventTs >= todayStart) {
+      val todayIr = store.getLargeTodayIr
+      updateLargeWindowColumns(todayIr, row)
+      store.putLargeTodayIr(todayIr)
+      val runningIr = store.getRunningLargeIr
+      updateLargeWindowColumns(runningIr, row)
+      store.putRunningLargeIr(runningIr)
+      dirty = true
+    } else if (eventTs >= yesterdayStart) {
+      // Late event from yesterday — within 2d tolerance
+      val yesterdayIr = store.getLargeYesterdayIr
+      updateLargeWindowColumns(yesterdayIr, row)
+      store.putLargeYesterdayIr(yesterdayIr)
+      val runningIr = store.getRunningLargeIr
+      updateLargeWindowColumns(runningIr, row)
+      store.putRunningLargeIr(runningIr)
+      dirty = true
+    }
+    // Events < yesterdayStart: dropped for large windows (> 2d late)
+
+    if (dirty) GigaEmitResult(packAndFinalize()) else GigaEmitResult(null)
+  }
+
+  /** Watermark-driven day transition. runningLargeIr is NOT reset — it's cumulative.
+    * Eviction corrects tail hop selection at the next timer firing.
+    */
+  def advanceWatermark(watermarkTs: Long): Unit = {
+    val currentDayStart = store.getCurrentDayStart
+    if (currentDayStart == -1L) return
+    val wmDay = TsUtils.round(watermarkTs, DayMillis)
+    if (wmDay > currentDayStart) {
+      val newYesterday =
+        if (wmDay == currentDayStart + DayMillis) store.getLargeTodayIr
+        else windowedAgg.init
+      store.putLargeYesterdayIr(newYesterday)
+      store.putLargeTodayIr(windowedAgg.init)
+      store.putCurrentDayStart(wmDay)
+    }
+  }
+
+  /** Periodic eviction: corrects small window sawtooth and large window tail hop selection. */
+  def onEviction(timerTs: Long): GigaEmitResult = {
+    val currentDayStart = store.getCurrentDayStart
+    if (currentDayStart == -1L) return GigaEmitResult(null)
+
+    // --- Small windows: evict stale tiles, rebuild cachedSmallWindowIr ---
+    if (hasSmallWindows) {
+      val earliest = store.getEarliestTileStart
+      if (earliest != Long.MaxValue) {
+        val staleEntries = mutable.ArrayBuffer.empty[(Long, Long)]
+        val iter = store.tileIterator
+        while (iter.hasNext) {
+          val (hopSize, tileStart, _) = iter.next()
+          if (smallWindowTiers.contains(hopSize)) {
+            val floor = megaTileAgg.retentionFloor(hopSize, timerTs, currentDayStart)
+            if (tileStart < floor) staleEntries += ((hopSize, tileStart))
+          }
+        }
+        staleEntries.foreach { case (h, t) => store.removeTile(h, t) }
+
+        val tiles: Map[Long, mutable.Map[Long, Array[Any]]] =
+          smallWindowTiers.map(hop => hop -> mutable.Map.empty[Long, Array[Any]]).toMap
+        var newEarliest = Long.MaxValue
+        val rebuildIter = store.tileIterator
+        while (rebuildIter.hasNext) {
+          val (hopSize, tileStart, ir) = rebuildIter.next()
+          tiles.get(hopSize).foreach(_(tileStart) = ir)
+          if (tileStart < newEarliest) newEarliest = tileStart
+        }
+        store.putEarliestTileStart(newEarliest)
+
+        val rebuiltIr = megaTileAgg.buildMegaTileIr(tiles, now = timerTs, batchEnd = currentDayStart)
+        store.putCachedSmallWindowIr(rebuiltIr)
+      }
+    }
+
+    // --- Large windows: recompute runningLargeIr from batch + streaming ---
+    recomputeRunningLargeIr(timerTs, currentDayStart)
+
+    GigaEmitResult(packAndFinalize())
+  }
+
+  /** Process a new batch IR from the Iceberg connected stream.
+    *
+    * @param newBatchIr  decoded FinalBatchIr from the Iceberg upload table
+    * @param newBatchEnd batch upload boundary timestamp (midnight-aligned)
+    * @param currentWatermark Flink's current watermark (for tail hop selection as queryTs)
+    */
+  def onBatchUpdate(newBatchIr: FinalBatchIr, newBatchEnd: Long, currentWatermark: Long): GigaEmitResult = {
+    val oldBatchEnd = store.getBatchEndTs
+    if (newBatchEnd <= oldBatchEnd) return GigaEmitResult(null)
+
+    val strippedBatchIr = stripSmallWindowHops(newBatchIr)
+    store.putBatchIr(strippedBatchIr)
+    store.putBatchEndTs(newBatchEnd)
+
+    var currentDayStart = store.getCurrentDayStart
+
+    if (newBatchEnd > currentDayStart) {
+      if (currentDayStart < 0) {
+        // Uninitialized (no events yet). Safe to set from batch — largeTodayIr is init,
+        // no overlap concern. Without this, all startup batch loads would defer.
+        currentDayStart = newBatchEnd
+        store.putCurrentDayStart(currentDayStart)
+      } else {
+        // Defer: watermark hasn't caught up. largeTodayIr has events that overlap
+        // with batch. Wait for advanceWatermark to rotate, then eviction recomputes.
+        return GigaEmitResult(null, needsEvictionTimer = true)
+      }
+    }
+
+    // Save old running for comparison
+    val oldRunningIr = store.getRunningLargeIr
+
+    // Clear yesterday if batch covers it
+    if (newBatchEnd >= currentDayStart) {
+      store.putLargeYesterdayIr(windowedAgg.init)
+    }
+
+    // Recompute running sum from batch + streaming
+    recomputeRunningLargeIr(currentWatermark, currentDayStart)
+
+    val newRunningIr = store.getRunningLargeIr
+
+    // Emit only on mismatch
+    if (!irEqual(oldRunningIr, newRunningIr)) {
+      GigaEmitResult(packAndFinalize(), needsEvictionTimer = true)
+    } else {
+      GigaEmitResult(null, needsEvictionTimer = true)
+    }
+  }
+
+  // --- Private helpers ---
+
+  /** Recompute runningLargeIr from: batch (collapsed + tail hops) + streaming (today + yesterday). */
+  private def recomputeRunningLargeIr(queryTs: Long, currentDayStart: Long): Unit = {
+    val batchIr = store.getBatchIr
+    val batchEndTs = store.getBatchEndTs
+    val runningIr = if (batchIr != null) {
+      val ir = windowedAgg.clone(batchIr.collapsed)
+      megaTileAgg.mergeTailHopsForBatchColumns(ir, queryTs, batchEndTs, batchIr)
+      ir
+    } else {
+      windowedAgg.init
+    }
+
+    // Merge streaming daily accumulators
+    val todayIr = store.getLargeTodayIr
+    val yesterdayIr = store.getLargeYesterdayIr
+    var col = 0
+    while (col < windowedAgg.length) {
+      if (!isNoBatch(col)) {
+        if (todayIr(col) != null)
+          runningIr(col) = windowedAgg.columnAggregators(col).merge(runningIr(col), todayIr(col))
+        if (batchEndTs < currentDayStart && yesterdayIr(col) != null)
+          runningIr(col) = windowedAgg.columnAggregators(col).merge(runningIr(col), yesterdayIr(col))
+      }
+      col += 1
+    }
+
+    store.putRunningLargeIr(runningIr)
+  }
+
+  private def updateLargeWindowColumns(ir: Array[Any], row: Row): Unit = {
+    var col = 0
+    while (col < windowedAgg.length) {
+      if (!isNoBatch(col)) {
+        windowedAgg.columnAggregators(col).update(ir, row)
+      }
+      col += 1
+    }
+  }
+
+  /** Pack small + large window columns into a single IR and finalize to output values. */
+  private[windowing] def packAndFinalize(): Array[Any] = {
+    val cachedIr = store.getCachedSmallWindowIr
+    val runningIr = store.getRunningLargeIr
+    val packed = new Array[Any](windowedAgg.length)
+    var col = 0
+    while (col < windowedAgg.length) {
+      packed(col) = if (isNoBatch(col)) cachedIr(col) else runningIr(col)
+      col += 1
+    }
+    windowedAgg.finalize(packed)
+  }
+
+  /** Strip tail hops that are only used by small windows to reduce state size.
+    * 5-min hops for ≤12h windows are never consumed by mergeTailHopsForBatchColumns.
+    */
+  private[windowing] def stripSmallWindowHops(batchIr: FinalBatchIr): FinalBatchIr = {
+    if (smallWindowOnlyHopIndices.isEmpty || batchIr.tailHops == null) return batchIr
+    val strippedHops = batchIr.tailHops.clone()
+    for (idx <- smallWindowOnlyHopIndices) {
+      if (idx < strippedHops.length) {
+        strippedHops(idx) = Array.empty
+      }
+    }
+    FinalBatchIr(batchIr.collapsed, strippedHops)
+  }
+}
+
+case class GigaEmitResult(
+    finalizedVector: Array[Any],
+    needsEvictionTimer: Boolean = false
+)

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStreamProcessor.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStreamProcessor.scala
@@ -5,6 +5,8 @@ import ai.chronon.api.TsUtils
 
 import scala.collection.mutable
 
+private[chronon] final case class EvictionTimes(timerTs: Long, smallWindowAsOfTs: Long)
+
 /** Pure Scala state manager for the GigaTile streaming pipeline.
   *
   * Flink holds the FinalBatchIr in state (loaded from Iceberg) and one daily large-window
@@ -39,6 +41,11 @@ class GigaTileStreamProcessor(
   private val baseAgg = megaTileAgg.baseAggregator
   private val isNoBatch = megaTileAgg.isNoBatch
   private val columnHopSize = megaTileAgg.columnHopSize
+  private val isFiniteLargeWindow: Array[Boolean] = megaTileAgg.windowMappings.zipWithIndex.map { case (mapping, col) =>
+    val window = mapping.aggregationPart.window
+    !isNoBatch(col) && window != null && window.length > 0 && window.length < Int.MaxValue
+  }
+  private val hasFiniteLargeWindows = isFiniteLargeWindow.contains(true)
 
   val smallWindowTiers: Set[Long] = {
     val tiers = mutable.Set.empty[Long]
@@ -93,7 +100,18 @@ class GigaTileStreamProcessor(
     * rebuild correctly), but only events inside each column's effective horizon contribute
     * to the live cached IR that gets emitted.
     */
-  def onEvent(row: Row, eventTs: Long, smallWindowAsOfTs: Long): GigaEmitResult = {
+  def onEvent(row: Row, eventTs: Long, smallWindowAsOfTs: Long): GigaEmitResult =
+    onEvent(row, eventTs, largeWindowAsOfTs = smallWindowAsOfTs, smallWindowAsOfTs = smallWindowAsOfTs)
+
+  /** Separate horizons keep the small-window exclusive upper bound from shifting the
+    * large-window query time at an exact hop boundary.
+    */
+  private[chronon] def onEvent(
+      row: Row,
+      eventTs: Long,
+      largeWindowAsOfTs: Long,
+      smallWindowAsOfTs: Long
+  ): GigaEmitResult = {
     var currentDayStart = store.getCurrentDayStart
     if (currentDayStart == -1L) {
       currentDayStart = TsUtils.round(eventTs, DayMillis)
@@ -105,6 +123,19 @@ class GigaTileStreamProcessor(
     // --- Small windows: update tiles, then update cached IR only for columns whose
     // tile lies inside the smallWindowAsOfTs horizon. ---
     if (hasSmallWindows) {
+      val targetHop = TsUtils.round(smallWindowAsOfTs, minSmallWindowTileSize)
+      val cachedHop = store.getCachedSmallWindowAsOfTs
+      // An older or delayed callback can arrive after this cache has advanced. Keep the live
+      // horizon monotonic instead of rebuilding or gating the event against an older range
+      // and resurrecting an expired tile.
+      val effectiveSmallWindowAsOfTs = if (cachedHop > targetHop) cachedHop else smallWindowAsOfTs
+      // A delayed callback can advance to a new hop before the scheduled eviction runs.
+      // Rebuild first so this event cannot publish an expired tile from the previous hop.
+      if (store.getEarliestTileStart != Long.MaxValue && cachedHop < targetHop) {
+        rebuildCachedSmallWindowIr(smallWindowAsOfTs, currentDayStart)
+        dirty = true
+      }
+
       val acceptedTileStarts = mutable.Map.empty[Long, Long]
       val tileStarts = megaTileAgg.tileStartsForEvent(eventTs)
       for ((hopSize, tileStart) <- tileStarts) {
@@ -131,10 +162,10 @@ class GigaTileStreamProcessor(
           if (isNoBatch(col)) {
             val hopSize = columnHopSize(col)
             acceptedTileStarts.get(hopSize).foreach { tileStart =>
-              val effStart = megaTileAgg.effectiveStart(col, smallWindowAsOfTs, currentDayStart)
+              val effStart = megaTileAgg.effectiveStart(col, effectiveSmallWindowAsOfTs, currentDayStart)
               // Retained late events: keep the base tile but skip cached-IR update so the live
               // emit reflects only events inside the as-of horizon for this column's window.
-              if (tileStart >= effStart && tileStart < smallWindowAsOfTs) {
+              if (tileStart >= effStart && tileStart < effectiveSmallWindowAsOfTs) {
                 if (cachedIr == null) cachedIr = store.getCachedSmallWindowIr
                 windowedAgg.columnAggregators(col).update(cachedIr, row)
                 cachedIrUpdated = true
@@ -145,17 +176,22 @@ class GigaTileStreamProcessor(
         }
         if (cachedIrUpdated) {
           store.putCachedSmallWindowIr(cachedIr)
+          store.putCachedSmallWindowAsOfTs(math.max(cachedHop, targetHop))
           dirty = true
         }
       }
     }
 
+    // A delayed callback can cross one or more large-window boundaries before its
+    // scheduled eviction runs. Track the last full recompute per key so the event path
+    // repairs a stale large view once per hop without coupling it to the small horizon.
+    if (recomputeRunningLargeIrForEventIfNeeded(largeWindowAsOfTs, currentDayStart)) dirty = true
+
     // --- Large windows: route to the per-day slot for round(eventTs, DayMillis) ---
-    // Accept events as far back as the staleness bound. Events whose dayStart is already
-    // covered by batch are still accepted for the incremental running IR (so onEvent emits
-    // see them immediately), and recomputeRunningLargeIr will drop their daily slot at the
-    // next eviction — matching the original "incremental shows it, eviction may drop it"
-    // trade-off when the late event was not in the prior batch's source data.
+    // Accept events as far back as the staleness bound. The daily slot retains the event for
+    // every large column, but the incremental running view only updates columns whose daily
+    // slot overlaps the monotonic materialized horizon. This prevents an out-of-order event
+    // from resurrecting an already-expired shorter window before the next eviction.
     //
     // Daily slot IRs are sized to the BASE aggregator (one column per (op, input)) — not
     // the windowed aggregator. The same SUM(num) value covers every windowed SUM(num, W)
@@ -171,7 +207,11 @@ class GigaTileStreamProcessor(
       store.putDailyLargeIr(eventDayStart, dayIr)
 
       val runningIr = store.getRunningLargeIr
-      updateLargeWindowColumns(runningIr, row)
+      val lastLargeRecomputeAsOfTs = store.getLastLargeRecomputeAsOfTs
+      val effectiveLargeAsOfTs =
+        if (lastLargeRecomputeAsOfTs == Long.MinValue) largeWindowAsOfTs
+        else math.max(lastLargeRecomputeAsOfTs, largeWindowAsOfTs)
+      updateLargeWindowColumns(runningIr, row, eventDayStart, effectiveLargeAsOfTs)
       store.putRunningLargeIr(runningIr)
       dirty = true
     } else {
@@ -182,25 +222,23 @@ class GigaTileStreamProcessor(
     else GigaEmitResult(null, droppedStaleEvent = droppedStaleEvent)
   }
 
-  /** As-of-driven day transition. Updates currentDayStart and rebuilds the small-window
-    * cache because each column's effectiveStart shifts with the new as-of horizon. Daily
-    * large-IR slots are unaffected — they're keyed by day-start and persist across rollovers
-    * until batch covers them.
+  /** As-of-driven day transition. Finite day jumps rebuild both views so the next callback
+    * cannot combine a corrected small-window cache with stale large-window state.
     */
   def advanceWatermark(watermarkTs: Long): GigaEmitResult = {
     val currentDayStart = store.getCurrentDayStart
     if (currentDayStart == -1L) return GigaEmitResult(null)
     val wmDay = TsUtils.round(watermarkTs, DayMillis)
     if (wmDay > currentDayStart) {
-      val isAdjacentRollover = wmDay == currentDayStart + DayMillis
+      val previousPackedIr = windowedAgg.clone(pack())
       store.putCurrentDayStart(wmDay)
-      // Rebuild only on an adjacent-day transition. Multi-day jumps and end-of-stream
-      // (watermark = MAX) push the as-of so far past retained tiles that everything would be
-      // marked stale and the cache cleared — emitting a spurious null that would overwrite the
-      // PUSH KV row. Leave those cases to the next eviction at a sane timer timestamp.
-      if (isAdjacentRollover && hasSmallWindows) {
-        val previousPackedIr = windowedAgg.clone(pack())
+      // A terminal MAX watermark is not a serving horizon. Rebuilding at MAX would expire
+      // every retained value and publish a synthetic all-null row when a bounded input ends.
+      if (watermarkTs != Long.MaxValue) {
         rebuildCachedSmallWindowIr(watermarkTs, wmDay)
+        // A future batch row is retained but must not become active until its boundary.
+        // Small-window time can still advance while the prior large view remains serving.
+        if (!largeRecomputeDeferred(wmDay)) recomputeRunningLargeIr(watermarkTs, wmDay)
         val packed = pack()
         val packedIsEmpty = isAllNull(packed)
         val previousWasEmpty = isAllNull(previousPackedIr)
@@ -209,33 +247,35 @@ class GigaTileStreamProcessor(
         }
       }
     }
-    GigaEmitResult(null)
+    GigaEmitResult(null, isEmpty = isAllNull(pack()))
   }
 
   /** Direct eviction/serve-as-of: corrects small window sawtooth and large window tail selection. */
   def onEviction(timerTs: Long): GigaEmitResult =
-    runEviction(timerTs, force = true)
+    onEviction(EvictionTimes(timerTs = timerTs, smallWindowAsOfTs = timerTs))
 
-  /** Scheduled eviction used by Flink timers. Timer cadence stays fixed, but a timer that does
-    * not cross a real small or large boundary skips the expensive state rebuilds.
-    */
-  def onScheduledEviction(timerTs: Long): GigaEmitResult =
-    runEviction(timerTs, force = false)
-
-  private def runEviction(timerTs: Long, force: Boolean): GigaEmitResult = {
+  private[chronon] def onEviction(evictionTimes: EvictionTimes): GigaEmitResult = {
     val currentDayStart = store.getCurrentDayStart
     if (currentDayStart == -1L) return GigaEmitResult(null)
 
-    val smallMayChange = force || smallWindowMayChangeAt(timerTs, currentDayStart)
-    val largeMayChange = force || largeIrMayChangeAt(timerTs)
+    val cachedSmallWindowHop = store.getCachedSmallWindowAsOfTs
+    val requestedSmallWindowHop = TsUtils.round(evictionTimes.smallWindowAsOfTs, minSmallWindowTileSize)
+    val cachedSmallWindowHopUnknown = cachedSmallWindowHop < 0L
+    val smallWindowCanAdvance = hasSmallWindows &&
+      (cachedSmallWindowHopUnknown || requestedSmallWindowHop >= cachedSmallWindowHop)
+    val smallMayChange = smallWindowCanAdvance
+    val largeRecomputeIsDeferred = largeRecomputeDeferred(currentDayStart)
+    val largeMayChange = !largeRecomputeIsDeferred
     if (!smallMayChange && !largeMayChange) {
-      return GigaEmitResult(null, isEmpty = isAllNull(pack()))
+      // Do not advance the large recompute marker. A later callback checks the entire gap
+      // from the last materialized horizon, including boundaries skipped by delayed timers.
+      return GigaEmitResult(null, needsEvictionTimer = largeRecomputeIsDeferred, isEmpty = isAllNull(pack()))
     }
 
     val previousPackedIr = windowedAgg.clone(pack())
 
-    if (smallMayChange) rebuildCachedSmallWindowIr(timerTs, currentDayStart)
-    if (largeMayChange) recomputeRunningLargeIr(timerTs, currentDayStart)
+    if (smallMayChange) rebuildCachedSmallWindowIr(evictionTimes.smallWindowAsOfTs, currentDayStart)
+    if (largeMayChange) recomputeRunningLargeIr(evictionTimes.timerTs, currentDayStart)
 
     val packed = pack()
     val packedIsEmpty = isAllNull(packed)
@@ -243,9 +283,11 @@ class GigaTileStreamProcessor(
     if ((packedIsEmpty && previousWasEmpty) || irEqual(previousPackedIr, packed)) {
       // Nothing changed for this key. Suppress redundant KV writes, including fully-decayed
       // idle entities where the previous and current packed IR are both all-null.
-      GigaEmitResult(null, isEmpty = packedIsEmpty)
+      GigaEmitResult(null, needsEvictionTimer = largeRecomputeIsDeferred, isEmpty = packedIsEmpty)
     } else {
-      GigaEmitResult(windowedAgg.finalize(packed), isEmpty = packedIsEmpty)
+      GigaEmitResult(windowedAgg.finalize(packed),
+                     needsEvictionTimer = largeRecomputeIsDeferred,
+                     isEmpty = packedIsEmpty)
     }
   }
 
@@ -296,7 +338,7 @@ class GigaTileStreamProcessor(
   }
 
   /** True when every column in the packed pre-finalize IR is null. Used by the eviction
-    * suppress path and surfaced on GigaEmitResult so the Flink writer can DELETE the KV row.
+    * suppress path and surfaced so Flink can stop scheduling further decay callbacks.
     */
   private def isAllNull(packed: Array[Any]): Boolean = {
     var i = 0
@@ -313,10 +355,19 @@ class GigaTileStreamProcessor(
     * @param newBatchEnd batch upload boundary timestamp (midnight-aligned)
     * @param currentWatermark Flink's current watermark (for tail hop selection as queryTs)
     */
-  def onBatchUpdate(newBatchIr: FinalBatchIr, newBatchEnd: Long, currentWatermark: Long): GigaEmitResult = {
+  def onBatchUpdate(newBatchIr: FinalBatchIr, newBatchEnd: Long, currentWatermark: Long): GigaEmitResult =
+    onBatchUpdate(newBatchIr, newBatchEnd, largeWindowAsOfTs = currentWatermark, smallWindowAsOfTs = currentWatermark)
+
+  private[chronon] def onBatchUpdate(
+      newBatchIr: FinalBatchIr,
+      newBatchEnd: Long,
+      largeWindowAsOfTs: Long,
+      smallWindowAsOfTs: Long
+  ): GigaEmitResult = {
     val oldBatchEnd = store.getBatchEndTs
     if (newBatchEnd <= oldBatchEnd) return GigaEmitResult(null)
 
+    val previousPackedIr = windowedAgg.clone(pack())
     val strippedBatchIr = stripSmallWindowHops(newBatchIr)
     store.putBatchIr(strippedBatchIr)
     store.putBatchEndTs(newBatchEnd)
@@ -330,7 +381,8 @@ class GigaTileStreamProcessor(
         store.putCurrentDayStart(currentDayStart)
       } else {
         // Defer until watermark advances past batchEnd. Daily slots between currentDayStart
-        // and batchEnd would otherwise overlap with batch and double-count.
+        // and batchEnd would otherwise overlap with batch and double-count. Event, timer, and
+        // day-roll recomputation paths all honor largeRecomputeDeferred.
         return GigaEmitResult(null, needsEvictionTimer = true)
       }
     }
@@ -346,116 +398,53 @@ class GigaTileStreamProcessor(
     }
     toRemove.foreach(store.removeDailyLargeIr)
 
-    val oldRunningIr = store.getRunningLargeIr
-    recomputeRunningLargeIr(currentWatermark, currentDayStart)
+    rebuildCachedSmallWindowIr(smallWindowAsOfTs, currentDayStart)
+    recomputeRunningLargeIr(largeWindowAsOfTs, currentDayStart)
+    val packed = pack()
+    val packedIsEmpty = isAllNull(packed)
 
-    val newRunningIr = store.getRunningLargeIr
-
-    if (!irEqual(oldRunningIr, newRunningIr)) {
-      GigaEmitResult(packAndFinalize(), needsEvictionTimer = true)
+    if (!irEqual(previousPackedIr, packed)) {
+      GigaEmitResult(windowedAgg.finalize(packed), needsEvictionTimer = true, isEmpty = packedIsEmpty)
     } else {
-      GigaEmitResult(null, needsEvictionTimer = true)
+      GigaEmitResult(null, needsEvictionTimer = true, isEmpty = packedIsEmpty)
     }
   }
 
   // --- Private helpers ---
 
-  private def previousTimerTs(queryTs: Long): Long =
-    if (queryTs <= Long.MinValue + minEvictionInterval) Long.MinValue else queryTs - minEvictionInterval
+  private def recomputeRunningLargeIrForEventIfNeeded(queryTs: Long, currentDayStart: Long): Boolean = {
+    if (!hasFiniteLargeWindows || largeRecomputeDeferred(currentDayStart)) return false
 
-  private def crossedSincePreviousTimer(queryTs: Long, boundaryTs: Long): Boolean =
-    boundaryTs > previousTimerTs(queryTs) && boundaryTs <= queryTs
-
-  private def smallWindowMayChangeAt(queryTs: Long, currentDayStart: Long): Boolean = {
-    if (!hasSmallWindows || store.getEarliestTileStart == Long.MaxValue) return false
-
-    var col = 0
-    while (col < windowedAgg.length) {
-      val windowMillis = megaTileAgg.columnWindowMillis(col)
-      if (isNoBatch(col) && windowMillis > 0) {
-        val hopSize = columnHopSize(col)
-        val effectiveStart = megaTileAgg.effectiveStart(col, queryTs, currentDayStart)
-        if (effectiveStart >= Long.MinValue + hopSize) {
-          val expiredTileStart = effectiveStart - hopSize
-          if (store.getTile(hopSize, expiredTileStart) != null) return true
-        }
-      }
-      col += 1
+    if (largeIrMayChangeSinceLastRecompute(queryTs)) {
+      recomputeRunningLargeIr(queryTs, currentDayStart)
+      true
+    } else {
+      false
     }
-
-    false
   }
 
-  private def largeIrMayChangeAt(queryTs: Long): Boolean = {
-    val batchIr = store.getBatchIr
-    val batchEndTs = store.getBatchEndTs
-    val batchEndDay = if (batchEndTs > 0) TsUtils.round(batchEndTs, DayMillis) else Long.MinValue
+  private def largeRecomputeDeferred(currentDayStart: Long): Boolean =
+    currentDayStart >= 0L && store.getBatchEndTs > currentDayStart
 
-    if (batchEndDay != Long.MinValue) {
-      val iter = store.dailyLargeIrIterator
-      while (iter.hasNext) {
-        val (dayStart, _) = iter.next()
-        if (dayStart < batchEndDay) return true
-      }
-    }
+  /** True when a finite large-window start crossed its own tail-hop boundary since the exact
+    * prior materialized horizon. Batch ends and daily slots are midnight-aligned, and every
+    * tail hop divides a day, so the same boundary covers collapsed, tail, and daily expiry.
+    * This stays O(columns) on the event path; iterating retained daily state here would decode
+    * every slot for every event until the next real boundary.
+    */
+  private def largeIrMayChangeSinceLastRecompute(queryTs: Long): Boolean = {
+    val previousAsOfTs = store.getLastLargeRecomputeAsOfTs
+    if (previousAsOfTs == Long.MinValue) return true
+    if (queryTs <= previousAsOfTs) return false
 
-    if (batchIr != null && batchEndTs > 0L) {
-      var col = 0
-      while (col < windowedAgg.length) {
-        val windowMillis = megaTileAgg.columnWindowMillis(col)
-        if (!isNoBatch(col) && windowMillis > 0) {
-          val collapsedExpiry = addIfNoOverflow(batchEndTs, windowMillis)
-          if (
-            batchIr.collapsed != null && col < batchIr.collapsed.length &&
-            batchIr.collapsed(col) != null && crossedSincePreviousTimer(queryTs, collapsedExpiry)
-          ) {
-            return true
-          }
-
-          val hopIndex = megaTileAgg.tailHopIndicesArray(col)
-          if (batchIr.tailHops != null && hopIndex < batchIr.tailHops.length && batchIr.tailHops(hopIndex) != null) {
-            val hopSize = megaTileAgg.hopSizesArray(hopIndex)
-            val prevTs = previousTimerTs(queryTs)
-            val previousTail =
-              if (prevTs == Long.MinValue) Long.MinValue
-              else TsUtils.round(subtractIfNoUnderflow(prevTs, windowMillis), hopSize)
-            val queryTail = TsUtils.round(subtractIfNoUnderflow(queryTs, windowMillis), hopSize)
-            if (queryTail > previousTail) {
-              val baseIrIndex = megaTileAgg.baseIrIndicesArray(col)
-              val hopIrs = batchIr.tailHops(hopIndex)
-              var idx = 0
-              while (idx < hopIrs.length) {
-                val hopIr = hopIrs(idx)
-                if (hopIr != null && baseIrIndex < hopIr.length - 1) {
-                  val hopStart = hopIr.last.asInstanceOf[Long]
-                  if (hopStart >= previousTail && hopStart < queryTail && hopIr(baseIrIndex) != null) {
-                    return true
-                  }
-                }
-                idx += 1
-              }
-            }
-          }
-        }
-        col += 1
-      }
-    }
-
-    val columnWindowMillis = megaTileAgg.columnWindowMillis
-    val baseIrIndices = megaTileAgg.baseIrIndicesArray
     var col = 0
     while (col < windowedAgg.length) {
-      val windowMillis = columnWindowMillis(col)
-      if (!isNoBatch(col) && windowMillis > 0 && queryTs >= windowMillis + DayMillis) {
-        val dayStart = TsUtils.round(queryTs - windowMillis - DayMillis, DayMillis)
-        val expiryTs = addIfNoOverflow(addIfNoOverflow(dayStart, DayMillis), windowMillis)
-        if (crossedSincePreviousTimer(queryTs, expiryTs)) {
-          val dayIr = store.getDailyLargeIr(dayStart)
-          val baseIrIndex = baseIrIndices(col)
-          if (dayIr != null && baseIrIndex < dayIr.length && dayIr(baseIrIndex) != null) {
-            return true
-          }
-        }
+      if (isFiniteLargeWindow(col)) {
+        val windowMillis = megaTileAgg.columnWindowMillis(col)
+        val hopSize = columnHopSize(col)
+        val previousStart = TsUtils.round(subtractIfNoUnderflow(previousAsOfTs, windowMillis), hopSize)
+        val queryStart = TsUtils.round(subtractIfNoUnderflow(queryTs, windowMillis), hopSize)
+        if (queryStart > previousStart) return true
       }
       col += 1
     }
@@ -493,7 +482,7 @@ class GigaTileStreamProcessor(
     // windowed column via baseIrIndices, but only for columns whose own window overlaps the
     // slot's date range. Otherwise we'd over-count smaller-window columns by an entire day's
     // worth of out-of-window events.
-    val batchEndDay = if (batchEndTs > 0) TsUtils.round(batchEndTs, DayMillis) else Long.MinValue
+    val batchEndDay = if (batchEndTs >= 0L) TsUtils.round(batchEndTs, DayMillis) else Long.MinValue
     val maxWindowMillis = megaTileAgg.maxWindowMillis
     val columnWindowMillis = megaTileAgg.columnWindowMillis
     val baseIrIndices = megaTileAgg.baseIrIndicesArray
@@ -534,11 +523,12 @@ class GigaTileStreamProcessor(
     // aliased to cached tail-hop or daily-slot IRs; subsequent in-place onEvent updates would
     // then mutate that shared state and corrupt future serves.
     store.putRunningLargeIr(windowedAgg.clone(runningIr))
+    store.putLastLargeRecomputeAsOfTs(queryTs)
   }
 
   /** Rebuild cachedSmallWindowIr from retained tiles using the supplied as-of horizon.
-    * Called from advanceWatermark on day rollover (effective starts shift) and from
-    * onEviction (sawtooth correction at hop boundaries).
+    * Used for day-roll and hop-boundary correction, and before event publication whenever
+    * the cached as-of marker is stale.
     */
   private def rebuildCachedSmallWindowIr(asOfTs: Long, currentDayStart: Long): Unit = {
     if (!hasSmallWindows) return
@@ -569,13 +559,23 @@ class GigaTileStreamProcessor(
 
     val rebuiltIr = megaTileAgg.buildMegaTileIr(tiles, now = asOfTs, batchEnd = currentDayStart)
     store.putCachedSmallWindowIr(rebuiltIr)
+    store.putCachedSmallWindowAsOfTs(TsUtils.round(asOfTs, minSmallWindowTileSize))
   }
 
-  private def updateLargeWindowColumns(ir: Array[Any], row: Row): Unit = {
+  private def updateLargeWindowColumns(
+      ir: Array[Any],
+      row: Row,
+      eventDayStart: Long,
+      effectiveAsOfTs: Long
+  ): Unit = {
+    val slotEnd = addIfNoOverflow(eventDayStart, DayMillis)
     var col = 0
     while (col < windowedAgg.length) {
       if (!isNoBatch(col)) {
-        windowedAgg.columnAggregators(col).update(ir, row)
+        val include =
+          !isFiniteLargeWindow(col) ||
+            slotEnd > subtractIfNoUnderflow(effectiveAsOfTs, megaTileAgg.columnWindowMillis(col))
+        if (include) windowedAgg.columnAggregators(col).update(ir, row)
       }
       col += 1
     }
@@ -626,13 +626,11 @@ class GigaTileStreamProcessor(
 
 case class GigaEmitResult(
     finalizedVector: Array[Any],
-    // True when a non-timer path, such as batch update, wants the next fixed-cadence
-    // eviction timer registered.
+    // True when this key must keep its fixed-cadence eviction timer registered. Batch
+    // updates start the cadence; deferred future batches keep it live even for empty keys.
     needsEvictionTimer: Boolean = false,
-    // True when the packed pre-finalize IR has every column null. The Flink wiring uses this
-    // to (a) DELETE the PUSH KV row instead of writing a row of nulls and (b) decide whether
-    // to keep re-registering decay timers — once a key is fully empty, no further decay is
-    // possible until a new event arrives.
+    // True when the packed pre-finalize IR has every column null. Flink can emit the encoded
+    // all-null correction and stop decay timers; the current sink does not issue a DELETE.
     isEmpty: Boolean = false,
     // True when this onEvent call dropped its event because eventTs was older than the
     // staleness bound. Surfaced so the Flink wiring can bump a metric / log instead of

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStreamProcessor.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStreamProcessor.scala
@@ -182,24 +182,34 @@ class GigaTileStreamProcessor(
     else GigaEmitResult(null, droppedStaleEvent = droppedStaleEvent)
   }
 
-  /** Watermark-driven day transition. Updates currentDayStart and rebuilds the small-window
+  /** As-of-driven day transition. Updates currentDayStart and rebuilds the small-window
     * cache because each column's effectiveStart shifts with the new as-of horizon. Daily
     * large-IR slots are unaffected — they're keyed by day-start and persist across rollovers
     * until batch covers them.
     */
-  def advanceWatermark(watermarkTs: Long): Unit = {
+  def advanceWatermark(watermarkTs: Long): GigaEmitResult = {
     val currentDayStart = store.getCurrentDayStart
-    if (currentDayStart == -1L) return
+    if (currentDayStart == -1L) return GigaEmitResult(null)
     val wmDay = TsUtils.round(watermarkTs, DayMillis)
     if (wmDay > currentDayStart) {
       val isAdjacentRollover = wmDay == currentDayStart + DayMillis
       store.putCurrentDayStart(wmDay)
-      // Rebuild only on the adjacent-day case Bug B targets. Multi-day jumps and end-of-stream
+      // Rebuild only on an adjacent-day transition. Multi-day jumps and end-of-stream
       // (watermark = MAX) push the as-of so far past retained tiles that everything would be
       // marked stale and the cache cleared — emitting a spurious null that would overwrite the
-      // PUSH KV row. Leave those cases to the next event-time eviction at a sane timer ts.
-      if (isAdjacentRollover) rebuildCachedSmallWindowIr(watermarkTs, wmDay)
+      // PUSH KV row. Leave those cases to the next eviction at a sane timer timestamp.
+      if (isAdjacentRollover && hasSmallWindows) {
+        val previousPackedIr = windowedAgg.clone(pack())
+        rebuildCachedSmallWindowIr(watermarkTs, wmDay)
+        val packed = pack()
+        val packedIsEmpty = isAllNull(packed)
+        val previousWasEmpty = isAllNull(previousPackedIr)
+        if (!((packedIsEmpty && previousWasEmpty) || irEqual(previousPackedIr, packed))) {
+          return GigaEmitResult(windowedAgg.finalize(packed), isEmpty = packedIsEmpty)
+        }
+      }
     }
+    GigaEmitResult(null)
   }
 
   /** Direct eviction/serve-as-of: corrects small window sawtooth and large window tail selection. */
@@ -395,8 +405,10 @@ class GigaTileStreamProcessor(
         val windowMillis = megaTileAgg.columnWindowMillis(col)
         if (!isNoBatch(col) && windowMillis > 0) {
           val collapsedExpiry = addIfNoOverflow(batchEndTs, windowMillis)
-          if (batchIr.collapsed != null && col < batchIr.collapsed.length &&
-              batchIr.collapsed(col) != null && crossedSincePreviousTimer(queryTs, collapsedExpiry)) {
+          if (
+            batchIr.collapsed != null && col < batchIr.collapsed.length &&
+            batchIr.collapsed(col) != null && crossedSincePreviousTimer(queryTs, collapsedExpiry)
+          ) {
             return true
           }
 
@@ -590,6 +602,12 @@ class GigaTileStreamProcessor(
   }
 
   private[windowing] def packAndFinalize(): Array[Any] = windowedAgg.finalize(pack())
+
+  /** Snapshot the current value without moving either aggregation clock. */
+  private[chronon] def currentSnapshot: GigaEmitResult = {
+    val packed = pack()
+    GigaEmitResult(windowedAgg.finalize(packed), isEmpty = isAllNull(packed))
+  }
 
   /** Strip tail hops that are only used by small windows to reduce state size.
     * 5-min hops for ≤12h windows are never consumed by mergeTailHopsForBatchColumns.

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStreamProcessor.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStreamProcessor.scala
@@ -59,6 +59,8 @@ class GigaTileStreamProcessor(
 
   val hasSmallWindows: Boolean = smallWindowTiers.nonEmpty
 
+  val hasBatchBackedColumns: Boolean = isNoBatch.contains(false)
+
   // Eviction cadence: smallest hop across ALL windows (not just small).
   // Large-window-only GroupBys need eviction for tail hop correction.
   val minEvictionInterval: Long = megaTileAgg.activeTiers.min
@@ -411,6 +413,26 @@ class GigaTileStreamProcessor(
     } else {
       GigaEmitResult(null, needsEvictionTimer = true, isEmpty = packedIsEmpty)
     }
+  }
+
+  /** Treat a first-seen key as having no historical batch contribution.
+    *
+    * This only installs the empty baseline. It deliberately leaves batchEndTs unchanged so a
+    * later real batch row remains authoritative and retained live slots are not pruned early.
+    */
+  private[chronon] def initializeEmptyBatchIr(
+      largeWindowAsOfTs: Long,
+      installEmptyBatchIr: FinalBatchIr => Unit
+  ): GigaEmitResult = {
+    if (store.getBatchIr != null) return GigaEmitResult(null)
+
+    installEmptyBatchIr(megaTileAgg.finalizeSnapshot(megaTileAgg.init))
+    val currentDayStart = store.getCurrentDayStart
+    if (currentDayStart >= 0L) recomputeRunningLargeIr(largeWindowAsOfTs, currentDayStart)
+
+    val packed = pack()
+    val packedIsEmpty = isAllNull(packed)
+    GigaEmitResult(windowedAgg.finalize(packed), needsEvictionTimer = true, isEmpty = packedIsEmpty)
   }
 
   // --- Private helpers ---

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStreamProcessor.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStreamProcessor.scala
@@ -65,8 +65,6 @@ class GigaTileStreamProcessor(
   private def defaultSmallWindowAsOfTs(eventTs: Long): Long =
     TsUtils.round(eventTs, minSmallWindowTileSize) + minSmallWindowTileSize
 
-  private var lastEvictionPackedIr: Array[Any] = _
-
   // Hop indices only used by small (NO BATCH) windows — stripped from batch IR on load.
   // 5-min tail hops for ≤12h windows are never used by mergeTailHopsForBatchColumns.
   private[windowing] val smallWindowOnlyHopIndices: Set[Int] = {
@@ -81,6 +79,12 @@ class GigaTileStreamProcessor(
     }
     (0 until megaTileAgg.hopSizesArray.length).filterNot(usedByBatch.contains(_)).toSet
   }
+
+  private def addIfNoOverflow(a: Long, b: Long): Long =
+    if (a > Long.MaxValue - b) Long.MaxValue else a + b
+
+  private def subtractIfNoUnderflow(a: Long, b: Long): Long =
+    if (a < Long.MinValue + b) Long.MinValue else a - b
 
   def onEvent(row: Row, eventTs: Long): GigaEmitResult = onEvent(row, eventTs, defaultSmallWindowAsOfTs(eventTs))
 
@@ -198,26 +202,39 @@ class GigaTileStreamProcessor(
     }
   }
 
-  /** Periodic eviction: corrects small window sawtooth and large window tail hop selection. */
-  def onEviction(timerTs: Long): GigaEmitResult = {
+  /** Direct eviction/serve-as-of: corrects small window sawtooth and large window tail selection. */
+  def onEviction(timerTs: Long): GigaEmitResult =
+    runEviction(timerTs, force = true)
+
+  /** Scheduled eviction used by Flink timers. Timer cadence stays fixed, but a timer that does
+    * not cross a real small or large boundary skips the expensive state rebuilds.
+    */
+  def onScheduledEviction(timerTs: Long): GigaEmitResult =
+    runEviction(timerTs, force = false)
+
+  private def runEviction(timerTs: Long, force: Boolean): GigaEmitResult = {
     val currentDayStart = store.getCurrentDayStart
     if (currentDayStart == -1L) return GigaEmitResult(null)
 
-    rebuildCachedSmallWindowIr(timerTs, currentDayStart)
-    recomputeRunningLargeIr(timerTs, currentDayStart)
+    val smallMayChange = force || smallWindowMayChangeAt(timerTs, currentDayStart)
+    val largeMayChange = force || largeIrMayChangeAt(timerTs)
+    if (!smallMayChange && !largeMayChange) {
+      return GigaEmitResult(null, isEmpty = isAllNull(pack()))
+    }
+
+    val previousPackedIr = windowedAgg.clone(pack())
+
+    if (smallMayChange) rebuildCachedSmallWindowIr(timerTs, currentDayStart)
+    if (largeMayChange) recomputeRunningLargeIr(timerTs, currentDayStart)
 
     val packed = pack()
     val packedIsEmpty = isAllNull(packed)
-    val previousWasEmpty = lastEvictionPackedIr != null && isAllNull(lastEvictionPackedIr)
-    if (packedIsEmpty && previousWasEmpty) {
-      // Both rebuilds produced all-null vectors — nothing has changed and nothing more can
-      // decay until a new event arrives. Suppress to avoid burning a KV write per eviction
-      // for fully-decayed idle entities.
-      GigaEmitResult(null, isEmpty = true)
-    } else if (lastEvictionPackedIr != null && irEqual(lastEvictionPackedIr, packed)) {
+    val previousWasEmpty = isAllNull(previousPackedIr)
+    if ((packedIsEmpty && previousWasEmpty) || irEqual(previousPackedIr, packed)) {
+      // Nothing changed for this key. Suppress redundant KV writes, including fully-decayed
+      // idle entities where the previous and current packed IR are both all-null.
       GigaEmitResult(null, isEmpty = packedIsEmpty)
     } else {
-      lastEvictionPackedIr = windowedAgg.clone(packed)
       GigaEmitResult(windowedAgg.finalize(packed), isEmpty = packedIsEmpty)
     }
   }
@@ -333,6 +350,107 @@ class GigaTileStreamProcessor(
 
   // --- Private helpers ---
 
+  private def previousTimerTs(queryTs: Long): Long =
+    if (queryTs <= Long.MinValue + minEvictionInterval) Long.MinValue else queryTs - minEvictionInterval
+
+  private def crossedSincePreviousTimer(queryTs: Long, boundaryTs: Long): Boolean =
+    boundaryTs > previousTimerTs(queryTs) && boundaryTs <= queryTs
+
+  private def smallWindowMayChangeAt(queryTs: Long, currentDayStart: Long): Boolean = {
+    if (!hasSmallWindows || store.getEarliestTileStart == Long.MaxValue) return false
+
+    var col = 0
+    while (col < windowedAgg.length) {
+      val windowMillis = megaTileAgg.columnWindowMillis(col)
+      if (isNoBatch(col) && windowMillis > 0) {
+        val hopSize = columnHopSize(col)
+        val effectiveStart = megaTileAgg.effectiveStart(col, queryTs, currentDayStart)
+        if (effectiveStart >= Long.MinValue + hopSize) {
+          val expiredTileStart = effectiveStart - hopSize
+          if (store.getTile(hopSize, expiredTileStart) != null) return true
+        }
+      }
+      col += 1
+    }
+
+    false
+  }
+
+  private def largeIrMayChangeAt(queryTs: Long): Boolean = {
+    val batchIr = store.getBatchIr
+    val batchEndTs = store.getBatchEndTs
+    val batchEndDay = if (batchEndTs > 0) TsUtils.round(batchEndTs, DayMillis) else Long.MinValue
+
+    if (batchEndDay != Long.MinValue) {
+      val iter = store.dailyLargeIrIterator
+      while (iter.hasNext) {
+        val (dayStart, _) = iter.next()
+        if (dayStart < batchEndDay) return true
+      }
+    }
+
+    if (batchIr != null && batchEndTs > 0L) {
+      var col = 0
+      while (col < windowedAgg.length) {
+        val windowMillis = megaTileAgg.columnWindowMillis(col)
+        if (!isNoBatch(col) && windowMillis > 0) {
+          val collapsedExpiry = addIfNoOverflow(batchEndTs, windowMillis)
+          if (batchIr.collapsed != null && col < batchIr.collapsed.length &&
+              batchIr.collapsed(col) != null && crossedSincePreviousTimer(queryTs, collapsedExpiry)) {
+            return true
+          }
+
+          val hopIndex = megaTileAgg.tailHopIndicesArray(col)
+          if (batchIr.tailHops != null && hopIndex < batchIr.tailHops.length && batchIr.tailHops(hopIndex) != null) {
+            val hopSize = megaTileAgg.hopSizesArray(hopIndex)
+            val prevTs = previousTimerTs(queryTs)
+            val previousTail =
+              if (prevTs == Long.MinValue) Long.MinValue
+              else TsUtils.round(subtractIfNoUnderflow(prevTs, windowMillis), hopSize)
+            val queryTail = TsUtils.round(subtractIfNoUnderflow(queryTs, windowMillis), hopSize)
+            if (queryTail > previousTail) {
+              val baseIrIndex = megaTileAgg.baseIrIndicesArray(col)
+              val hopIrs = batchIr.tailHops(hopIndex)
+              var idx = 0
+              while (idx < hopIrs.length) {
+                val hopIr = hopIrs(idx)
+                if (hopIr != null && baseIrIndex < hopIr.length - 1) {
+                  val hopStart = hopIr.last.asInstanceOf[Long]
+                  if (hopStart >= previousTail && hopStart < queryTail && hopIr(baseIrIndex) != null) {
+                    return true
+                  }
+                }
+                idx += 1
+              }
+            }
+          }
+        }
+        col += 1
+      }
+    }
+
+    val columnWindowMillis = megaTileAgg.columnWindowMillis
+    val baseIrIndices = megaTileAgg.baseIrIndicesArray
+    var col = 0
+    while (col < windowedAgg.length) {
+      val windowMillis = columnWindowMillis(col)
+      if (!isNoBatch(col) && windowMillis > 0 && queryTs >= windowMillis + DayMillis) {
+        val dayStart = TsUtils.round(queryTs - windowMillis - DayMillis, DayMillis)
+        val expiryTs = addIfNoOverflow(addIfNoOverflow(dayStart, DayMillis), windowMillis)
+        if (crossedSincePreviousTimer(queryTs, expiryTs)) {
+          val dayIr = store.getDailyLargeIr(dayStart)
+          val baseIrIndex = baseIrIndices(col)
+          if (dayIr != null && baseIrIndex < dayIr.length && dayIr(baseIrIndex) != null) {
+            return true
+          }
+        }
+      }
+      col += 1
+    }
+
+    false
+  }
+
   /** Recompute runningLargeIr from: batch (collapsed + tail hops) + every retained daily slot
     * with dayStart >= batchEndDay. For columns where the entire window has moved past
     * batchEndTs, the collapsed value is stale — zero it out so stale batch data doesn't
@@ -373,7 +491,9 @@ class GigaTileStreamProcessor(
       val (dayStart, dayIr) = iter.next()
       val slotEnd = dayStart + DayMillis
       // Slot entirely outside the largest window — useful to no column. Drop from state.
-      if (maxWindowMillis > 0 && slotEnd <= queryTs - maxWindowMillis) {
+      if (dayStart < batchEndDay) {
+        toEvict += dayStart
+      } else if (maxWindowMillis > 0 && slotEnd <= queryTs - maxWindowMillis) {
         toEvict += dayStart
       } else if (dayStart >= batchEndDay && dayIr != null) {
         var col = 0
@@ -488,6 +608,8 @@ class GigaTileStreamProcessor(
 
 case class GigaEmitResult(
     finalizedVector: Array[Any],
+    // True when a non-timer path, such as batch update, wants the next fixed-cadence
+    // eviction timer registered.
     needsEvictionTimer: Boolean = false,
     // True when the packed pre-finalize IR has every column null. The Flink wiring uses this
     // to (a) DELETE the PUSH KV row instead of writing a row of nulls and (b) decide whether

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStreamProcessor.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStreamProcessor.scala
@@ -10,7 +10,7 @@ private[chronon] final case class EvictionTimes(timerTs: Long, smallWindowAsOfTs
 /** Pure Scala state manager for the GigaTile streaming pipeline.
   *
   * Flink holds the FinalBatchIr in state (loaded from Iceberg) and one daily large-window
-  * IR slot per day with streaming events between batchEndDay and the watermark day. The
+  * IR slot per day with streaming events between batchEndDay and the current materialized day. The
   * runningLargeIr cache is the merged batch + every retained daily slot, refreshed on
   * eviction and on batch update.
   *
@@ -225,20 +225,20 @@ class GigaTileStreamProcessor(
   /** As-of-driven day transition. Finite day jumps rebuild both views so the next callback
     * cannot combine a corrected small-window cache with stale large-window state.
     */
-  def advanceWatermark(watermarkTs: Long): GigaEmitResult = {
+  def advanceDayAsOf(asOfTs: Long): GigaEmitResult = {
     val currentDayStart = store.getCurrentDayStart
     if (currentDayStart == -1L) return GigaEmitResult(null)
-    val wmDay = TsUtils.round(watermarkTs, DayMillis)
-    if (wmDay > currentDayStart) {
+    val asOfDay = TsUtils.round(asOfTs, DayMillis)
+    if (asOfDay > currentDayStart) {
       val previousPackedIr = windowedAgg.clone(pack())
-      store.putCurrentDayStart(wmDay)
-      // A terminal MAX watermark is not a serving horizon. Rebuilding at MAX would expire
-      // every retained value and publish a synthetic all-null row when a bounded input ends.
-      if (watermarkTs != Long.MaxValue) {
-        rebuildCachedSmallWindowIr(watermarkTs, wmDay)
+      store.putCurrentDayStart(asOfDay)
+      // A terminal Long.MaxValue horizon from a bounded watermark is not a serving horizon.
+      // Rebuilding there would expire every retained value and publish a synthetic all-null row.
+      if (asOfTs != Long.MaxValue) {
+        rebuildCachedSmallWindowIr(asOfTs, asOfDay)
         // A future batch row is retained but must not become active until its boundary.
         // Small-window time can still advance while the prior large view remains serving.
-        if (!largeRecomputeDeferred(wmDay)) recomputeRunningLargeIr(watermarkTs, wmDay)
+        if (!largeRecomputeDeferred(asOfDay)) recomputeRunningLargeIr(asOfTs, asOfDay)
         val packed = pack()
         val packedIsEmpty = isAllNull(packed)
         val previousWasEmpty = isAllNull(previousPackedIr)
@@ -249,6 +249,9 @@ class GigaTileStreamProcessor(
     }
     GigaEmitResult(null, isEmpty = isAllNull(pack()))
   }
+
+  // Compatibility wrapper for callers that still pass an event-time watermark directly.
+  def advanceWatermark(watermarkTs: Long): GigaEmitResult = advanceDayAsOf(watermarkTs)
 
   /** Direct eviction/serve-as-of: corrects small window sawtooth and large window tail selection. */
   def onEviction(timerTs: Long): GigaEmitResult =
@@ -380,9 +383,9 @@ class GigaTileStreamProcessor(
         currentDayStart = newBatchEnd
         store.putCurrentDayStart(currentDayStart)
       } else {
-        // Defer until watermark advances past batchEnd. Daily slots between currentDayStart
-        // and batchEnd would otherwise overlap with batch and double-count. Event, timer, and
-        // day-roll recomputation paths all honor largeRecomputeDeferred.
+        // Defer until the selected large-window as-of day reaches batchEnd. Daily slots between
+        // currentDayStart and batchEnd would otherwise overlap with batch and double-count. Event,
+        // timer, and day-roll recomputation paths all honor largeRecomputeDeferred.
         return GigaEmitResult(null, needsEvictionTimer = true)
       }
     }
@@ -494,7 +497,7 @@ class GigaTileStreamProcessor(
       // Slot entirely outside the largest window — useful to no column. Drop from state.
       if (dayStart < batchEndDay) {
         toEvict += dayStart
-      } else if (maxWindowMillis > 0 && slotEnd <= queryTs - maxWindowMillis) {
+      } else if (maxWindowMillis > 0 && maxWindowMillis < Long.MaxValue && slotEnd <= queryTs - maxWindowMillis) {
         toEvict += dayStart
       } else if (dayStart >= batchEndDay && dayIr != null) {
         var col = 0
@@ -606,7 +609,9 @@ class GigaTileStreamProcessor(
   /** Snapshot the current value without moving either aggregation clock. */
   private[chronon] def currentSnapshot: GigaEmitResult = {
     val packed = pack()
-    GigaEmitResult(windowedAgg.finalize(packed), isEmpty = isAllNull(packed))
+    GigaEmitResult(windowedAgg.finalize(packed),
+                   needsEvictionTimer = largeRecomputeDeferred(store.getCurrentDayStart),
+                   isEmpty = isAllNull(packed))
   }
 
   /** Strip tail hops that are only used by small windows to reduce state size.

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStreamProcessor.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStreamProcessor.scala
@@ -152,13 +152,18 @@ class GigaTileStreamProcessor(
     // see them immediately), and recomputeRunningLargeIr will drop their daily slot at the
     // next eviction — matching the original "incremental shows it, eviction may drop it"
     // trade-off when the late event was not in the prior batch's source data.
+    //
+    // Daily slot IRs are sized to the BASE aggregator (one column per (op, input)) — not
+    // the windowed aggregator. The same SUM(num) value covers every windowed SUM(num, W)
+    // column when fanned out at recompute time via baseIrIndices. Saves N× state and
+    // update cost when the same input appears in many window sizes.
     val eventDayStart = TsUtils.round(eventTs, DayMillis)
     val oldestAcceptedDay = currentDayStart - maxStalenessMillis
     var droppedStaleEvent = false
     if (eventDayStart >= oldestAcceptedDay) {
       val existing = store.getDailyLargeIr(eventDayStart)
-      val dayIr = if (existing != null) existing else windowedAgg.init
-      updateLargeWindowColumns(dayIr, row)
+      val dayIr = if (existing != null) existing else baseAgg.init
+      baseAgg.update(dayIr, row)
       store.putDailyLargeIr(eventDayStart, dayIr)
 
       val runningIr = store.getRunningLargeIr
@@ -352,20 +357,45 @@ class GigaTileStreamProcessor(
       windowedAgg.init
     }
 
+    // Slot eviction (state size): drop slots whose [dayStart, dayStart+1d) is entirely older
+    // than the largest column window — they cannot contribute to any column.
+    // Per-column merge (correctness): for retained slots, fan out from base-IR shape to each
+    // windowed column via baseIrIndices, but only for columns whose own window overlaps the
+    // slot's date range. Otherwise we'd over-count smaller-window columns by an entire day's
+    // worth of out-of-window events.
     val batchEndDay = if (batchEndTs > 0) TsUtils.round(batchEndTs, DayMillis) else Long.MinValue
+    val maxWindowMillis = megaTileAgg.maxWindowMillis
+    val columnWindowMillis = megaTileAgg.columnWindowMillis
+    val baseIrIndices = megaTileAgg.baseIrIndicesArray
+    val toEvict = mutable.ArrayBuffer.empty[Long]
     val iter = store.dailyLargeIrIterator
     while (iter.hasNext) {
       val (dayStart, dayIr) = iter.next()
-      if (dayStart >= batchEndDay && dayIr != null) {
+      val slotEnd = dayStart + DayMillis
+      // Slot entirely outside the largest window — useful to no column. Drop from state.
+      if (maxWindowMillis > 0 && slotEnd <= queryTs - maxWindowMillis) {
+        toEvict += dayStart
+      } else if (dayStart >= batchEndDay && dayIr != null) {
         var col = 0
         while (col < windowedAgg.length) {
-          if (!isNoBatch(col) && dayIr(col) != null) {
-            runningIr(col) = windowedAgg.columnAggregators(col).merge(runningIr(col), dayIr(col))
+          if (!isNoBatch(col)) {
+            val baseSlotValue = dayIr(baseIrIndices(col))
+            if (baseSlotValue != null) {
+              // Per-column window overlap: slot's [dayStart, slotEnd) must intersect the
+              // column's window [queryTs - colWindow, queryTs]. Unwindowed columns
+              // (colWindow < 0) always include all events ever.
+              val colWindow = columnWindowMillis(col)
+              val include = colWindow < 0 || slotEnd > queryTs - colWindow
+              if (include) {
+                runningIr(col) = windowedAgg.columnAggregators(col).merge(runningIr(col), baseSlotValue)
+              }
+            }
           }
           col += 1
         }
       }
     }
+    toEvict.foreach(store.removeDailyLargeIr)
 
     // Some column aggregators (FIRST, LAST, and similar non-mutating reducers) return one of
     // their merge inputs by reference. Without re-cloning, runningIr columns can end up

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStreamProcessor.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStreamProcessor.scala
@@ -604,7 +604,7 @@ class GigaTileStreamProcessor(
     packed
   }
 
-  private[windowing] def packAndFinalize(): Array[Any] = windowedAgg.finalize(pack())
+  private[chronon] def packAndFinalize(): Array[Any] = windowedAgg.finalize(pack())
 
   /** Snapshot the current value without moving either aggregation clock. */
   private[chronon] def currentSnapshot: GigaEmitResult = {

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStreamProcessor.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStreamProcessor.scala
@@ -7,26 +7,33 @@ import scala.collection.mutable
 
 /** Pure Scala state manager for the GigaTile streaming pipeline.
   *
-  * Extends the MegaTile approach: Flink holds batch IR in state (loaded from Iceberg)
-  * and maintains a runningLargeIr that's the fully merged value (batch + streaming).
-  * Emits finalized feature vectors instead of windowed IRs.
+  * Flink holds the FinalBatchIr in state (loaded from Iceberg) and one daily large-window
+  * IR slot per day with streaming events between batchEndDay and the watermark day. The
+  * runningLargeIr cache is the merged batch + every retained daily slot, refreshed on
+  * eviction and on batch update.
   *
-  * State layout (extends MegaTile):
-  *   - tiles, cachedSmallWindowIr: unchanged (small window sawtooth)
-  *   - largeTodayIr, largeYesterdayIr: unchanged (daily accumulators)
+  * State layout:
+  *   - tiles, cachedSmallWindowIr: small-window sawtooth (per-hop tile state + cached IR)
+  *   - dailyLargeIrs: per-day accumulator keyed by day-start. Slots with dayStart < batchEndDay
+  *     are pruned when batch advances (their data is now in batch).
   *   - batchIr: FinalBatchIr from Iceberg (collapsed + tail hops)
   *   - batchEndTs: when batch was last computed
-  *   - runningLargeIr: fully merged large window IR (batch + streaming)
+  *   - runningLargeIr: fully merged large-window IR (batch + every retained daily slot)
   */
 class GigaTileStreamProcessor(
     val megaTileAgg: MegaTileAggregator,
     val store: GigaTileStore,
     // Returns true if two windowed IRs are equal (for batch update mismatch detection).
     // Default: always report mismatch (always emit on batch update).
-    val irEqual: (Array[Any], Array[Any]) => Boolean = (_, _) => false
+    val irEqual: (Array[Any], Array[Any]) => Boolean = (_, _) => false,
+    // Bound on how stale the batch can get before late events for the oldest covered days
+    // are dropped. Keeps daily-IR state from growing unbounded if the Iceberg connected
+    // stream stalls. 32 days is well past any realistic batch SLA.
+    val maxBatchStalenessDays: Int = 32
 ) {
 
   val DayMillis: Long = 24 * 3600 * 1000L
+  private val maxStalenessMillis: Long = maxBatchStalenessDays.toLong * DayMillis
 
   private val windowedAgg = megaTileAgg.windowedAggregator
   private val baseAgg = megaTileAgg.baseAggregator
@@ -49,8 +56,15 @@ class GigaTileStreamProcessor(
   // Large-window-only GroupBys need eviction for tail hop correction.
   val minEvictionInterval: Long = megaTileAgg.activeTiers.min
 
-  // Tracks the packed IR from the last eviction emit. Used to suppress redundant KV writes
-  // when nothing changed between evictions (idle entities, no tail hop shift).
+  val minSmallWindowTileSize: Long = if (smallWindowTiers.nonEmpty) smallWindowTiers.min else minEvictionInterval
+
+  // Default as-of bumped to the next small-window hop boundary so an event at exactly eventTs
+  // is included in its own emit (chronon's as-of is exclusive). Production callers should pass
+  // smallWindowAsOfTs explicitly — derived from processingTs / watermark — so retained late
+  // events don't get their own permissive horizon.
+  private def defaultSmallWindowAsOfTs(eventTs: Long): Long =
+    TsUtils.round(eventTs, minSmallWindowTileSize) + minSmallWindowTileSize
+
   private var lastEvictionPackedIr: Array[Any] = _
 
   // Hop indices only used by small (NO BATCH) windows — stripped from batch IR on load.
@@ -60,7 +74,6 @@ class GigaTileStreamProcessor(
     var col = 0
     while (col < windowedAgg.length) {
       val window = megaTileAgg.windowMappings(col).aggregationPart.window
-      // Only windowed BATCH columns actually use tail hops
       if (!isNoBatch(col) && window != null) {
         usedByBatch += megaTileAgg.tailHopIndicesArray(col)
       }
@@ -69,7 +82,14 @@ class GigaTileStreamProcessor(
     (0 until megaTileAgg.hopSizesArray.length).filterNot(usedByBatch.contains(_)).toSet
   }
 
-  def onEvent(row: Row, eventTs: Long): GigaEmitResult = {
+  def onEvent(row: Row, eventTs: Long): GigaEmitResult = onEvent(row, eventTs, defaultSmallWindowAsOfTs(eventTs))
+
+  /** smallWindowAsOfTs is the as-of timestamp used to gate cached small-window IR updates.
+    * Late retained events still update the underlying base tile (so a future eviction can
+    * rebuild correctly), but only events inside each column's effective horizon contribute
+    * to the live cached IR that gets emitted.
+    */
+  def onEvent(row: Row, eventTs: Long, smallWindowAsOfTs: Long): GigaEmitResult = {
     var currentDayStart = store.getCurrentDayStart
     if (currentDayStart == -1L) {
       currentDayStart = TsUtils.round(eventTs, DayMillis)
@@ -78,9 +98,10 @@ class GigaTileStreamProcessor(
 
     var dirty = false
 
-    // --- Small windows: update tiles + cachedSmallWindowIr ---
+    // --- Small windows: update tiles, then update cached IR only for columns whose
+    // tile lies inside the smallWindowAsOfTs horizon. ---
     if (hasSmallWindows) {
-      var tilesUpdated = false
+      val acceptedTileStarts = mutable.Map.empty[Long, Long]
       val tileStarts = megaTileAgg.tileStartsForEvent(eventTs)
       for ((hopSize, tileStart) <- tileStarts) {
         if (smallWindowTiers.contains(hopSize)) {
@@ -93,76 +114,78 @@ class GigaTileStreamProcessor(
             store.putTile(hopSize, tileStart, ir)
             val earliest = store.getEarliestTileStart
             if (tileStart < earliest) store.putEarliestTileStart(tileStart)
-            tilesUpdated = true
+            acceptedTileStarts(hopSize) = tileStart
           }
         }
       }
 
-      if (tilesUpdated) {
-        val cachedIr = store.getCachedSmallWindowIr
+      if (acceptedTileStarts.nonEmpty) {
+        var cachedIr: Array[Any] = null
+        var cachedIrUpdated = false
         var col = 0
         while (col < windowedAgg.length) {
           if (isNoBatch(col)) {
-            windowedAgg.columnAggregators(col).update(cachedIr, row)
+            val hopSize = columnHopSize(col)
+            acceptedTileStarts.get(hopSize).foreach { tileStart =>
+              val effStart = megaTileAgg.effectiveStart(col, smallWindowAsOfTs, currentDayStart)
+              // Retained late events: keep the base tile but skip cached-IR update so the live
+              // emit reflects only events inside the as-of horizon for this column's window.
+              if (tileStart >= effStart && tileStart < smallWindowAsOfTs) {
+                if (cachedIr == null) cachedIr = store.getCachedSmallWindowIr
+                windowedAgg.columnAggregators(col).update(cachedIr, row)
+                cachedIrUpdated = true
+              }
+            }
           }
           col += 1
         }
-        store.putCachedSmallWindowIr(cachedIr)
-        dirty = true
+        if (cachedIrUpdated) {
+          store.putCachedSmallWindowIr(cachedIr)
+          dirty = true
+        }
       }
     }
 
-    // --- Large windows: update daily accumulator AND running sum ---
-    val todayStart = currentDayStart
-    val nextDayStart = todayStart + DayMillis
-    val yesterdayStart = todayStart - DayMillis
+    // --- Large windows: route to the per-day slot for round(eventTs, DayMillis) ---
+    // Accept events as far back as the staleness bound. Events whose dayStart is already
+    // covered by batch are still accepted for the incremental running IR (so onEvent emits
+    // see them immediately), and recomputeRunningLargeIr will drop their daily slot at the
+    // next eviction — matching the original "incremental shows it, eviction may drop it"
+    // trade-off when the late event was not in the prior batch's source data.
+    val eventDayStart = TsUtils.round(eventTs, DayMillis)
+    val oldestAcceptedDay = currentDayStart - maxStalenessMillis
+    if (eventDayStart >= oldestAcceptedDay) {
+      val existing = store.getDailyLargeIr(eventDayStart)
+      val dayIr = if (existing != null) existing else windowedAgg.init
+      updateLargeWindowColumns(dayIr, row)
+      store.putDailyLargeIr(eventDayStart, dayIr)
 
-    if (eventTs >= nextDayStart) {
-      // Future event — clamp to today. Day transitions are watermark-driven.
-      val todayIr = store.getLargeTodayIr
-      updateLargeWindowColumns(todayIr, row)
-      store.putLargeTodayIr(todayIr)
-      val runningIr = store.getRunningLargeIr
-      updateLargeWindowColumns(runningIr, row)
-      store.putRunningLargeIr(runningIr)
-      dirty = true
-    } else if (eventTs >= todayStart) {
-      val todayIr = store.getLargeTodayIr
-      updateLargeWindowColumns(todayIr, row)
-      store.putLargeTodayIr(todayIr)
-      val runningIr = store.getRunningLargeIr
-      updateLargeWindowColumns(runningIr, row)
-      store.putRunningLargeIr(runningIr)
-      dirty = true
-    } else if (eventTs >= yesterdayStart) {
-      // Late event from yesterday — within 2d tolerance
-      val yesterdayIr = store.getLargeYesterdayIr
-      updateLargeWindowColumns(yesterdayIr, row)
-      store.putLargeYesterdayIr(yesterdayIr)
       val runningIr = store.getRunningLargeIr
       updateLargeWindowColumns(runningIr, row)
       store.putRunningLargeIr(runningIr)
       dirty = true
     }
-    // Events < yesterdayStart: dropped for large windows (> 2d late)
 
     if (dirty) GigaEmitResult(packAndFinalize()) else GigaEmitResult(null)
   }
 
-  /** Watermark-driven day transition. runningLargeIr is NOT reset — it's cumulative.
-    * Eviction corrects tail hop selection at the next timer firing.
+  /** Watermark-driven day transition. Updates currentDayStart and rebuilds the small-window
+    * cache because each column's effectiveStart shifts with the new as-of horizon. Daily
+    * large-IR slots are unaffected — they're keyed by day-start and persist across rollovers
+    * until batch covers them.
     */
   def advanceWatermark(watermarkTs: Long): Unit = {
     val currentDayStart = store.getCurrentDayStart
     if (currentDayStart == -1L) return
     val wmDay = TsUtils.round(watermarkTs, DayMillis)
     if (wmDay > currentDayStart) {
-      val newYesterday =
-        if (wmDay == currentDayStart + DayMillis) store.getLargeTodayIr
-        else windowedAgg.init
-      store.putLargeYesterdayIr(newYesterday)
-      store.putLargeTodayIr(windowedAgg.init)
+      val isAdjacentRollover = wmDay == currentDayStart + DayMillis
       store.putCurrentDayStart(wmDay)
+      // Rebuild only on the adjacent-day case Bug B targets. Multi-day jumps and end-of-stream
+      // (watermark = MAX) push the as-of so far past retained tiles that everything would be
+      // marked stale and the cache cleared — emitting a spurious null that would overwrite the
+      // PUSH KV row. Leave those cases to the next event-time eviction at a sane timer ts.
+      if (isAdjacentRollover) rebuildCachedSmallWindowIr(watermarkTs, wmDay)
     }
   }
 
@@ -171,42 +194,9 @@ class GigaTileStreamProcessor(
     val currentDayStart = store.getCurrentDayStart
     if (currentDayStart == -1L) return GigaEmitResult(null)
 
-    // --- Small windows: evict stale tiles, rebuild cachedSmallWindowIr ---
-    if (hasSmallWindows) {
-      val earliest = store.getEarliestTileStart
-      if (earliest != Long.MaxValue) {
-        val staleEntries = mutable.ArrayBuffer.empty[(Long, Long)]
-        val iter = store.tileIterator
-        while (iter.hasNext) {
-          val (hopSize, tileStart, _) = iter.next()
-          if (smallWindowTiers.contains(hopSize)) {
-            val floor = megaTileAgg.retentionFloor(hopSize, timerTs, currentDayStart)
-            if (tileStart < floor) staleEntries += ((hopSize, tileStart))
-          }
-        }
-        staleEntries.foreach { case (h, t) => store.removeTile(h, t) }
-
-        val tiles: Map[Long, mutable.Map[Long, Array[Any]]] =
-          smallWindowTiers.map(hop => hop -> mutable.Map.empty[Long, Array[Any]]).toMap
-        var newEarliest = Long.MaxValue
-        val rebuildIter = store.tileIterator
-        while (rebuildIter.hasNext) {
-          val (hopSize, tileStart, ir) = rebuildIter.next()
-          tiles.get(hopSize).foreach(_(tileStart) = ir)
-          if (tileStart < newEarliest) newEarliest = tileStart
-        }
-        store.putEarliestTileStart(newEarliest)
-
-        val rebuiltIr = megaTileAgg.buildMegaTileIr(tiles, now = timerTs, batchEnd = currentDayStart)
-        store.putCachedSmallWindowIr(rebuiltIr)
-      }
-    }
-
-    // --- Large windows: recompute runningLargeIr from batch + streaming ---
+    rebuildCachedSmallWindowIr(timerTs, currentDayStart)
     recomputeRunningLargeIr(timerTs, currentDayStart)
 
-    // Suppress redundant emits: skip if the packed IR hasn't changed since last eviction.
-    // For idle entities with no events and no tail hop shift, this avoids O(entities) KV writes per interval.
     val packed = pack()
     if (lastEvictionPackedIr != null && irEqual(lastEvictionPackedIr, packed)) {
       GigaEmitResult(null)
@@ -234,31 +224,32 @@ class GigaTileStreamProcessor(
 
     if (newBatchEnd > currentDayStart) {
       if (currentDayStart < 0) {
-        // Uninitialized (no events yet). Safe to set from batch — largeTodayIr is init,
-        // no overlap concern. Without this, all startup batch loads would defer.
+        // Uninitialized (no events yet). Daily slots are empty so there's no overlap risk.
         currentDayStart = newBatchEnd
         store.putCurrentDayStart(currentDayStart)
       } else {
-        // Defer: watermark hasn't caught up. largeTodayIr has events that overlap
-        // with batch. Wait for advanceWatermark to rotate, then eviction recomputes.
+        // Defer until watermark advances past batchEnd. Daily slots between currentDayStart
+        // and batchEnd would otherwise overlap with batch and double-count.
         return GigaEmitResult(null, needsEvictionTimer = true)
       }
     }
 
-    // Save old running for comparison
-    val oldRunningIr = store.getRunningLargeIr
-
-    // Clear yesterday if batch covers it
-    if (newBatchEnd >= currentDayStart) {
-      store.putLargeYesterdayIr(windowedAgg.init)
+    // Prune daily slots now covered by batch. Batch ends are midnight-aligned, so any slot
+    // with dayStart strictly less than batchEndDay is fully inside batch.
+    val batchEndDay = TsUtils.round(newBatchEnd, DayMillis)
+    val toRemove = mutable.ArrayBuffer.empty[Long]
+    val iter = store.dailyLargeIrIterator
+    while (iter.hasNext) {
+      val (dayStart, _) = iter.next()
+      if (dayStart < batchEndDay) toRemove += dayStart
     }
+    toRemove.foreach(store.removeDailyLargeIr)
 
-    // Recompute running sum from batch + streaming
+    val oldRunningIr = store.getRunningLargeIr
     recomputeRunningLargeIr(currentWatermark, currentDayStart)
 
     val newRunningIr = store.getRunningLargeIr
 
-    // Emit only on mismatch
     if (!irEqual(oldRunningIr, newRunningIr)) {
       GigaEmitResult(packAndFinalize(), needsEvictionTimer = true)
     } else {
@@ -268,9 +259,10 @@ class GigaTileStreamProcessor(
 
   // --- Private helpers ---
 
-  /** Recompute runningLargeIr from: batch (collapsed + tail hops) + streaming (today + yesterday).
-    * For columns where the entire window has moved past batchEndTs, the collapsed value
-    * is stale — zero it out so stale batch data doesn't persist for idle entities.
+  /** Recompute runningLargeIr from: batch (collapsed + tail hops) + every retained daily slot
+    * with dayStart >= batchEndDay. For columns where the entire window has moved past
+    * batchEndTs, the collapsed value is stale — zero it out so stale batch data doesn't
+    * persist for idle entities.
     */
   private def recomputeRunningLargeIr(queryTs: Long, currentDayStart: Long): Unit = {
     val batchIr = store.getBatchIr
@@ -278,9 +270,6 @@ class GigaTileStreamProcessor(
     val runningIr = if (batchIr != null) {
       val ir = windowedAgg.clone(batchIr.collapsed)
       megaTileAgg.mergeTailHopsForBatchColumns(ir, queryTs, batchEndTs, batchIr)
-      // Zero out columns where the window has moved entirely past batch data.
-      // collapsed covers [alignedCollapsedBoundary, batchEnd) — if the window start
-      // (queryTs - windowMillis) is past batchEnd, collapsed is outside the window.
       var col = 0
       while (col < windowedAgg.length) {
         val window = megaTileAgg.windowMappings(col).aggregationPart.window
@@ -294,21 +283,61 @@ class GigaTileStreamProcessor(
       windowedAgg.init
     }
 
-    // Merge streaming daily accumulators
-    val todayIr = store.getLargeTodayIr
-    val yesterdayIr = store.getLargeYesterdayIr
-    var col = 0
-    while (col < windowedAgg.length) {
-      if (!isNoBatch(col)) {
-        if (todayIr(col) != null)
-          runningIr(col) = windowedAgg.columnAggregators(col).merge(runningIr(col), todayIr(col))
-        if (batchEndTs < currentDayStart && yesterdayIr(col) != null)
-          runningIr(col) = windowedAgg.columnAggregators(col).merge(runningIr(col), yesterdayIr(col))
+    val batchEndDay = if (batchEndTs > 0) TsUtils.round(batchEndTs, DayMillis) else Long.MinValue
+    val iter = store.dailyLargeIrIterator
+    while (iter.hasNext) {
+      val (dayStart, dayIr) = iter.next()
+      if (dayStart >= batchEndDay && dayIr != null) {
+        var col = 0
+        while (col < windowedAgg.length) {
+          if (!isNoBatch(col) && dayIr(col) != null) {
+            runningIr(col) = windowedAgg.columnAggregators(col).merge(runningIr(col), dayIr(col))
+          }
+          col += 1
+        }
       }
-      col += 1
     }
 
-    store.putRunningLargeIr(runningIr)
+    // Some column aggregators (FIRST, LAST, and similar non-mutating reducers) return one of
+    // their merge inputs by reference. Without re-cloning, runningIr columns can end up
+    // aliased to cached tail-hop or daily-slot IRs; subsequent in-place onEvent updates would
+    // then mutate that shared state and corrupt future serves.
+    store.putRunningLargeIr(windowedAgg.clone(runningIr))
+  }
+
+  /** Rebuild cachedSmallWindowIr from retained tiles using the supplied as-of horizon.
+    * Called from advanceWatermark on day rollover (effective starts shift) and from
+    * onEviction (sawtooth correction at hop boundaries).
+    */
+  private def rebuildCachedSmallWindowIr(asOfTs: Long, currentDayStart: Long): Unit = {
+    if (!hasSmallWindows) return
+    val earliest = store.getEarliestTileStart
+    if (earliest == Long.MaxValue) return
+
+    // Single-pass classify-and-collect. Flink-backed TileStore decodes values during
+    // iteration, so a second full scan would deserialize every retained tile again.
+    val staleEntries = mutable.ArrayBuffer.empty[(Long, Long)]
+    val tiles: Map[Long, mutable.Map[Long, Array[Any]]] =
+      smallWindowTiers.map(hop => hop -> mutable.Map.empty[Long, Array[Any]]).toMap
+    var newEarliest = Long.MaxValue
+    val iter = store.tileIterator
+    while (iter.hasNext) {
+      val (hopSize, tileStart, ir) = iter.next()
+      if (smallWindowTiers.contains(hopSize)) {
+        val floor = megaTileAgg.retentionFloor(hopSize, asOfTs, currentDayStart)
+        if (tileStart < floor) {
+          staleEntries += ((hopSize, tileStart))
+        } else {
+          tiles(hopSize)(tileStart) = ir
+          if (tileStart < newEarliest) newEarliest = tileStart
+        }
+      }
+    }
+    staleEntries.foreach { case (h, t) => store.removeTile(h, t) }
+    store.putEarliestTileStart(newEarliest)
+
+    val rebuiltIr = megaTileAgg.buildMegaTileIr(tiles, now = asOfTs, batchEnd = currentDayStart)
+    store.putCachedSmallWindowIr(rebuiltIr)
   }
 
   private def updateLargeWindowColumns(ir: Array[Any], row: Row): Unit = {
@@ -321,7 +350,6 @@ class GigaTileStreamProcessor(
     }
   }
 
-  /** Pack small + large window columns into a single windowed IR (before finalization). */
   private def pack(): Array[Any] = {
     val cachedIr = store.getCachedSmallWindowIr
     val runningIr = store.getRunningLargeIr
@@ -334,7 +362,6 @@ class GigaTileStreamProcessor(
     packed
   }
 
-  /** Pack small + large window columns and finalize to output values. */
   private[windowing] def packAndFinalize(): Array[Any] = windowedAgg.finalize(pack())
 
   /** Strip tail hops that are only used by small windows to reduce state size.

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStreamProcessor.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStreamProcessor.scala
@@ -154,6 +154,7 @@ class GigaTileStreamProcessor(
     // trade-off when the late event was not in the prior batch's source data.
     val eventDayStart = TsUtils.round(eventTs, DayMillis)
     val oldestAcceptedDay = currentDayStart - maxStalenessMillis
+    var droppedStaleEvent = false
     if (eventDayStart >= oldestAcceptedDay) {
       val existing = store.getDailyLargeIr(eventDayStart)
       val dayIr = if (existing != null) existing else windowedAgg.init
@@ -164,9 +165,12 @@ class GigaTileStreamProcessor(
       updateLargeWindowColumns(runningIr, row)
       store.putRunningLargeIr(runningIr)
       dirty = true
+    } else {
+      droppedStaleEvent = true
     }
 
-    if (dirty) GigaEmitResult(packAndFinalize()) else GigaEmitResult(null)
+    if (dirty) GigaEmitResult(packAndFinalize(), droppedStaleEvent = droppedStaleEvent)
+    else GigaEmitResult(null, droppedStaleEvent = droppedStaleEvent)
   }
 
   /** Watermark-driven day transition. Updates currentDayStart and rebuilds the small-window
@@ -198,12 +202,77 @@ class GigaTileStreamProcessor(
     recomputeRunningLargeIr(timerTs, currentDayStart)
 
     val packed = pack()
-    if (lastEvictionPackedIr != null && irEqual(lastEvictionPackedIr, packed)) {
-      GigaEmitResult(null)
+    val packedIsEmpty = isAllNull(packed)
+    val previousWasEmpty = lastEvictionPackedIr != null && isAllNull(lastEvictionPackedIr)
+    if (packedIsEmpty && previousWasEmpty) {
+      // Both rebuilds produced all-null vectors — nothing has changed and nothing more can
+      // decay until a new event arrives. Suppress to avoid burning a KV write per eviction
+      // for fully-decayed idle entities.
+      GigaEmitResult(null, isEmpty = true)
+    } else if (lastEvictionPackedIr != null && irEqual(lastEvictionPackedIr, packed)) {
+      GigaEmitResult(null, isEmpty = packedIsEmpty)
     } else {
       lastEvictionPackedIr = windowedAgg.clone(packed)
-      GigaEmitResult(windowedAgg.finalize(packed))
+      GigaEmitResult(windowedAgg.finalize(packed), isEmpty = packedIsEmpty)
     }
+  }
+
+  /** Serve-as-of helper for the Flink wiring: decay an idle entity's state at the requested
+    * as-of timestamp without requiring a new event. Same semantics as onEviction but named
+    * for the use case so callers don't get confused.
+    */
+  def serveAsOf(asOfTs: Long): GigaEmitResult = onEviction(asOfTs)
+
+  /** Global batch-advance hook for entities not present in a new batch row.
+    *
+    * The Iceberg connected stream emits a BatchIrRow only for entities included in the new
+    * batch. Idle entities receive no per-key signal that the global batchEnd has moved, so
+    * their batchEndTs in state stays stale forever. This method lets the Flink wiring
+    * broadcast a batch boundary advance: it advances batchEndTs (without loading a new
+    * batch IR), prunes daily slots covered by the new boundary, and recomputes the running
+    * IR so the next emit reflects the new horizon.
+    *
+    * Caller responsibility: only call this for entities the global batch is known to cover.
+    * Calling for an entity whose events are NOT in batch will delete those events from
+    * state without batch backfilling them — a real correctness loss.
+    */
+  def onGlobalBatchAdvance(newBatchEnd: Long, currentWatermark: Long): GigaEmitResult = {
+    val oldBatchEnd = store.getBatchEndTs
+    if (newBatchEnd <= oldBatchEnd) return GigaEmitResult(null)
+
+    store.putBatchEndTs(newBatchEnd)
+
+    var currentDayStart = store.getCurrentDayStart
+    if (currentDayStart < 0) {
+      currentDayStart = newBatchEnd
+      store.putCurrentDayStart(currentDayStart)
+    }
+
+    val batchEndDay = TsUtils.round(newBatchEnd, DayMillis)
+    val toRemove = mutable.ArrayBuffer.empty[Long]
+    val iter = store.dailyLargeIrIterator
+    while (iter.hasNext) {
+      val (dayStart, _) = iter.next()
+      if (dayStart < batchEndDay) toRemove += dayStart
+    }
+    toRemove.foreach(store.removeDailyLargeIr)
+
+    recomputeRunningLargeIr(currentWatermark, currentDayStart)
+    val packed = pack()
+    val packedIsEmpty = isAllNull(packed)
+    GigaEmitResult(windowedAgg.finalize(packed), needsEvictionTimer = true, isEmpty = packedIsEmpty)
+  }
+
+  /** True when every column in the packed pre-finalize IR is null. Used by the eviction
+    * suppress path and surfaced on GigaEmitResult so the Flink writer can DELETE the KV row.
+    */
+  private def isAllNull(packed: Array[Any]): Boolean = {
+    var i = 0
+    while (i < packed.length) {
+      if (packed(i) != null) return false
+      i += 1
+    }
+    true
   }
 
   /** Process a new batch IR from the Iceberg connected stream.
@@ -353,10 +422,18 @@ class GigaTileStreamProcessor(
   private def pack(): Array[Any] = {
     val cachedIr = store.getCachedSmallWindowIr
     val runningIr = store.getRunningLargeIr
+    // Until a batch IR has loaded, the running IR for batch-dependent columns is just the
+    // streaming-since-startup partial sum — emitting that would write an under-counted row
+    // to the PUSH KV that the fetcher then serves indefinitely. Null those columns out so
+    // the writer can either suppress the emit or write nulls for batch-dependent fields.
+    val batchAvailable = store.getBatchIr != null
     val packed = new Array[Any](windowedAgg.length)
     var col = 0
     while (col < windowedAgg.length) {
-      packed(col) = if (isNoBatch(col)) cachedIr(col) else runningIr(col)
+      packed(col) =
+        if (isNoBatch(col)) cachedIr(col)
+        else if (batchAvailable) runningIr(col)
+        else null
       col += 1
     }
     packed
@@ -381,5 +458,14 @@ class GigaTileStreamProcessor(
 
 case class GigaEmitResult(
     finalizedVector: Array[Any],
-    needsEvictionTimer: Boolean = false
+    needsEvictionTimer: Boolean = false,
+    // True when the packed pre-finalize IR has every column null. The Flink wiring uses this
+    // to (a) DELETE the PUSH KV row instead of writing a row of nulls and (b) decide whether
+    // to keep re-registering decay timers — once a key is fully empty, no further decay is
+    // possible until a new event arrives.
+    isEmpty: Boolean = false,
+    // True when this onEvent call dropped its event because eventTs was older than the
+    // staleness bound. Surfaced so the Flink wiring can bump a metric / log instead of
+    // silently losing data.
+    droppedStaleEvent: Boolean = false
 )

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/InMemoryGigaTileStore.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/InMemoryGigaTileStore.scala
@@ -1,0 +1,19 @@
+package ai.chronon.aggregator.windowing
+
+import ai.chronon.aggregator.row.RowAggregator
+
+/** In-memory GigaTileStore for tests. Extends InMemoryTileStore with batch state. */
+class InMemoryGigaTileStore(windowedAgg: RowAggregator) extends InMemoryTileStore(windowedAgg) with GigaTileStore {
+  private var _batchIr: FinalBatchIr = _
+  private var _batchEndTs: Long = -1L
+  private var _runningLargeIr: Array[Any] = windowedAgg.init
+
+  override def getBatchIr: FinalBatchIr = _batchIr
+  override def putBatchIr(ir: FinalBatchIr): Unit = _batchIr = ir
+
+  override def getBatchEndTs: Long = _batchEndTs
+  override def putBatchEndTs(ts: Long): Unit = _batchEndTs = ts
+
+  override def getRunningLargeIr: Array[Any] = _runningLargeIr
+  override def putRunningLargeIr(ir: Array[Any]): Unit = _runningLargeIr = ir
+}

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/InMemoryGigaTileStore.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/InMemoryGigaTileStore.scala
@@ -8,6 +8,8 @@ class InMemoryGigaTileStore(windowedAgg: RowAggregator) extends InMemoryTileStor
   private var _batchIr: FinalBatchIr = _
   private var _batchEndTs: Long = -1L
   private var _runningLargeIr: Array[Any] = windowedAgg.init
+  private var _cachedSmallWindowAsOfTs: Long = -1L
+  private var _lastLargeRecomputeAsOfTs: Long = Long.MinValue
   private val _dailyLargeIrs: mutable.Map[Long, Array[Any]] = mutable.Map.empty
 
   override def getBatchIr: FinalBatchIr = _batchIr
@@ -18,6 +20,12 @@ class InMemoryGigaTileStore(windowedAgg: RowAggregator) extends InMemoryTileStor
 
   override def getRunningLargeIr: Array[Any] = _runningLargeIr
   override def putRunningLargeIr(ir: Array[Any]): Unit = _runningLargeIr = ir
+
+  override def getCachedSmallWindowAsOfTs: Long = _cachedSmallWindowAsOfTs
+  override def putCachedSmallWindowAsOfTs(ts: Long): Unit = _cachedSmallWindowAsOfTs = ts
+
+  override def getLastLargeRecomputeAsOfTs: Long = _lastLargeRecomputeAsOfTs
+  override def putLastLargeRecomputeAsOfTs(ts: Long): Unit = _lastLargeRecomputeAsOfTs = ts
 
   override def getDailyLargeIr(dayStart: Long): Array[Any] = _dailyLargeIrs.getOrElse(dayStart, null)
   override def putDailyLargeIr(dayStart: Long, ir: Array[Any]): Unit = _dailyLargeIrs(dayStart) = ir

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/InMemoryGigaTileStore.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/InMemoryGigaTileStore.scala
@@ -2,11 +2,13 @@ package ai.chronon.aggregator.windowing
 
 import ai.chronon.aggregator.row.RowAggregator
 
-/** In-memory GigaTileStore for tests. Extends InMemoryTileStore with batch state. */
+import scala.collection.mutable
+
 class InMemoryGigaTileStore(windowedAgg: RowAggregator) extends InMemoryTileStore(windowedAgg) with GigaTileStore {
   private var _batchIr: FinalBatchIr = _
   private var _batchEndTs: Long = -1L
   private var _runningLargeIr: Array[Any] = windowedAgg.init
+  private val _dailyLargeIrs: mutable.Map[Long, Array[Any]] = mutable.Map.empty
 
   override def getBatchIr: FinalBatchIr = _batchIr
   override def putBatchIr(ir: FinalBatchIr): Unit = _batchIr = ir
@@ -16,4 +18,9 @@ class InMemoryGigaTileStore(windowedAgg: RowAggregator) extends InMemoryTileStor
 
   override def getRunningLargeIr: Array[Any] = _runningLargeIr
   override def putRunningLargeIr(ir: Array[Any]): Unit = _runningLargeIr = ir
+
+  override def getDailyLargeIr(dayStart: Long): Array[Any] = _dailyLargeIrs.getOrElse(dayStart, null)
+  override def putDailyLargeIr(dayStart: Long, ir: Array[Any]): Unit = _dailyLargeIrs(dayStart) = ir
+  override def removeDailyLargeIr(dayStart: Long): Unit = _dailyLargeIrs.remove(dayStart)
+  override def dailyLargeIrIterator: Iterator[(Long, Array[Any])] = _dailyLargeIrs.iterator
 }

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileAggregator.scala
@@ -113,6 +113,10 @@ class MegaTileAggregator(aggregations: Seq[Aggregation],
     windowedAggregator.finalize(resultIr)
   }
 
+  // Expose protected fields from SawtoothAggregator for use by GigaTileStreamProcessor
+  val tailHopIndicesArray: Array[Int] = tailHopIndices
+  val hopSizesArray: Array[Long] = hopSizes
+
   // Like mergeTailHops but skips NO BATCH columns (window <= tailBuffer)
   private[windowing] def mergeTailHopsForBatchColumns(ir: Array[Any],
                                                       queryTs: Long,

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileAggregator.scala
@@ -118,19 +118,21 @@ class MegaTileAggregator(aggregations: Seq[Aggregation],
   val hopSizesArray: Array[Long] = hopSizes
   val baseIrIndicesArray: Array[Int] = baseIrIndices
 
-  /** Largest window across all windowed columns, in millis. Used by GigaTile to bound daily-
-    * slot retention: any slot whose dayStart + DayMillis is older than (queryTs - maxWindowMillis)
-    * cannot contribute to any column and can be evicted from state.
+  /** Largest retention horizon across all columns, in millis. Used by GigaTile to bound daily-
+    * slot retention. Unwindowed columns retain uncovered slots until a later batch includes them,
+    * so their horizon is intentionally unbounded.
     */
   val maxWindowMillis: Long = {
     var m: Long = 0L
+    var hasUnwindowedColumn = false
     var i = 0
     while (i < windowMappings.length) {
       val w = windowMappings(i).aggregationPart.window
-      if (w != null && w.millis > m) m = w.millis
+      if (w == null) hasUnwindowedColumn = true
+      else if (w.millis > m) m = w.millis
       i += 1
     }
-    m
+    if (hasUnwindowedColumn) Long.MaxValue else m
   }
 
   /** Per-windowed-column window in millis. -1 for unwindowed columns (which always include the slot). */

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileAggregator.scala
@@ -116,6 +116,27 @@ class MegaTileAggregator(aggregations: Seq[Aggregation],
   // Expose protected fields from SawtoothAggregator for use by GigaTileStreamProcessor
   val tailHopIndicesArray: Array[Int] = tailHopIndices
   val hopSizesArray: Array[Long] = hopSizes
+  val baseIrIndicesArray: Array[Int] = baseIrIndices
+
+  /** Largest window across all windowed columns, in millis. Used by GigaTile to bound daily-
+    * slot retention: any slot whose dayStart + DayMillis is older than (queryTs - maxWindowMillis)
+    * cannot contribute to any column and can be evicted from state.
+    */
+  val maxWindowMillis: Long = {
+    var m: Long = 0L
+    var i = 0
+    while (i < windowMappings.length) {
+      val w = windowMappings(i).aggregationPart.window
+      if (w != null && w.millis > m) m = w.millis
+      i += 1
+    }
+    m
+  }
+
+  /** Per-windowed-column window in millis. -1 for unwindowed columns (which always include the slot). */
+  val columnWindowMillis: Array[Long] = windowMappings.map { mapping =>
+    Option(mapping.aggregationPart.window).map(_.millis).getOrElse(-1L)
+  }
 
   // Like mergeTailHops but skips NO BATCH columns (window <= tailBuffer)
   private[windowing] def mergeTailHopsForBatchColumns(ir: Array[Any],

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileBugRegressionTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileBugRegressionTest.scala
@@ -451,21 +451,25 @@ class GigaTileBugRegressionTest extends AnyFlatSpec {
   // are guaranteed equivalent by construction.
   // -----------------------------------------------------------------
   // -----------------------------------------------------------------
-  // Gap L — Multi-window per-column merge. Slots that fall outside a smaller window must
-  // not contribute to that column even when a larger window on the same key still needs them.
+  // Gap L — Multi-window per-column merge for *large* windows. Slots that fall outside a
+  // smaller large-window must not contribute to that column even when a larger large-window
+  // on the same key still needs them.
   //
-  // Scenario: aggregations {SUM(num,1d), SUM(num,7d)} on the same input. Batch is broken,
-  // events arrive on day 0. Query at day 4 12:00. The 1d window at day 4 12:00 covers
-  // [day 3 12:00, day 4 12:00] — slot day 0 is entirely outside, must contribute 0 to 1d.
-  // The 7d window at day 4 12:00 covers [day -2 12:00, day 4 12:00] — slot day 0 is inside,
-  // must contribute its events to 7d.
+  // Both windows must be > tailBufferMillis (2d) so they go through the daily-slot path; a
+  // small window (≤ 2d) goes through the tile path and never reads slots.
   //
-  // Without per-column window-overlap filtering, slot day 0 was merged into BOTH columns,
-  // over-counting 1d sum. The fix in recomputeRunningLargeIr applies a per-column predicate.
+  // Scenario: aggregations {SUM(num,3d), SUM(num,14d)} on the same input. Batch is frozen
+  // at day 0. Events arrive on day 0. Query at day 4 12:00. The 3d window covers
+  // [day 1 12:00, day 4 12:00] — slot day 0 is entirely outside, must contribute 0 to 3d.
+  // The 14d window covers [day -9 12:00, day 4 12:00] — slot day 0 is inside, must
+  // contribute its events to 14d.
+  //
+  // Without per-column window-overlap filtering, slot day 0 is merged into BOTH columns,
+  // over-counting 3d. The fix in recomputeRunningLargeIr applies a per-column predicate.
   // -----------------------------------------------------------------
-  it should "must not over-count 1d when slot is in 7d but outside 1d (multi-window stale-batch)" in {
+  it should "FAIL: must not over-count 3d when slot is in 14d but outside 3d (multi-window stale-batch)" in {
     val aggregations: Seq[Aggregation] = Seq(
-      Builders.Aggregation(Operation.SUM, "num", Seq(new Window(1, TimeUnit.DAYS), new Window(7, TimeUnit.DAYS)))
+      Builders.Aggregation(Operation.SUM, "num", Seq(new Window(3, TimeUnit.DAYS), new Window(14, TimeUnit.DAYS)))
     )
     val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
     val store = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator)
@@ -477,32 +481,76 @@ class GigaTileBugRegressionTest extends AnyFlatSpec {
     val emptyBatch = onlineAgg.denormalizeBatchIr(onlineAgg.finalizeSnapshot(onlineAgg.init))
     processor.onBatchUpdate(emptyBatch, day0, day0)
 
-    // Three day-0 events at 09:00, 10:00, 11:00 (sum=6).
+    // Three day-0 events at 09:00, 10:00, 11:00 (each value 2 → sum=6).
     Seq(day0 + 9 * HourMillis, day0 + 10 * HourMillis, day0 + 11 * HourMillis).foreach { ts =>
       processor.advanceWatermark(ts)
       processor.onEvent(new TestRow(ts, 2L)(0), ts)
     }
 
-    // Batch never advances. Query at day 4 12:00 — slot day 0 is in the 7d window but
-    // outside the 1d window (1d window starts day 3 12:00, slot ends day 1 00:00).
+    // Batch never advances. Query at day 4 12:00 — slot day 0 is in the 14d window but
+    // outside the 3d window (3d window starts day 1 12:00, slot ends day 1 00:00).
     val queryTs = day0 + 4 * DayMillis + 12 * HourMillis
     processor.advanceWatermark(queryTs)
     val r = processor.onEviction(queryTs)
     assertNotNull("eviction must emit", r.finalizedVector)
 
-    // SUM(num,1d) is column 0, SUM(num,7d) is column 1 in the windowed aggregator's column
-    // ordering (window order matches the aggregations spec).
-    val sum1d = r.finalizedVector(0)
-    val sum7d = r.finalizedVector(1)
+    // SUM(num,3d) = col 0, SUM(num,14d) = col 1.
+    val sum3d = r.finalizedVector(0)
+    val sum14d = r.finalizedVector(1)
     assertEquals(
-      "1d SUM at day 4 12:00 must be null/0 — events on day 0 are outside the 1d window",
+      "3d SUM at day 4 12:00 must be null — events on day 0 are entirely before day 1 12:00 " +
+        "(3d window start). Without per-column window-overlap filtering, slot day 0's events " +
+        "leak into the 3d column.",
       null,
-      sum1d
+      sum3d
     )
     assertEquals(
-      "7d SUM at day 4 12:00 must include the day 0 events (within 7d window)",
+      "14d SUM at day 4 12:00 must include the day 0 events (within 14d window)",
       6L,
-      sum7d
+      sum14d
+    )
+  }
+
+  // -----------------------------------------------------------------
+  // Gap M — Slot eviction by largest window. A slot whose [dayStart, dayStart+1d) is
+  // entirely older than (queryTs - maxWindowMillis) cannot contribute to any column under
+  // any circumstance — pure pollution that grows Flink state unboundedly when batch never
+  // refreshes (gap J's broken-batch scenario).
+  //
+  // Pure window-bound check, independent of batchEndDay. Eviction must drop these slots
+  // from state every time recompute runs so total state per entity is bounded by the
+  // largest window, not by maxBatchStalenessDays.
+  // -----------------------------------------------------------------
+  it should "FAIL: slots older than the largest window must be evicted from state" in {
+    val largestWindow = new Window(7, TimeUnit.DAYS)
+    val aggregations: Seq[Aggregation] = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(largestWindow)))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val store = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator)
+    // Permissive staleness bound so we can demonstrate eviction is driven by window size,
+    // not by the staleness bound.
+    val processor = new GigaTileStreamProcessor(megaTileAgg, store, maxBatchStalenessDays = 100)
+
+    val day0 = TsUtils.round(1700000000000L, DayMillis)
+    // Empty batch at day0; batch never refreshes after this.
+    val onlineAgg = new SawtoothOnlineAggregator(day0, aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val emptyBatch = onlineAgg.denormalizeBatchIr(onlineAgg.finalizeSnapshot(onlineAgg.init))
+    processor.onBatchUpdate(emptyBatch, day0, day0)
+
+    // One event on day 0 → slot day 0 created.
+    processor.advanceWatermark(day0 + HourMillis)
+    processor.onEvent(new TestRow(day0 + HourMillis, 1L)(0), day0 + HourMillis)
+    assertNotNull("slot day 0 must exist after the event", store.getDailyLargeIr(day0))
+
+    // Query 10 days later — slot day 0 ends at day 1 00:00, which is well before
+    // (queryTs - 7d) = day 3 12:00. Slot is useless to any column. Recompute must evict it.
+    val queryTs = day0 + 10 * DayMillis + 12 * HourMillis
+    processor.advanceWatermark(queryTs)
+    processor.onEviction(queryTs)
+
+    assertNull(
+      "slot day 0 must be evicted from state once it's older than the largest window — " +
+        "without this, slots accumulate unboundedly when batch never advances (Gap J's broken-batch case)",
+      store.getDailyLargeIr(day0)
     )
   }
 

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileBugRegressionTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileBugRegressionTest.scala
@@ -269,15 +269,14 @@ class GigaTileBugRegressionTest extends AnyFlatSpec {
     val staleEvent = new TestRow(today - 5 * DayMillis, 100L)(0)
     val r = processor.onEvent(staleEvent, staleEvent.ts)
 
-    // GigaEmitResult does not currently expose a drop indicator. Ask reflection for a field
-    // named droppedStaleEvent (or similar) — the test fails until such a signal exists.
-    val signalField = r.getClass.getDeclaredFields
-      .find(f => f.getName.toLowerCase.contains("drop") || f.getName.toLowerCase.contains("stale"))
     assertTrue(
-      "GigaEmitResult must expose a drop signal so callers can bump a metric / log a stale event — " +
-        s"none of the fields ${r.getClass.getDeclaredFields.map(_.getName).mkString(",")} indicate this",
-      signalField.isDefined
+      "stale event drop must be observable on GigaEmitResult so the Flink wiring can " +
+        "bump a counter / log instead of silently losing data",
+      r.droppedStaleEvent
     )
+    // Sanity: a fresh event at `today` must not be flagged as a drop.
+    val freshResult = processor.onEvent(new TestRow(today + MinuteMillis, 1L)(0), today + MinuteMillis)
+    assertTrue("a fresh event must not be flagged as dropped", !freshResult.droppedStaleEvent)
   }
 
   // -----------------------------------------------------------------
@@ -317,22 +316,20 @@ class GigaTileBugRegressionTest extends AnyFlatSpec {
     assertEquals("baseline: 1h SUM after the event is 1", 1L, r1.finalizedVector(0))
 
     // Wall clock advances 2 hours past the event with no further events — the event is
-    // now well outside the 1h serving horizon. A read at this point must reflect that.
+    // now well outside the 1h serving horizon. The Flink wiring should be able to refresh
+    // the KV row without waiting for a new event by calling serveAsOf(asOfTs).
     val tServe = tEvent + 2 * HourMillis
-    processor.advanceWatermark(tServe)
-
-    // The processor exposes no "serve as of T without an event" API. The PUSH KV row
-    // therefore still holds r1.finalizedVector (sum=1), even though the correct
-    // as-of-tServe answer is 0/null. Assert the contract we actually want.
-    val servedAsOfTServe: Any = {
-      val method = processor.getClass.getDeclaredMethods.find(_.getName == "serveAsOf")
-      method.map { m => m.setAccessible(true); m.invoke(processor, java.lang.Long.valueOf(tServe)) }.orNull
-    }
-    assertNotNull(
-      "GigaTileStreamProcessor must expose a serveAsOf(asOfTs) helper so Flink can " +
-        "refresh idle KV rows without waiting for a new event. Without it, idle entities " +
-        "serve stale finalized vectors indefinitely.",
-      servedAsOfTServe
+    val served = processor.serveAsOf(tServe)
+    assertNotNull("serveAsOf must produce an emit result", served)
+    val sumValue = if (served.finalizedVector == null) null else served.finalizedVector(0)
+    assertNull(
+      "serveAsOf 2h after the event must decay the 1h SUM to null — the event is outside " +
+        "the 1h horizon at the new as-of",
+      sumValue
+    )
+    assertTrue(
+      "serveAsOf result must signal isEmpty=true when every column has decayed",
+      served.isEmpty
     )
   }
 
@@ -371,14 +368,10 @@ class GigaTileBugRegressionTest extends AnyFlatSpec {
     val allNull = emit.finalizedVector.forall(_ == null)
     assertTrue("baseline: every column should be null after the window decays", allNull)
 
-    // Once that's true, a tombstone signal is what lets the writer DELETE the KV row.
-    val tombstoneField = emit.getClass.getDeclaredFields
-      .find(f => Set("isEmpty", "tombstone", "isTombstone", "shouldDelete").contains(f.getName))
     assertTrue(
-      "GigaEmitResult must expose a tombstone signal so Flink can DELETE the PUSH KV row " +
-        "for fully-decayed entities — instead of writing a row of nulls that lives forever. " +
-        s"Available fields: ${emit.getClass.getDeclaredFields.map(_.getName).mkString(",")}",
-      tombstoneField.isDefined
+      "GigaEmitResult must expose isEmpty=true for fully-decayed emits so Flink can DELETE " +
+        "the PUSH KV row instead of writing a row of nulls that lives forever",
+      emit.isEmpty
     )
   }
 
@@ -426,18 +419,22 @@ class GigaTileBugRegressionTest extends AnyFlatSpec {
     // No per-key signal reaches the processor — exactly the production gap.
     processor.advanceWatermark(day20 + 12 * HourMillis)
 
-    // The processor should expose a broadcast / heartbeat hook that lets Flink wiring tell
-    // every key's state that the global batch boundary has moved, even without an entity-
-    // specific BatchIrRow. Without it, the serving value for this idle key remains stale.
-    val advanceMethod = processor.getClass.getDeclaredMethods
-      .find(m =>
-        Set("onGlobalBatchAdvance", "advanceBatchBoundary", "heartbeatBatchEnd").contains(m.getName))
-    assertTrue(
-      "GigaTileStreamProcessor must expose a global batch-advance hook (e.g. onGlobalBatchAdvance(newBatchEnd)) " +
-        "so idle keys not present in the new batch can still decay their state. Currently the only path to update " +
-        "batchEndTs is processElement2, which never fires for entities not in the batch — their KV rows stay " +
-        s"stale indefinitely. Available methods: ${processor.getClass.getDeclaredMethods.map(_.getName).filterNot(_.startsWith("$")).distinct.mkString(",")}",
-      advanceMethod.isDefined
+    // Simulate the global signal: advance the per-key batchEndTs without a per-key BatchIrRow.
+    val newBatchEnd = day20 - 5 * DayMillis // global batch is now ~15 days fresher
+    val advanced = processor.onGlobalBatchAdvance(newBatchEnd, day20 + 12 * HourMillis)
+    assertNotNull("onGlobalBatchAdvance must produce an emit", advanced)
+
+    // After advancement, the in-state batchEndTs must reflect the new boundary so the next
+    // recompute uses the correct horizon.
+    assertEquals(
+      "store.batchEndTs must advance to the new boundary so future eviction filters slots correctly",
+      newBatchEnd,
+      store.getBatchEndTs
+    )
+    // And the day-0 slot (now well behind the new batchEnd) must be pruned from state.
+    assertNull(
+      "daily slot for day 0 must be pruned once it falls before the new batchEndDay",
+      store.getDailyLargeIr(TsUtils.round(event.ts, DayMillis))
     )
   }
 

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileBugRegressionTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileBugRegressionTest.scala
@@ -335,4 +335,146 @@ class GigaTileBugRegressionTest extends AnyFlatSpec {
       servedAsOfTServe
     )
   }
+
+  // -----------------------------------------------------------------
+  // Gap I — Tombstone signal when the finalized vector is fully empty.
+  //
+  // After a 1h-windowed entity goes idle for 2h, the rebuilt cache is all-null. The
+  // resulting finalized vector encodes to a row of nulls. GigaTile writes that row to the
+  // PUSH KV table with no signal that it is semantically "empty". Two consequences:
+  //   1. Idle keys accumulate as zero-rows in KV indefinitely (no TTL on the values).
+  //   2. The fetcher cannot distinguish "Flink emitted an empty row for this key" from
+  //      "Flink never emitted for this key" — both serve nulls — so a freshly-decayed key
+  //      cannot be tombstoned via DELETE.
+  //
+  // The contract: GigaEmitResult should expose `isEmpty` (or equivalent) when the packed
+  // IR has every column null, so the Flink wiring can choose to issue a KV DELETE instead
+  // of a PUT-with-nulls. Currently no such field exists.
+  // -----------------------------------------------------------------
+  it should "FAIL: emit must signal a tombstone when the finalized vector is fully empty" in {
+    val window = new Window(1, TimeUnit.HOURS)
+    val aggregations: Seq[Aggregation] = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(window)))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val store = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, store)
+
+    val day0 = TsUtils.round(1700000000000L, DayMillis)
+    val tEvent = day0 + 6 * HourMillis
+    processor.advanceWatermark(tEvent)
+    processor.onEvent(new TestRow(tEvent, 1L)(0), tEvent)
+
+    // Eviction well past the window — every retained tile is stale, cache rebuilt to empty.
+    val tDecay = tEvent + 2 * HourMillis
+    processor.advanceWatermark(tDecay)
+    val emit = processor.onEviction(tDecay)
+    assertNotNull("eviction past window must still produce an emit", emit.finalizedVector)
+    val allNull = emit.finalizedVector.forall(_ == null)
+    assertTrue("baseline: every column should be null after the window decays", allNull)
+
+    // Once that's true, a tombstone signal is what lets the writer DELETE the KV row.
+    val tombstoneField = emit.getClass.getDeclaredFields
+      .find(f => Set("isEmpty", "tombstone", "isTombstone", "shouldDelete").contains(f.getName))
+    assertTrue(
+      "GigaEmitResult must expose a tombstone signal so Flink can DELETE the PUSH KV row " +
+        "for fully-decayed entities — instead of writing a row of nulls that lives forever. " +
+        s"Available fields: ${emit.getClass.getDeclaredFields.map(_.getName).mkString(",")}",
+      tombstoneField.isDefined
+    )
+  }
+
+  // -----------------------------------------------------------------
+  // Gap J — Idle entity post-batch-advance: stale row served indefinitely.
+  //
+  // Architectural gap, not a processor-internal bug. The Iceberg connected stream emits a
+  // BatchIrRow only for entities present in the new batch. An entity X that had events
+  // weeks ago and went silent has no row in the new batch, so processElement2 is never
+  // called for X. processElement1 also never fires (no Kafka events). Result:
+  //   - X's `batchEndTs` in Flink state stays at the OLD batch end.
+  //   - X's daily-slot map keeps the old streaming events.
+  //   - recomputeRunningLargeIr (when an eviction does fire) merges the OLD batch + OLD
+  //     slots, reproducing the stale value.
+  //
+  // The fetcher then serves X's stale row — even though every event for X is now outside
+  // every retained window. Worst case: a 7d window keeps reporting X's events from a year
+  // ago because the entity never received a per-key signal that the world moved on.
+  //
+  // Correct behavior requires a *broadcast* batch-advance signal that reaches every key
+  // (or some equivalent: scheduled per-key TTL, periodic null heartbeat from a side
+  // input). This test asserts a `onGlobalBatchAdvance` API exists on the processor; it
+  // currently does not.
+  // -----------------------------------------------------------------
+  it should "FAIL: idle entity must receive a global batch-advance signal so its KV row decays after weeks of silence" in {
+    val window = new Window(7, TimeUnit.DAYS)
+    val aggregations: Seq[Aggregation] = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(window)))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val store = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, store)
+
+    val day0 = TsUtils.round(1700000000000L, DayMillis)
+    val day20 = day0 + 20 * DayMillis
+
+    // Batch covers up to day0; this entity has events on day 0 and then goes silent.
+    val onlineAgg = new SawtoothOnlineAggregator(day0, aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val emptyBatch = onlineAgg.denormalizeBatchIr(onlineAgg.finalizeSnapshot(onlineAgg.init))
+    processor.onBatchUpdate(emptyBatch, day0, day0)
+
+    val event = new TestRow(day0 + HourMillis, 5L)(0)
+    processor.advanceWatermark(event.ts)
+    processor.onEvent(event, event.ts)
+
+    // 20 days pass globally. Other entities trigger batch advances; this entity never does.
+    // No per-key signal reaches the processor — exactly the production gap.
+    processor.advanceWatermark(day20 + 12 * HourMillis)
+
+    // The processor should expose a broadcast / heartbeat hook that lets Flink wiring tell
+    // every key's state that the global batch boundary has moved, even without an entity-
+    // specific BatchIrRow. Without it, the serving value for this idle key remains stale.
+    val advanceMethod = processor.getClass.getDeclaredMethods
+      .find(m =>
+        Set("onGlobalBatchAdvance", "advanceBatchBoundary", "heartbeatBatchEnd").contains(m.getName))
+    assertTrue(
+      "GigaTileStreamProcessor must expose a global batch-advance hook (e.g. onGlobalBatchAdvance(newBatchEnd)) " +
+        "so idle keys not present in the new batch can still decay their state. Currently the only path to update " +
+        "batchEndTs is processElement2, which never fires for entities not in the batch — their KV rows stay " +
+        s"stale indefinitely. Available methods: ${processor.getClass.getDeclaredMethods.map(_.getName).filterNot(_.startsWith("$")).distinct.mkString(",")}",
+      advanceMethod.isDefined
+    )
+  }
+
+  // -----------------------------------------------------------------
+  // Gap K — Decay produces a stable empty-emit only when irEqual is configured.
+  //
+  // With the default `irEqual = (_, _) => false`, every eviction past window decay emits
+  // the same all-null vector — burning O(idle_entities × eviction_interval) KV writes
+  // per day. With a value-aware irEqual, the second decay emit is suppressed correctly.
+  //
+  // This is more efficiency than correctness, but it ALSO masks a write-amplification bug
+  // that's user-visible (KV write traffic, write quota exhaustion). The processor should
+  // suppress consecutive all-empty emits even under the default no-op irEqual — those
+  // are guaranteed equivalent by construction.
+  // -----------------------------------------------------------------
+  it should "FAIL: consecutive all-empty eviction emits must be suppressed even under default irEqual" in {
+    val window = new Window(1, TimeUnit.HOURS)
+    val aggregations: Seq[Aggregation] = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(window)))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val store = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, store) // default irEqual
+
+    val day0 = TsUtils.round(1700000000000L, DayMillis)
+    val tEvent = day0 + 6 * HourMillis
+    processor.advanceWatermark(tEvent)
+    processor.onEvent(new TestRow(tEvent, 1L)(0), tEvent)
+
+    // Two evictions past the window — both rebuild to all-null.
+    val firstDecay = processor.onEviction(tEvent + 2 * HourMillis)
+    val secondDecay = processor.onEviction(tEvent + 3 * HourMillis)
+
+    assertNotNull("first decay emit must exist (transitions from non-null to all-null)", firstDecay.finalizedVector)
+    assertTrue("first decay emit should be all-null", firstDecay.finalizedVector.forall(_ == null))
+    assertNull(
+      "second decay emit must be suppressed — both rebuilds produce identical all-null vectors and " +
+        "burning a KV write per eviction past idle adds up to traffic quota exhaustion at scale",
+      secondDecay.finalizedVector
+    )
+  }
 }

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileBugRegressionTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileBugRegressionTest.scala
@@ -1,0 +1,212 @@
+package ai.chronon.aggregator.test
+
+import ai.chronon.aggregator.windowing._
+import ai.chronon.api._
+import ai.chronon.api.Extensions.WindowOps
+import com.google.gson.Gson
+import org.junit.Assert._
+import org.scalatest.flatspec.AnyFlatSpec
+
+/** Failing tests demonstrating bugs in GigaTile (PR #1645) that Mick already fixed in MegaTile (PRs #1680/#1776).
+  *
+  * Each test reproduces a specific bug at the processor / aggregator level. When a fix is ported
+  * from MegaTile, the corresponding test should turn green.
+  */
+class GigaTileBugRegressionTest extends AnyFlatSpec {
+  val gson = new Gson
+  val DayMillis: Long = new Window(1, TimeUnit.DAYS).millis
+  val HourMillis: Long = 3600 * 1000L
+  val MinuteMillis: Long = 60 * 1000L
+  val TailBufferMillis: Long = new Window(2, TimeUnit.DAYS).millis
+  val schema: Seq[(String, DataType)] = Seq("ts" -> LongType, "num" -> LongType)
+
+  // -----------------------------------------------------------------
+  // Bug A — Late retained event re-inflates the cached 1h window.
+  //
+  // Mirrors MegaTile fix `cedf6f4 — Fix MegaTile small-window as-of ingestion`.
+  // GigaTile's onEvent updates cachedSmallWindowIr for any column whose tier-aligned
+  // tile is within retention, regardless of whether the event lies inside the column's
+  // own as-of horizon. A late event valid for the 1d window therefore also bumps 1h.
+  //
+  // Both events share the same as-of (the current serving horizon). The retained late
+  // event must update the base tile (so a future eviction can rebuild correctly) but
+  // must NOT bump the live cached IR for columns whose horizon excludes it.
+  // -----------------------------------------------------------------
+  it should "FAIL: late retained event must not re-inflate 1h cached small-window IR" in {
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.COUNT, "num", Seq(new Window(1, TimeUnit.HOURS)))
+    )
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val store = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, store)
+
+    val baseDay = TsUtils.round(1700000000000L, DayMillis)
+    val tNow = baseDay + 12 * HourMillis
+    val asOfTs = tNow + 5 * MinuteMillis // current serving horizon, just past tNow
+    val tLate = tNow - 2 * HourMillis    // outside 1h horizon, inside 2d retention
+
+    processor.advanceWatermark(tNow)
+    val r1 = processor.onEvent(new TestRow(tNow, 1L)(0), tNow, asOfTs)
+    assertNotNull("first event should emit", r1.finalizedVector)
+    assertEquals("baseline: 1h count after first event must be 1", 1L, r1.finalizedVector(0))
+
+    val r2 = processor.onEvent(new TestRow(tLate, 1L)(0), tLate, asOfTs)
+    assertEquals(
+      "1h count must remain 1 — the late event is outside the 1h horizon at the current as-of",
+      1L,
+      Option(r2.finalizedVector).map(_(0)).getOrElse(r1.finalizedVector(0))
+    )
+  }
+
+  // -----------------------------------------------------------------
+  // Bug B — cachedSmallWindowIr is carried across day rollover unchanged.
+  //
+  // Mirrors MegaTile fix `eedd34a — Fix MegaTile small-window cache on day rollover`.
+  // advanceWatermark rotates large-IR slots but does not rebuild cachedSmallWindowIr,
+  // so events older than the new as-of horizon survive into the next day's serves
+  // until the next eviction timer fires.
+  // -----------------------------------------------------------------
+  it should "FAIL: cachedSmallWindowIr must not include yesterday's events after rollover" in {
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.COUNT, "num", Seq(new Window(1, TimeUnit.HOURS)))
+    )
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val store = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, store)
+
+    val baseDay = TsUtils.round(1700000000000L, DayMillis)
+    val day0_22h = baseDay + 22 * HourMillis
+    Seq(day0_22h, day0_22h + 5 * MinuteMillis, day0_22h + 10 * MinuteMillis).foreach { ts =>
+      processor.advanceWatermark(ts)
+      val r = processor.onEvent(new TestRow(ts, 1L)(0), ts)
+      assertNotNull(s"event at $ts should emit", r.finalizedVector)
+    }
+
+    // Roll over — wall clock has moved to day+1, three hours past midnight.
+    val day1_3h = baseDay + DayMillis + 3 * HourMillis
+    processor.advanceWatermark(day1_3h)
+
+    // Single fresh event 55 minutes later. Only this event lies inside the 1h horizon now.
+    val day1_3h_55m = day1_3h + 55 * MinuteMillis
+    processor.advanceWatermark(day1_3h_55m)
+    val r4 = processor.onEvent(new TestRow(day1_3h_55m, 1L)(0), day1_3h_55m)
+    assertNotNull("post-rollover event should emit", r4.finalizedVector)
+    assertEquals(
+      "1h count after rollover must reflect only the new event — yesterday's events fell out of the window",
+      1L,
+      r4.finalizedVector(0)
+    )
+  }
+
+  // -----------------------------------------------------------------
+  // Bug C — bulkMerge mutates the cached batch tail-hop IR.
+  //
+  // Mirrors MegaTile fix `c311a0a — Port MegaTile PT semantics and tail-hop fix`.
+  // mergeTailHopsForBatchColumns passes a tail-hop slot directly into bulkMerge as the
+  // (initially null) accumulator's first non-null entry. bulkMerge mutates that entry
+  // for non-trivial aggregators (e.g. AVERAGE → (sum,count) Array[Any]). Repeated serves
+  // therefore re-merge against a corrupted tail-hop and drift.
+  //
+  // This test goes through MegaTileAggregator.serveMegaTile — the same path GigaTile's
+  // GigaTileStreamProcessor.recomputeRunningLargeIr takes via mergeTailHopsForBatchColumns.
+  // -----------------------------------------------------------------
+  it should "FAIL: serveMegaTile must not mutate batch tail hops across repeated calls" in {
+    val avgSchema: Seq[(String, DataType)] = Seq("ts" -> LongType, "amount" -> DoubleType)
+    val batchEnd = TsUtils.round(1700000000000L, DayMillis)
+    val queryTs = batchEnd + HourMillis
+    val aggregations: Seq[Aggregation] = Seq(
+      Builders.Aggregation(Operation.AVERAGE, "amount", Seq(new Window(3, TimeUnit.DAYS)))
+    )
+
+    val megaTileAgg = new MegaTileAggregator(aggregations, avgSchema, tailBufferMillis = TailBufferMillis)
+    val onlineAgg = new SawtoothOnlineAggregator(batchEnd, aggregations, avgSchema, tailBufferMillis = TailBufferMillis)
+    var batchIr = onlineAgg.init
+    batchIr = onlineAgg.update(batchIr, new TestRow(batchEnd - 26 * HourMillis, 2.0)(0))
+    batchIr = onlineAgg.update(batchIr, new TestRow(batchEnd - 25 * HourMillis, 4.0)(0))
+    val finalBatchIr = onlineAgg.finalizeSnapshot(batchIr)
+
+    val emptyMegaTileIr = megaTileAgg.buildMegaTileIr(
+      Map.empty[Long, collection.Map[Long, Array[Any]]],
+      now = queryTs,
+      batchEnd = batchEnd
+    )
+    val first = megaTileAgg.serveMegaTile(finalBatchIr, emptyMegaTileIr, queryTs, batchEnd)
+    val second = megaTileAgg.serveMegaTile(finalBatchIr, emptyMegaTileIr, queryTs, batchEnd)
+
+    assertEquals(
+      "first serve should report the true 3-day average over (2.0, 4.0)",
+      3.0,
+      first(0).asInstanceOf[Double],
+      1e-6
+    )
+    assertEquals(
+      "second serve must equal first — tail hops in batchIr must be untouched between calls",
+      first(0).asInstanceOf[Double],
+      second(0).asInstanceOf[Double],
+      1e-6
+    )
+  }
+
+  // -----------------------------------------------------------------
+  // Bug D — Delayed batch (>1d stale) loses streaming events from intermediate days.
+  //
+  // Analogous to MegaTile fix `ced0185` (the multi-day fetch part), but the architectural
+  // shape is different: GigaTile keeps only `largeTodayIr` and `largeYesterdayIr` per
+  // entity. When the batch upload is more than 1 day stale and the watermark advances
+  // through sequential day rollovers, each rollover overwrites yesterday with today and
+  // the previous yesterday is silently dropped. recomputeRunningLargeIr (run on every
+  // eviction and batch update) then merges only batch + today + yesterday and the
+  // intermediate streaming day disappears from the finalized vector.
+  //
+  // Setup: 7d SUM, batch covers up to day0 with no events. Stream 5 events × 1 each on
+  // days 0, 1, 2. After eviction on day 2, the running large IR should contain all 15
+  // events; with the bug it contains 10 (day 0 lost between rollovers).
+  // -----------------------------------------------------------------
+  it should "FAIL: delayed batch (>1d) must not lose streaming events from intermediate days" in {
+    val window = new Window(7, TimeUnit.DAYS)
+    val aggregations: Seq[Aggregation] = Seq(
+      Builders.Aggregation(Operation.SUM, "num", Seq(window))
+    )
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val store = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, store)
+
+    val day0 = TsUtils.round(1700000000000L, DayMillis)
+    val day1 = day0 + DayMillis
+    val day2 = day1 + DayMillis
+
+    // Empty batch covering up to day0 — keeps the assertion clean (all 15 events come from streaming).
+    val onlineAgg = new SawtoothOnlineAggregator(day0, aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val emptyFinalized = onlineAgg.finalizeSnapshot(onlineAgg.init)
+    val batchIr = onlineAgg.denormalizeBatchIr(emptyFinalized)
+    processor.onBatchUpdate(batchIr, day0, day0)
+
+    def streamDay(dayStart: Long): Unit = {
+      (1 to 5).foreach { i =>
+        val ts = dayStart + i * HourMillis
+        processor.advanceWatermark(ts)
+        processor.onEvent(new TestRow(ts, 1L)(0), ts)
+      }
+    }
+
+    // Sequential adjacent rollovers — this is what surfaces the bug. A single multi-day
+    // jump would zero yesterday out via the `wmDay == currentDayStart + DayMillis` branch,
+    // so the only way to lose day0 is to walk through day1 in between.
+    streamDay(day0)
+    processor.advanceWatermark(day1)
+    streamDay(day1)
+    processor.advanceWatermark(day2)
+    streamDay(day2)
+
+    val queryTs = day2 + 12 * HourMillis
+    processor.advanceWatermark(queryTs)
+    val r = processor.onEviction(queryTs)
+    assertNotNull("eviction at day2 should emit", r.finalizedVector)
+    val sum = r.finalizedVector(0).asInstanceOf[Long]
+    assertEquals(
+      "7d sum after delayed batch must include all 15 streaming events — batch is 2d stale, day0 must not be lost",
+      15L,
+      sum
+    )
+  }
+}

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileBugRegressionTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileBugRegressionTest.scala
@@ -281,7 +281,9 @@ class GigaTileBugRegressionTest extends AnyFlatSpec {
 
     // Roll over — wall clock has moved to day+1, three hours past midnight.
     val day1_3h = baseDay + DayMillis + 3 * HourMillis
-    processor.advanceWatermark(day1_3h)
+    val rollover = processor.advanceWatermark(day1_3h)
+    assertNotNull("day rollover should surface the cache correction", rollover.finalizedVector)
+    assertNull("expired values should be removed at rollover", rollover.finalizedVector(0))
 
     // Single fresh event 55 minutes later. Only this event lies inside the 1h horizon now.
     val day1_3h_55m = day1_3h + 55 * MinuteMillis

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileBugRegressionTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileBugRegressionTest.scala
@@ -209,4 +209,130 @@ class GigaTileBugRegressionTest extends AnyFlatSpec {
       sum
     )
   }
+
+  // -----------------------------------------------------------------
+  // Gap E — Bootstrap underreport: emits before batch IR is loaded report a 7d window as
+  // if it equalled the streaming-since-startup partial sum. The fetcher's PUSH branch
+  // already returns null for "no streaming data", but as soon as Flink emits one vector
+  // (with batchIr still null), that under-counted vector overwrites the KV row and is
+  // served indefinitely.
+  //
+  // Correct behavior: don't emit a finalized vector for any column whose contract requires
+  // batch (large/unwindowed). Either suppress the emit entirely, or null out the batch-
+  // dependent columns until onBatchUpdate has run.
+  // -----------------------------------------------------------------
+  it should "FAIL: must not emit batch-dependent columns before batch IR has loaded" in {
+    val window = new Window(7, TimeUnit.DAYS)
+    val aggregations: Seq[Aggregation] = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(window)))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val store = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, store)
+
+    // Deliberately skip onBatchUpdate — Iceberg connected stream hasn't fired yet.
+    val day0 = TsUtils.round(1700000000000L, DayMillis)
+    val event = new TestRow(day0 + HourMillis, 5L)(0)
+    processor.advanceWatermark(event.ts)
+    val r = processor.onEvent(event, event.ts)
+
+    assertNotNull("event must produce some emit", r)
+    val sumIr = r.finalizedVector
+    val sumValue = if (sumIr == null) null else sumIr(0)
+    assertNull(
+      "7d SUM must not be emitted as the streaming-only partial sum while batchIr is unloaded — " +
+        "fetcher will serve this under-counted value indefinitely from the PUSH KV row",
+      sumValue
+    )
+  }
+
+  // -----------------------------------------------------------------
+  // Gap F — Silent drop of events older than the staleness bound. With
+  // maxBatchStalenessDays=2 and an event 5 days old, the event is dropped from BOTH the
+  // small-window path (out of retention) and the daily-slot path (older than oldestAcceptedDay).
+  // Nothing surfaces — no exception, no metric, no return signal. A consumer downstream
+  // cannot tell that data was silently lost.
+  //
+  // Correct behavior at minimum: signal the drop on the GigaEmitResult so the Flink wiring
+  // can bump a counter / log. The simplest API surface is a `droppedStaleEvent: Boolean`
+  // field on GigaEmitResult. This test asserts that signal exists; it currently doesn't.
+  // -----------------------------------------------------------------
+  it should "FAIL: events older than maxBatchStalenessDays must surface a drop signal" in {
+    val window = new Window(7, TimeUnit.DAYS)
+    val aggregations: Seq[Aggregation] = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(window)))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val store = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, store, maxBatchStalenessDays = 2)
+
+    val today = TsUtils.round(1700000000000L, DayMillis) + 12 * HourMillis
+    processor.advanceWatermark(today)
+    processor.onEvent(new TestRow(today, 1L)(0), today)
+
+    val staleEvent = new TestRow(today - 5 * DayMillis, 100L)(0)
+    val r = processor.onEvent(staleEvent, staleEvent.ts)
+
+    // GigaEmitResult does not currently expose a drop indicator. Ask reflection for a field
+    // named droppedStaleEvent (or similar) — the test fails until such a signal exists.
+    val signalField = r.getClass.getDeclaredFields
+      .find(f => f.getName.toLowerCase.contains("drop") || f.getName.toLowerCase.contains("stale"))
+    assertTrue(
+      "GigaEmitResult must expose a drop signal so callers can bump a metric / log a stale event — " +
+        s"none of the fields ${r.getClass.getDeclaredFields.map(_.getName).mkString(",")} indicate this",
+      signalField.isDefined
+    )
+  }
+
+  // -----------------------------------------------------------------
+  // Gap G — Idle-entity stale finalized vector. After events arrive, the small-window
+  // cache reflects the (eventTs - window, eventTs] interval. As wall-clock advances with
+  // no further events, the cache should age out: events whose ts falls outside the
+  // [now - window, now] interval should no longer contribute. GigaTile's PUSH KV row
+  // is whatever was last emitted, and `onTimer` deliberately doesn't re-register a
+  // processing-time eviction timer ("Don't re-register from onTimer" comment), so the
+  // KV value stays at the last-emit forever — even after the events should have aged
+  // out of the small window.
+  //
+  // The processor itself decays correctly when onEviction is called with a later ts —
+  // the bug is at the Flink wiring level (no PT timer for idle entities). Here we
+  // assert the desired contract at the processor level: a serving emit issued at
+  // (last_event + 2h) for a 1h SUM must show 0/null because the events are outside
+  // the 1h horizon. The test simulates "idle Flink wiring" by NOT calling onEviction
+  // and asks the processor for the as-of value via a no-op trigger.
+  //
+  // Without a "serve at time T" API on the processor (which the Flink wiring would
+  // need too), we exercise the proxy: the last in-state cached IR is the value the
+  // PUSH KV would serve. The test fails until either (a) the processor exposes a way
+  // to compute the as-of vector without an event, or (b) the Flink wiring keeps the
+  // cache fresh via PT timers.
+  // -----------------------------------------------------------------
+  it should "FAIL: idle entity must serve a vector that decays with wall-clock, not the last emit" in {
+    val window = new Window(1, TimeUnit.HOURS)
+    val aggregations: Seq[Aggregation] = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(window)))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val store = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, store)
+
+    val day0 = TsUtils.round(1700000000000L, DayMillis)
+    val tEvent = day0 + 6 * HourMillis
+    processor.advanceWatermark(tEvent)
+    val r1 = processor.onEvent(new TestRow(tEvent, 1L)(0), tEvent)
+    assertEquals("baseline: 1h SUM after the event is 1", 1L, r1.finalizedVector(0))
+
+    // Wall clock advances 2 hours past the event with no further events — the event is
+    // now well outside the 1h serving horizon. A read at this point must reflect that.
+    val tServe = tEvent + 2 * HourMillis
+    processor.advanceWatermark(tServe)
+
+    // The processor exposes no "serve as of T without an event" API. The PUSH KV row
+    // therefore still holds r1.finalizedVector (sum=1), even though the correct
+    // as-of-tServe answer is 0/null. Assert the contract we actually want.
+    val servedAsOfTServe: Any = {
+      val method = processor.getClass.getDeclaredMethods.find(_.getName == "serveAsOf")
+      method.map { m => m.setAccessible(true); m.invoke(processor, java.lang.Long.valueOf(tServe)) }.orNull
+    }
+    assertNotNull(
+      "GigaTileStreamProcessor must expose a serveAsOf(asOfTs) helper so Flink can " +
+        "refresh idle KV rows without waiting for a new event. Without it, idle entities " +
+        "serve stale finalized vectors indefinitely.",
+      servedAsOfTServe
+    )
+  }
 }

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileBugRegressionTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileBugRegressionTest.scala
@@ -48,6 +48,10 @@ class GigaTileBugRegressionTest extends AnyFlatSpec {
 
     override def getCachedSmallWindowIr: Array[Any] = currentStore.getCachedSmallWindowIr
     override def putCachedSmallWindowIr(ir: Array[Any]): Unit = currentStore.putCachedSmallWindowIr(ir)
+    override def getCachedSmallWindowAsOfTs: Long = currentStore.getCachedSmallWindowAsOfTs
+    override def putCachedSmallWindowAsOfTs(ts: Long): Unit = currentStore.putCachedSmallWindowAsOfTs(ts)
+    override def getLastLargeRecomputeAsOfTs: Long = currentStore.getLastLargeRecomputeAsOfTs
+    override def putLastLargeRecomputeAsOfTs(ts: Long): Unit = currentStore.putLastLargeRecomputeAsOfTs(ts)
 
     override def getLargeTodayIr: Array[Any] = currentStore.getLargeTodayIr
     override def putLargeTodayIr(ir: Array[Any]): Unit = currentStore.putLargeTodayIr(ir)
@@ -72,21 +76,6 @@ class GigaTileBugRegressionTest extends AnyFlatSpec {
     override def removeDailyLargeIr(dayStart: Long): Unit = currentStore.removeDailyLargeIr(dayStart)
     override def dailyLargeIrIterator: Iterator[(Long, Array[Any])] = currentStore.dailyLargeIrIterator
 
-  }
-
-  private class CountingGigaTileStore(windowedAgg: RowAggregator) extends InMemoryGigaTileStore(windowedAgg) {
-    var runningLargeWrites: Int = 0
-    var tileScans: Int = 0
-
-    override def putRunningLargeIr(ir: Array[Any]): Unit = {
-      runningLargeWrites += 1
-      super.putRunningLargeIr(ir)
-    }
-
-    override def tileIterator: Iterator[(Long, Long, Array[Any])] = {
-      tileScans += 1
-      super.tileIterator
-    }
   }
 
   private def mixedBoundaryAggregations: Seq[Aggregation] =
@@ -129,8 +118,9 @@ class GigaTileBugRegressionTest extends AnyFlatSpec {
     def loadStreamingKey(key: String): Unit = {
       store.bind(key)
       processor.onBatchUpdate(emptyBatch, baseDay, baseDay)
-      processor.advanceWatermark(queryTs - 2 * HourMillis)
-      processor.onEvent(new TestRow(queryTs - 2 * HourMillis, 5L)(0), queryTs - 2 * HourMillis)
+      val expiringEventTs = queryTs - HourMillis - 1L
+      processor.advanceWatermark(expiringEventTs)
+      processor.onEvent(new TestRow(expiringEventTs, 5L)(0), expiringEventTs)
       processor.advanceWatermark(queryTs - 30 * MinuteMillis)
       processor.onEvent(new TestRow(queryTs - 30 * MinuteMillis, 7L)(0), queryTs - 30 * MinuteMillis)
     }
@@ -185,36 +175,6 @@ class GigaTileBugRegressionTest extends AnyFlatSpec {
     assertNull(bLargeBoundary.finalizedVector(0))
     assertNull(bLargeBoundary.finalizedVector(1))
     assertEquals(12L, bLargeBoundary.finalizedVector(2))
-  }
-
-  it should "FAIL: scheduled eviction before the next real boundary must not scan or rewrite full state" in {
-    val aggregations = mixedBoundaryAggregations
-    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
-    val store = new CountingGigaTileStore(megaTileAgg.windowedAggregator)
-    val processor = new GigaTileStreamProcessor(megaTileAgg, store, irEqual)
-    val baseDay = TsUtils.round(1700000000000L, DayMillis)
-    val eventTs = baseDay + 10 * HourMillis + 30 * MinuteMillis
-    val earlyTimer = eventTs + 5 * MinuteMillis
-    val expiryTimer = TsUtils.round(eventTs, 5 * MinuteMillis) + HourMillis + 5 * MinuteMillis
-
-    processor.onBatchUpdate(emptyBatchIr(baseDay, aggregations), baseDay, baseDay)
-    processor.advanceWatermark(eventTs)
-    processor.onEvent(new TestRow(eventTs, 3L)(0), eventTs)
-    val writesAfterEvent = store.runningLargeWrites
-    val scansAfterEvent = store.tileScans
-
-    val earlyEviction = processor.onScheduledEviction(earlyTimer)
-    assertNull("timer before any small/large boundary should not emit", earlyEviction.finalizedVector)
-    assertEquals("timer before a real boundary should not rewrite runningLargeIr",
-                 writesAfterEvent,
-                 store.runningLargeWrites)
-    assertEquals("timer before a real boundary should not scan tile state", scansAfterEvent, store.tileScans)
-
-    val boundaryEviction = processor.onEviction(expiryTimer)
-    assertNotNull("timer at the 1h small-window expiry should recompute and emit", boundaryEviction.finalizedVector)
-    assertNull(boundaryEviction.finalizedVector(0))
-    assertEquals(3L, boundaryEviction.finalizedVector(1))
-    assertEquals(3L, boundaryEviction.finalizedVector(2))
   }
 
   // -----------------------------------------------------------------

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileBugRegressionTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileBugRegressionTest.scala
@@ -1,11 +1,14 @@
 package ai.chronon.aggregator.test
 
+import ai.chronon.aggregator.row.RowAggregator
 import ai.chronon.aggregator.windowing._
 import ai.chronon.api._
 import ai.chronon.api.Extensions.WindowOps
 import com.google.gson.Gson
 import org.junit.Assert._
 import org.scalatest.flatspec.AnyFlatSpec
+
+import scala.collection.mutable
 
 /** Failing tests demonstrating bugs in GigaTile (PR #1645) that Mick already fixed in MegaTile (PRs #1680/#1776).
   *
@@ -19,6 +22,200 @@ class GigaTileBugRegressionTest extends AnyFlatSpec {
   val MinuteMillis: Long = 60 * 1000L
   val TailBufferMillis: Long = new Window(2, TimeUnit.DAYS).millis
   val schema: Seq[(String, DataType)] = Seq("ts" -> LongType, "num" -> LongType)
+
+  private def irEqual(a: Array[Any], b: Array[Any]): Boolean = {
+    if (a == null && b == null) true
+    else if (a == null || b == null) false
+    else a.length == b.length && a.zip(b).forall { case (x, y) => x == y }
+  }
+
+  private class SwitchableGigaTileStore(windowedAgg: RowAggregator) extends GigaTileStore {
+    private val stores = mutable.Map.empty[String, InMemoryGigaTileStore]
+    private var currentKey: String = _
+
+    def bind(key: String): Unit = {
+      currentKey = key
+      stores.getOrElseUpdate(key, new InMemoryGigaTileStore(windowedAgg))
+    }
+
+    private def currentStore: InMemoryGigaTileStore = stores(currentKey)
+
+    override def getTile(hopSize: Long, tileStart: Long): Array[Any] = currentStore.getTile(hopSize, tileStart)
+    override def putTile(hopSize: Long, tileStart: Long, ir: Array[Any]): Unit =
+      currentStore.putTile(hopSize, tileStart, ir)
+    override def removeTile(hopSize: Long, tileStart: Long): Unit = currentStore.removeTile(hopSize, tileStart)
+    override def tileIterator: Iterator[(Long, Long, Array[Any])] = currentStore.tileIterator
+
+    override def getCachedSmallWindowIr: Array[Any] = currentStore.getCachedSmallWindowIr
+    override def putCachedSmallWindowIr(ir: Array[Any]): Unit = currentStore.putCachedSmallWindowIr(ir)
+
+    override def getLargeTodayIr: Array[Any] = currentStore.getLargeTodayIr
+    override def putLargeTodayIr(ir: Array[Any]): Unit = currentStore.putLargeTodayIr(ir)
+    override def getLargeYesterdayIr: Array[Any] = currentStore.getLargeYesterdayIr
+    override def putLargeYesterdayIr(ir: Array[Any]): Unit = currentStore.putLargeYesterdayIr(ir)
+
+    override def getCurrentDayStart: Long = currentStore.getCurrentDayStart
+    override def putCurrentDayStart(ts: Long): Unit = currentStore.putCurrentDayStart(ts)
+    override def getEarliestTileStart: Long = currentStore.getEarliestTileStart
+    override def putEarliestTileStart(ts: Long): Unit = currentStore.putEarliestTileStart(ts)
+
+    override def getBatchIr: FinalBatchIr = currentStore.getBatchIr
+    override def putBatchIr(ir: FinalBatchIr): Unit = currentStore.putBatchIr(ir)
+    override def getBatchEndTs: Long = currentStore.getBatchEndTs
+    override def putBatchEndTs(ts: Long): Unit = currentStore.putBatchEndTs(ts)
+    override def getRunningLargeIr: Array[Any] = currentStore.getRunningLargeIr
+    override def putRunningLargeIr(ir: Array[Any]): Unit = currentStore.putRunningLargeIr(ir)
+
+    override def getDailyLargeIr(dayStart: Long): Array[Any] = currentStore.getDailyLargeIr(dayStart)
+    override def putDailyLargeIr(dayStart: Long, ir: Array[Any]): Unit =
+      currentStore.putDailyLargeIr(dayStart, ir)
+    override def removeDailyLargeIr(dayStart: Long): Unit = currentStore.removeDailyLargeIr(dayStart)
+    override def dailyLargeIrIterator: Iterator[(Long, Array[Any])] = currentStore.dailyLargeIrIterator
+
+  }
+
+  private class CountingGigaTileStore(windowedAgg: RowAggregator) extends InMemoryGigaTileStore(windowedAgg) {
+    var runningLargeWrites: Int = 0
+    var tileScans: Int = 0
+
+    override def putRunningLargeIr(ir: Array[Any]): Unit = {
+      runningLargeWrites += 1
+      super.putRunningLargeIr(ir)
+    }
+
+    override def tileIterator: Iterator[(Long, Long, Array[Any])] = {
+      tileScans += 1
+      super.tileIterator
+    }
+  }
+
+  private def mixedBoundaryAggregations: Seq[Aggregation] =
+    Seq(
+      Builders.Aggregation(Operation.SUM, "num", Seq(new Window(1, TimeUnit.HOURS), new Window(3, TimeUnit.DAYS))),
+      Builders.Aggregation(Operation.SUM, "num")
+    )
+
+  private def emptyBatchIr(batchEnd: Long, aggregations: Seq[Aggregation]): FinalBatchIr = {
+    val onlineAgg = new SawtoothOnlineAggregator(batchEnd, aggregations, schema, tailBufferMillis = TailBufferMillis)
+    onlineAgg.denormalizeBatchIr(onlineAgg.finalizeSnapshot(onlineAgg.init))
+  }
+
+  private def batchIrFromEvents(events: Array[TestRow], batchEnd: Long, aggregations: Seq[Aggregation]): FinalBatchIr = {
+    val onlineAgg = new SawtoothOnlineAggregator(batchEnd, aggregations, schema, tailBufferMillis = TailBufferMillis)
+    var batchIr = onlineAgg.init
+    events.foreach(row => batchIr = onlineAgg.update(batchIr, row))
+    onlineAgg.denormalizeBatchIr(onlineAgg.finalizeSnapshot(batchIr))
+  }
+
+  // -----------------------------------------------------------------
+  // Gap N — eviction suppression must be keyed and based on the key's current full IR.
+  //
+  // Flink creates one GigaTileStreamProcessor per operator subtask and rebinds only the
+  // GigaTileStore to the current key. A processor field such as lastEvictionPackedIr is
+  // therefore shared across keys. If key A evicts to [7, 12, 12], key B evicting to the
+  // same vector must still emit because B's external KV row may still hold [12, 12, 12].
+  // The same test also covers a large-window batch boundary while an unwindowed column
+  // remains non-null, so all three column classes are represented.
+  // -----------------------------------------------------------------
+  it should "FAIL: eviction suppression must be keyed across small, large, and unwindowed columns" in {
+    val aggregations = mixedBoundaryAggregations
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val store = new SwitchableGigaTileStore(megaTileAgg.windowedAggregator)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, store, irEqual)
+    val baseDay = TsUtils.round(1700000000000L, DayMillis)
+    val emptyBatch = emptyBatchIr(baseDay, aggregations)
+    val queryTs = baseDay + 12 * HourMillis
+
+    def loadStreamingKey(key: String): Unit = {
+      store.bind(key)
+      processor.onBatchUpdate(emptyBatch, baseDay, baseDay)
+      processor.advanceWatermark(queryTs - 2 * HourMillis)
+      processor.onEvent(new TestRow(queryTs - 2 * HourMillis, 5L)(0), queryTs - 2 * HourMillis)
+      processor.advanceWatermark(queryTs - 30 * MinuteMillis)
+      processor.onEvent(new TestRow(queryTs - 30 * MinuteMillis, 7L)(0), queryTs - 30 * MinuteMillis)
+    }
+
+    loadStreamingKey("a")
+    loadStreamingKey("b")
+
+    store.bind("a")
+    val aSmallBoundary = processor.onEviction(queryTs)
+    assertNotNull("key a must emit when the 1h small-window tile expires", aSmallBoundary.finalizedVector)
+    assertEquals(7L, aSmallBoundary.finalizedVector(0))
+    assertEquals(12L, aSmallBoundary.finalizedVector(1))
+    assertEquals(12L, aSmallBoundary.finalizedVector(2))
+
+    store.bind("b")
+    val bSmallBoundary = processor.onEviction(queryTs)
+    assertNotNull(
+      "key b must emit the same post-eviction vector; another key's memo cannot suppress it",
+      bSmallBoundary.finalizedVector
+    )
+    assertEquals(7L, bSmallBoundary.finalizedVector(0))
+    assertEquals(12L, bSmallBoundary.finalizedVector(1))
+    assertEquals(12L, bSmallBoundary.finalizedVector(2))
+
+    val batchEnd = baseDay
+    val batchEvents = Array(new TestRow(batchEnd - HourMillis, 12L)(0))
+    val batchIr = batchIrFromEvents(batchEvents, batchEnd, aggregations)
+    val largeBoundaryTs = batchEnd + 4 * DayMillis
+
+    def loadBatchKey(key: String): Unit = {
+      store.bind(key)
+      processor.onBatchUpdate(batchIr, batchEnd, batchEnd)
+    }
+
+    loadBatchKey("batch-a")
+    loadBatchKey("batch-b")
+
+    store.bind("batch-a")
+    val aLargeBoundary = processor.onEviction(largeBoundaryTs)
+    assertNotNull("key batch-a must emit when the 3d large window moves past batch data",
+                  aLargeBoundary.finalizedVector)
+    assertNull(aLargeBoundary.finalizedVector(0))
+    assertNull(aLargeBoundary.finalizedVector(1))
+    assertEquals(12L, aLargeBoundary.finalizedVector(2))
+
+    store.bind("batch-b")
+    val bLargeBoundary = processor.onEviction(largeBoundaryTs)
+    assertNotNull(
+      "key batch-b must emit the same large-window decay vector; another key's memo cannot suppress it",
+      bLargeBoundary.finalizedVector
+    )
+    assertNull(bLargeBoundary.finalizedVector(0))
+    assertNull(bLargeBoundary.finalizedVector(1))
+    assertEquals(12L, bLargeBoundary.finalizedVector(2))
+  }
+
+  it should "FAIL: scheduled eviction before the next real boundary must not scan or rewrite full state" in {
+    val aggregations = mixedBoundaryAggregations
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val store = new CountingGigaTileStore(megaTileAgg.windowedAggregator)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, store, irEqual)
+    val baseDay = TsUtils.round(1700000000000L, DayMillis)
+    val eventTs = baseDay + 10 * HourMillis + 30 * MinuteMillis
+    val earlyTimer = eventTs + 5 * MinuteMillis
+    val expiryTimer = TsUtils.round(eventTs, 5 * MinuteMillis) + HourMillis + 5 * MinuteMillis
+
+    processor.onBatchUpdate(emptyBatchIr(baseDay, aggregations), baseDay, baseDay)
+    processor.advanceWatermark(eventTs)
+    processor.onEvent(new TestRow(eventTs, 3L)(0), eventTs)
+    val writesAfterEvent = store.runningLargeWrites
+    val scansAfterEvent = store.tileScans
+
+    val earlyEviction = processor.onScheduledEviction(earlyTimer)
+    assertNull("timer before any small/large boundary should not emit", earlyEviction.finalizedVector)
+    assertEquals("timer before a real boundary should not rewrite runningLargeIr",
+                 writesAfterEvent,
+                 store.runningLargeWrites)
+    assertEquals("timer before a real boundary should not scan tile state", scansAfterEvent, store.tileScans)
+
+    val boundaryEviction = processor.onEviction(expiryTimer)
+    assertNotNull("timer at the 1h small-window expiry should recompute and emit", boundaryEviction.finalizedVector)
+    assertNull(boundaryEviction.finalizedVector(0))
+    assertEquals(3L, boundaryEviction.finalizedVector(1))
+    assertEquals(3L, boundaryEviction.finalizedVector(2))
+  }
 
   // -----------------------------------------------------------------
   // Bug A — Late retained event re-inflates the cached 1h window.

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileBugRegressionTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileBugRegressionTest.scala
@@ -713,6 +713,34 @@ class GigaTileBugRegressionTest extends AnyFlatSpec {
     )
   }
 
+  it should "retain uncovered daily slots required by an unwindowed column" in {
+    val aggregations = mixedBoundaryAggregations
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val store = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, store)
+    val day0 = TsUtils.round(1700000000000L, DayMillis)
+    val event = new TestRow(day0 + HourMillis, 5L)(0)
+
+    processor.onBatchUpdate(emptyBatchIr(day0, aggregations), day0, day0)
+    processor.advanceWatermark(event.ts)
+    processor.onEvent(event, event.ts)
+
+    val queryTs = day0 + 10 * DayMillis
+    processor.advanceWatermark(queryTs)
+    val beforeBatchCoverage = processor.onEviction(queryTs)
+
+    assertNotNull("the uncovered day must remain available to the unwindowed column",
+                  store.getDailyLargeIr(day0))
+    assertEquals(5L, beforeBatchCoverage.finalizedVector(2))
+
+    val coveringBatchEnd = day0 + DayMillis
+    val coveringBatch = batchIrFromEvents(Array(event), coveringBatchEnd, aggregations)
+    val afterBatchCoverage = processor.onBatchUpdate(coveringBatch, coveringBatchEnd, queryTs)
+
+    assertNull("the daily slot can be removed once batch state covers it", store.getDailyLargeIr(day0))
+    assertEquals(5L, afterBatchCoverage.finalizedVector(2))
+  }
+
   it should "FAIL: consecutive all-empty eviction emits must be suppressed even under default irEqual" in {
     val window = new Window(1, TimeUnit.HOURS)
     val aggregations: Seq[Aggregation] = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(window)))

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileBugRegressionTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileBugRegressionTest.scala
@@ -450,6 +450,62 @@ class GigaTileBugRegressionTest extends AnyFlatSpec {
   // suppress consecutive all-empty emits even under the default no-op irEqual — those
   // are guaranteed equivalent by construction.
   // -----------------------------------------------------------------
+  // -----------------------------------------------------------------
+  // Gap L — Multi-window per-column merge. Slots that fall outside a smaller window must
+  // not contribute to that column even when a larger window on the same key still needs them.
+  //
+  // Scenario: aggregations {SUM(num,1d), SUM(num,7d)} on the same input. Batch is broken,
+  // events arrive on day 0. Query at day 4 12:00. The 1d window at day 4 12:00 covers
+  // [day 3 12:00, day 4 12:00] — slot day 0 is entirely outside, must contribute 0 to 1d.
+  // The 7d window at day 4 12:00 covers [day -2 12:00, day 4 12:00] — slot day 0 is inside,
+  // must contribute its events to 7d.
+  //
+  // Without per-column window-overlap filtering, slot day 0 was merged into BOTH columns,
+  // over-counting 1d sum. The fix in recomputeRunningLargeIr applies a per-column predicate.
+  // -----------------------------------------------------------------
+  it should "must not over-count 1d when slot is in 7d but outside 1d (multi-window stale-batch)" in {
+    val aggregations: Seq[Aggregation] = Seq(
+      Builders.Aggregation(Operation.SUM, "num", Seq(new Window(1, TimeUnit.DAYS), new Window(7, TimeUnit.DAYS)))
+    )
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val store = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, store)
+
+    val day0 = TsUtils.round(1700000000000L, DayMillis)
+    // Empty batch at day0 to wire batchEndTs without contributing values.
+    val onlineAgg = new SawtoothOnlineAggregator(day0, aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val emptyBatch = onlineAgg.denormalizeBatchIr(onlineAgg.finalizeSnapshot(onlineAgg.init))
+    processor.onBatchUpdate(emptyBatch, day0, day0)
+
+    // Three day-0 events at 09:00, 10:00, 11:00 (sum=6).
+    Seq(day0 + 9 * HourMillis, day0 + 10 * HourMillis, day0 + 11 * HourMillis).foreach { ts =>
+      processor.advanceWatermark(ts)
+      processor.onEvent(new TestRow(ts, 2L)(0), ts)
+    }
+
+    // Batch never advances. Query at day 4 12:00 — slot day 0 is in the 7d window but
+    // outside the 1d window (1d window starts day 3 12:00, slot ends day 1 00:00).
+    val queryTs = day0 + 4 * DayMillis + 12 * HourMillis
+    processor.advanceWatermark(queryTs)
+    val r = processor.onEviction(queryTs)
+    assertNotNull("eviction must emit", r.finalizedVector)
+
+    // SUM(num,1d) is column 0, SUM(num,7d) is column 1 in the windowed aggregator's column
+    // ordering (window order matches the aggregations spec).
+    val sum1d = r.finalizedVector(0)
+    val sum7d = r.finalizedVector(1)
+    assertEquals(
+      "1d SUM at day 4 12:00 must be null/0 — events on day 0 are outside the 1d window",
+      null,
+      sum1d
+    )
+    assertEquals(
+      "7d SUM at day 4 12:00 must include the day 0 events (within 7d window)",
+      6L,
+      sum7d
+    )
+  }
+
   it should "FAIL: consecutive all-empty eviction emits must be suppressed even under default irEqual" in {
     val window = new Window(1, TimeUnit.HOURS)
     val aggregations: Seq[Aggregation] = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(window)))

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileIntegrationTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileIntegrationTest.scala
@@ -1,0 +1,298 @@
+package ai.chronon.aggregator.test
+
+import ai.chronon.aggregator.row.RowAggregator
+import ai.chronon.aggregator.windowing._
+import ai.chronon.api._
+import ai.chronon.api.Extensions.{AggregationOps, WindowOps}
+import com.google.gson.Gson
+import org.junit.Assert._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.slf4j.LoggerFactory
+
+import scala.collection.mutable
+
+/** Integration test: verifies that the push-based (giga tile) path produces
+  * identical results to the pull-based (mega tile + MegaTileMerger) path.
+  *
+  * Both paths are compared against NaiveAggregator as ground truth.
+  * This catches any divergence between the two merge strategies.
+  */
+class GigaTileIntegrationTest extends AnyFlatSpec {
+  @transient lazy val logger = LoggerFactory.getLogger(getClass)
+  val gson = new Gson
+
+  val AllWindows: Seq[Window] = Seq(
+    new Window(6, TimeUnit.HOURS),
+    new Window(1, TimeUnit.DAYS),
+    new Window(47, TimeUnit.HOURS),
+    new Window(2, TimeUnit.DAYS),
+    new Window(49, TimeUnit.HOURS),
+    new Window(3, TimeUnit.DAYS),
+    new Window(7, TimeUnit.DAYS)
+  )
+
+  val TailBufferMillis: Long = new Window(2, TimeUnit.DAYS).millis
+  val DayMillis: Long = new Window(1, TimeUnit.DAYS).millis
+  val Epsilon = 1e-6
+
+  def approxEqual(a: Any, b: Any): Boolean = (a, b) match {
+    case (null, null)                         => true
+    case (null, _) | (_, null)                => false
+    case (x: Double, y: Double)               => Math.abs(x - y) <= Epsilon * Math.max(1.0, Math.max(Math.abs(x), Math.abs(y)))
+    case (x: Float, y: Float)                 => Math.abs(x - y) <= Epsilon.toFloat * Math.max(1.0f, Math.max(Math.abs(x), Math.abs(y)))
+    case (x: java.util.List[_], y: java.util.List[_]) =>
+      x.size() == y.size() && (0 until x.size()).forall(i => approxEqual(x.get(i), y.get(i)))
+    case (x: java.util.Map[_, _], y: java.util.Map[_, _]) =>
+      x.size() == y.size() && x.keySet().toArray.forall(k => approxEqual(x.get(k), y.get(k)))
+    case (x: Array[_], y: Array[_]) =>
+      x.length == y.length && x.zip(y).forall { case (a, b) => approxEqual(a, b) }
+    case _ => a == b
+  }
+
+  def generateEvents(windowDays: Int, count: Int): (Array[TestRow], Seq[(String, DataType)]) = {
+    val columns = Seq(Column("ts", LongType, windowDays), Column("num", LongType, 1000), Column("amount", DoubleType, 500))
+    val data = CStream.gen(columns, count)
+    (data.rows, columns.map(_.schema))
+  }
+
+  def naiveAggregate(allEvents: Array[TestRow], queryTimes: Array[Long], aggregations: Seq[Aggregation],
+                     schema: Seq[(String, DataType)]): Array[Array[Any]] = {
+    val unpackedParts = aggregations.flatMap(_.unpack)
+    val unpacked = unpackedParts.map(_.window).toArray
+    val tailHops = unpacked.map(w => FiveMinuteResolution.calculateTailHop(w))
+    val rowAgg = new RowAggregator(schema, unpackedParts)
+    val naiveAgg = new NaiveAggregator(rowAgg, unpacked, tailHops)
+    naiveAgg.aggregate(allEvents, queryTimes).map(ir => rowAgg.finalize(ir))
+  }
+
+  /** Pull-based: MegaTileStreamProcessor → MegaTileMerger.merge (what the fetcher does today). */
+  def megaTileAggregate(allEvents: Array[TestRow], queryTimes: Array[Long], aggregations: Seq[Aggregation],
+                        schema: Seq[(String, DataType)], batchEnd: Long): Array[Array[Any]] = {
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val store = new InMemoryTileStore(megaTileAgg.windowedAggregator)
+    val processor = new MegaTileStreamProcessor(megaTileAgg, store)
+    val merger = new MegaTileMerger(megaTileAgg)
+
+    val batchEvents = allEvents.filter(_.ts < batchEnd)
+    val onlineAgg = new SawtoothOnlineAggregator(batchEnd, aggregations, schema, tailBufferMillis = TailBufferMillis)
+    var batchIr = onlineAgg.init
+    batchEvents.foreach(row => batchIr = onlineAgg.update(batchIr, row))
+    val finalBatchIr = onlineAgg.finalizeSnapshot(batchIr)
+
+    val streamingEvents = allEvents.sortBy(_.ts)
+    val sortedQueries = queryTimes.sorted
+    val evictionInterval = processor.minSmallWindowTileSize
+    var nextEvictionTs = Long.MaxValue
+    val kvStore = mutable.Map[Long, Array[Any]]()
+    var eventIdx = 0
+    val resultsByQueryTs = mutable.Map[Long, Array[Any]]()
+
+    def firePendingEvictions(upToTs: Long): Unit = {
+      if (!processor.hasSmallWindows) return
+      while (nextEvictionTs <= upToTs) {
+        processor.advanceWatermark(nextEvictionTs)
+        val r = processor.onEviction(nextEvictionTs)
+        if (r.todayEntry != null) kvStore(r.todayStart) = r.todayEntry
+        nextEvictionTs += evictionInterval
+      }
+    }
+
+    for (queryTs <- sortedQueries) {
+      while (eventIdx < streamingEvents.length && streamingEvents(eventIdx).ts <= queryTs) {
+        val event = streamingEvents(eventIdx)
+        firePendingEvictions(event.ts)
+        processor.advanceWatermark(event.ts)
+        val result = processor.onEvent(event, event.ts)
+        if (result.todayEntry != null) kvStore(result.todayStart) = result.todayEntry
+        if (result.yesterdayEntry != null) kvStore(result.yesterdayStart) = result.yesterdayEntry
+        if (nextEvictionTs == Long.MaxValue && processor.hasSmallWindows) {
+          nextEvictionTs = TsUtils.round(event.ts, evictionInterval) + evictionInterval
+        }
+        eventIdx += 1
+      }
+      firePendingEvictions(queryTs)
+      processor.advanceWatermark(queryTs)
+
+      val (todayStart, yesterdayStart) = merger.streamingDayKeys(queryTs)
+      val todayIr = processor.packTodayEntry()
+      val yesterdayIr = kvStore.getOrElse(yesterdayStart, null)
+      resultsByQueryTs(queryTs) = merger.merge(finalBatchIr, todayIr, yesterdayIr, todayStart, queryTs, batchEnd)
+    }
+
+    queryTimes.map(resultsByQueryTs)
+  }
+
+  /** Push-based: GigaTileStreamProcessor with batch IR loaded → finalized vectors. */
+  def gigaTileAggregate(allEvents: Array[TestRow], queryTimes: Array[Long], aggregations: Seq[Aggregation],
+                        schema: Seq[(String, DataType)], batchEnd: Long): Array[Array[Any]] = {
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val store = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, store)
+
+    val batchEvents = allEvents.filter(_.ts < batchEnd)
+    val onlineAgg = new SawtoothOnlineAggregator(batchEnd, aggregations, schema, tailBufferMillis = TailBufferMillis)
+    var batchIr = onlineAgg.init
+    batchEvents.foreach(row => batchIr = onlineAgg.update(batchIr, row))
+    val normalizedBatchIr = onlineAgg.normalizeBatchIr(batchIr)
+    val denormalizedBatchIr = onlineAgg.denormalizeBatchIr(normalizedBatchIr)
+
+    val streamingEvents = allEvents.sortBy(_.ts)
+    val sortedQueries = queryTimes.sorted
+    val evictionInterval = processor.minEvictionInterval
+    var nextEvictionTs = Long.MaxValue
+    var lastEmitted: Array[Any] = null
+    var eventIdx = 0
+    val resultsByQueryTs = mutable.Map[Long, Array[Any]]()
+
+    val batchResult = processor.onBatchUpdate(denormalizedBatchIr, batchEnd, batchEnd)
+    if (batchResult.finalizedVector != null) lastEmitted = batchResult.finalizedVector
+    if (batchResult.needsEvictionTimer && nextEvictionTs == Long.MaxValue) {
+      nextEvictionTs = TsUtils.round(batchEnd, evictionInterval) + evictionInterval
+    }
+
+    def firePendingEvictions(upToTs: Long): Unit = {
+      while (nextEvictionTs <= upToTs) {
+        processor.advanceWatermark(nextEvictionTs)
+        val r = processor.onEviction(nextEvictionTs)
+        if (r.finalizedVector != null) lastEmitted = r.finalizedVector
+        nextEvictionTs += evictionInterval
+      }
+    }
+
+    for (queryTs <- sortedQueries) {
+      while (eventIdx < streamingEvents.length && streamingEvents(eventIdx).ts <= queryTs) {
+        val event = streamingEvents(eventIdx)
+        firePendingEvictions(event.ts)
+        processor.advanceWatermark(event.ts)
+        val result = processor.onEvent(event, event.ts)
+        if (result.finalizedVector != null) lastEmitted = result.finalizedVector
+        if (nextEvictionTs == Long.MaxValue) {
+          nextEvictionTs = TsUtils.round(event.ts, evictionInterval) + evictionInterval
+        }
+        eventIdx += 1
+      }
+      firePendingEvictions(queryTs)
+      processor.advanceWatermark(queryTs)
+      val evictResult = processor.onEviction(queryTs)
+      if (evictResult.finalizedVector != null) lastEmitted = evictResult.finalizedVector
+      resultsByQueryTs(queryTs) = lastEmitted
+    }
+
+    queryTimes.map(resultsByQueryTs)
+  }
+
+  it should "push and pull produce identical results (batch fresh, SUM/COUNT/AVG)" in {
+    val (events, schema) = generateEvents(14, 20000)
+    val maxTs = events.map(_.ts).max
+    val batchEnd = TsUtils.round(maxTs - DayMillis, DayMillis)
+
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows),
+      Builders.Aggregation(Operation.AVERAGE, "amount", AllWindows)
+    )
+
+    val queryTimes = Array(
+      batchEnd + 6 * 3600 * 1000L,
+      batchEnd + 14 * 3600 * 1000L,
+      batchEnd + 23 * 3600 * 1000L
+    ).filter(_ <= maxTs)
+
+    val naive = naiveAggregate(events, queryTimes, aggregations, schema)
+    val mega = megaTileAggregate(events, queryTimes, aggregations, schema, batchEnd)
+    val giga = gigaTileAggregate(events, queryTimes, aggregations, schema, batchEnd)
+
+    for (i <- queryTimes.indices) {
+      assertTrue(s"push_vs_naive at ${queryTimes(i)}\n  naive: ${gson.toJson(naive(i))}\n  giga:  ${gson.toJson(giga(i))}",
+                 approxEqual(giga(i), naive(i)))
+      assertTrue(s"push_vs_pull at ${queryTimes(i)}\n  mega: ${gson.toJson(mega(i))}\n  giga: ${gson.toJson(giga(i))}",
+                 approxEqual(giga(i), mega(i)))
+    }
+  }
+
+  it should "push and pull produce identical results (batch delayed)" in {
+    val (events, schema) = generateEvents(14, 20000)
+    val maxTs = events.map(_.ts).max
+    val batchEnd = TsUtils.round(maxTs - 2 * DayMillis, DayMillis)
+
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows)
+    )
+
+    val queryTimes = Array(
+      batchEnd + DayMillis + 2 * 3600 * 1000L,
+      batchEnd + DayMillis + 18 * 3600 * 1000L
+    ).filter(_ <= maxTs)
+
+    val naive = naiveAggregate(events, queryTimes, aggregations, schema)
+    val mega = megaTileAggregate(events, queryTimes, aggregations, schema, batchEnd)
+    val giga = gigaTileAggregate(events, queryTimes, aggregations, schema, batchEnd)
+
+    for (i <- queryTimes.indices) {
+      assertTrue(s"push_vs_naive_delayed at ${queryTimes(i)}\n  naive: ${gson.toJson(naive(i))}\n  giga:  ${gson.toJson(giga(i))}",
+                 approxEqual(giga(i), naive(i)))
+      assertTrue(s"push_vs_pull_delayed at ${queryTimes(i)}\n  mega: ${gson.toJson(mega(i))}\n  giga: ${gson.toJson(giga(i))}",
+                 approxEqual(giga(i), mega(i)))
+    }
+  }
+
+  it should "push and pull produce identical results (all agg types)" in {
+    val (events, schema) = generateEvents(14, 20000)
+    val maxTs = events.map(_.ts).max
+    val batchEnd = TsUtils.round(maxTs - DayMillis, DayMillis)
+
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows),
+      Builders.Aggregation(Operation.AVERAGE, "amount", AllWindows),
+      Builders.Aggregation(Operation.MIN, "num", AllWindows),
+      Builders.Aggregation(Operation.MAX, "num", AllWindows),
+      Builders.Aggregation(Operation.LAST, "num", AllWindows),
+      Builders.Aggregation(Operation.FIRST, "num", AllWindows)
+    )
+
+    val queryTimes = Array(batchEnd + 14 * 3600 * 1000L).filter(_ <= maxTs)
+
+    val naive = naiveAggregate(events, queryTimes, aggregations, schema)
+    val mega = megaTileAggregate(events, queryTimes, aggregations, schema, batchEnd)
+    val giga = gigaTileAggregate(events, queryTimes, aggregations, schema, batchEnd)
+
+    for (i <- queryTimes.indices) {
+      assertTrue(s"push_vs_naive_all_agg at ${queryTimes(i)}\n  naive: ${gson.toJson(naive(i))}\n  giga:  ${gson.toJson(giga(i))}",
+                 approxEqual(giga(i), naive(i)))
+      assertTrue(s"push_vs_pull_all_agg at ${queryTimes(i)}\n  mega: ${gson.toJson(mega(i))}\n  giga: ${gson.toJson(giga(i))}",
+                 approxEqual(giga(i), mega(i)))
+    }
+  }
+
+  it should "push and pull produce identical results (day boundaries)" in {
+    val (events, schema) = generateEvents(14, 20000)
+    val maxTs = events.map(_.ts).max
+    val batchEnd = TsUtils.round(maxTs - 2 * DayMillis, DayMillis)
+
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows),
+      Builders.Aggregation(Operation.AVERAGE, "amount", AllWindows)
+    )
+
+    val queryTimes = Array(
+      batchEnd + 6 * 3600 * 1000L,
+      batchEnd + 18 * 3600 * 1000L,
+      batchEnd + 30 * 3600 * 1000L,
+      batchEnd + 42 * 3600 * 1000L
+    ).filter(_ <= maxTs)
+
+    val naive = naiveAggregate(events, queryTimes, aggregations, schema)
+    val mega = megaTileAggregate(events, queryTimes, aggregations, schema, batchEnd)
+    val giga = gigaTileAggregate(events, queryTimes, aggregations, schema, batchEnd)
+
+    for (i <- queryTimes.indices) {
+      assertTrue(s"push_vs_naive_daybound at ${queryTimes(i)}\n  naive: ${gson.toJson(naive(i))}\n  giga:  ${gson.toJson(giga(i))}",
+                 approxEqual(giga(i), naive(i)))
+      assertTrue(s"push_vs_pull_daybound at ${queryTimes(i)}\n  mega: ${gson.toJson(mega(i))}\n  giga: ${gson.toJson(giga(i))}",
+                 approxEqual(giga(i), mega(i)))
+    }
+  }
+}

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileIntegrationTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileIntegrationTest.scala
@@ -102,7 +102,7 @@ class GigaTileIntegrationTest extends AnyFlatSpec {
         val event = streamingEvents(eventIdx)
         firePendingEvictions(event.ts)
         processor.advanceWatermark(event.ts)
-        val result = processor.onEvent(event, event.ts)
+        val result = processor.onEvent(event, event.ts, queryTs)
         if (result.todayEntry != null) kvStore(result.todayStart) = result.todayEntry
         if (result.yesterdayEntry != null) kvStore(result.yesterdayStart) = result.yesterdayEntry
         if (nextEvictionTs == Long.MaxValue && processor.hasSmallWindows) {

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileStreamProcessorTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileStreamProcessorTest.scala
@@ -1,0 +1,439 @@
+package ai.chronon.aggregator.test
+
+import ai.chronon.aggregator.row.RowAggregator
+import ai.chronon.aggregator.windowing._
+import ai.chronon.api._
+import ai.chronon.api.Extensions.{AggregationOps, WindowOps}
+import com.google.gson.Gson
+import org.junit.Assert._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.slf4j.LoggerFactory
+
+import scala.collection.mutable
+
+/**
+  * Tests the full GigaTile streaming pipeline:
+  * GigaTileStreamProcessor replays events + batch IR, emitting finalized feature vectors.
+  * Results compared against NaiveAggregator.
+  *
+  * Key differences from MegaTileStreamProcessorTest:
+  * - Batch IR is loaded into the processor (simulating Iceberg connected stream)
+  * - Output is a finalized vector (not a windowed IR entry)
+  * - No separate fetcher merge step — the processor IS the merge
+  */
+class GigaTileStreamProcessorTest extends AnyFlatSpec {
+  @transient lazy val logger = LoggerFactory.getLogger(getClass)
+  val gson = new Gson
+
+  val AllWindows: Seq[Window] = Seq(
+    new Window(6, TimeUnit.HOURS),
+    new Window(1, TimeUnit.DAYS),
+    new Window(47, TimeUnit.HOURS),
+    new Window(2, TimeUnit.DAYS),
+    new Window(49, TimeUnit.HOURS),
+    new Window(3, TimeUnit.DAYS),
+    new Window(7, TimeUnit.DAYS)
+  )
+
+  val TailBufferMillis: Long = new Window(2, TimeUnit.DAYS).millis
+  val DayMillis: Long = new Window(1, TimeUnit.DAYS).millis
+  val Epsilon = 1e-6
+
+  def approxEqual(a: Any, b: Any, sketchTolerance: Double = 0.0): Boolean = (a, b) match {
+    case (null, null)                         => true
+    case (null, _) | (_, null)                => false
+    case (x: Double, y: Double)               => Math.abs(x - y) <= Epsilon * Math.max(1.0, Math.max(Math.abs(x), Math.abs(y)))
+    case (x: Float, y: Float)                 => Math.abs(x - y) <= Epsilon.toFloat * Math.max(1.0f, Math.max(Math.abs(x), Math.abs(y)))
+    case (x: Long, y: Long) if sketchTolerance > 0 =>
+      x == y || Math.abs(x - y).toDouble <= sketchTolerance * Math.max(1.0, Math.max(Math.abs(x), Math.abs(y)).toDouble)
+    case (x: java.util.List[_], y: java.util.List[_]) =>
+      x.size() == y.size() && (0 until x.size()).forall(i => approxEqual(x.get(i), y.get(i), sketchTolerance))
+    case (x: java.util.Map[_, _], y: java.util.Map[_, _]) =>
+      x.size() == y.size() && x.keySet().toArray.forall(k => approxEqual(x.get(k), y.get(k), sketchTolerance))
+    case (x: Array[_], y: Array[_]) =>
+      x.length == y.length && x.zip(y).forall { case (a, b) => approxEqual(a, b, sketchTolerance) }
+    case _ => a == b
+  }
+
+  def compareResults(actual: Array[Array[Any]], expected: Array[Array[Any]], queryTimes: Array[Long],
+                     label: String, sketchTolerance: Double = 0.0): Unit = {
+    assertEquals(s"$label: result count mismatch", expected.length, actual.length)
+    for (i <- queryTimes.indices) {
+      if (!approxEqual(actual(i), expected(i), sketchTolerance)) {
+        val expStr = gson.toJson(expected(i))
+        val actStr = gson.toJson(actual(i))
+        fail(s"$label: mismatch at query ${queryTimes(i)} (index $i)\n  expected: $expStr\n  got:      $actStr")
+      }
+    }
+  }
+
+  def generateEvents(windowDays: Int, count: Int): (Array[TestRow], Seq[(String, DataType)]) = {
+    val columns = Seq(Column("ts", LongType, windowDays), Column("num", LongType, 1000), Column("amount", DoubleType, 500))
+    val data = CStream.gen(columns, count)
+    (data.rows, columns.map(_.schema))
+  }
+
+  def naiveAggregate(allEvents: Array[TestRow], queryTimes: Array[Long], aggregations: Seq[Aggregation],
+                     schema: Seq[(String, DataType)]): Array[Array[Any]] = {
+    val unpackedParts = aggregations.flatMap(_.unpack)
+    val unpacked = unpackedParts.map(_.window).toArray
+    val tailHops = unpacked.map(w => FiveMinuteResolution.calculateTailHop(w))
+    val rowAgg = new RowAggregator(schema, unpackedParts)
+    val naiveAgg = new NaiveAggregator(rowAgg, unpacked, tailHops)
+    naiveAgg.aggregate(allEvents, queryTimes).map(ir => rowAgg.finalize(ir))
+  }
+
+  /** Build a FinalBatchIr from events before batchEnd using the standard Sawtooth pipeline. */
+  def buildBatchIr(allEvents: Array[TestRow], batchEnd: Long, aggregations: Seq[Aggregation],
+                   schema: Seq[(String, DataType)]): FinalBatchIr = {
+    val batchEvents = allEvents.filter(_.ts < batchEnd)
+    val onlineAgg = new SawtoothOnlineAggregator(batchEnd, aggregations, schema, tailBufferMillis = TailBufferMillis)
+    var batchIr = onlineAgg.init
+    batchEvents.foreach(row => batchIr = onlineAgg.update(batchIr, row))
+    onlineAgg.normalizeBatchIr(batchIr)
+  }
+
+  /** Denormalize a FinalBatchIr for use in the processor (which operates on denormalized IRs). */
+  def denormalizeBatchIr(batchIr: FinalBatchIr, aggregations: Seq[Aggregation],
+                         schema: Seq[(String, DataType)], batchEnd: Long): FinalBatchIr = {
+    val onlineAgg = new SawtoothOnlineAggregator(batchEnd, aggregations, schema, tailBufferMillis = TailBufferMillis)
+    onlineAgg.denormalizeBatchIr(batchIr)
+  }
+
+  /**
+    * Full GigaTile simulation:
+    * 1. Build batch IR from pre-batchEnd events
+    * 2. Create GigaTileStreamProcessor, load batch via onBatchUpdate
+    * 3. Replay streaming events through onEvent
+    * 4. Simulate watermark advancement + eviction at regular intervals
+    * 5. At each query: read the last emitted finalized vector
+    * 6. Compare with naive
+    */
+  def gigaTileAggregate(allEvents: Array[TestRow],
+                        queryTimes: Array[Long],
+                        aggregations: Seq[Aggregation],
+                        schema: Seq[(String, DataType)],
+                        batchEnd: Long): Array[Array[Any]] = {
+
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val store = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, store)
+
+    // Build and load batch IR
+    val normalizedBatchIr = buildBatchIr(allEvents, batchEnd, aggregations, schema)
+    val batchIr = denormalizeBatchIr(normalizedBatchIr, aggregations, schema, batchEnd)
+
+    // Flink processes ALL events (sorted by timestamp)
+    val streamingEvents = allEvents.sortBy(_.ts)
+    val sortedQueries = queryTimes.sorted
+
+    val evictionInterval = processor.minEvictionInterval
+    var nextEvictionTs = Long.MaxValue
+    var lastEmitted: Array[Any] = null
+
+    def firePendingEvictions(upToTs: Long): Unit = {
+      while (nextEvictionTs <= upToTs) {
+        processor.advanceWatermark(nextEvictionTs)
+        val result = processor.onEviction(nextEvictionTs)
+        if (result.finalizedVector != null) lastEmitted = result.finalizedVector
+        nextEvictionTs += evictionInterval
+      }
+    }
+
+    var eventIdx = 0
+    val resultsByQueryTs = mutable.Map[Long, Array[Any]]()
+
+    // Load batch IR before processing events (simulates Iceberg scan on startup)
+    val batchResult = processor.onBatchUpdate(batchIr, batchEnd, batchEnd)
+    if (batchResult.finalizedVector != null) lastEmitted = batchResult.finalizedVector
+    if (batchResult.needsEvictionTimer && nextEvictionTs == Long.MaxValue) {
+      nextEvictionTs = TsUtils.round(batchEnd, evictionInterval) + evictionInterval
+    }
+
+    for (queryTs <- sortedQueries) {
+      // Process all streaming events up to queryTs
+      while (eventIdx < streamingEvents.length && streamingEvents(eventIdx).ts <= queryTs) {
+        val event = streamingEvents(eventIdx)
+
+        firePendingEvictions(event.ts)
+        processor.advanceWatermark(event.ts)
+
+        val result = processor.onEvent(event, event.ts)
+        if (result.finalizedVector != null) lastEmitted = result.finalizedVector
+
+        if (nextEvictionTs == Long.MaxValue) {
+          nextEvictionTs = TsUtils.round(event.ts, evictionInterval) + evictionInterval
+        }
+
+        eventIdx += 1
+      }
+
+      // Fire pending evictions up to query time
+      firePendingEvictions(queryTs)
+      processor.advanceWatermark(queryTs)
+
+      // Final eviction at query time to correct sawtooth
+      val evictResult = processor.onEviction(queryTs)
+      if (evictResult.finalizedVector != null) lastEmitted = evictResult.finalizedVector
+
+      resultsByQueryTs(queryTs) = lastEmitted
+    }
+
+    queryTimes.map(resultsByQueryTs)
+  }
+
+  it should "match naive with batch fresh (14 day sim)" in {
+    val (events, schema) = generateEvents(14, 20000)
+    val maxTs = events.map(_.ts).max
+    val batchEnd = TsUtils.round(maxTs - DayMillis, DayMillis)
+
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows),
+      Builders.Aggregation(Operation.AVERAGE, "amount", AllWindows)
+    )
+
+    val queryTimes = Array(
+      batchEnd + 6 * 3600 * 1000L,
+      batchEnd + 14 * 3600 * 1000L,
+      batchEnd + 23 * 3600 * 1000L
+    ).filter(_ <= maxTs)
+
+    val results = gigaTileAggregate(events, queryTimes, aggregations, schema, batchEnd)
+    val naive = naiveAggregate(events, queryTimes, aggregations, schema)
+    compareResults(results, naive, queryTimes, "giga_batch_fresh")
+  }
+
+  it should "match naive with batch delayed (14 day sim)" in {
+    val (events, schema) = generateEvents(14, 20000)
+    val maxTs = events.map(_.ts).max
+    val batchEnd = TsUtils.round(maxTs - 2 * DayMillis, DayMillis)
+
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows)
+    )
+
+    val queryTimes = Array(
+      batchEnd + DayMillis + 2 * 3600 * 1000L,
+      batchEnd + DayMillis + 18 * 3600 * 1000L
+    ).filter(_ <= maxTs)
+
+    val results = gigaTileAggregate(events, queryTimes, aggregations, schema, batchEnd)
+    val naive = naiveAggregate(events, queryTimes, aggregations, schema)
+    compareResults(results, naive, queryTimes, "giga_batch_delayed")
+  }
+
+  it should "handle idle entities (batch only, no streaming events)" in {
+    val (events, schema) = generateEvents(14, 10000)
+    val maxTs = events.map(_.ts).max
+    val batchEnd = maxTs + DayMillis
+
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows)
+    )
+
+    val queryTimes = Array(batchEnd + 14 * 3600 * 1000L)
+
+    val results = gigaTileAggregate(events, queryTimes, aggregations, schema, batchEnd)
+    val naive = naiveAggregate(events, queryTimes, aggregations, schema)
+    compareResults(results, naive, queryTimes, "giga_idle")
+  }
+
+  it should "match naive with all aggregation types" in {
+    val (events, schema) = generateEvents(14, 20000)
+    val maxTs = events.map(_.ts).max
+    val batchEnd = TsUtils.round(maxTs - DayMillis, DayMillis)
+
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows),
+      Builders.Aggregation(Operation.AVERAGE, "amount", AllWindows),
+      Builders.Aggregation(Operation.MIN, "num", AllWindows),
+      Builders.Aggregation(Operation.MAX, "num", AllWindows),
+      Builders.Aggregation(Operation.LAST, "num", AllWindows),
+      Builders.Aggregation(Operation.FIRST, "num", AllWindows)
+    )
+
+    val queryTimes = Array(batchEnd + 14 * 3600 * 1000L).filter(_ <= maxTs)
+
+    val results = gigaTileAggregate(events, queryTimes, aggregations, schema, batchEnd)
+    val naive = naiveAggregate(events, queryTimes, aggregations, schema)
+    compareResults(results, naive, queryTimes, "giga_multi_agg")
+  }
+
+  it should "handle day boundary transitions across multiple days" in {
+    val (events, schema) = generateEvents(14, 20000)
+    val maxTs = events.map(_.ts).max
+    val batchEnd = TsUtils.round(maxTs - 2 * DayMillis, DayMillis)
+
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows),
+      Builders.Aggregation(Operation.AVERAGE, "amount", AllWindows)
+    )
+
+    val queryTimes = Array(
+      batchEnd + 6 * 3600 * 1000L,
+      batchEnd + 18 * 3600 * 1000L,
+      batchEnd + 30 * 3600 * 1000L,
+      batchEnd + 42 * 3600 * 1000L
+    ).filter(_ <= maxTs)
+
+    val results = gigaTileAggregate(events, queryTimes, aggregations, schema, batchEnd)
+    val naive = naiveAggregate(events, queryTimes, aggregations, schema)
+    compareResults(results, naive, queryTimes, "giga_day_boundary")
+  }
+
+  it should "handle multi-day watermark gap (3+ day idle then resume)" in {
+    val (allEvents, schema) = generateEvents(14, 20000)
+    val maxTs = allEvents.map(_.ts).max
+    val gapEnd = TsUtils.round(maxTs - 2 * DayMillis, DayMillis)
+    val gapStart = gapEnd - 3 * DayMillis
+
+    val events = allEvents.filter(e => e.ts < gapStart || e.ts >= gapEnd)
+    val batchEnd = TsUtils.round(maxTs - DayMillis, DayMillis)
+
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows)
+    )
+
+    val queryTimes = Array(
+      batchEnd + 6 * 3600 * 1000L,
+      batchEnd + 14 * 3600 * 1000L
+    ).filter(_ <= maxTs)
+
+    val results = gigaTileAggregate(events, queryTimes, aggregations, schema, batchEnd)
+    val naive = naiveAggregate(events, queryTimes, aggregations, schema)
+    compareResults(results, naive, queryTimes, "giga_multi_day_gap")
+  }
+
+  it should "handle new entity (streaming only, no batch IR)" in {
+    val (events, schema) = generateEvents(2, 5000)
+    val maxTs = events.map(_.ts).max
+    val now = TsUtils.round(maxTs, DayMillis) + 14 * 3600 * 1000L
+
+    // Only small windows — these are fully covered by streaming tiles
+    val smallWindows = Seq(
+      new Window(6, TimeUnit.HOURS),
+      new Window(1, TimeUnit.DAYS),
+      new Window(2, TimeUnit.DAYS)
+    )
+
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM, "num", smallWindows),
+      Builders.Aggregation(Operation.COUNT, "num", smallWindows)
+    )
+
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val store = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, store)
+
+    // No batch loaded — entity type C
+    val streamingEvents = events.filter(_.ts <= now).sortBy(_.ts)
+    val evictionInterval = processor.minEvictionInterval
+    var nextEvictionTs = Long.MaxValue
+    var lastEmitted: Array[Any] = null
+
+    for (event <- streamingEvents) {
+      while (nextEvictionTs <= event.ts) {
+        processor.advanceWatermark(nextEvictionTs)
+        val r = processor.onEviction(nextEvictionTs)
+        if (r.finalizedVector != null) lastEmitted = r.finalizedVector
+        nextEvictionTs += evictionInterval
+      }
+      processor.advanceWatermark(event.ts)
+      val result = processor.onEvent(event, event.ts)
+      if (result.finalizedVector != null) lastEmitted = result.finalizedVector
+      if (nextEvictionTs == Long.MaxValue) {
+        nextEvictionTs = TsUtils.round(event.ts, evictionInterval) + evictionInterval
+      }
+    }
+
+    // Final eviction at query time
+    while (nextEvictionTs <= now) {
+      processor.advanceWatermark(nextEvictionTs)
+      val r = processor.onEviction(nextEvictionTs)
+      if (r.finalizedVector != null) lastEmitted = r.finalizedVector
+      nextEvictionTs += evictionInterval
+    }
+    processor.advanceWatermark(now)
+    val evictResult = processor.onEviction(now)
+    if (evictResult.finalizedVector != null) lastEmitted = evictResult.finalizedVector
+
+    val naive = naiveAggregate(events.filter(_.ts <= now), Array(now), aggregations, schema)
+    if (!approxEqual(lastEmitted, naive(0))) {
+      val expStr = gson.toJson(naive(0))
+      val actStr = gson.toJson(lastEmitted)
+      fail(s"giga_new_entity: mismatch\n  expected: $expStr\n  got:      $actStr")
+    }
+  }
+
+  it should "handle batch refresh (old batch → events → new batch)" in {
+    val (events, schema) = generateEvents(14, 20000)
+    val maxTs = events.map(_.ts).max
+    val oldBatchEnd = TsUtils.round(maxTs - 3 * DayMillis, DayMillis)
+    val newBatchEnd = TsUtils.round(maxTs - DayMillis, DayMillis)
+
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows)
+    )
+
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val store = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, store)
+
+    // Build both batch IRs
+    val oldNormalizedBatchIr = buildBatchIr(events, oldBatchEnd, aggregations, schema)
+    val oldBatchIr = denormalizeBatchIr(oldNormalizedBatchIr, aggregations, schema, oldBatchEnd)
+    val newNormalizedBatchIr = buildBatchIr(events, newBatchEnd, aggregations, schema)
+    val newBatchIr = denormalizeBatchIr(newNormalizedBatchIr, aggregations, schema, newBatchEnd)
+
+    // Load old batch
+    processor.onBatchUpdate(oldBatchIr, oldBatchEnd, oldBatchEnd)
+
+    // Process events
+    val streamingEvents = events.sortBy(_.ts)
+    val evictionInterval = processor.minEvictionInterval
+    var nextEvictionTs = TsUtils.round(oldBatchEnd, evictionInterval) + evictionInterval
+    var lastEmitted: Array[Any] = null
+
+    val queryTs = newBatchEnd + 14 * 3600 * 1000L
+    for (event <- streamingEvents if event.ts <= queryTs) {
+      while (nextEvictionTs <= event.ts) {
+        processor.advanceWatermark(nextEvictionTs)
+        val r = processor.onEviction(nextEvictionTs)
+        if (r.finalizedVector != null) lastEmitted = r.finalizedVector
+        nextEvictionTs += evictionInterval
+      }
+      processor.advanceWatermark(event.ts)
+      val result = processor.onEvent(event, event.ts)
+      if (result.finalizedVector != null) lastEmitted = result.finalizedVector
+    }
+
+    // Load new batch (simulates daily Iceberg refresh)
+    val batchResult = processor.onBatchUpdate(newBatchIr, newBatchEnd, queryTs)
+    if (batchResult.finalizedVector != null) lastEmitted = batchResult.finalizedVector
+
+    // Final eviction
+    while (nextEvictionTs <= queryTs) {
+      processor.advanceWatermark(nextEvictionTs)
+      val r = processor.onEviction(nextEvictionTs)
+      if (r.finalizedVector != null) lastEmitted = r.finalizedVector
+      nextEvictionTs += evictionInterval
+    }
+    processor.advanceWatermark(queryTs)
+    val evictResult = processor.onEviction(queryTs)
+    if (evictResult.finalizedVector != null) lastEmitted = evictResult.finalizedVector
+
+    val naive = naiveAggregate(events, Array(queryTs), aggregations, schema)
+    if (!approxEqual(lastEmitted, naive(0))) {
+      val expStr = gson.toJson(naive(0))
+      val actStr = gson.toJson(lastEmitted)
+      fail(s"giga_batch_refresh: mismatch\n  expected: $expStr\n  got:      $actStr")
+    }
+  }
+}

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileStreamProcessorTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileStreamProcessorTest.scala
@@ -536,4 +536,397 @@ class GigaTileStreamProcessorTest extends AnyFlatSpec {
     val result2 = processor.onEviction(nextEviction)
     assertNull("redundant eviction should not emit when nothing changed", result2.finalizedVector)
   }
+
+  // ==========================================================================
+  // Targeted edge case tests — steady state focus
+  // ==========================================================================
+
+  private def row(ts: Long, num: Long, amount: Double): TestRow = new TestRow(ts, num, amount)()
+
+  /** Helper: build a processor with batch loaded, return (processor, store). */
+  private def buildProcessor(
+      aggregations: Seq[Aggregation],
+      schema: Seq[(String, DataType)],
+      batchEvents: Array[TestRow],
+      batchEnd: Long
+  ): (GigaTileStreamProcessor, InMemoryGigaTileStore) = {
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val store = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, store)
+    val normalizedBatchIr = buildBatchIr(batchEvents, batchEnd, aggregations, schema)
+    val batchIr = denormalizeBatchIr(normalizedBatchIr, aggregations, schema, batchEnd)
+    processor.onBatchUpdate(batchIr, batchEnd, batchEnd)
+    (processor, store)
+  }
+
+  it should "not lose an event at exactly batchEnd timestamp after eviction" in {
+    // Event at exactly midnight = batchEnd. Batch is exclusive [0, batchEnd), so event is NOT in batch.
+    // onEvent clamps it to today (>= nextDayStart branch). After day rotation, it lands in
+    // largeYesterdayIr. Eviction with batchEnd == currentDayStart skips yesterday merge.
+    // The event must still be in the final answer.
+    val batchEnd = 1743033600000L // Mar 27 00:00 UTC (arbitrary fixed point)
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+
+    // Batch events: everything before batchEnd
+    val batchEvents = Array(
+      row(batchEnd - 3 * 3600 * 1000L, 10L, 1.0),
+      row(batchEnd - 6 * 3600 * 1000L, 20L, 2.0)
+    )
+
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM, "num", Seq(new Window(3, TimeUnit.DAYS))),
+      Builders.Aggregation(Operation.COUNT, "num", Seq(new Window(3, TimeUnit.DAYS)))
+    )
+
+    val (processor, _) = buildProcessor(aggregations, schema, batchEvents, batchEnd)
+
+    // Event at exactly batchEnd — this is the edge case
+    val midnightEvent = row(batchEnd, 100L, 5.0)
+    processor.advanceWatermark(batchEnd)
+    val eventResult = processor.onEvent(midnightEvent, batchEnd)
+    assertNotNull("event at batchEnd should emit", eventResult.finalizedVector)
+
+    // Advance watermark past midnight — triggers day rotation
+    processor.advanceWatermark(batchEnd + DayMillis + 60000L)
+
+    // Eviction after rotation
+    val evictResult = processor.onEviction(batchEnd + DayMillis + 60000L)
+    assertNotNull("eviction should emit", evictResult.finalizedVector)
+
+    // The 100 from the midnight event must be present in the 3d SUM
+    // Batch has 10 + 20 = 30. Midnight event adds 100. Total = 130.
+    val naive = naiveAggregate(
+      batchEvents :+ midnightEvent,
+      Array(batchEnd + DayMillis + 60000L),
+      aggregations,
+      schema
+    )
+    if (!approxEqual(evictResult.finalizedVector, naive(0))) {
+      val expStr = gson.toJson(naive(0))
+      val actStr = gson.toJson(evictResult.finalizedVector)
+      fail(s"midnight_event: expected $expStr got $actStr — event at batchEnd likely lost after eviction")
+    }
+  }
+
+  it should "detect incremental vs eviction divergence for late yesterday event after fresh batch" in {
+    // Fresh batch (batchEnd = currentDayStart). A late event from yesterday arrives AFTER
+    // batch was loaded. The event was NOT in the batch source data.
+    // onEvent adds it to largeYesterdayIr + runningLargeIr (incremental).
+    // Eviction recomputes: yesterday not merged (batchEnd >= currentDayStart).
+    // This tests whether the two paths agree.
+    val batchEnd = 1743033600000L // Mar 27 00:00 UTC
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+
+    // Batch events: does NOT include the late event
+    val batchEvents = Array(
+      row(batchEnd - 12 * 3600 * 1000L, 10L, 1.0)
+    )
+
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM, "num", Seq(new Window(3, TimeUnit.DAYS)))
+    )
+
+    val (processor, _) = buildProcessor(aggregations, schema, batchEvents, batchEnd)
+
+    // Advance watermark to today
+    processor.advanceWatermark(batchEnd + 3600 * 1000L)
+
+    // Late event from yesterday — NOT in batch
+    val lateEvent = row(batchEnd - 2 * 3600 * 1000L, 50L, 3.0)
+    val eventResult = processor.onEvent(lateEvent, lateEvent.ts)
+    assertNotNull("late event should emit", eventResult.finalizedVector)
+
+    // Capture incremental value (from onEvent)
+    val incrementalVector = eventResult.finalizedVector.clone()
+
+    // Eviction recomputes from scratch
+    val evictResult = processor.onEviction(batchEnd + 3600 * 1000L)
+    assertNotNull("eviction should emit", evictResult.finalizedVector)
+    val evictionVector = evictResult.finalizedVector
+
+    // Document the divergence: incremental includes the late event, eviction may not.
+    // Both are compared against naive (which DOES include the event).
+    val allEvents = batchEvents :+ lateEvent
+    val naive = naiveAggregate(allEvents, Array(batchEnd + 3600 * 1000L), aggregations, schema)
+
+    val incrementalMatch = approxEqual(incrementalVector, naive(0))
+    val evictionMatch = approxEqual(evictionVector, naive(0))
+
+    // At minimum one of these should match. If neither matches, there's a bug.
+    // The known design trade-off: eviction may drop the late event to avoid double-counting.
+    assertTrue(
+      s"at least one path should match naive. incremental=$incrementalMatch eviction=$evictionMatch",
+      incrementalMatch || evictionMatch
+    )
+
+    // Log which path diverges for visibility
+    if (incrementalMatch && !evictionMatch) {
+      logger.warn("KNOWN TRADE-OFF: eviction drops late yesterday event not in batch " +
+        "(avoids double-count, causes transient value flip)")
+    }
+    if (!incrementalMatch) {
+      fail(s"incremental path should always include the late event: " +
+        s"expected ${gson.toJson(naive(0))} got ${gson.toJson(incrementalVector)}")
+    }
+  }
+
+  it should "not double-count events present in both batch and streaming after eviction" in {
+    // Event at batchEnd - 1hr is in both batch IR and streaming.
+    // Between event and eviction, runningLargeIr double-counts it.
+    // After eviction, it must be counted exactly once.
+    val batchEnd = 1743033600000L
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+
+    val overlapTs = batchEnd - 3600 * 1000L // 1hr before batchEnd
+    val batchEvents = Array(
+      row(overlapTs, 100L, 5.0),
+      row(batchEnd - 12 * 3600 * 1000L, 10L, 1.0)
+    )
+
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM, "num", Seq(new Window(3, TimeUnit.DAYS)))
+    )
+
+    val (processor, _) = buildProcessor(aggregations, schema, batchEvents, batchEnd)
+    processor.advanceWatermark(batchEnd + 3600 * 1000L)
+
+    // Replay the overlap event (simulates Kafka delivering it after batch)
+    val overlapEvent = row(overlapTs, 100L, 5.0)
+    processor.onEvent(overlapEvent, overlapEvent.ts)
+
+    // Eviction should correct the double-count
+    val evictResult = processor.onEviction(batchEnd + 3600 * 1000L)
+    assertNotNull("eviction should emit", evictResult.finalizedVector)
+
+    val naive = naiveAggregate(batchEvents, Array(batchEnd + 3600 * 1000L), aggregations, schema)
+    if (!approxEqual(evictResult.finalizedVector, naive(0))) {
+      val expStr = gson.toJson(naive(0))
+      val actStr = gson.toJson(evictResult.finalizedVector)
+      fail(s"double_count: expected $expStr got $actStr — overlap event likely counted twice")
+    }
+  }
+
+  it should "correctly shift tail hops at hourly boundary for large-window-only GroupBy" in {
+    // Large windows only (49h, 3d, 7d) — hourly hops.
+    // Two evictions straddle an hourly boundary: the tail hop selection should change.
+    val batchEnd = 1743033600000L
+    val hourMillis = 3600 * 1000L
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+
+    // Dense events every hour for 10 days before batchEnd
+    val batchEvents = (0 until 240).map { i =>
+      row(batchEnd - (240 - i) * hourMillis, (i + 1).toLong, 1.0)
+    }.toArray
+
+    val largeWindows = Seq(new Window(49, TimeUnit.HOURS))
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM, "num", largeWindows),
+      Builders.Aggregation(Operation.COUNT, "num", largeWindows)
+    )
+
+    val (processor, _) = buildProcessor(aggregations, schema, batchEvents, batchEnd)
+
+    // No streaming events — batch only entity
+
+    // Eviction just before hourly boundary
+    val queryBefore = batchEnd + 48 * hourMillis + 59 * 60 * 1000L
+    processor.advanceWatermark(queryBefore)
+    val r1 = processor.onEviction(queryBefore)
+    assertNotNull("eviction before hour boundary should emit", r1.finalizedVector)
+
+    // Eviction just after hourly boundary — a different hop enters/exits the 49h window
+    val queryAfter = batchEnd + 49 * hourMillis + 60 * 1000L
+    processor.advanceWatermark(queryAfter)
+    val r2 = processor.onEviction(queryAfter)
+
+    // Verify both match naive
+    val naiveBefore = naiveAggregate(batchEvents, Array(queryBefore), aggregations, schema)
+    val naiveAfter = naiveAggregate(batchEvents, Array(queryAfter), aggregations, schema)
+
+    if (!approxEqual(r1.finalizedVector, naiveBefore(0))) {
+      fail(s"hop_shift: before boundary mismatch: expected ${gson.toJson(naiveBefore(0))} got ${gson.toJson(r1.finalizedVector)}")
+    }
+    if (r2.finalizedVector != null) {
+      if (!approxEqual(r2.finalizedVector, naiveAfter(0))) {
+        fail(s"hop_shift: after boundary mismatch: expected ${gson.toJson(naiveAfter(0))} got ${gson.toJson(r2.finalizedVector)}")
+      }
+    }
+  }
+
+  it should "survive day rotation with no events and produce correct values" in {
+    // Batch loaded, events processed, then entity goes idle across a day boundary.
+    // Verify eviction produces correct results after rotation.
+    val batchEnd = 1743033600000L
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+
+    val batchEvents = (0 until 100).map { i =>
+      row(batchEnd - (100 - i) * 3600 * 1000L, (i + 1).toLong, 1.0)
+    }.toArray
+
+    // A few streaming events on day 1 only
+    val streamEvents = Array(
+      row(batchEnd + 3600 * 1000L, 200L, 10.0),
+      row(batchEnd + 6 * 3600 * 1000L, 300L, 15.0)
+    )
+
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows)
+    )
+
+    val (processor, _) = buildProcessor(aggregations, schema, batchEvents, batchEnd)
+
+    // Process streaming events
+    for (event <- streamEvents) {
+      processor.advanceWatermark(event.ts)
+      processor.onEvent(event, event.ts)
+    }
+
+    // Eviction before day boundary
+    val preRotation = batchEnd + 23 * 3600 * 1000L
+    processor.advanceWatermark(preRotation)
+    processor.onEviction(preRotation)
+
+    // Day rotation
+    processor.advanceWatermark(batchEnd + DayMillis + 60000L)
+
+    // Eviction after rotation — no new events
+    val postRotation = batchEnd + DayMillis + 3600 * 1000L
+    processor.advanceWatermark(postRotation)
+    val result = processor.onEviction(postRotation)
+    assertNotNull("post-rotation eviction should emit", result.finalizedVector)
+
+    val allEvents = batchEvents ++ streamEvents
+    val naive = naiveAggregate(allEvents, Array(postRotation), aggregations, schema)
+    if (!approxEqual(result.finalizedVector, naive(0))) {
+      fail(s"day_rotation: expected ${gson.toJson(naive(0))} got ${gson.toJson(result.finalizedVector)}")
+    }
+  }
+
+  it should "handle MIN correctly when min value is at the sawtooth boundary" in {
+    // The global MIN is in the oldest tail hop. As the window slides forward,
+    // that hop should fall off and MIN should increase.
+    val batchEnd = 1743033600000L
+    val hourMillis = 3600 * 1000L
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+
+    // Place the minimum value exactly at the 3d window's oldest hop boundary
+    val oldHopTs = batchEnd - 71 * hourMillis // ~71 hours before batchEnd
+    val batchEvents = Array(
+      row(oldHopTs, 1L, 1.0), // the min
+      row(batchEnd - 24 * hourMillis, 100L, 10.0),
+      row(batchEnd - 12 * hourMillis, 200L, 20.0),
+      row(batchEnd - 1 * hourMillis, 150L, 15.0)
+    )
+
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.MIN, "num", Seq(new Window(3, TimeUnit.DAYS)))
+    )
+
+    val (processor, _) = buildProcessor(aggregations, schema, batchEvents, batchEnd)
+
+    // Query while old hop is still in window — MIN should be 1
+    val earlyQuery = batchEnd + 60000L
+    processor.advanceWatermark(earlyQuery)
+    val r1 = processor.onEviction(earlyQuery)
+    val naive1 = naiveAggregate(batchEvents, Array(earlyQuery), aggregations, schema)
+    if (!approxEqual(r1.finalizedVector, naive1(0))) {
+      fail(s"min_boundary early: expected ${gson.toJson(naive1(0))} got ${gson.toJson(r1.finalizedVector)}")
+    }
+
+    // Query after old hop falls off the 3d window — MIN should increase to 100
+    val lateQuery = batchEnd + 2 * hourMillis
+    processor.advanceWatermark(lateQuery)
+    val r2 = processor.onEviction(lateQuery)
+    assertNotNull(r2.finalizedVector)
+    val naive2 = naiveAggregate(batchEvents, Array(lateQuery), aggregations, schema)
+    if (!approxEqual(r2.finalizedVector, naive2(0))) {
+      fail(s"min_boundary late: expected ${gson.toJson(naive2(0))} got ${gson.toJson(r2.finalizedVector)}")
+    }
+  }
+
+  it should "produce identical results from two consecutive emits (finalize must not corrupt IR)" in {
+    val batchEnd = 1743033600000L
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+
+    val batchEvents = Array(
+      row(batchEnd - 3600 * 1000L, 10L, 1.0),
+      row(batchEnd - 7200 * 1000L, 20L, 2.0)
+    )
+
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.AVERAGE, "amount", AllWindows),
+      Builders.Aggregation(Operation.FIRST, "num", AllWindows),
+      Builders.Aggregation(Operation.LAST, "num", AllWindows)
+    )
+
+    val (processor, _) = buildProcessor(aggregations, schema, batchEvents, batchEnd)
+
+    processor.advanceWatermark(batchEnd + 3600 * 1000L)
+    processor.onEvent(row(batchEnd + 1000L, 30L, 3.0), batchEnd + 1000L)
+
+    // Two consecutive events — each triggers packAndFinalize. Second must not be corrupted.
+    val r1 = processor.onEvent(row(batchEnd + 2000L, 40L, 4.0), batchEnd + 2000L)
+    val r2 = processor.onEvent(row(batchEnd + 3000L, 0L, 0.0), batchEnd + 3000L)
+    assertNotNull(r1.finalizedVector)
+    assertNotNull(r2.finalizedVector)
+
+    val allEvents = batchEvents ++ Array(
+      row(batchEnd + 1000L, 30L, 3.0), row(batchEnd + 2000L, 40L, 4.0), row(batchEnd + 3000L, 0L, 0.0))
+    val naive2 = naiveAggregate(allEvents, Array(batchEnd + 2000L), aggregations, schema)
+    val naive3 = naiveAggregate(allEvents, Array(batchEnd + 3000L), aggregations, schema)
+
+    if (!approxEqual(r1.finalizedVector, naive2(0))) {
+      fail(s"finalize_corruption: first emit ${gson.toJson(r1.finalizedVector)} != naive ${gson.toJson(naive2(0))}")
+    }
+    if (!approxEqual(r2.finalizedVector, naive3(0))) {
+      fail(s"finalize_corruption: second emit ${gson.toJson(r2.finalizedVector)} != naive ${gson.toJson(naive3(0))}")
+    }
+  }
+
+  it should "handle all-small-window GroupBy with batch loaded correctly" in {
+    // Only small windows (all <= tailBuffer). Large window paths should be no-ops.
+    // Batch IR is loaded but only small window columns matter (from tiles).
+    val batchEnd = 1743033600000L
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+
+    val smallWindows = Seq(
+      new Window(6, TimeUnit.HOURS),
+      new Window(1, TimeUnit.DAYS),
+      new Window(2, TimeUnit.DAYS)
+    )
+
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM, "num", smallWindows),
+      Builders.Aggregation(Operation.COUNT, "num", smallWindows)
+    )
+
+    val batchEvents = (0 until 200).map { i =>
+      row(batchEnd - (200 - i) * 5 * 60 * 1000L, (i + 1).toLong, 1.0)
+    }.toArray
+
+    val (processor, _) = buildProcessor(aggregations, schema, batchEvents, batchEnd)
+
+    // Streaming events
+    val streamEvents = Array(
+      row(batchEnd + 3600 * 1000L, 500L, 25.0),
+      row(batchEnd + 2 * 3600 * 1000L, 600L, 30.0)
+    )
+    for (event <- streamEvents) {
+      processor.advanceWatermark(event.ts)
+      processor.onEvent(event, event.ts)
+    }
+
+    val queryTs = batchEnd + 3 * 3600 * 1000L
+    processor.advanceWatermark(queryTs)
+    val result = processor.onEviction(queryTs)
+    assertNotNull("all-small-window eviction should emit", result.finalizedVector)
+
+    val allEvents = batchEvents ++ streamEvents
+    val naive = naiveAggregate(allEvents, Array(queryTs), aggregations, schema)
+    if (!approxEqual(result.finalizedVector, naive(0))) {
+      fail(s"all_small_windows: expected ${gson.toJson(naive(0))} got ${gson.toJson(result.finalizedVector)}")
+    }
+  }
 }

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileStreamProcessorTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileStreamProcessorTest.scala
@@ -436,4 +436,104 @@ class GigaTileStreamProcessorTest extends AnyFlatSpec {
       fail(s"giga_batch_refresh: mismatch\n  expected: $expStr\n  got:      $actStr")
     }
   }
+
+  it should "accept sequential batch updates with advancing batchEnd (Bug 1 regression)" in {
+    val (events, schema) = generateEvents(14, 20000)
+    val maxTs = events.map(_.ts).max
+    val day1End = TsUtils.round(maxTs - 3 * DayMillis, DayMillis)
+    val day2End = day1End + DayMillis
+    val day3End = day2End + DayMillis
+
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows)
+    )
+
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val store = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, store)
+
+    // Day 1 batch — initializes currentDayStart = day1End
+    val batch1 = denormalizeBatchIr(buildBatchIr(events, day1End, aggregations, schema), aggregations, schema, day1End)
+    val result1 = processor.onBatchUpdate(batch1, day1End, day1End)
+    assertNotNull("first batch should emit", result1.finalizedVector)
+    assertEquals("store should track day1 batchEnd", day1End, store.getBatchEndTs)
+
+    // Advance watermark past day2End so currentDayStart catches up (avoids defer)
+    processor.advanceWatermark(day2End + 6 * 3600 * 1000L)
+
+    // Day 2 batch — batchEnd advances, must NOT be rejected as stale
+    val batch2 = denormalizeBatchIr(buildBatchIr(events, day2End, aggregations, schema), aggregations, schema, day2End)
+    val result2 = processor.onBatchUpdate(batch2, day2End, day2End)
+    assertNotNull("second batch should emit (not rejected as stale)", result2.finalizedVector)
+    assertEquals("store should track day2 batchEnd", day2End, store.getBatchEndTs)
+
+    // Advance watermark past day3End
+    processor.advanceWatermark(day3End + 6 * 3600 * 1000L)
+
+    // Day 3 batch
+    val batch3 = denormalizeBatchIr(buildBatchIr(events, day3End, aggregations, schema), aggregations, schema, day3End)
+    val result3 = processor.onBatchUpdate(batch3, day3End, day3End)
+    assertNotNull("third batch should emit", result3.finalizedVector)
+    assertEquals("store should track day3 batchEnd", day3End, store.getBatchEndTs)
+  }
+
+  it should "suppress redundant eviction emits when nothing changed (Bug 2 regression)" in {
+    val (events, schema) = generateEvents(14, 10000)
+    val maxTs = events.map(_.ts).max
+    val batchEnd = TsUtils.round(maxTs - DayMillis, DayMillis)
+
+    // Large windows only — no small windows, no tile rebuilding.
+    // This ensures eviction only recomputes runningLargeIr from batch hops.
+    // With 1hr hops, two evictions 5 min apart produce the same tail hop selection.
+    val largeWindows = Seq(
+      new Window(49, TimeUnit.HOURS),
+      new Window(3, TimeUnit.DAYS),
+      new Window(7, TimeUnit.DAYS)
+    )
+
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM, "num", largeWindows),
+      Builders.Aggregation(Operation.COUNT, "num", largeWindows)
+    )
+
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    // irEqual that actually compares values
+    val irEqual: (Array[Any], Array[Any]) => Boolean = { (a, b) =>
+      if (a == null && b == null) true
+      else if (a == null || b == null) false
+      else a.length == b.length && a.zip(b).forall {
+        case (null, null) => true
+        case (null, _) | (_, null) => false
+        case (x, y) => x == y
+      }
+    }
+    val store = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, store, irEqual)
+
+    assertFalse("should have no small windows", processor.hasSmallWindows)
+
+    // Load batch
+    val batchIr = denormalizeBatchIr(buildBatchIr(events, batchEnd, aggregations, schema), aggregations, schema, batchEnd)
+    processor.onBatchUpdate(batchIr, batchEnd, batchEnd)
+
+    // Process some events
+    val streamEvents = events.filter(e => e.ts >= batchEnd && e.ts < batchEnd + 12 * 3600 * 1000L).sortBy(_.ts)
+    for (event <- streamEvents) {
+      processor.advanceWatermark(event.ts)
+      processor.onEvent(event, event.ts)
+    }
+
+    // First eviction at an hour boundary — should emit
+    val evictionTs = TsUtils.round(batchEnd + 12 * 3600 * 1000L, 3600 * 1000L)
+    processor.advanceWatermark(evictionTs)
+    val result1 = processor.onEviction(evictionTs)
+    assertNotNull("first eviction should emit", result1.finalizedVector)
+
+    // Second eviction 5 min later — same hour boundary, no events, nothing changed
+    val nextEviction = evictionTs + 5 * 60 * 1000L
+    processor.advanceWatermark(nextEviction)
+    val result2 = processor.onEviction(nextEviction)
+    assertNull("redundant eviction should not emit when nothing changed", result2.finalizedVector)
+  }
 }

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileStreamProcessorTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileStreamProcessorTest.scala
@@ -543,7 +543,10 @@ class GigaTileStreamProcessorTest extends AnyFlatSpec {
 
   private def row(ts: Long, num: Long, amount: Double): TestRow = new TestRow(ts, num, amount)()
 
-  /** Helper: build a processor with batch loaded, return (processor, store). */
+  /** Helper: build a processor with batch loaded AND events replayed through onEvent.
+    * Flink processes ALL events (including pre-batch) to populate tiles for small windows.
+    * Without this, small window columns are empty (tiles not populated by onBatchUpdate).
+    */
   private def buildProcessor(
       aggregations: Seq[Aggregation],
       schema: Seq[(String, DataType)],
@@ -555,6 +558,17 @@ class GigaTileStreamProcessorTest extends AnyFlatSpec {
     val processor = new GigaTileStreamProcessor(megaTileAgg, store)
     val normalizedBatchIr = buildBatchIr(batchEvents, batchEnd, aggregations, schema)
     val batchIr = denormalizeBatchIr(normalizedBatchIr, aggregations, schema, batchEnd)
+    // Replay all events through onEvent FIRST to populate tiles (small window state).
+    // In production, Flink processes ALL events from Kafka — tiles capture them for small windows.
+    // Must happen BEFORE onBatchUpdate to avoid double-counting in largeTodayIr.
+    for (event <- batchEvents.sortBy(_.ts)) {
+      processor.advanceWatermark(event.ts)
+      processor.onEvent(event, event.ts)
+    }
+    // Then load batch IR — onBatchUpdate recomputes runningLargeIr from batch + streaming.
+    // Since events are pre-batchEnd, they route to yesterday/today accumulators but the
+    // onBatchUpdate clears yesterday (batchEnd >= currentDayStart) and recomputes from batch.
+    processor.advanceWatermark(batchEnd)
     processor.onBatchUpdate(batchIr, batchEnd, batchEnd)
     (processor, store)
   }
@@ -706,14 +720,16 @@ class GigaTileStreamProcessorTest extends AnyFlatSpec {
     }
   }
 
-  it should "correctly shift tail hops at hourly boundary for large-window-only GroupBy" in {
-    // Large windows only (49h, 3d, 7d) — hourly hops.
-    // Two evictions straddle an hourly boundary: the tail hop selection should change.
+  it should "return null for large windows when entire window has moved past batch data" in {
+    // Batch-only entity queried >windowSize after batchEnd. The 49h window covers
+    // [queryTs - 49h, queryTs) which is entirely past batchEnd — no data in window.
+    // recomputeRunningLargeIr starts from clone(batchIr.collapsed) which is non-null.
+    // The collapsed value is stale — it covers data before batchEnd, outside the window.
+    // After eviction, the result should match naive (which returns null).
     val batchEnd = 1743033600000L
     val hourMillis = 3600 * 1000L
     val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
 
-    // Dense events every hour for 10 days before batchEnd
     val batchEvents = (0 until 240).map { i =>
       row(batchEnd - (240 - i) * hourMillis, (i + 1).toLong, 1.0)
     }.toArray
@@ -726,29 +742,18 @@ class GigaTileStreamProcessorTest extends AnyFlatSpec {
 
     val (processor, _) = buildProcessor(aggregations, schema, batchEvents, batchEnd)
 
-    // No streaming events — batch only entity
+    // Query 50 hours after batchEnd — entire 49h window is past all batch data
+    val queryTs = batchEnd + 50 * hourMillis
+    processor.advanceWatermark(queryTs)
+    val result = processor.onEviction(queryTs)
 
-    // Eviction just before hourly boundary
-    val queryBefore = batchEnd + 48 * hourMillis + 59 * 60 * 1000L
-    processor.advanceWatermark(queryBefore)
-    val r1 = processor.onEviction(queryBefore)
-    assertNotNull("eviction before hour boundary should emit", r1.finalizedVector)
+    val naive = naiveAggregate(batchEvents, Array(queryTs), aggregations, schema)
+    // naive returns [null, null] — no events in [queryTs - 49h, queryTs)
 
-    // Eviction just after hourly boundary — a different hop enters/exits the 49h window
-    val queryAfter = batchEnd + 49 * hourMillis + 60 * 1000L
-    processor.advanceWatermark(queryAfter)
-    val r2 = processor.onEviction(queryAfter)
-
-    // Verify both match naive
-    val naiveBefore = naiveAggregate(batchEvents, Array(queryBefore), aggregations, schema)
-    val naiveAfter = naiveAggregate(batchEvents, Array(queryAfter), aggregations, schema)
-
-    if (!approxEqual(r1.finalizedVector, naiveBefore(0))) {
-      fail(s"hop_shift: before boundary mismatch: expected ${gson.toJson(naiveBefore(0))} got ${gson.toJson(r1.finalizedVector)}")
-    }
-    if (r2.finalizedVector != null) {
-      if (!approxEqual(r2.finalizedVector, naiveAfter(0))) {
-        fail(s"hop_shift: after boundary mismatch: expected ${gson.toJson(naiveAfter(0))} got ${gson.toJson(r2.finalizedVector)}")
+    if (result.finalizedVector != null) {
+      if (!approxEqual(result.finalizedVector, naive(0))) {
+        fail(s"stale_collapsed: expected ${gson.toJson(naive(0))} got ${gson.toJson(result.finalizedVector)} " +
+          s"— collapsed included when window has moved entirely past batch data")
       }
     }
   }
@@ -845,43 +850,73 @@ class GigaTileStreamProcessorTest extends AnyFlatSpec {
     }
   }
 
-  it should "produce identical results from two consecutive emits (finalize must not corrupt IR)" in {
+  it should "transiently double-count pre-batch events replayed after batch load, corrected by eviction" in {
+    // Production scenario: batch loads, then Kafka replays pre-batchEnd events.
+    // onEvent adds these to largeTodayIr + runningLargeIr (incremental).
+    // But batch already has them → large window columns are transiently double-counted.
+    // Eviction recomputes from scratch and corrects.
     val batchEnd = 1743033600000L
     val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
 
+    // Batch events that will be in both batch IR and Kafka replay
     val batchEvents = Array(
-      row(batchEnd - 3600 * 1000L, 10L, 1.0),
-      row(batchEnd - 7200 * 1000L, 20L, 2.0)
+      row(batchEnd - 3600 * 1000L, 10L, 1.0),  // 1hr before batchEnd
+      row(batchEnd - 7200 * 1000L, 20L, 2.0)   // 2hr before batchEnd
     )
 
+    // Only large windows to isolate the effect (small windows use tiles, not runningLargeIr)
     val aggregations = Seq(
-      Builders.Aggregation(Operation.SUM, "num", AllWindows),
-      Builders.Aggregation(Operation.AVERAGE, "amount", AllWindows),
-      Builders.Aggregation(Operation.FIRST, "num", AllWindows),
-      Builders.Aggregation(Operation.LAST, "num", AllWindows)
+      Builders.Aggregation(Operation.SUM, "num", Seq(new Window(3, TimeUnit.DAYS)))
     )
 
-    val (processor, _) = buildProcessor(aggregations, schema, batchEvents, batchEnd)
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val store = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, store)
 
+    // Step 1: Load batch first
+    val normalizedBatchIr = buildBatchIr(batchEvents, batchEnd, aggregations, schema)
+    val batchIr = denormalizeBatchIr(normalizedBatchIr, aggregations, schema, batchEnd)
+    processor.onBatchUpdate(batchIr, batchEnd, batchEnd)
+
+    // Step 2: Kafka replays the SAME events (this is what happens in production)
     processor.advanceWatermark(batchEnd + 3600 * 1000L)
-    processor.onEvent(row(batchEnd + 1000L, 30L, 3.0), batchEnd + 1000L)
-
-    // Two consecutive events — each triggers packAndFinalize. Second must not be corrupted.
-    val r1 = processor.onEvent(row(batchEnd + 2000L, 40L, 4.0), batchEnd + 2000L)
-    val r2 = processor.onEvent(row(batchEnd + 3000L, 0L, 0.0), batchEnd + 3000L)
-    assertNotNull(r1.finalizedVector)
-    assertNotNull(r2.finalizedVector)
-
-    val allEvents = batchEvents ++ Array(
-      row(batchEnd + 1000L, 30L, 3.0), row(batchEnd + 2000L, 40L, 4.0), row(batchEnd + 3000L, 0L, 0.0))
-    val naive2 = naiveAggregate(allEvents, Array(batchEnd + 2000L), aggregations, schema)
-    val naive3 = naiveAggregate(allEvents, Array(batchEnd + 3000L), aggregations, schema)
-
-    if (!approxEqual(r1.finalizedVector, naive2(0))) {
-      fail(s"finalize_corruption: first emit ${gson.toJson(r1.finalizedVector)} != naive ${gson.toJson(naive2(0))}")
+    for (event <- batchEvents.sortBy(_.ts)) {
+      processor.onEvent(event, event.ts)
     }
-    if (!approxEqual(r2.finalizedVector, naive3(0))) {
-      fail(s"finalize_corruption: second emit ${gson.toJson(r2.finalizedVector)} != naive ${gson.toJson(naive3(0))}")
+
+    // The incremental path now has batch(10+20) + largeTodayIr(10+20) = 60 for SUM_3d
+    // But correct answer is 30 (each event counted once)
+    val incrementalResult = processor.onEvent(row(batchEnd + 1000L, 0L, 0.0), batchEnd + 1000L)
+    assertNotNull("should emit", incrementalResult.finalizedVector)
+
+    val naive = naiveAggregate(
+      batchEvents :+ row(batchEnd + 1000L, 0L, 0.0),
+      Array(batchEnd + 1000L),
+      aggregations,
+      schema
+    )
+
+    // Large window SUM should be 30 (10+20+0) but incremental path has double-counted
+    val incrementalMatchesNaive = approxEqual(incrementalResult.finalizedVector, naive(0))
+
+    // Eviction corrects: recomputes runningLargeIr = batch + hops + todayIr.
+    // Yesterday is cleared (batchEnd >= currentDayStart), so the pre-batch events
+    // in largeYesterdayIr are dropped. Only batch contributes.
+    val evictResult = processor.onEviction(batchEnd + 3600 * 1000L)
+    assertNotNull("eviction should emit", evictResult.finalizedVector)
+    val evictionMatchesNaive = approxEqual(evictResult.finalizedVector, naive(0))
+
+    // Assert: eviction MUST correct to match naive
+    if (!evictionMatchesNaive) {
+      fail(s"eviction should correct double-count: expected ${gson.toJson(naive(0))} " +
+        s"got ${gson.toJson(evictResult.finalizedVector)}")
+    }
+
+    // Document: the incremental path transiently double-counts (this is the sawtooth)
+    if (!incrementalMatchesNaive) {
+      logger.warn(s"EXPECTED: incremental path transiently double-counts pre-batch events. " +
+        s"naive=${gson.toJson(naive(0))} incremental=${gson.toJson(incrementalResult.finalizedVector)} " +
+        s"eviction(corrected)=${gson.toJson(evictResult.finalizedVector)}")
     }
   }
 

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileStreamProcessorTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileStreamProcessorTest.scala
@@ -524,11 +524,12 @@ class GigaTileStreamProcessorTest extends AnyFlatSpec {
       processor.onEvent(event, event.ts)
     }
 
-    // First eviction at an hour boundary — should emit
+    // Event-path recomputes already kept the large view current. Both forced evictions
+    // must suppress their write because recomputing produces the same packed IR.
     val evictionTs = TsUtils.round(batchEnd + 12 * 3600 * 1000L, 3600 * 1000L)
     processor.advanceWatermark(evictionTs)
     val result1 = processor.onEviction(evictionTs)
-    assertNotNull("first eviction should emit", result1.finalizedVector)
+    assertNull("an already-current eviction should not emit", result1.finalizedVector)
 
     // Second eviction 5 min later — same hour boundary, no events, nothing changed
     val nextEviction = evictionTs + 5 * 60 * 1000L
@@ -963,5 +964,452 @@ class GigaTileStreamProcessorTest extends AnyFlatSpec {
     if (!approxEqual(result.finalizedVector, naive(0))) {
       fail(s"all_small_windows: expected ${gson.toJson(naive(0))} got ${gson.toJson(result.finalizedVector)}")
     }
+  }
+
+  it should "exclude an expired small-window tile when a hop timer callback is delayed" in {
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+    val aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(1, TimeUnit.HOURS))))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, new InMemoryGigaTileStore(megaTileAgg.windowedAggregator))
+    val hopMillis = 5 * 60 * 1000L
+    val expiredTileEventTs = 10 * hopMillis
+    val previousHopTs = expiredTileEventTs + 12 * hopMillis + 1L
+    val delayedEventTs = previousHopTs + hopMillis + 9 * 1000L
+
+    // Seed the left-edge 1h tile, then stop before the next hop eviction fires.
+    // The delayed event path must rebuild the stale cache before adding the fresh 7.
+    processor.onEvent(row(expiredTileEventTs, 5L, 1.0), expiredTileEventTs + 1L)
+    processor.onEviction(previousHopTs)
+
+    val result = processor.onEvent(row(delayedEventTs, 7L, 1.0), delayedEventTs)
+    assertEquals("expired left-edge tile must not survive a delayed hop timer", 7L, result.finalizedVector(0))
+  }
+
+  it should "rebuild a sparse small window when a timer skips multiple hops" in {
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+    val aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(1, TimeUnit.HOURS))))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val store = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, store)
+    val hopMillis = processor.minSmallWindowTileSize
+
+    processor.onEvent(row(0L, 5L, 1.0), 0L, hopMillis + 1L)
+    assertEquals(hopMillis, store.getCachedSmallWindowAsOfTs)
+
+    // The 0-minute tile expires before this callback, but the immediately preceding
+    // hop tile is empty. The full skipped range still has to trigger a rebuild.
+    val delayedCallbackTs = 14 * hopMillis + 1L
+    val result = processor.onEviction(delayedCallbackTs)
+
+    assertNotNull("the delayed timer must publish the sparse-key correction", result.finalizedVector)
+    assertNull("the old sparse tile must not survive the skipped hops", result.finalizedVector(0))
+    assertTrue("the corrected sparse key must be empty", result.isEmpty)
+
+    // A +1 exclusive bound can cache the tile that starts exactly at the rounded marker.
+    // The bounded gap scan must include that marker tile as well.
+    val markerStore = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator)
+    val markerProcessor = new GigaTileStreamProcessor(megaTileAgg, markerStore)
+    markerProcessor.onEvent(row(hopMillis, 7L, 1.0), hopMillis, hopMillis + 1L)
+    assertEquals(hopMillis, markerStore.getCachedSmallWindowAsOfTs)
+
+    val markerResult = markerProcessor.onEviction(delayedCallbackTs)
+    assertNotNull("the delayed timer must publish the exact-marker correction", markerResult.finalizedVector)
+    assertNull("the exact-marker tile must expire across the skipped hops", markerResult.finalizedVector(0))
+    assertTrue("the corrected exact-marker key must be empty", markerResult.isEmpty)
+  }
+
+  it should "exclude an expired batch tail for a large-window-only delayed callback" in {
+    val batchEnd = 10 * DayMillis
+    val hourMillis = 60 * 60 * 1000L
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+    val aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(49, TimeUnit.HOURS))))
+    val batchEvents = Array(row(batchEnd - 48 * hourMillis, 5L, 1.0))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val store = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator) {
+      var runningLargeWrites: Int = 0
+
+      override def putRunningLargeIr(ir: Array[Any]): Unit = {
+        runningLargeWrites += 1
+        super.putRunningLargeIr(ir)
+      }
+    }
+    val processor = new GigaTileStreamProcessor(megaTileAgg, store)
+    val batchIr = denormalizeBatchIr(buildBatchIr(batchEvents, batchEnd, aggregations, schema),
+                                     aggregations,
+                                     schema,
+                                     batchEnd)
+    val beforeExpiry = batchEnd + 59 * 60 * 1000L
+    // Skip past the +2h boundary where the -48h tail hop leaves this 49h sawtooth.
+    val delayedCallbackTs = batchEnd + 3 * hourMillis + 60 * 1000L
+    val freshEvent = row(delayedCallbackTs - 1L, 7L, 1.0)
+
+    processor.onBatchUpdate(batchIr, batchEnd, batchEnd)
+    processor.onEviction(beforeExpiry)
+    val delayedTimerResult = processor.onEviction(delayedCallbackTs)
+    assertNull("the delayed timer must remove the expired batch tail", delayedTimerResult.finalizedVector(0))
+    assertEquals(delayedCallbackTs, store.getLastLargeRecomputeAsOfTs)
+
+    val writesBeforeDelayedCallback = store.runningLargeWrites
+    val result = processor.onEvent(freshEvent,
+                                   freshEvent.ts,
+                                   largeWindowAsOfTs = delayedCallbackTs,
+                                   smallWindowAsOfTs = delayedCallbackTs)
+
+    assertEquals("the expired batch tail must be removed before adding the fresh event",
+                 7L,
+                 result.finalizedVector(0))
+    assertEquals("the event must reuse the timer-corrected horizon and then apply once",
+                 writesBeforeDelayedCallback + 1,
+                 store.runningLargeWrites)
+    assertEquals(delayedCallbackTs, store.getLastLargeRecomputeAsOfTs)
+
+    val writesAfterRebuild = store.runningLargeWrites
+    val sameHopCallbackTs = delayedCallbackTs + 30 * 60 * 1000L
+    val sameHopEvent = row(sameHopCallbackTs - 1L, 3L, 1.0)
+    val sameHopResult = processor.onEvent(sameHopEvent,
+                                         sameHopEvent.ts,
+                                         largeWindowAsOfTs = sameHopCallbackTs,
+                                         smallWindowAsOfTs = sameHopCallbackTs)
+
+    assertEquals(10L, sameHopResult.finalizedVector(0))
+    assertEquals("a second event in the same large-window hop must not rebuild again",
+                 writesAfterRebuild + 1,
+                 store.runningLargeWrites)
+    assertEquals("the last recompute marker must remain at the first callback in the hop",
+                 delayedCallbackTs,
+                 store.getLastLargeRecomputeAsOfTs)
+  }
+
+  it should "rebuild at an offset tail boundary inside one eviction hop" in {
+    val batchEnd = 10 * DayMillis
+    val hourMillis = 60 * 60 * 1000L
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+    val window = new Window(49 * 60 + 20, TimeUnit.MINUTES)
+    val aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(window)))
+    val batchEvents = Array(row(batchEnd - 48 * hourMillis, 5L, 1.0))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val store = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator) {
+      var runningLargeWrites: Int = 0
+
+      override def putRunningLargeIr(ir: Array[Any]): Unit = {
+        runningLargeWrites += 1
+        super.putRunningLargeIr(ir)
+      }
+    }
+    val processor = new GigaTileStreamProcessor(megaTileAgg, store)
+    val batchIr = denormalizeBatchIr(buildBatchIr(batchEvents, batchEnd, aggregations, schema),
+                                     aggregations,
+                                     schema,
+                                     batchEnd)
+    val beforeOffsetBoundary = batchEnd + 2 * hourMillis + 5 * 60 * 1000L
+    val afterOffsetBoundary = batchEnd + 2 * hourMillis + 30 * 60 * 1000L
+
+    processor.onBatchUpdate(batchIr, batchEnd, batchEnd)
+    processor.onEviction(beforeOffsetBoundary)
+    assertEquals(5L, processor.currentSnapshot.finalizedVector(0))
+
+    val writesBeforeEvent = store.runningLargeWrites
+    val result = processor.onEvent(row(afterOffsetBoundary - 1L, 7L, 1.0),
+                                   afterOffsetBoundary - 1L,
+                                   largeWindowAsOfTs = afterOffsetBoundary,
+                                   smallWindowAsOfTs = afterOffsetBoundary)
+
+    assertEquals("the tail that expired at +2h20 must be removed before the event", 7L, result.finalizedVector(0))
+    assertEquals("the callback must rebuild once and then apply the event",
+                 writesBeforeEvent + 2,
+                 store.runningLargeWrites)
+    assertEquals(afterOffsetBoundary, store.getLastLargeRecomputeAsOfTs)
+  }
+
+  it should "rebuild at an offset daily-slot boundary inside one eviction hop" in {
+    val hourMillis = 60 * 60 * 1000L
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+    val window = new Window(49 * 60 + 20, TimeUnit.MINUTES)
+    val aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(window)))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val store = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, store)
+    val emptyBatch = denormalizeBatchIr(buildBatchIr(Array.empty[TestRow], 0L, aggregations, schema),
+                                        aggregations,
+                                        schema,
+                                        0L)
+    val oldEventTs = hourMillis
+    val beforeOffsetBoundary = 3 * DayMillis + hourMillis + 5 * 60 * 1000L
+    val afterOffsetBoundary = 3 * DayMillis + hourMillis + 30 * 60 * 1000L
+
+    processor.onBatchUpdate(emptyBatch, 0L, 0L)
+    processor.onEvent(row(oldEventTs, 5L, 1.0), oldEventTs)
+    processor.onEviction(beforeOffsetBoundary)
+    assertEquals(5L, processor.currentSnapshot.finalizedVector(0))
+
+    val result = processor.onEvent(row(afterOffsetBoundary - 1L, 7L, 1.0),
+                                   afterOffsetBoundary - 1L,
+                                   largeWindowAsOfTs = afterOffsetBoundary,
+                                   smallWindowAsOfTs = afterOffsetBoundary)
+
+    assertEquals("the expired day slot must be removed before the fresh event", 7L, result.finalizedVector(0))
+    assertEquals(afterOffsetBoundary, store.getLastLargeRecomputeAsOfTs)
+  }
+
+  it should "keep an out-of-order daily slot out of an expired shorter window" in {
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM,
+                           "num",
+                           Seq(new Window(3, TimeUnit.DAYS), new Window(7, TimeUnit.DAYS))))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, new InMemoryGigaTileStore(megaTileAgg.windowedAggregator))
+    val materializedAsOfTs = 10 * DayMillis
+    val oldEventTs = 4 * DayMillis + 60 * 60 * 1000L
+    val emptyBatch = denormalizeBatchIr(buildBatchIr(Array.empty[TestRow], 0L, aggregations, schema),
+                                        aggregations,
+                                        schema,
+                                        0L)
+
+    processor.onBatchUpdate(emptyBatch, 0L, 0L)
+    processor.advanceWatermark(materializedAsOfTs)
+    val result = processor.onEvent(row(oldEventTs, 5L, 1.0),
+                                   oldEventTs,
+                                   largeWindowAsOfTs = oldEventTs,
+                                   smallWindowAsOfTs = oldEventTs)
+
+    assertNull("the old slot must not re-inflate the already-expired 3d window", result.finalizedVector(0))
+    assertEquals("the same slot remains eligible for the 7d window", 5L, result.finalizedVector(1))
+    assertEquals(materializedAsOfTs, processor.store.getLastLargeRecomputeAsOfTs)
+  }
+
+  it should "keep a deferred future batch inactive until its day" in {
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+    val aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(7, TimeUnit.DAYS))))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, new InMemoryGigaTileStore(megaTileAgg.windowedAggregator))
+    val futureBatchEnd = 2 * DayMillis
+    val oldBatch = denormalizeBatchIr(
+      buildBatchIr(Array(row(-60 * 60 * 1000L, 5L, 1.0)), 0L, aggregations, schema),
+      aggregations,
+      schema,
+      0L)
+    val futureBatch = denormalizeBatchIr(
+      buildBatchIr(Array(row(futureBatchEnd - 60 * 60 * 1000L, 50L, 1.0)),
+                   futureBatchEnd,
+                   aggregations,
+                   schema),
+      aggregations,
+      schema,
+      futureBatchEnd)
+
+    processor.onBatchUpdate(oldBatch, 0L, 0L)
+    val deferred = processor.onBatchUpdate(futureBatch,
+                                           futureBatchEnd,
+                                           largeWindowAsOfTs = DayMillis,
+                                           smallWindowAsOfTs = DayMillis)
+    assertNull(deferred.finalizedVector)
+
+    val beforeActivation = processor.onEvent(row(DayMillis + 60 * 60 * 1000L, 7L, 1.0),
+                                             DayMillis + 60 * 60 * 1000L)
+    assertEquals("the event path must retain the prior large view", 12L, beforeActivation.finalizedVector(0))
+    assertNull(processor.onEviction(DayMillis + 2 * 60 * 60 * 1000L).finalizedVector)
+    processor.advanceWatermark(DayMillis + 2 * 60 * 60 * 1000L)
+    assertEquals(12L, processor.currentSnapshot.finalizedVector(0))
+
+    processor.advanceWatermark(futureBatchEnd + 60 * 60 * 1000L)
+    assertEquals("the deferred batch becomes active only once its day is current",
+                 50L,
+                 processor.currentSnapshot.finalizedVector(0))
+  }
+
+  it should "keep eviction live for an empty view with a deferred future batch" in {
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+    val aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(7, TimeUnit.DAYS))))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, new InMemoryGigaTileStore(megaTileAgg.windowedAggregator))
+    val currentBatchEnd = 10 * DayMillis
+    val futureBatchEnd = currentBatchEnd + DayMillis
+    val emptyBatch = denormalizeBatchIr(buildBatchIr(Array.empty[TestRow], currentBatchEnd, aggregations, schema),
+                                        aggregations,
+                                        schema,
+                                        currentBatchEnd)
+    val futureBatch = denormalizeBatchIr(
+      buildBatchIr(Array(row(futureBatchEnd - 60 * 60 * 1000L, 50L, 1.0)),
+                   futureBatchEnd,
+                   aggregations,
+                   schema),
+      aggregations,
+      schema,
+      futureBatchEnd)
+
+    processor.onBatchUpdate(emptyBatch,
+                            currentBatchEnd,
+                            largeWindowAsOfTs = currentBatchEnd,
+                            smallWindowAsOfTs = currentBatchEnd)
+    processor.onBatchUpdate(futureBatch,
+                            futureBatchEnd,
+                            largeWindowAsOfTs = currentBatchEnd + 60 * 60 * 1000L,
+                            smallWindowAsOfTs = currentBatchEnd + 60 * 60 * 1000L)
+
+    val waiting = processor.onEviction(currentBatchEnd + 2 * 60 * 60 * 1000L)
+    assertNull(waiting.finalizedVector)
+    assertTrue("the empty key must retain a timer until its future batch activates", waiting.needsEvictionTimer)
+    assertTrue(waiting.isEmpty)
+
+    val activated = processor.advanceWatermark(futureBatchEnd + 60 * 60 * 1000L)
+    assertEquals(50L, activated.finalizedVector(0))
+  }
+
+  it should "not rewind the cached small-window horizon for an older event" in {
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+    val aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(1, TimeUnit.HOURS))))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val store = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, store)
+    val hopMillis = 5 * 60 * 1000L
+    val expiredEventTs = 0L
+    val liveAsOfTs = 13 * hopMillis + 1L
+
+    processor.onEvent(row(expiredEventTs, 5L, 1.0), expiredEventTs + 1L)
+    val eviction = processor.onEviction(liveAsOfTs)
+    assertNull("the original tile must be expired at the live horizon", eviction.finalizedVector(0))
+
+    val result = processor.onEvent(row(expiredEventTs, 7L, 1.0), expiredEventTs)
+    assertNull("an older event must not resurrect the expired tile", result.finalizedVector(0))
+    assertEquals("the cache marker must not move backwards", 13 * hopMillis, store.getCachedSmallWindowAsOfTs)
+  }
+
+  it should "surface a cache-only correction from an adjacent day rollover" in {
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+    val aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(1, TimeUnit.HOURS))))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, new InMemoryGigaTileStore(megaTileAgg.windowedAggregator))
+    val eventTs = DayMillis - 90 * 60 * 1000L
+
+    processor.onEvent(row(eventTs, 5L, 1.0), eventTs + 1L)
+    val rollover = processor.advanceWatermark(DayMillis + 60 * 1000L)
+
+    assertNotNull("the rollover correction must be publishable", rollover.finalizedVector)
+    assertNull("the event must expire from the 1h window", rollover.finalizedVector(0))
+    assertTrue("the corrected vector must be marked empty", rollover.isEmpty)
+  }
+
+  it should "publish a stale-cache correction when a delayed event is fully dropped" in {
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+    val aggregations =
+      Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(1, TimeUnit.HOURS), new Window(7, TimeUnit.DAYS))))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, new InMemoryGigaTileStore(megaTileAgg.windowedAggregator))
+    val hopMillis = 5 * 60 * 1000L
+    val baseDay = 40 * DayMillis
+    val oldLargeWindowEventTs = baseDay - 8 * DayMillis + 60 * 60 * 1000L
+    val expiredTileEventTs = baseDay + 10 * hopMillis
+    val delayedProcessingTs = expiredTileEventTs + 13 * hopMillis + 9 * 1000L
+    val droppedEventTs = baseDay - 33 * DayMillis
+    val emptyBatchIr =
+      denormalizeBatchIr(buildBatchIr(Array.empty[TestRow], 0L, aggregations, schema), aggregations, schema, 0L)
+
+    // Keep a 7d value live while the 1h tile expires, then trigger the stale-cache rebuild
+    // with an event so old that it is dropped. The rebuild still changed the PUSH value.
+    processor.onBatchUpdate(emptyBatchIr, 0L, 0L)
+    processor.advanceWatermark(baseDay)
+    processor.onEvent(row(oldLargeWindowEventTs, 5L, 1.0), oldLargeWindowEventTs)
+    processor.onEvent(row(expiredTileEventTs, 11L, 1.0), expiredTileEventTs + 1L)
+
+    val result = processor.onEvent(row(droppedEventTs, 7L, 1.0), droppedEventTs, delayedProcessingTs)
+    assertTrue("event outside the retained daily range must be reported as dropped", result.droppedStaleEvent)
+    assertNotNull("stale-cache correction must publish even when the triggering event is dropped",
+                  result.finalizedVector)
+    assertNull("expired left-edge tile must not survive a fully dropped delayed event", result.finalizedVector(0))
+    assertEquals("the correction must also expire the stale large-window tail", 11L, result.finalizedVector(1))
+  }
+
+  it should "retain an exact-hop event when a delayed scheduled eviction rebuilds the cache" in {
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+    val aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(1, TimeUnit.HOURS))))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, new InMemoryGigaTileStore(megaTileAgg.windowedAggregator))
+    val hopMillis = 5 * 60 * 1000L
+    val exactHopTs = 20 * hopMillis
+    val expiredBufferTileTs = exactHopTs - 13 * hopMillis
+
+    processor.onEvent(row(expiredBufferTileTs, 3L, 1.0), expiredBufferTileTs + 1L)
+    processor.onEvent(row(exactHopTs - 1L, 0L, 1.0), exactHopTs - 1L, exactHopTs + 1L)
+    processor.onEvent(row(exactHopTs, 5L, 1.0), exactHopTs, exactHopTs + 1L)
+
+    val result = processor.onEviction(EvictionTimes(timerTs = exactHopTs, smallWindowAsOfTs = exactHopTs + 1L))
+    assertNotNull("the scheduled boundary rebuild should emit", result.finalizedVector)
+    assertEquals("the just-opened exact-hop tile must remain visible", 5L, result.finalizedVector(0))
+  }
+
+  it should "rebuild mixed small and large state across a day rollover" in {
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+    val aggregations =
+      Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(1, TimeUnit.HOURS), new Window(7, TimeUnit.DAYS))))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, new InMemoryGigaTileStore(megaTileAgg.windowedAggregator))
+    val rolloverDay = 10 * DayMillis
+    val beforeRollover = rolloverDay - 60 * 1000L
+    val afterRollover = rolloverDay + 60 * 1000L
+    val oldLargeEventTs = rolloverDay - 8 * DayMillis + 60 * 60 * 1000L
+    val recentEventTs = rolloverDay - 30 * 60 * 1000L
+    val emptyBatchIr =
+      denormalizeBatchIr(buildBatchIr(Array.empty[TestRow], 0L, aggregations, schema), aggregations, schema, 0L)
+
+    processor.onBatchUpdate(emptyBatchIr, 0L, 0L)
+    processor.advanceWatermark(beforeRollover)
+    processor.onEvent(row(oldLargeEventTs, 5L, 1.0), oldLargeEventTs, beforeRollover)
+    processor.onEvent(row(recentEventTs, 7L, 1.0), recentEventTs, beforeRollover)
+
+    val rollover = processor.advanceWatermark(afterRollover)
+    assertNotNull("the mixed-window correction must be publishable", rollover.finalizedVector)
+    assertEquals("the recent value remains in the 1h window", 7L, rollover.finalizedVector(0))
+    assertEquals("the expired daily slot must leave the 7d window", 7L, rollover.finalizedVector(1))
+  }
+
+  it should "keep the large-window horizon separate from the small-window boundary" in {
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+    val aggregations =
+      Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(1, TimeUnit.HOURS), new Window(7, TimeUnit.DAYS))))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, new InMemoryGigaTileStore(megaTileAgg.windowedAggregator))
+    val baseDay = 40 * DayMillis
+    val largeWindowAsOfTs = baseDay + 7 * DayMillis
+    val smallWindowAsOfTs = largeWindowAsOfTs + DayMillis
+    val oldLargeEventTs = baseDay + 60 * 60 * 1000L
+    val recentEventTs = largeWindowAsOfTs - 30 * 60 * 1000L
+    val droppedEventTs = largeWindowAsOfTs - 33 * DayMillis
+    val emptyBatchIr =
+      denormalizeBatchIr(buildBatchIr(Array.empty[TestRow], 0L, aggregations, schema), aggregations, schema, 0L)
+
+    processor.onBatchUpdate(emptyBatchIr, 0L, 0L)
+    processor.advanceWatermark(largeWindowAsOfTs)
+    processor.onEvent(row(oldLargeEventTs, 5L, 1.0), oldLargeEventTs, largeWindowAsOfTs)
+    processor.onEvent(row(recentEventTs, 11L, 1.0), recentEventTs, largeWindowAsOfTs)
+
+    val result = processor.onEvent(row(droppedEventTs, 7L, 1.0),
+                                   droppedEventTs,
+                                   largeWindowAsOfTs = largeWindowAsOfTs,
+                                   smallWindowAsOfTs = smallWindowAsOfTs)
+    assertTrue("the trigger must be outside retained history", result.droppedStaleEvent)
+    assertNull("the small horizon should expire both streaming tiles", result.finalizedVector(0))
+    assertEquals("the large horizon must retain both 7d contributions", 16L, result.finalizedVector(1))
+  }
+
+  it should "rebuild stale small state when a batch row is the next callback" in {
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+    val aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(1, TimeUnit.HOURS))))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, new InMemoryGigaTileStore(megaTileAgg.windowedAggregator))
+    val eventTs = 4 * DayMillis + 60 * 60 * 1000L
+    val batchCallbackTs = eventTs + 2 * 60 * 60 * 1000L
+    val emptyBatchIr =
+      denormalizeBatchIr(buildBatchIr(Array.empty[TestRow], 0L, aggregations, schema), aggregations, schema, 0L)
+
+    processor.onEvent(row(eventTs, 5L, 1.0), eventTs, eventTs + 1L)
+    val result = processor.onBatchUpdate(emptyBatchIr,
+                                         newBatchEnd = 0L,
+                                         largeWindowAsOfTs = batchCallbackTs,
+                                         smallWindowAsOfTs = batchCallbackTs)
+
+    assertNotNull("the batch callback must surface the stale-cache correction", result.finalizedVector)
+    assertNull("the expired 1h value must not remain published", result.finalizedVector(0))
+    assertTrue("the correction is an encoded all-null value", result.isEmpty)
   }
 }

--- a/api/src/main/scala/ai/chronon/api/Extensions.scala
+++ b/api/src/main/scala/ai/chronon/api/Extensions.scala
@@ -555,7 +555,7 @@ object Extensions {
     def isMegaTilingEnabled: Boolean =
       groupBy.onlineStrategy == OnlineStrategy.STREAMING_MEGATILES
 
-    def isGigaTilingEnabled: Boolean =
+    def isPushEnabled: Boolean =
       groupBy.onlineStrategy == OnlineStrategy.PUSH
 
     def semanticHash: String = {

--- a/api/src/main/scala/ai/chronon/api/Extensions.scala
+++ b/api/src/main/scala/ai/chronon/api/Extensions.scala
@@ -555,6 +555,9 @@ object Extensions {
     def isMegaTilingEnabled: Boolean =
       groupBy.onlineStrategy == OnlineStrategy.STREAMING_MEGATILES
 
+    def isGigaTilingEnabled: Boolean =
+      groupBy.onlineStrategy == OnlineStrategy.PUSH
+
     def semanticHash: String = {
       val newGroupBy = groupBy.deepCopy()
       newGroupBy.unsetMetaData()

--- a/api/src/main/scala/ai/chronon/api/Extensions.scala
+++ b/api/src/main/scala/ai/chronon/api/Extensions.scala
@@ -604,6 +604,10 @@ object Extensions {
 
     lazy val batchDataset: String = s"${groupBy.metaData.cleanName.toUpperCase()}_BATCH"
     lazy val streamingDataset: String = s"${groupBy.metaData.cleanName.toUpperCase()}_STREAMING"
+    // PUSH dataset: simple key→value (no sort key, no time-series).
+    // Name intentionally avoids _STREAMING suffix so DynamoDB creates it without sort key,
+    // BigTable reads use cellsPerRow(1), and Redis uses simple setex/get.
+    lazy val pushDataset: String = s"${groupBy.metaData.cleanName.toUpperCase()}_PUSH"
 
     def kvTable: String = s"${groupBy.metaData.outputTable}_upload"
 

--- a/api/src/main/scala/ai/chronon/api/planner/GroupByPlanner.scala
+++ b/api/src/main/scala/ai/chronon/api/planner/GroupByPlanner.scala
@@ -134,7 +134,7 @@ case class GroupByPlanner(groupBy: GroupBy)(implicit outputPartitionSpec: Partit
     // PUSH GroupBys write serving info to KV directly from GroupByUpload — skip the
     // KVUploadNodeRunner step (which would bulkPut entity rows that Flink reads from Iceberg).
     val groupByOps = new GroupByOps(groupBy)
-    val kvUploadNodes = if (groupByOps.isGigaTilingEnabled) Seq.empty else Seq(uploadToKVNode)
+    val kvUploadNodes = if (groupByOps.isPushEnabled) Seq.empty else Seq(uploadToKVNode)
     val allNodes = Seq(backfill, uploadNode) ++ kvUploadNodes ++ sensorNodes ++ streamingNode.toSeq
 
     val deployTerminalNode = streamingNode.map(_.metaData.name)

--- a/api/src/main/scala/ai/chronon/api/planner/GroupByPlanner.scala
+++ b/api/src/main/scala/ai/chronon/api/planner/GroupByPlanner.scala
@@ -131,9 +131,14 @@ case class GroupByPlanner(groupBy: GroupBy)(implicit outputPartitionSpec: Partit
       .map { es =>
         toNode(es.metaData, _.setExternalSourceSensor(es), ExternalSourceSensorUtil.semanticExternalSourceSensor(es))
       }
-    val allNodes = Seq(backfill, uploadNode, uploadToKVNode) ++ sensorNodes ++ streamingNode.toSeq
+    // PUSH GroupBys write serving info to KV directly from GroupByUpload — skip the
+    // KVUploadNodeRunner step (which would bulkPut entity rows that Flink reads from Iceberg).
+    val groupByOps = new GroupByOps(groupBy)
+    val kvUploadNodes = if (groupByOps.isGigaTilingEnabled) Seq.empty else Seq(uploadToKVNode)
+    val allNodes = Seq(backfill, uploadNode) ++ kvUploadNodes ++ sensorNodes ++ streamingNode.toSeq
 
-    val deployTerminalNode = streamingNode.map(_.metaData.name).getOrElse(uploadToKVNode.metaData.name)
+    val deployTerminalNode = streamingNode.map(_.metaData.name)
+      .getOrElse(if (kvUploadNodes.nonEmpty) uploadToKVNode.metaData.name else uploadNode.metaData.name)
 
     val terminalNodeNames = Map(
       ai.chronon.planner.Mode.BACKFILL -> backfill.metaData.name,

--- a/docs/source/gigatile.md
+++ b/docs/source/gigatile.md
@@ -195,6 +195,10 @@ def onBatchUpdate(newBatchIr, newBatchEnd):
   // Register eviction timer unconditionally — needed for:
   // - batch-only entities (no streaming events to trigger it)
   // - large-windows-only GroupBys (no small window tiles to drive eviction)
+  // minEvictionInterval = min(activeTiers) across ALL windows (small + large).
+  // For small-windows-only: 5min or 1hr (from small window hop sizes).
+  // For large-windows-only: 1hr (from large window hop size, not DayMillis).
+  // This ensures tail hop corrections fire at hop granularity.
   registerEvictionTimer(now + minEvictionInterval)
 
   if newBatchEnd > currentDayStart:

--- a/docs/source/gigatile.md
+++ b/docs/source/gigatile.md
@@ -60,23 +60,46 @@ Fetcher: read → return
 
 ## Batch IR Ingestion
 
-Flink reads the batch IR table from Iceberg using a connected keyed stream.
-Both real events and batch updates flow through the same `keyBy(entityKey)` routing.
+Flink reads the batch IR from the **existing GroupByUpload Iceberg table** — the same table
+that Spark already writes to. No new tables, no new Spark changes.
 
 ```
-Stream 1: real events (Kafka)                → keyBy(entityKey) ──┐
-                                                                   ├→ CoProcessFunction
-Stream 2: batch IR (Iceberg, periodic scan)  → keyBy(entityKey) ──┘
+GroupByUpload (Spark)
+  │  Writes partition ds=YYYY-MM-DD to Iceberg upload table
+  │  Columns: key_bytes, value_bytes, key_json, value_json, ds
+  │  Iceberg commits a new snapshot on write
+  │
+  ▼
+Flink-Iceberg Source (streaming monitor mode)
+  │  monitorInterval = 30 min
+  │  On startup: full table scan (latest ds partition) → all entities
+  │  On new snapshot: incremental read → only new/changed files
+  │
+  │  Decode key_bytes → entityKey
+  │  keyBy(entityKey) → network shuffle to correct task slot
+  │
+  ▼
+CoProcessFunction (same task slot as Kafka events for this entity)
+  │  processElement1: Kafka event → onEvent
+  │  processElement2: batch IR row → onBatchUpdate
 ```
 
-The Iceberg source uses streaming monitor mode: periodically checks for new snapshots
-(e.g., every 30 minutes) and emits new/changed rows. This means:
-- On startup: full table scan → every entity gets its batch IR loaded
-- After GroupByUpload: incremental snapshot → only changed entities re-emitted
-- Entities that only exist in batch (no streaming events) still get a Flink key slot
+```
+Stream 1: real events (Kafka)                            → keyBy(entityKey) ──┐
+                                                                               ├→ CoProcessFunction
+Stream 2: batch IR (Iceberg upload table, monitor mode)  → keyBy(entityKey) ──┘
+```
 
-This solves the key superset problem: Flink doesn't need to have seen a streaming event
-to serve an entity. The batch IR stream bootstraps all entities.
+**Why this works without any Spark changes:**
+- GroupByUpload already writes `(key_bytes, value_bytes)` to an Iceberg table partitioned by `ds`
+- Each write commits an Iceberg snapshot (standard Iceberg behavior)
+- Flink's Iceberg source detects new snapshots and reads the new data
+- `value_bytes` contains Avro-encoded `FinalBatchIr` — same format the fetcher reads today
+- `key_bytes` contains Avro-encoded entity keys — same encoding as the Kafka event keys
+
+**Key superset:** The Iceberg source emits ALL entities from the batch table. Entities that
+only exist in batch (no streaming events) get a Flink key slot via the batch stream.
+This solves the key superset problem without requiring Kafka events for every entity.
 
 ## State Layout
 
@@ -405,21 +428,105 @@ When restoring from a checkpoint/savepoint, Flink resumes from the checkpointed 
 No gap. No replay needed. The Iceberg source re-scans for any batch updates that landed
 during downtime.
 
+### First-ever startup (no prior state, no prior KV entries)
+
+This is the greenfield case: the giga tile Flink job starts for the first time. The KV store
+has no giga tile entries. The batch upload table has historical batch IRs.
+
+```
+First startup sequence:
+
+1. Iceberg source scans the upload table (latest ds partition)
+   → emits (key_bytes, value_bytes) for ALL entities
+   → includes the GroupByServingInfo metadata row (filtered out by key)
+   → N entities × ~1KB = ~1GB for 1M entities. One-time bounded scan.
+
+2. keyBy(entityKey) routes each batch IR to the correct task slot
+   → CoProcessFunction.processElement2 fires for each entity
+   → onBatchUpdate stores batchIr, computes runningLargeIr
+   → entities with no streaming events: emit finalized vector immediately
+   → KV store now has entries for ALL batch entities (batch-only answer)
+
+3. Kafka consumer starts from batchEndTs offset
+   → replays events from [batchEnd, now)
+   → KV writes suppressed during replay
+
+4. Watermark catches up to wall clock
+   → suppress lifted
+   → entities that had streaming events now emit full (batch + streaming) vectors
+   → KV store has correct entries for all entities
+```
+
+**Key question: will all keys be in the KV store?**
+
+Yes, because:
+- The Iceberg source emits ALL entities from the batch table (step 1)
+- Each entity triggers `onBatchUpdate` which emits to KV (step 2)
+- Batch-only entities get their vector from step 2 and never need streaming
+- Streaming entities get an initial batch-only vector (step 2), then a corrected
+  batch+streaming vector after replay (step 4)
+
+**What about entities in Kafka but NOT in batch?**
+
+These are brand-new entities that have streaming events but no batch history.
+- Their first Kafka event creates Flink state
+- `batchIr` is null → `runningLargeIr` = streaming only
+- The emitted vector is streaming-only (correct for new entities with no history)
+- When the next batch run picks them up, `onBatchUpdate` adds the batch component
+
+**Timing between Iceberg scan and Kafka replay:**
+
+The Iceberg scan and Kafka replay happen concurrently (two input streams).
+For any given entity, events might arrive before the batch IR:
+- Event arrives first → `batchIr` is null → streaming-only answer emitted
+  (but KV writes are suppressed during replay, so this isn't served)
+- Batch IR arrives during replay → `onBatchUpdate` stores it, but defers
+  recomputation if watermark hasn't caught up
+- After watermark catches up: eviction triggers full recomputation with
+  both batch and streaming → correct vector emitted
+
+The suppress-until-caught-up mechanism ensures the fetcher never sees
+intermediate/incomplete vectors during the startup window.
+
+**KV store population timeline (first startup):**
+
+```
+Time          KV state
+──────────    ──────────────────────────────────────────────────
+T+0           Empty (no prior entries)
+T+1 min       Batch-only entities start appearing (Iceberg scan in progress)
+              Streaming entities: suppressed (Kafka replay in progress)
+T+5 min       Iceberg scan complete. All batch entities have KV entries.
+              These are batch-only answers (no streaming component).
+T+10 min      Kafka replay complete. Watermark caught up.
+              Streaming entities now emit full batch+streaming vectors.
+              All entities have correct KV entries.
+```
+
 ### State transitions
 
 ```
                     ┌──────────────────────────────────────────────┐
-                    │          Cold start (no checkpoint)          │
+                    │        First startup (greenfield)             │
                     │                                              │
-                    │  1. Load batch IRs from Iceberg              │
-                    │  2. Set Kafka offset to batchEndTs           │
-                    │  3. Replay events [batchEnd, now)            │
-                    │  4. Suppress KV writes during replay         │
+                    │  1. Iceberg scan: load all batch IRs         │
+                    │  2. Batch-only entities: emit immediately    │
+                    │  3. Kafka replay from batchEndTs             │
+                    │  4. Suppress streaming KV writes             │
                     │                                              │
                     │  ── watermark catches up to wall clock ──    │
                     │                                              │
-                    │  5. Transition to normal mode                │
-                    │  6. Emit to KV on events + eviction          │
+                    │  5. Emit batch+streaming vectors             │
+                    │  6. All entities now in KV store             │
+                    └──────────────────────────────────────────────┘
+
+                    ┌──────────────────────────────────────────────┐
+                    │          Cold restart (no checkpoint)         │
+                    │                                              │
+                    │  Same as first startup, but KV store has     │
+                    │  stale entries from previous run.             │
+                    │  Batch-only entities: overwrite stale entry  │
+                    │  Streaming entities: stale until replay done │
                     └──────────────────────────────────────────────┘
 
                     ┌──────────────────────────────────────────────┐

--- a/docs/source/gigatile.md
+++ b/docs/source/gigatile.md
@@ -562,32 +562,27 @@ and edge cases for each, showing which code paths fire and what gets emitted.
 
 Building on the existing mega tile infrastructure:
 
-1. **Batch tail cumulation algorithm** (aggregator package, issue #1377 Task 1)
-   - `cumulateTails(FinalBatchIr, SawtoothAggregator) → Array[(Long, Array[Any])]`
-   - Produces cumulated entries indexed by query_ts
-   - Used by GroupByUpload to write cumulated batch to Iceberg
-
-2. **Extend TileStore with batch state**
+1. **Extend TileStore with batch state**
    - Add `getBatchIr/putBatchIr`, `getBatchEndTs/putBatchEndTs`, `getRunningLargeIr/putRunningLargeIr`
    - InMemoryTileStore + FlinkTileStore implementations
 
-3. **Extend MegaTileStreamProcessor → GigaTileStreamProcessor**
+2. **Extend MegaTileStreamProcessor → GigaTileStreamProcessor**
    - Add `onBatchUpdate(newBatchIr, newBatchEnd)` method
    - Modify eviction to recompute `runningLargeIr` from batch hops
    - Emit finalized vectors instead of windowed IRs
 
-4. **Add Iceberg connected stream to Flink job**
+3. **Add Iceberg connected stream to Flink job**
    - `CoProcessFunction` handling both event stream and batch IR stream
    - Periodic Iceberg snapshot monitoring (every 30 min)
 
-5. **Simplify fetcher path**
+4. **Simplify fetcher path**
    - Single point get on entity key
    - Decode finalized vector → return
    - No merge logic needed
 
-6. **Integration test**
+5. **Integration test**
    - Traffic replay: events + batch uploads + queries, time-ordered
    - Compare push-based results with backfilled results via `.diff`
 
-Steps 1-3 are pure aggregator/online changes (testable without Flink/Spark).
-Step 4 is Flink wiring. Steps 5-6 are cleanup and validation.
+Steps 1-2 are pure aggregator/online changes (testable without Flink/Spark).
+Step 3 is Flink wiring. Steps 4-5 are cleanup and validation.

--- a/docs/source/gigatile.md
+++ b/docs/source/gigatile.md
@@ -162,11 +162,15 @@ def onEviction(timerTs):
 
   // Large windows: recompute running sum from batch + streaming.
   // queryTs advanced → tail hops may have shifted (oldest hop excluded).
-  runningLargeIr = clone(batchIr.collapsed)
-  mergeTailHops(runningLargeIr, queryTs=timerTs, batchEndTs=batchEndTs, batchIr)
+  if batchIr != null:
+    runningLargeIr = clone(batchIr.collapsed)
+    mergeTailHops(runningLargeIr, queryTs=timerTs, batchEndTs=batchEndTs, batchIr)
+  else:
+    // No batch yet (new entity, batch hasn't run). Streaming-only.
+    runningLargeIr = windowedAgg.init
+
   for col where !isNoBatch(col):
     runningLargeIr(col) = merge(runningLargeIr(col), largeTodayIr(col))
-    // Include yesterday if batchEnd < todayStart (batch hasn't caught up)
     if batchEndTs < todayStart:
       runningLargeIr(col) = merge(runningLargeIr(col), largeYesterdayIr(col))
 
@@ -188,17 +192,21 @@ def onBatchUpdate(newBatchIr, newBatchEnd):
   batchIr = newBatchIr
   batchEndTs = newBatchEnd
 
-  // Register eviction timer for batch-only entities (no streaming events to trigger it).
-  if hasSmallWindows:
-    registerEvictionTimer(now + minSmallWindowTileSize)
+  // Register eviction timer unconditionally — needed for:
+  // - batch-only entities (no streaming events to trigger it)
+  // - large-windows-only GroupBys (no small window tiles to drive eviction)
+  registerEvictionTimer(now + minEvictionInterval)
 
   if newBatchEnd > currentDayStart:
-    // Batch is ahead of watermark (race: Iceberg delivered before watermark caught up).
-    // largeTodayIr covers [currentDayStart, now) which overlaps with batch [.., newBatchEnd).
-    // Cannot recompute without double-counting for non-invertible aggregations.
-    // Defer — the next eviction will recompute with correct boundaries after
-    // advanceWatermark moves currentDayStart past newBatchEnd.
-    return
+    if currentDayStart < 0:
+      // Uninitialized (no events yet). Safe to set from batch — largeTodayIr is init,
+      // no overlap concern. Without this, all startup batch loads would defer.
+      currentDayStart = newBatchEnd
+      // fall through to recomputation
+    else:
+      // Real defer: watermark hasn't caught up. largeTodayIr has events that overlap
+      // with batch. Wait for advanceWatermark to rotate, then eviction recomputes.
+      return
 
   // Safe: newBatchEnd <= currentDayStart — no overlap between batch and largeTodayIr.
 
@@ -379,20 +387,18 @@ No suppress logic inside Flink. Flink always emits when it has something to emit
 The serving layer doesn't route traffic until the orchestrator signals "ready."
 
 **Emit triggers:**
-- **Batch IR null→value** (first batch load for an entity): always emit. Covers both
-  initial startup (Iceberg scan) and new entities picked up by a later batch run.
 - **Event arrival**: emit on every event (existing mega tile behavior).
 - **Eviction timer**: emit on periodic eviction (existing).
-- **Batch IR update** (daily refresh): emit only on mismatch (existing).
+- **Batch IR update**: emit if `runningLargeIr` changed. Single rule covers
+  null→value (first batch load), batch correction, tail shift, no-change skip.
 
 ```
 def onBatchUpdate(newBatchIr, newBatchEnd):
+  // ... store batchIr, register timer, defer if overlap (see detailed pseudocode above) ...
+
   oldRunningLargeIr = clone(runningLargeIr)
+  // ... recompute runningLargeIr from batch + hops + streaming ...
 
-  // ... existing logic: store, defer if watermark lag, recompute ...
-
-  // Single rule: emit if the merged answer changed.
-  // Covers null→value (first batch load), batch correction, tail shift, etc.
   if !equal(oldRunningLargeIr, runningLargeIr):
     emit(finalize(pack(cachedSmallWindowIr, runningLargeIr)))
 ```

--- a/docs/source/gigatile.md
+++ b/docs/source/gigatile.md
@@ -215,6 +215,81 @@ KV value: finalized feature vector (Avro encoded output schema)
 
 Single entry per entity. Overwritten on every emit. The fetcher reads one key, decodes, returns.
 
+## Scenario Tables
+
+All windows, tailBuffer = 2d, now = Mar 26 14:00.
+
+### Scenario 1: Batch fresh (batchEnd = Mar 26 00:00, 14h stale)
+
+Streaming covers [batchEnd, now) = [Mar 26 00:00, Mar 26 14:00) = 14h.
+`largeTodayIr` covers [Mar 26 00:00, Mar 26 14:00). `largeYesterdayIr` is empty (batch is fresh).
+
+| window | category | runningLargeIr composition | tail hops selected | streaming added |
+|--------|----------|----------------------------|--------------------|-----------------|
+| 6h | SMALL | — (uses cachedSmallWindowIr) | — | — |
+| 1d | SMALL | — | — | — |
+| 2d | SMALL | — | — | — |
+| 49h | LARGE | collapsed [Mar 24 23:00, Mar 26 00:00) + 1 hop [Mar 24 01:00, Mar 24 23:00) | hops where hopStart >= round(Mar 26 14:00 - 49h) = Mar 24 13:00 | + largeTodayIr [Mar 26 00:00, 14:00) |
+| 3d | LARGE | collapsed [Mar 24 00:00, Mar 26 00:00) + 24 hops [Mar 23 00:00, Mar 24 00:00) | hops where hopStart >= round(Mar 26 14:00 - 3d) = Mar 23 14:00 | + largeTodayIr |
+| 7d | LARGE | collapsed [Mar 20 00:00, Mar 26 00:00) + 48 hops [Mar 19 00:00, Mar 20 00:00) | hops where hopStart >= round(Mar 26 14:00 - 7d) = Mar 19 14:00 | + largeTodayIr |
+
+**On event at Mar 26 14:00:**
+- `runningLargeIr(49h)` = batch portion (collapsed + selected hops) + `largeTodayIr` contribution + new event
+- Emit: `finalize(pack(cachedSmallWindowIr, runningLargeIr))` → single KV write
+
+**On eviction at Mar 26 14:05:**
+- `queryTs` advanced by 5min → `queryTail` for 49h advances → no hop falls off (1hr hops)
+- `queryTail` for 3d advances → no hop falls off
+- `runningLargeIr` recomputed from batch hops + streaming. Same value (no tail shift). No-op.
+
+### Scenario 2: Batch stale (batchEnd = Mar 25 00:00, 38h stale)
+
+Streaming covers [batchEnd, now) = [Mar 25 00:00, Mar 26 14:00) = 38h.
+`largeYesterdayIr` covers [Mar 25 00:00, Mar 26 00:00). `largeTodayIr` covers [Mar 26 00:00, Mar 26 14:00).
+Both are included because `batchEnd < todayStart`.
+
+| window | category | runningLargeIr composition | tail hops selected | streaming added |
+|--------|----------|----------------------------|--------------------|-----------------|
+| 6h | SMALL | — | — | — |
+| 1d | SMALL | — | — | — |
+| 2d | SMALL | — | — | — |
+| 49h | LARGE | collapsed [Mar 22 23:00, Mar 25 00:00) + hops | hops where hopStart >= Mar 24 13:00 | + largeYesterdayIr + largeTodayIr |
+| 3d | LARGE | collapsed [Mar 23 00:00, Mar 25 00:00) + hops | hops where hopStart >= Mar 23 14:00 | + largeYesterdayIr + largeTodayIr |
+| 7d | LARGE | collapsed [Mar 19 00:00, Mar 25 00:00) + hops | hops where hopStart >= Mar 19 14:00 | + largeYesterdayIr + largeTodayIr |
+
+**On batch refresh (batchEnd advances Mar 25 → Mar 26 00:00):**
+1. Store new batchIr (collapsed now covers [Mar 20 00:00, Mar 26 00:00) for 7d window)
+2. Clear `largeYesterdayIr` — batch now covers [Mar 25 00:00, Mar 26 00:00)
+3. Recompute `runningLargeIr`:
+   - 49h: new collapsed + selected hops + largeTodayIr only (yesterday cleared)
+   - 3d: new collapsed + selected hops + largeTodayIr only
+4. Compare with old `runningLargeIr`
+5. Emit only if mismatch (likely: batch incorporated Mar 25's full data, replacing streaming's accumulation)
+
+### State transitions through a day
+
+```
+Time        Event                   runningLargeIr state
+─────────── ─────────────────────── ──────────────────────────────────────────────
+Mar 26 00:00  advanceWatermark       yesterday→today rotation. Running sum unchanged
+              (day transition)       (sawtooth: slightly over-inclusive at tail)
+
+Mar 26 00:05  eviction timer         Recompute from batch hops + streaming.
+                                     Tail hops re-selected with queryTs=00:05.
+                                     Running sum corrected.
+
+Mar 26 00:05  event arrives          Merge into largeTodayIr + runningLargeIr.
+  to 06:00    (continuous)           Emit finalized vector on each event.
+
+Mar 26 06:00  batch refresh          New batchIr loaded from Iceberg.
+              (Iceberg snapshot)     Clear largeYesterdayIr.
+                                     Recompute running sum.
+                                     Emit only if value changed.
+
+Mar 26 06:00  events continue        runningLargeIr updated incrementally.
+  to 24:00                           Eviction corrects tail every minTileSize.
+```
+
 ## Comparison with Mega Tile
 
 | | Mega tile (current) | Giga tile (proposed) |

--- a/docs/source/gigatile.md
+++ b/docs/source/gigatile.md
@@ -1,0 +1,289 @@
+# Giga Tile Design
+
+## Problem
+
+The mega tile architecture (see [megatile.md](megatile.md)) reduces KV reads from O(N tiles) to
+3 point gets, but the fetcher still does work on every read: decode batch IR + decode today/yesterday
+streaming entries + merge collapsed + scan tail hops + merge streaming + finalize. This compute
+happens on every feature request.
+
+## Goal
+
+Push the merge to the write path. Flink produces a **fully finalized feature vector** per entity.
+The fetcher does a single point get with zero compute.
+
+```
+Current (mega tile, pull-based):
+  Fetcher: 3 KV gets → decode → merge batch + streaming → finalize → return
+
+Proposed (giga tile, push-based):
+  Flink: on event → merge batch + streaming → finalize → KV write
+  Fetcher: 1 KV get → return
+```
+
+## Key Insight: Hop-Based Pruning
+
+The `FinalBatchIr` structure stores tail hops as individual hop-aligned partial aggregates:
+```
+collapsed: aggregate of [alignedCollapsedBoundary, batchEnd)
+tailHops[hopIndex]: time-sorted array of [baseIr_0, ..., hopStartTs]
+```
+
+`mergeTailHops` selects relevant hops using `queryTail = round(queryTs - windowMillis, hopSize)`.
+As `queryTs` advances, `queryTail` advances, and older hops are **excluded** (not subtracted).
+This gives us "invertibility for free" — even for non-invertible aggregations like MIN, MAX, FIRST,
+LAST. We simply re-run `mergeTailHops` with the current `queryTs` and get the correct answer.
+
+## Architecture
+
+```
+Iceberg (batch IR, written daily by GroupByUpload)
+    │
+    │  Flink reads periodically (connected keyed stream)
+    ▼
+Flink state per entity:
+    batchIr: FinalBatchIr           // latest batch IR (collapsed + tail hops)
+    batchEndTs: Long                // when batch was last computed
+    runningLargeIr: Array[Any]      // fully merged: batch + streaming for large window cols
+    largeTodayIr: Array[Any]        // today's streaming delta (for rotation tracking)
+    largeYesterdayIr: Array[Any]    // yesterday's streaming delta
+    tiles + cachedSmallWindowIr     // (existing mega tile state for small windows)
+    │
+    │  On event: update streaming state + running sum → emit finalized vector
+    ▼
+KV Store: (entity) → finalized feature vector
+    │
+    │  Single point get
+    ▼
+Fetcher: read → return
+```
+
+## Batch IR Ingestion
+
+Flink reads the batch IR table from Iceberg using a connected keyed stream.
+Both real events and batch updates flow through the same `keyBy(entityKey)` routing.
+
+```
+Stream 1: real events (Kafka)                → keyBy(entityKey) ──┐
+                                                                   ├→ CoProcessFunction
+Stream 2: batch IR (Iceberg, periodic scan)  → keyBy(entityKey) ──┘
+```
+
+The Iceberg source uses streaming monitor mode: periodically checks for new snapshots
+(e.g., every 30 minutes) and emits new/changed rows. This means:
+- On startup: full table scan → every entity gets its batch IR loaded
+- After GroupByUpload: incremental snapshot → only changed entities re-emitted
+- Entities that only exist in batch (no streaming events) still get a Flink key slot
+
+This solves the key superset problem: Flink doesn't need to have seen a streaming event
+to serve an entity. The batch IR stream bootstraps all entities.
+
+## State Layout
+
+Extends the existing mega tile `TileStore` with batch-side state:
+
+```
+// Existing (mega tile, small windows):
+tiles: MapState                    // per-tier base IRs for small window columns
+cachedSmallWindowIr: ValueState    // sawtooth running sum, corrected on eviction
+
+// Existing (mega tile, large window streaming delta):
+largeTodayIr: ValueState           // daily accumulator [todayStart, now)
+largeYesterdayIr: ValueState       // daily accumulator [yesterdayStart, todayStart)
+
+// New (giga tile, batch + merged):
+batchIr: ValueState                // FinalBatchIr (collapsed + tail hops)
+batchEndTs: ValueState             // Long
+runningLargeIr: ValueState         // fully merged large window IR (batch + streaming)
+
+// Bookkeeping:
+currentDayStart, earliestTileStart // (existing)
+```
+
+## Processing Logic
+
+### On Event (hot path)
+
+Same cost as mega tile — O(1) per event for large windows, O(tiers) for small windows.
+
+```
+def onEvent(row, eventTs):
+  // Small windows: unchanged from mega tile
+  updateTiles(row, eventTs)
+  updateCachedSmallWindowIr(row)
+
+  // Large windows: update daily accumulator AND running sum
+  if eventTs >= todayStart:
+    updateLargeWindowColumns(largeTodayIr, row)
+    updateLargeWindowColumns(runningLargeIr, row)    // running sum stays current
+  else if eventTs >= yesterdayStart:
+    updateLargeWindowColumns(largeYesterdayIr, row)
+    updateLargeWindowColumns(runningLargeIr, row)    // late event also merged into running sum
+
+  // Emit finalized feature vector
+  emit(finalize(pack(cachedSmallWindowIr, runningLargeIr)))
+```
+
+The `runningLargeIr` is the fully merged value: batch collapsed + relevant tail hops + all
+streaming events. Updated incrementally on each event. Sawtooth at the tail — corrected on eviction.
+
+### On Eviction (periodic, every minTileSize)
+
+Corrects both small window sawtooth and large window tail hop selection.
+
+```
+def onEviction(timerTs):
+  // Small windows: rebuild from tiles (existing mega tile logic)
+  evictStaleTiles(timerTs)
+  cachedSmallWindowIr = buildMegaTileIr(tiles, timerTs, todayStart)
+
+  // Large windows: recompute running sum from batch + streaming.
+  // queryTs advanced → tail hops may have shifted (oldest hop excluded).
+  runningLargeIr = clone(batchIr.collapsed)
+  mergeTailHops(runningLargeIr, queryTs=timerTs, batchEndTs=batchEndTs, batchIr)
+  for col where !isNoBatch(col):
+    runningLargeIr(col) = merge(runningLargeIr(col), largeTodayIr(col))
+    // Include yesterday if batchEnd < todayStart (batch hasn't caught up)
+    if batchEndTs < todayStart:
+      runningLargeIr(col) = merge(runningLargeIr(col), largeYesterdayIr(col))
+
+  emit(finalize(pack(cachedSmallWindowIr, runningLargeIr)))
+```
+
+### On Batch IR Update (daily, from Iceberg stream)
+
+Recomputes `runningLargeIr` with the new batch data. Emits only if the merged value changed.
+
+```
+def onBatchUpdate(newBatchIr, newBatchEnd):
+  oldBatchEnd = batchEndTs
+  if newBatchEnd <= oldBatchEnd: return   // same or older batch, skip
+
+  // Save old running sum for comparison
+  oldRunningLargeIr = clone(runningLargeIr)
+
+  // Store new batch state
+  batchIr = newBatchIr
+  batchEndTs = newBatchEnd
+
+  // Rotate streaming state — batch now covers what yesterday covered
+  largeYesterdayIr = init
+  if newBatchEnd > currentDayStart:
+    largeTodayIr = init    // batch overlaps today — clear and rebuild from events
+
+  // Recompute running sum: new batch + remaining streaming
+  runningLargeIr = clone(newBatchIr.collapsed)
+  mergeTailHops(runningLargeIr, queryTs=now, batchEndTs=newBatchEnd, newBatchIr)
+  for col where !isNoBatch(col):
+    runningLargeIr(col) = merge(runningLargeIr(col), largeTodayIr(col))
+
+  // Emit only on mismatch — most entities won't change materially
+  if !equal(oldRunningLargeIr, runningLargeIr):
+    emit(finalize(pack(cachedSmallWindowIr, runningLargeIr)))
+```
+
+### Day Transition (advanceWatermark)
+
+Same as mega tile, plus `runningLargeIr` gets yesterday cleared.
+
+```
+def advanceWatermark(watermarkTs):
+  wmDay = round(watermarkTs, DayMillis)
+  if wmDay > currentDayStart:
+    // Rotate yesterday → discard (or keep if single-day hop, clear if multi-day)
+    largeYesterdayIr = if (wmDay == currentDayStart + DayMillis) largeTodayIr else init
+    largeTodayIr = init
+    currentDayStart = wmDay
+
+    // runningLargeIr is NOT reset here — it's a cumulative sum.
+    // Yesterday's data is still valid in the running sum.
+    // The eviction timer will re-run mergeTailHops with the new queryTs
+    // to prune any tail hops that fell off. Between the day transition
+    // and the next eviction, the running sum is slightly over-inclusive
+    // at the tail (sawtooth).
+```
+
+## Emit and KV Key
+
+The emitted value is a **finalized feature vector** — the same format that the fetcher would
+return to the ML model. No further processing needed.
+
+```
+KV key:   entityKeyBytes (plain entity key, no TileKey wrapper, no day suffix)
+KV value: finalized feature vector (Avro encoded output schema)
+```
+
+Single entry per entity. Overwritten on every emit. The fetcher reads one key, decodes, returns.
+
+## Comparison with Mega Tile
+
+| | Mega tile (current) | Giga tile (proposed) |
+|---|---|---|
+| **KV reads per query** | 3 (today + yesterday + batch) | 1 |
+| **Fetcher compute** | decode + merge + finalize | decode only |
+| **Flink state** | ~17 KB/entity | ~19 KB/entity (+batchIr ~1-2 KB) |
+| **KV writes per event** | 1 (streaming entry) | 1 (finalized vector) |
+| **Batch data in Flink** | No | Yes (via Iceberg connected stream) |
+| **Cold entity serving** | Fetcher reads batch KV | Flink emits on batch load |
+| **Batch correction** | Implicit (fetcher merges latest) | Flink re-merges, emits on mismatch |
+
+## Cost Model
+
+**Per event (hot path):**
+- Small windows: ~6 codec ops (unchanged from mega tile)
+- Large windows: 1 additional `updateLargeWindowColumns(runningLargeIr, row)` — same column aggregator update as largeTodayIr. Negligible.
+- Emit: encode finalized vector instead of windowed IR. Similar cost.
+
+**Per eviction (every minTileSize):**
+- Small windows: rebuild from tiles (unchanged)
+- Large windows: `clone(collapsed) + mergeTailHops + merge(streaming)` — O(tailHops × columns). For 48 hops × 7 columns = 336 merge ops per eviction. At 5min cadence, that's ~1.1 merges/sec. Negligible.
+
+**Per batch refresh (daily):**
+- Recompute `runningLargeIr` for all entities. O(entities × tailHops × columns).
+- Mismatch check + conditional emit. Most entities won't emit.
+- Spread over the Iceberg scan duration (~minutes). Not bursty.
+
+## Bootstrapping
+
+On Flink job startup:
+1. Iceberg source emits all entities' batch IRs (bounded scan)
+2. Each entity's `batchIr` state is populated
+3. `runningLargeIr` is computed from batch IR (no streaming yet)
+4. Emitted to KV store — all entities are immediately servable
+5. As streaming events arrive, `runningLargeIr` is incrementally updated
+
+No Kafka replay needed. No warm-up period for serving.
+
+## Implementation Path
+
+Building on the existing mega tile infrastructure:
+
+1. **Batch tail cumulation algorithm** (aggregator package, issue #1377 Task 1)
+   - `cumulateTails(FinalBatchIr, SawtoothAggregator) → Array[(Long, Array[Any])]`
+   - Produces cumulated entries indexed by query_ts
+   - Used by GroupByUpload to write cumulated batch to Iceberg
+
+2. **Extend TileStore with batch state**
+   - Add `getBatchIr/putBatchIr`, `getBatchEndTs/putBatchEndTs`, `getRunningLargeIr/putRunningLargeIr`
+   - InMemoryTileStore + FlinkTileStore implementations
+
+3. **Extend MegaTileStreamProcessor → GigaTileStreamProcessor**
+   - Add `onBatchUpdate(newBatchIr, newBatchEnd)` method
+   - Modify eviction to recompute `runningLargeIr` from batch hops
+   - Emit finalized vectors instead of windowed IRs
+
+4. **Add Iceberg connected stream to Flink job**
+   - `CoProcessFunction` handling both event stream and batch IR stream
+   - Periodic Iceberg snapshot monitoring (every 30 min)
+
+5. **Simplify fetcher path**
+   - Single point get on entity key
+   - Decode finalized vector → return
+   - No merge logic needed
+
+6. **Integration test**
+   - Traffic replay: events + batch uploads + queries, time-ordered
+   - Compare push-based results with backfilled results via `.diff`
+
+Steps 1-3 are pure aggregator/online changes (testable without Flink/Spark).
+Step 4 is Flink wiring. Steps 5-6 are cleanup and validation.

--- a/docs/source/gigatile.md
+++ b/docs/source/gigatile.md
@@ -457,18 +457,22 @@ First startup sequence:
    → KV store has correct entries for all entities
 ```
 
+**Note:** Giga tile only applies to `Accuracy.TEMPORAL` GroupBys (those with a streaming topic).
+`SNAPSHOT` GroupBys have no Flink job — they go through the traditional `bulkPut` path
+directly from Spark to KV store.
+
 **Key question: will all keys be in the KV store?**
 
-Yes, because:
-- The Iceberg source emits ALL entities from the batch table (step 1)
-- Each entity triggers `onBatchUpdate` which emits to KV (step 2)
-- Batch-only entities get their vector from step 2 and never need streaming
-- Streaming entities get an initial batch-only vector (step 2), then a corrected
-  batch+streaming vector after replay (step 4)
+Yes, for all temporal entities:
+- **Inactive entities** (in batch table, no recent streaming events): the Iceberg source
+  emits their batch IR → Flink computes a batch-only vector → emits to KV (step 2).
+  These entities have a topic but haven't sent events recently.
+- **Active entities** (have streaming events): get an initial batch-only vector (step 2),
+  then a corrected batch+streaming vector after Kafka replay (step 4).
 
 **What about entities in Kafka but NOT in batch?**
 
-These are brand-new entities that have streaming events but no batch history.
+Brand-new entities that have streaming events but no batch history yet:
 - Their first Kafka event creates Flink state
 - `batchIr` is null → `runningLargeIr` = streaming only
 - The emitted vector is streaming-only (correct for new entities with no history)

--- a/docs/source/gigatile.md
+++ b/docs/source/gigatile.md
@@ -371,176 +371,130 @@ Mar 26 06:00  events continue        runningLargeIr updated incrementally.
 - Mismatch check + conditional emit. Most entities won't emit.
 - Spread over the Iceberg scan duration (~minutes). Not bursty.
 
-## Bootstrapping and Cold Start Recovery
+## Bootstrapping and Startup
 
-### The problem
+### Emit strategy
 
-In both mega tile and giga tile, a stateless restart (no checkpoint/savepoint) creates a gap:
-Kafka events from `[last_emit, restart_time)` are consumed and gone. Flink has no state for them.
+No suppress logic inside Flink. Flink always emits when it has something to emit.
+The serving layer doesn't route traffic until the orchestrator signals "ready."
 
-- **Mega tile**: fetcher re-reads batch KV on every query, so large windows recover immediately.
-  Small windows (streaming-only) lose data until events refill the window. The first new event
-  overwrites the old streaming KV entry, causing a sudden drop.
-- **Giga tile**: the fetcher serves whatever's in KV (last-emitted vector). ALL windows are stale
-  until Flink catches up. No fallback.
-
-Giga tile makes this worse because the fetcher has no independent data path to compensate.
-
-### Fix: Kafka replay from batchEnd on cold start
-
-On cold start (no checkpoint to restore), Flink must replay Kafka events to reconstruct
-streaming state before emitting to KV.
+**Emit triggers:**
+- **Batch IR null→value** (first batch load for an entity): always emit. Covers both
+  initial startup (Iceberg scan) and new entities picked up by a later batch run.
+- **Event arrival**: emit on every event (existing mega tile behavior).
+- **Eviction timer**: emit on periodic eviction (existing).
+- **Batch IR update** (daily refresh): emit only on mismatch (existing).
 
 ```
-Cold start sequence:
+def onBatchUpdate(newBatchIr, newBatchEnd):
+  hadBatchBefore = (batchIr != null)
+
+  // ... existing logic: store, defer if watermark lag, recompute ...
+
+  if !hadBatchBefore:
+    // First batch IR for this entity — emit the best available answer
+    emit(finalize(pack(cachedSmallWindowIr, runningLargeIr)))
+  else:
+    // Subsequent update — emit only on mismatch
+    if !equal(oldRunningLargeIr, runningLargeIr):
+      emit(...)
+```
+
+### Readiness signal
+
+The Flink job exposes a readiness condition: **initial Iceberg scan complete AND watermark
+caught up** (within configurable `maxLag` of wall clock). The orchestrator checks this
+before routing model traffic to the giga tile KV dataset.
+
+```
+isReady = icebergInitialScanComplete
+          AND currentWatermark >= System.currentTimeMillis() - maxLag
+```
+
+This is a metric/health endpoint — not part of the emit logic. Flink doesn't gate emits
+on readiness. It writes to KV freely. The orchestrator decides when to trust the output.
+
+### Kafka replay on cold start
+
+On cold start (no checkpoint), Flink replays Kafka from `batchEndTs` to reconstruct
+streaming state. During replay, Flink emits progressively-building vectors. This is fine
+because the orchestrator hasn't signaled "ready" yet — no traffic is routed.
+
+```
+Cold start / first startup:
 1. Flink starts with no state
-2. Iceberg source loads batch IRs for all entities
-   → batchEndTs known per entity (or globally if same GroupBy)
-3. Kafka consumer start offset = timestamp(batchEndTs)
-   → replays events from [batchEndTs, now)
-4. Flink processes replayed events, building tiles + accumulators
-   → does NOT emit to KV during replay (suppress until caught up)
-5. Watermark reaches near-realtime (within eviction interval of wall clock)
-   → Flink transitions to normal mode: emit on every event
+2. Iceberg source scans upload table (latest ds partition)
+   → all entities get batch IR via onBatchUpdate
+   → null→value trigger: each entity emits batch-only vector
+3. Kafka consumer starts from batchEndTs offset
+   → replays events from [batchEnd, now)
+   → each event emits updated vector (progressively improving)
+4. Watermark catches up + Iceberg scan done → isReady = true
+5. Orchestrator routes traffic → fetcher reads correct vectors
 ```
 
-**Suppress-until-caught-up** is critical. Without it, the KV store sees progressively-building
-vectors during replay — the fetcher would serve fluctuating values (e.g., `sum_7d` climbing
-from 0 to 5000 over 30 seconds of replay). With suppression, the KV entry stays at the
-last-emitted value from the previous run until Flink is fully caught up.
-
-Detection: Flink is "caught up" when `currentWatermark >= System.currentTimeMillis() - maxLag`
-where `maxLag` is configurable (e.g., 1 minute). This is a standard Flink pattern for
-distinguishing replay from live processing.
+During replay (steps 2-3), the KV store has intermediate vectors. Nobody reads them
+because readiness hasn't been signaled.
 
 ### Kafka retention requirement
 
-Kafka topic retention must be ≥ max batch staleness (typically 2 days). This ensures that
-on cold start, events from `[batchEnd, now)` are available for replay. If retention is shorter,
-the gap between Kafka's oldest available offset and `batchEnd` creates a data hole.
+Kafka topic retention must be ≥ max batch staleness (typically 2 days). This ensures
+events from `[batchEnd, now)` are available for replay. For GroupBys with only small
+windows (≤ 2d), retention must cover the max window size.
 
-For GroupBys with only small windows (≤ 2d), Kafka retention must cover the max window size.
-These windows are self-contained in streaming — batch doesn't help.
+### Key completeness
 
-### Checkpoint restore (normal case)
-
-When restoring from a checkpoint/savepoint, Flink resumes from the checkpointed Kafka offsets.
-No gap. No replay needed. The Iceberg source re-scans for any batch updates that landed
-during downtime.
-
-### First-ever startup (no prior state, no prior KV entries)
-
-This is the greenfield case: the giga tile Flink job starts for the first time. The KV store
-has no giga tile entries. The batch upload table has historical batch IRs.
-
-```
-First startup sequence:
-
-1. Iceberg source scans the upload table (latest ds partition)
-   → emits (key_bytes, value_bytes) for ALL entities
-   → includes the GroupByServingInfo metadata row (filtered out by key)
-   → N entities × ~1KB = ~1GB for 1M entities. One-time bounded scan.
-
-2. keyBy(entityKey) routes each batch IR to the correct task slot
-   → CoProcessFunction.processElement2 fires for each entity
-   → onBatchUpdate stores batchIr, computes runningLargeIr
-   → entities with no streaming events: emit finalized vector immediately
-   → KV store now has entries for ALL batch entities (batch-only answer)
-
-3. Kafka consumer starts from batchEndTs offset
-   → replays events from [batchEnd, now)
-   → KV writes suppressed during replay
-
-4. Watermark catches up to wall clock
-   → suppress lifted
-   → entities that had streaming events now emit full (batch + streaming) vectors
-   → KV store has correct entries for all entities
-```
-
-**Note:** Giga tile only applies to `Accuracy.TEMPORAL` GroupBys (those with a streaming topic).
-`SNAPSHOT` GroupBys have no Flink job — they go through the traditional `bulkPut` path
-directly from Spark to KV store.
-
-**Key question: will all keys be in the KV store?**
+**Will all keys be in the KV store after startup?**
 
 Yes, for all temporal entities:
-- **Inactive entities** (in batch table, no recent streaming events): the Iceberg source
-  emits their batch IR → Flink computes a batch-only vector → emits to KV (step 2).
-  These entities have a topic but haven't sent events recently.
-- **Active entities** (have streaming events): get an initial batch-only vector (step 2),
-  then a corrected batch+streaming vector after Kafka replay (step 4).
+- **Inactive entities** (in batch table, no recent streaming events): Iceberg source
+  emits their batch IR → null→value trigger → batch-only vector emitted to KV.
+- **Active entities**: batch-only vector first (Iceberg), then corrected with streaming
+  during Kafka replay.
+- **New entities (in Kafka, not in batch)**: first event creates Flink state. `batchIr`
+  is null → streaming-only vector emitted. Correct for entities with no history.
+  Next batch run picks them up via onBatchUpdate (null→value trigger).
 
-**What about entities in Kafka but NOT in batch?**
+**Note:** Giga tile only applies to `Accuracy.TEMPORAL` GroupBys (with a streaming topic).
+`SNAPSHOT` GroupBys bypass Flink — they use the traditional `bulkPut` from Spark to KV.
 
-Brand-new entities that have streaming events but no batch history yet:
-- Their first Kafka event creates Flink state
-- `batchIr` is null → `runningLargeIr` = streaming only
-- The emitted vector is streaming-only (correct for new entities with no history)
-- When the next batch run picks them up, `onBatchUpdate` adds the batch component
-
-**Timing between Iceberg scan and Kafka replay:**
-
-The Iceberg scan and Kafka replay happen concurrently (two input streams).
-For any given entity, events might arrive before the batch IR:
-- Event arrives first → `batchIr` is null → streaming-only answer emitted
-  (but KV writes are suppressed during replay, so this isn't served)
-- Batch IR arrives during replay → `onBatchUpdate` stores it, but defers
-  recomputation if watermark hasn't caught up
-- After watermark catches up: eviction triggers full recomputation with
-  both batch and streaming → correct vector emitted
-
-The suppress-until-caught-up mechanism ensures the fetcher never sees
-intermediate/incomplete vectors during the startup window.
-
-**KV store population timeline (first startup):**
+### Startup timeline
 
 ```
-Time          KV state
-──────────    ──────────────────────────────────────────────────
-T+0           Empty (no prior entries)
-T+1 min       Batch-only entities start appearing (Iceberg scan in progress)
-              Streaming entities: suppressed (Kafka replay in progress)
-T+5 min       Iceberg scan complete. All batch entities have KV entries.
-              These are batch-only answers (no streaming component).
-T+10 min      Kafka replay complete. Watermark caught up.
-              Streaming entities now emit full batch+streaming vectors.
-              All entities have correct KV entries.
+Time          KV state                              isReady
+──────────    ──────────────────────────────────     ───────
+T+0           Empty                                  false
+T+1 min       Batch-only vectors appearing           false
+              (Iceberg scan in progress)
+T+5 min       All batch entities in KV               false
+              (Iceberg scan complete)
+              Streaming entities: partial
+              (Kafka replay in progress)
+T+10 min      All entities fully correct             true
+              (watermark caught up)
+              Orchestrator routes traffic
 ```
 
 ### State transitions
 
 ```
-                    ┌──────────────────────────────────────────────┐
-                    │        First startup (greenfield)             │
-                    │                                              │
-                    │  1. Iceberg scan: load all batch IRs         │
-                    │  2. Batch-only entities: emit immediately    │
-                    │  3. Kafka replay from batchEndTs             │
-                    │  4. Suppress streaming KV writes             │
-                    │                                              │
-                    │  ── watermark catches up to wall clock ──    │
-                    │                                              │
-                    │  5. Emit batch+streaming vectors             │
-                    │  6. All entities now in KV store             │
-                    └──────────────────────────────────────────────┘
+┌──────────────────────────────────────────────┐
+│   First startup / cold restart                │
+│                                              │
+│   1. Iceberg scan: batch IRs → KV           │
+│   2. Kafka replay: streaming → KV           │
+│   3. Both complete → isReady = true          │
+│   4. Orchestrator routes traffic             │
+└──────────────────────────────────────────────┘
 
-                    ┌──────────────────────────────────────────────┐
-                    │          Cold restart (no checkpoint)         │
-                    │                                              │
-                    │  Same as first startup, but KV store has     │
-                    │  stale entries from previous run.             │
-                    │  Batch-only entities: overwrite stale entry  │
-                    │  Streaming entities: stale until replay done │
-                    └──────────────────────────────────────────────┘
-
-                    ┌──────────────────────────────────────────────┐
-                    │       Checkpoint restore (normal case)        │
-                    │                                              │
-                    │  1. Restore Flink state from checkpoint      │
-                    │  2. Resume Kafka from checkpointed offsets   │
-                    │  3. Iceberg re-scan for batch updates        │
-                    │  4. Immediately emit — no gap                │
-                    └──────────────────────────────────────────────┘
+┌──────────────────────────────────────────────┐
+│   Checkpoint restore (normal)                 │
+│                                              │
+│   1. Restore state from checkpoint           │
+│   2. Resume Kafka from checkpointed offsets  │
+│   3. Iceberg re-scan for batch updates       │
+│   4. isReady = true immediately              │
+└──────────────────────────────────────────────┘
 ```
 
 ## Implementation Path

--- a/docs/source/gigatile.md
+++ b/docs/source/gigatile.md
@@ -166,10 +166,13 @@ def onBatchUpdate(newBatchIr, newBatchEnd):
   batchIr = newBatchIr
   batchEndTs = newBatchEnd
 
-  // Rotate streaming state — batch now covers what yesterday covered
-  largeYesterdayIr = init
-  if newBatchEnd > currentDayStart:
-    largeTodayIr = init    // batch overlaps today — clear and rebuild from events
+  // Clear streaming accumulators that batch now covers.
+  // Only clear yesterday if batch actually covers through yesterday's range.
+  // Only clear today if batch covers into today (unusual — requires watermark lag).
+  if newBatchEnd >= currentDayStart:
+    largeYesterdayIr = init    // batch covers through yesterday
+  // largeTodayIr is NOT cleared — batchEnd falls on a day boundary (partition date),
+  // and largeTodayIr covers [currentDayStart, now) which is post-batchEnd.
 
   // Recompute running sum: new batch + remaining streaming
   runningLargeIr = clone(newBatchIr.collapsed)
@@ -180,6 +183,11 @@ def onBatchUpdate(newBatchIr, newBatchEnd):
   // Emit only on mismatch — most entities won't change materially
   if !equal(oldRunningLargeIr, runningLargeIr):
     emit(finalize(pack(cachedSmallWindowIr, runningLargeIr)))
+
+  // Register eviction timer for batch-only entities (no streaming events to trigger it).
+  // Without this, tail hops go stale as queryTs drifts from the batch-load-time value.
+  if hasSmallWindows:
+    registerEvictionTimer(now + minSmallWindowTileSize)
 ```
 
 ### Day Transition (advanceWatermark)
@@ -318,16 +326,89 @@ Mar 26 06:00  events continue        runningLargeIr updated incrementally.
 - Mismatch check + conditional emit. Most entities won't emit.
 - Spread over the Iceberg scan duration (~minutes). Not bursty.
 
-## Bootstrapping
+## Bootstrapping and Cold Start Recovery
 
-On Flink job startup:
-1. Iceberg source emits all entities' batch IRs (bounded scan)
-2. Each entity's `batchIr` state is populated
-3. `runningLargeIr` is computed from batch IR (no streaming yet)
-4. Emitted to KV store — all entities are immediately servable
-5. As streaming events arrive, `runningLargeIr` is incrementally updated
+### The problem
 
-No Kafka replay needed. No warm-up period for serving.
+In both mega tile and giga tile, a stateless restart (no checkpoint/savepoint) creates a gap:
+Kafka events from `[last_emit, restart_time)` are consumed and gone. Flink has no state for them.
+
+- **Mega tile**: fetcher re-reads batch KV on every query, so large windows recover immediately.
+  Small windows (streaming-only) lose data until events refill the window. The first new event
+  overwrites the old streaming KV entry, causing a sudden drop.
+- **Giga tile**: the fetcher serves whatever's in KV (last-emitted vector). ALL windows are stale
+  until Flink catches up. No fallback.
+
+Giga tile makes this worse because the fetcher has no independent data path to compensate.
+
+### Fix: Kafka replay from batchEnd on cold start
+
+On cold start (no checkpoint to restore), Flink must replay Kafka events to reconstruct
+streaming state before emitting to KV.
+
+```
+Cold start sequence:
+1. Flink starts with no state
+2. Iceberg source loads batch IRs for all entities
+   → batchEndTs known per entity (or globally if same GroupBy)
+3. Kafka consumer start offset = timestamp(batchEndTs)
+   → replays events from [batchEndTs, now)
+4. Flink processes replayed events, building tiles + accumulators
+   → does NOT emit to KV during replay (suppress until caught up)
+5. Watermark reaches near-realtime (within eviction interval of wall clock)
+   → Flink transitions to normal mode: emit on every event
+```
+
+**Suppress-until-caught-up** is critical. Without it, the KV store sees progressively-building
+vectors during replay — the fetcher would serve fluctuating values (e.g., `sum_7d` climbing
+from 0 to 5000 over 30 seconds of replay). With suppression, the KV entry stays at the
+last-emitted value from the previous run until Flink is fully caught up.
+
+Detection: Flink is "caught up" when `currentWatermark >= System.currentTimeMillis() - maxLag`
+where `maxLag` is configurable (e.g., 1 minute). This is a standard Flink pattern for
+distinguishing replay from live processing.
+
+### Kafka retention requirement
+
+Kafka topic retention must be ≥ max batch staleness (typically 2 days). This ensures that
+on cold start, events from `[batchEnd, now)` are available for replay. If retention is shorter,
+the gap between Kafka's oldest available offset and `batchEnd` creates a data hole.
+
+For GroupBys with only small windows (≤ 2d), Kafka retention must cover the max window size.
+These windows are self-contained in streaming — batch doesn't help.
+
+### Checkpoint restore (normal case)
+
+When restoring from a checkpoint/savepoint, Flink resumes from the checkpointed Kafka offsets.
+No gap. No replay needed. The Iceberg source re-scans for any batch updates that landed
+during downtime.
+
+### State transitions
+
+```
+                    ┌──────────────────────────────────────────────┐
+                    │          Cold start (no checkpoint)          │
+                    │                                              │
+                    │  1. Load batch IRs from Iceberg              │
+                    │  2. Set Kafka offset to batchEndTs           │
+                    │  3. Replay events [batchEnd, now)            │
+                    │  4. Suppress KV writes during replay         │
+                    │                                              │
+                    │  ── watermark catches up to wall clock ──    │
+                    │                                              │
+                    │  5. Transition to normal mode                │
+                    │  6. Emit to KV on events + eviction          │
+                    └──────────────────────────────────────────────┘
+
+                    ┌──────────────────────────────────────────────┐
+                    │       Checkpoint restore (normal case)        │
+                    │                                              │
+                    │  1. Restore Flink state from checkpoint      │
+                    │  2. Resume Kafka from checkpointed offsets   │
+                    │  3. Iceberg re-scan for batch updates        │
+                    │  4. Immediately emit — no gap                │
+                    └──────────────────────────────────────────────┘
+```
 
 ## Implementation Path
 

--- a/docs/source/gigatile.md
+++ b/docs/source/gigatile.md
@@ -387,17 +387,14 @@ The serving layer doesn't route traffic until the orchestrator signals "ready."
 
 ```
 def onBatchUpdate(newBatchIr, newBatchEnd):
-  hadBatchBefore = (batchIr != null)
+  oldRunningLargeIr = clone(runningLargeIr)
 
   // ... existing logic: store, defer if watermark lag, recompute ...
 
-  if !hadBatchBefore:
-    // First batch IR for this entity — emit the best available answer
+  // Single rule: emit if the merged answer changed.
+  // Covers null→value (first batch load), batch correction, tail shift, etc.
+  if !equal(oldRunningLargeIr, runningLargeIr):
     emit(finalize(pack(cachedSmallWindowIr, runningLargeIr)))
-  else:
-    // Subsequent update — emit only on mismatch
-    if !equal(oldRunningLargeIr, runningLargeIr):
-      emit(...)
 ```
 
 ### Readiness signal

--- a/docs/source/gigatile.md
+++ b/docs/source/gigatile.md
@@ -152,43 +152,65 @@ def onEviction(timerTs):
 
 ### On Batch IR Update (daily, from Iceberg stream)
 
-Recomputes `runningLargeIr` with the new batch data. Emits only if the merged value changed.
+Stores the new batch IR immediately. Recomputation of `runningLargeIr` is deferred if the
+watermark hasn't caught up to the new `batchEnd` (prevents double-counting from overlap
+between batch and `largeTodayIr`). The next eviction picks it up.
 
 ```
 def onBatchUpdate(newBatchIr, newBatchEnd):
   oldBatchEnd = batchEndTs
   if newBatchEnd <= oldBatchEnd: return   // same or older batch, skip
 
-  // Save old running sum for comparison
-  oldRunningLargeIr = clone(runningLargeIr)
-
-  // Store new batch state
+  // Always store the new batch IR — eviction and future events use it.
   batchIr = newBatchIr
   batchEndTs = newBatchEnd
 
-  // Clear streaming accumulators that batch now covers.
-  // Only clear yesterday if batch actually covers through yesterday's range.
-  // Only clear today if batch covers into today (unusual — requires watermark lag).
-  if newBatchEnd >= currentDayStart:
-    largeYesterdayIr = init    // batch covers through yesterday
-  // largeTodayIr is NOT cleared — batchEnd falls on a day boundary (partition date),
-  // and largeTodayIr covers [currentDayStart, now) which is post-batchEnd.
+  // Register eviction timer for batch-only entities (no streaming events to trigger it).
+  if hasSmallWindows:
+    registerEvictionTimer(now + minSmallWindowTileSize)
 
-  // Recompute running sum: new batch + remaining streaming
+  if newBatchEnd > currentDayStart:
+    // Batch is ahead of watermark (race: Iceberg delivered before watermark caught up).
+    // largeTodayIr covers [currentDayStart, now) which overlaps with batch [.., newBatchEnd).
+    // Cannot recompute without double-counting for non-invertible aggregations.
+    // Defer — the next eviction will recompute with correct boundaries after
+    // advanceWatermark moves currentDayStart past newBatchEnd.
+    return
+
+  // Safe: newBatchEnd <= currentDayStart — no overlap between batch and largeTodayIr.
+
+  // Save old running sum for comparison
+  oldRunningLargeIr = clone(runningLargeIr)
+
+  // Clear yesterday if batch now covers it
+  if newBatchEnd >= currentDayStart:
+    largeYesterdayIr = init
+
+  // Recompute running sum: new batch + tail hops + streaming
   runningLargeIr = clone(newBatchIr.collapsed)
-  mergeTailHops(runningLargeIr, queryTs=now, batchEndTs=newBatchEnd, newBatchIr)
+  mergeTailHops(runningLargeIr, queryTs=watermark, batchEndTs=newBatchEnd, newBatchIr)
   for col where !isNoBatch(col):
     runningLargeIr(col) = merge(runningLargeIr(col), largeTodayIr(col))
+    // Include yesterday if batch doesn't cover it
+    if newBatchEnd < currentDayStart and largeYesterdayIr(col) != null:
+      runningLargeIr(col) = merge(runningLargeIr(col), largeYesterdayIr(col))
 
   // Emit only on mismatch — most entities won't change materially
   if !equal(oldRunningLargeIr, runningLargeIr):
     emit(finalize(pack(cachedSmallWindowIr, runningLargeIr)))
-
-  // Register eviction timer for batch-only entities (no streaming events to trigger it).
-  // Without this, tail hops go stale as queryTs drifts from the batch-load-time value.
-  if hasSmallWindows:
-    registerEvictionTimer(now + minSmallWindowTileSize)
 ```
+
+**Why defer when `newBatchEnd > currentDayStart`?**
+
+`largeTodayIr` covers `[currentDayStart, now)`. If `newBatchEnd > currentDayStart`, batch covers
+`[..., newBatchEnd)` which overlaps with `[currentDayStart, newBatchEnd)` in `largeTodayIr`.
+We can't subtract the overlap (non-invertible aggregations). We can't clear `largeTodayIr`
+(loses post-`batchEnd` events). So we wait for the watermark to advance past `newBatchEnd`,
+which rotates `largeTodayIr` via `advanceWatermark`. The next eviction then recomputes cleanly.
+
+In normal operation, this defer never triggers: batch lands at ~6 AM, watermark passed midnight
+hours ago, `newBatchEnd = currentDayStart`. The defer is a safety net for the narrow race window
+when batch arrives just before the watermark crosses midnight.
 
 ### Day Transition (advanceWatermark)
 

--- a/docs/source/gigatile.md
+++ b/docs/source/gigatile.md
@@ -195,10 +195,8 @@ def onBatchUpdate(newBatchIr, newBatchEnd):
   // Register eviction timer unconditionally — needed for:
   // - batch-only entities (no streaming events to trigger it)
   // - large-windows-only GroupBys (no small window tiles to drive eviction)
-  // minEvictionInterval = min(activeTiers) across ALL windows (small + large).
-  // For small-windows-only: 5min or 1hr (from small window hop sizes).
-  // For large-windows-only: 1hr (from large window hop size, not DayMillis).
-  // This ensures tail hop corrections fire at hop granularity.
+  // minEvictionInterval = min(activeTiers) — the smallest hop size across ALL windows.
+  // Matches hop granularity so tail hop corrections fire at the right cadence.
   registerEvictionTimer(now + minEvictionInterval)
 
   if newBatchEnd > currentDayStart:

--- a/docs/source/gigatile.md
+++ b/docs/source/gigatile.md
@@ -500,6 +500,62 @@ T+10 min      All entities fully correct             true
 └──────────────────────────────────────────────┘
 ```
 
+## Entity Scenario Matrix
+
+Each entity falls into one of these categories. The matrix traces through startup, steady state,
+and edge cases for each, showing which code paths fire and what gets emitted.
+
+### Entity types
+
+| Type | Description | Has batch IR? | Has Kafka events? |
+|------|-------------|---------------|-------------------|
+| **A: Active** | In batch table AND streaming topic | Yes | Yes |
+| **B: Inactive** | In batch table, no recent events | Yes | No |
+| **C: New** | Not in batch yet, has streaming events | No | Yes |
+
+### Startup (first deploy or cold restart)
+
+| Entity | Iceberg scan | Kafka replay | First emit | Fully correct at |
+|--------|-------------|-------------|------------|------------------|
+| **A** | batch IR loaded → `currentDayStart` init'd from `batchEnd` → `runningLargeIr` computed → emit batch-only vector | Events replay from `batchEnd` → `onEvent` merges into `runningLargeIr` → emit on each event | On batch IR load (Iceberg) | Watermark caught up (~minutes) |
+| **B** | batch IR loaded → same as A → emit batch-only vector | No events → no Kafka processing | On batch IR load (Iceberg) | Immediately (batch is the full answer) |
+| **C** | No row in Iceberg → no `onBatchUpdate` | Events arrive → `batchIr = null` → `onEvent` emits streaming-only vector | On first Kafka event | Next batch run picks it up |
+
+### Steady state (job running, daily batch refresh)
+
+| Entity | On event | On eviction | On batch refresh |
+|--------|----------|-------------|------------------|
+| **A** | Update tiles + `cachedSmallWindowIr` + `largeTodayIr` + `runningLargeIr` → emit | Rebuild small windows from tiles. Recompute `runningLargeIr` from batch hops + streaming → emit | Store new `batchIr`. Recompute `runningLargeIr`. Emit on mismatch. |
+| **B** | No events → nothing | Timer fires (registered by `onBatchUpdate`). Recompute `runningLargeIr` from batch hops → emit if tail shifted. | Store new `batchIr`. Recompute. Emit on mismatch. |
+| **C** | Same as A but `batchIr = null` → `runningLargeIr` = streaming only → emit | Rebuild small windows. `batchIr = null` → `runningLargeIr` = streaming only → emit | **Transition to type A:** `batchIr` goes null→value. Recompute includes batch. Mismatch → emit. |
+
+### Day transition (advanceWatermark crosses midnight)
+
+| Entity | What happens |
+|--------|-------------|
+| **A** | `largeYesterdayIr = largeTodayIr`, `largeTodayIr = init`, `currentDayStart` advances. `runningLargeIr` NOT reset (cumulative). Eviction corrects tail within one interval. |
+| **B** | `advanceWatermark` fires from global watermark advancement. Same rotation. No events → `largeTodayIr` stays init. Eviction timer recomputes `runningLargeIr` with shifted tail hops. |
+| **C** | Same as A but no batch component. Rotation is streaming-only. |
+
+### Batch refresh (onBatchUpdate) edge cases
+
+| Scenario | Guard | Behavior |
+|----------|-------|----------|
+| `newBatchEnd <= oldBatchEnd` | Early return | Skip (same or older batch) |
+| `currentDayStart < 0` (uninitialized, no events) | Init `currentDayStart = newBatchEnd` | Safe: no events → no overlap. Recompute and emit. |
+| `newBatchEnd > currentDayStart` (watermark lag) | Defer (return) | Store `batchIr` but don't recompute. Next eviction handles it after watermark advances. |
+| `newBatchEnd >= currentDayStart` (normal) | Clear `largeYesterdayIr` | Batch covers through yesterday. Recompute without yesterday. |
+| `newBatchEnd < currentDayStart` (stale batch catch-up) | Keep `largeYesterdayIr` | Batch doesn't cover yesterday. Include yesterday in recomputation. |
+
+### Eviction edge cases
+
+| Scenario | Behavior |
+|----------|----------|
+| `batchIr = null` (new entity, type C) | `runningLargeIr = init + streaming`. No NPE. |
+| `batchIr != null` (types A, B) | `runningLargeIr = clone(collapsed) + mergeTailHops + streaming` |
+| `earliestTileStart = MaxValue` (no tiles, large-windows-only) | Skip tile eviction. Still recompute `runningLargeIr` from batch hops. |
+| Batch-only entity (type B), no `hasSmallWindows` | Timer registered unconditionally by `onBatchUpdate`. Eviction fires at `minEvictionInterval`. |
+
 ## Implementation Path
 
 Building on the existing mega tile infrastructure:

--- a/docs/source/gigatile.md
+++ b/docs/source/gigatile.md
@@ -272,11 +272,47 @@ The emitted value is a **finalized feature vector** — the same format that the
 return to the ML model. No further processing needed.
 
 ```
-KV key:   entityKeyBytes (plain entity key, no TileKey wrapper, no day suffix)
-KV value: finalized feature vector (Avro encoded output schema)
+KV dataset: {GROUP_BY_NAME}_PUSH  (not _STREAMING)
+KV key:     entityKeyBytes (plain entity key, no TileKey wrapper, no day suffix)
+KV value:   finalized feature vector (Avro encoded output schema)
 ```
 
 Single entry per entity. Overwritten on every emit. The fetcher reads one key, decodes, returns.
+
+### Why a dedicated `_PUSH` dataset
+
+Push writes use simple key→value semantics (one value per entity, overwritten on every emit).
+The existing `_STREAMING` dataset has **time-series semantics** baked into all KV implementations:
+
+| Implementation | `_STREAMING` behavior | Problem for push |
+|---|---|---|
+| DynamoDB | Composite key (partition + sort key = timestamp) | `GetItem` on plain entity key fails — sort key not specified |
+| BigTable | Day-based row key generation for time-series reads | Won't find rows written with plain entity keys |
+| Redis | Sorted sets (`zadd`/`zrangebyscore`) | Each timestamp creates a new member — unbounded growth |
+
+The `_PUSH` dataset avoids all of this:
+
+| Implementation | `_PUSH` behavior | Why it works |
+|---|---|---|
+| DynamoDB | Partition key only (no sort key) | `PutItem` overwrites; `GetItem` returns single value |
+| BigTable | Non-time-series; `cellsPerRow(1)` GC | `setCell` overwrites; read returns latest cell |
+| Redis | Simple `setex`/`get` | Overwrites on every write; single value per key |
+| Cosmos | Batch-style `upsertItem` by key hash | Document ID has no timestamp; upsert overwrites |
+
+The `_PUSH` suffix is chosen intentionally: DynamoDB's `isStreamingTable` check (`dataset.endsWith("_STREAMING")`)
+determines whether to add a sort key. `_PUSH` doesn't match, so the table is created as a simple key-value store.
+
+### Planner and upload changes
+
+For `OnlineStrategy.PUSH` GroupBys:
+
+- **Planner**: The `uploadToKVNode` is excluded from the plan — `KVUploadNodeRunner` (bulkPut of entity
+  rows) is not scheduled. Flink reads entity batch IRs directly from the Iceberg upload table.
+- **GroupByUpload**: Writes `GroupByServingInfo` directly to KV via `kvStore.put()` at the end of the
+  upload job. This replaces the `KVUploadNodeRunner` path for the metadata row. The serving info is
+  already in memory from `buildServingInfo()` — no extra table read needed.
+- **Upload table**: Still receives both entity rows and the serving info row (unchanged). Flink's Iceberg
+  source reads entity rows from here.
 
 ## Scenario Tables
 

--- a/docs/source/gigatile.md
+++ b/docs/source/gigatile.md
@@ -421,12 +421,14 @@ Mar 26 06:00  events continue        runningLargeIr updated incrementally.
 
 ### Emit strategy
 
-No suppress logic inside Flink. Flink always emits when it has something to emit.
-The serving layer doesn't route traffic until the orchestrator signals "ready."
+Flink continues rebuilding state during replay, but PUSH writes are fenced until the connected
+watermark is near wall clock. A batch source that is still active can hold that watermark at
+`MIN`; source idleness lets it advance but does not prove the initial scan completed. An optional
+write cadence can further coalesce hot-key updates after the fence opens.
 
 **Emit triggers:**
-- **Event arrival**: emit on every event (existing mega tile behavior).
-- **Eviction timer**: emit on periodic eviction (existing).
+- **Event arrival**: update state and publish only when the replay fence is open.
+- **Eviction timer**: rebuild expired state and publish a changed or deferred snapshot.
 - **Batch IR update**: emit if `runningLargeIr` changed. Single rule covers
   null→value (first batch load), batch correction, tail shift, no-change skip.
 
@@ -441,47 +443,33 @@ def onBatchUpdate(newBatchIr, newBatchEnd):
     emit(finalize(pack(cachedSmallWindowIr, runningLargeIr)))
 ```
 
-### Readiness signal
+### Readiness
 
-The Flink job exposes a readiness condition: **initial Iceberg scan complete AND watermark
-caught up** (within configurable `maxLag` of wall clock). The orchestrator checks this
-before routing model traffic to the giga tile KV dataset.
-
-```
-isReady = icebergInitialScanComplete
-          AND currentWatermark >= System.currentTimeMillis() - maxLag
-```
-
-This is a metric/health endpoint — not part of the emit logic. Flink doesn't gate emits
-on readiness. It writes to KV freely. The orchestrator decides when to trust the output.
+The implementation has no positive initial-Iceberg-scan-complete signal. A near-live connected
+watermark proves Kafka catch-up, not batch coverage. Rollout tooling must validate batch input and
+serving output separately before routing traffic.
 
 ### Kafka replay on cold start
 
-On cold start (no checkpoint), Flink replays Kafka from `batchEndTs` to reconstruct
-streaming state. During replay, Flink emits progressively-building vectors. This is fine
-because the orchestrator hasn't signaled "ready" yet — no traffic is routed.
+On cold start (no checkpoint), Flink rebuilds batch and streaming state from the configured
+sources. Serving writes remain fenced until the connected watermark reaches `Live`.
 
 ```
 Cold start / first startup:
 1. Flink starts with no state
 2. Iceberg source scans upload table (latest ds partition)
-   → all entities get batch IR via onBatchUpdate
-   → null→value trigger: each entity emits batch-only vector
-3. Kafka consumer starts from batchEndTs offset
-   → replays events from [batchEnd, now)
-   → each event emits updated vector (progressively improving)
-4. Watermark catches up + Iceberg scan done → isReady = true
-5. Orchestrator routes traffic → fetcher reads correct vectors
+   → rows populate batch state as they arrive
+3. Kafka replay rebuilds retained streaming state
+4. Connected watermark reaches `Live`
+   → the latest deferred snapshot can publish (subject to optional cadence)
+5. Rollout tooling validates batch coverage and serving output before routing traffic
 ```
-
-During replay (steps 2-3), the KV store has intermediate vectors. Nobody reads them
-because readiness hasn't been signaled.
 
 ### Kafka retention requirement
 
-Kafka topic retention must be ≥ max batch staleness (typically 2 days). This ensures
-events from `[batchEnd, now)` are available for replay. For GroupBys with only small
-windows (≤ 2d), retention must cover the max window size.
+Kafka retention must cover the actual gap from `batchEnd` through replay plus the required
+correctness horizon. For GroupBys with only small windows, it must also cover the maximum
+window size.
 
 ### Key completeness
 
@@ -489,91 +477,38 @@ windows (≤ 2d), retention must cover the max window size.
 
 Yes, for all temporal entities:
 - **Inactive entities** (in batch table, no recent streaming events): Iceberg source
-  emits their batch IR → null→value trigger → batch-only vector emitted to KV.
-- **Active entities**: batch-only vector first (Iceberg), then corrected with streaming
-  during Kafka replay.
-- **New entities (in Kafka, not in batch)**: first event creates Flink state. `batchIr`
-  is null → streaming-only vector emitted. Correct for entities with no history.
-  Next batch run picks them up via onBatchUpdate (null→value trigger).
+  loads their batch IR; the batch-only vector can publish after the live fence opens.
+- **Active entities**: Iceberg and Kafka replay rebuild one deferred snapshot, which can
+  publish after the live fence opens.
+- **New entities (in Kafka, not in batch)**: first event creates Flink state. Columns that
+  require batch history remain unset until a batch row arrives, unless the batch-absent
+  fallback below is explicitly enabled.
+
+`gigatile_first_seen_key_grace_millis` enables the batch-absent fallback when set to a
+positive value; it is disabled by default. The operator-local grace starts on the first keyed
+callback after open or restore. Its deadline is a lower bound: the fallback installs on the next
+eligible keyed callback, which may be the next 5m, 1h, or 1d eviction for a sparse key. A missing
+row may then be treated as empty history, while a later real batch row remains authoritative.
+The grace is an operational assertion, not proof that the initial Iceberg scan completed.
+Enabling it therefore requires a configured Iceberg source and fails the job on source
+construction or entity-row decode/update errors; the serving-info metadata row is ignored.
+
+To roll back this option, fence serving first, disable it on the current binary, and keep serving
+fenced until null corrections are verified in KV and a later checkpoint completes. Only then
+roll back the binary or unfence. Correction waits for a live watermark and the affected key's
+next eviction callback (5m, 1h, or 1d), so binary rollback alone is not an immediate retraction.
 
 **Note:** Giga tile only applies to `Accuracy.TEMPORAL` GroupBys (with a streaming topic).
 `SNAPSHOT` GroupBys bypass Flink — they use the traditional `bulkPut` from Spark to KV.
 
-### Startup timeline
+## Entity behavior
 
-```
-Time          KV state                              isReady
-──────────    ──────────────────────────────────     ───────
-T+0           Empty                                  false
-T+1 min       Batch-only vectors appearing           false
-              (Iceberg scan in progress)
-T+5 min       All batch entities in KV               false
-              (Iceberg scan complete)
-              Streaming entities: partial
-              (Kafka replay in progress)
-T+10 min      All entities fully correct             true
-              (watermark caught up)
-              Orchestrator routes traffic
-```
+- **Active:** combine batch state with replayed and live events; publish after the live fence opens.
+- **Batch-only:** load and publish batch state after the fence opens; no per-key event is required.
+- **New:** retain streaming state, but leave batch-backed values unset until a real batch row arrives
+  or the explicit grace installs an empty baseline.
 
-### State transitions
-
-```
-┌──────────────────────────────────────────────┐
-│   First startup / cold restart                │
-│                                              │
-│   1. Iceberg scan: batch IRs → KV           │
-│   2. Kafka replay: streaming → KV           │
-│   3. Both complete → isReady = true          │
-│   4. Orchestrator routes traffic             │
-└──────────────────────────────────────────────┘
-
-┌──────────────────────────────────────────────┐
-│   Checkpoint restore (normal)                 │
-│                                              │
-│   1. Restore state from checkpoint           │
-│   2. Resume Kafka from checkpointed offsets  │
-│   3. Iceberg re-scan for batch updates       │
-│   4. isReady = true immediately              │
-└──────────────────────────────────────────────┘
-```
-
-## Entity Scenario Matrix
-
-Each entity falls into one of these categories. The matrix traces through startup, steady state,
-and edge cases for each, showing which code paths fire and what gets emitted.
-
-### Entity types
-
-| Type | Description | Has batch IR? | Has Kafka events? |
-|------|-------------|---------------|-------------------|
-| **A: Active** | In batch table AND streaming topic | Yes | Yes |
-| **B: Inactive** | In batch table, no recent events | Yes | No |
-| **C: New** | Not in batch yet, has streaming events | No | Yes |
-
-### Startup (first deploy or cold restart)
-
-| Entity | Iceberg scan | Kafka replay | First emit | Fully correct at |
-|--------|-------------|-------------|------------|------------------|
-| **A** | batch IR loaded → `currentDayStart` init'd from `batchEnd` → `runningLargeIr` computed → emit batch-only vector | Events replay from `batchEnd` → `onEvent` merges into `runningLargeIr` → emit on each event | On batch IR load (Iceberg) | Watermark caught up (~minutes) |
-| **B** | batch IR loaded → same as A → emit batch-only vector | No events → no Kafka processing | On batch IR load (Iceberg) | Immediately (batch is the full answer) |
-| **C** | No row in Iceberg → no `onBatchUpdate` | Events arrive → `batchIr = null` → `onEvent` emits streaming-only vector | On first Kafka event | Next batch run picks it up |
-
-### Steady state (job running, daily batch refresh)
-
-| Entity | On event | On eviction | On batch refresh |
-|--------|----------|-------------|------------------|
-| **A** | Update tiles + `cachedSmallWindowIr` + `largeTodayIr` + `runningLargeIr` → emit | Rebuild small windows from tiles. Recompute `runningLargeIr` from batch hops + streaming → emit | Store new `batchIr`. Recompute `runningLargeIr`. Emit on mismatch. |
-| **B** | No events → nothing | Timer fires (registered by `onBatchUpdate`). Recompute `runningLargeIr` from batch hops → emit if tail shifted. | Store new `batchIr`. Recompute. Emit on mismatch. |
-| **C** | Same as A but `batchIr = null` → `runningLargeIr` = streaming only → emit | Rebuild small windows. `batchIr = null` → `runningLargeIr` = streaming only → emit | **Transition to type A:** `batchIr` goes null→value. Recompute includes batch. Mismatch → emit. |
-
-### Day transition (advanceWatermark crosses midnight)
-
-| Entity | What happens |
-|--------|-------------|
-| **A** | `largeYesterdayIr = largeTodayIr`, `largeTodayIr = init`, `currentDayStart` advances. `runningLargeIr` NOT reset (cumulative). Eviction corrects tail within one interval. |
-| **B** | `advanceWatermark` fires from global watermark advancement. Same rotation. No events → `largeTodayIr` stays init. Eviction timer recomputes `runningLargeIr` with shifted tail hops. |
-| **C** | Same as A but no batch component. Rotation is streaming-only. |
+Daily state remains keyed by day and is pruned once covered by batch or outside every finite window.
 
 ### Batch refresh (onBatchUpdate) edge cases
 
@@ -581,16 +516,16 @@ and edge cases for each, showing which code paths fire and what gets emitted.
 |----------|-------|----------|
 | `newBatchEnd <= oldBatchEnd` | Early return | Skip (same or older batch) |
 | `currentDayStart < 0` (uninitialized, no events) | Init `currentDayStart = newBatchEnd` | Safe: no events → no overlap. Recompute and emit. |
-| `newBatchEnd > currentDayStart` (watermark lag) | Defer (return) | Store `batchIr` but don't recompute. Next eviction handles it after watermark advances. |
-| `newBatchEnd >= currentDayStart` (normal) | Clear `largeYesterdayIr` | Batch covers through yesterday. Recompute without yesterday. |
-| `newBatchEnd < currentDayStart` (stale batch catch-up) | Keep `largeYesterdayIr` | Batch doesn't cover yesterday. Include yesterday in recomputation. |
+| `newBatchEnd > currentDayStart` (batch ahead of the materialized horizon) | Defer (return) | Store `batchIr` but don't recompute. The next callback retries after the selected horizon advances. |
+| `newBatchEnd <= currentDayStart` (normal) | Prune slots with `dayStart < batchEndDay` | Recompute from the new batch plus uncovered daily slots. |
+| Stale batch catch-up | Retain slots at or after `batchEndDay` | Uncovered streaming days remain in the recomputed running view. |
 
 ### Eviction edge cases
 
 | Scenario | Behavior |
 |----------|----------|
-| `batchIr = null` (new entity, type C) | `runningLargeIr = init + streaming`. No NPE. |
-| `batchIr != null` (types A, B) | `runningLargeIr = clone(collapsed) + mergeTailHops + streaming` |
+| `batchIr = null` (new entity, type C) | Retain streaming state, but keep batch-backed output unset unless the explicit grace is active. |
+| `batchIr != null` (types A, B) | Rebuild `runningLargeIr` from batch collapsed/tail hops plus retained daily slots. |
 | `earliestTileStart = MaxValue` (no tiles, large-windows-only) | Skip tile eviction. Still recompute `runningLargeIr` from batch hops. |
 | Batch-only entity (type B), no `hasSmallWindows` | Timer registered unconditionally by `onBatchUpdate`. Eviction fires at `minEvictionInterval`. |
 

--- a/flink/package.mill
+++ b/flink/package.mill
@@ -13,6 +13,7 @@ trait FlinkModule extends Cross.Module[String] with build.BaseModule {
   def moduleDeps = Seq(build.aggregator(crossValue), build.api(crossValue), build.online(crossValue))
 
   def compileMvnDeps = build.Constants.providedFlinkDeps ++ Seq(
+    mvn"org.apache.flink:flink-table-common:${build.Constants.flinkVersion}",
     mvn"org.apache.spark::spark-core:${build.Constants.sparkVersion}",
     mvn"org.apache.spark::spark-sql:${build.Constants.sparkVersion}",
   )
@@ -33,6 +34,7 @@ trait FlinkModule extends Cross.Module[String] with build.BaseModule {
     mvn"com.google.protobuf:protobuf-java-util:${build.Constants.protobufVersion}",
     mvn"com.google.protobuf:protobuf-java:${build.Constants.protobufVersion}",
     mvn"org.apache.flink:flink-connector-kafka:3.0.2-1.18",
+    mvn"org.apache.iceberg:iceberg-flink-runtime-1.17:1.6.1",
     mvn"io.netty:netty-codec-http2:4.1.129.Final",
   )
 

--- a/flink/package.mill
+++ b/flink/package.mill
@@ -14,6 +14,12 @@ trait FlinkModule extends Cross.Module[String] with build.BaseModule {
 
   def compileMvnDeps = build.Constants.providedFlinkDeps ++ Seq(
     mvn"org.apache.flink:flink-table-common:${build.Constants.flinkVersion}",
+    // Iceberg Flink runtime: provided at compile time for BatchIrSourceBuilder.
+    // In production, deployed to Flink cluster's lib/ directory.
+    // In tests, this causes signer conflicts with flink-test-utils (Iceberg's shaded
+    // uber-jar bundles signed janino classes). The Iceberg integration test
+    // (IcebergBatchIrSourceIntegrationTest) is marked @Ignore and must run in isolation.
+    mvn"org.apache.iceberg:iceberg-flink-runtime-1.17:1.6.1",
     mvn"org.apache.spark::spark-core:${build.Constants.sparkVersion}",
     mvn"org.apache.spark::spark-sql:${build.Constants.sparkVersion}",
   )
@@ -34,7 +40,6 @@ trait FlinkModule extends Cross.Module[String] with build.BaseModule {
     mvn"com.google.protobuf:protobuf-java-util:${build.Constants.protobufVersion}",
     mvn"com.google.protobuf:protobuf-java:${build.Constants.protobufVersion}",
     mvn"org.apache.flink:flink-connector-kafka:3.0.2-1.18",
-    mvn"org.apache.iceberg:iceberg-flink-runtime-1.17:1.6.1",
     mvn"io.netty:netty-codec-http2:4.1.129.Final",
   )
 
@@ -77,7 +82,7 @@ trait FlinkModule extends Cross.Module[String] with build.BaseModule {
       // Force correct Jackson versions
       mvn"com.fasterxml.jackson.core:jackson-core:${build.Constants.jacksonVersion}",
       mvn"com.fasterxml.jackson.core:jackson-databind:${build.Constants.jacksonVersion}",
-      mvn"com.fasterxml.jackson.core:jackson-annotations:${build.Constants.jacksonVersion}"
+      mvn"com.fasterxml.jackson.core:jackson-annotations:${build.Constants.jacksonVersion}",
     )
   }
 }

--- a/flink/src/main/scala/ai/chronon/flink/FlinkGroupByStreamingJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkGroupByStreamingJob.scala
@@ -147,6 +147,12 @@ class FlinkGroupByStreamingJob(eventSrc: FlinkSource[ProjectedEvent],
                        bufferingOutputPolicy)
   }
 
+  override def runGigaTiledGroupByJob(env: StreamExecutionEnvironment): DataStream[WriteResponse] = {
+    logger.info(f"Running Giga Tiled (push) Flink job for groupByName=${groupByName}, Topic=${topic}.")
+    val preparedStream = buildSourceStream(env)
+    buildGigaTiledTail(preparedStream, inputSchema, parallelism, sinkFn, kvStoreCapacity, enableDebug)
+  }
+
   private def buildSourceStream(env: StreamExecutionEnvironment): DataStream[ProjectedEvent] = {
     val sourceSparkProjectedStream = eventSrc
       .getDataStream(topic, groupByName)(env, parallelism)

--- a/flink/src/main/scala/ai/chronon/flink/FlinkGroupByStreamingJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkGroupByStreamingJob.scala
@@ -56,6 +56,8 @@ class FlinkGroupByStreamingJob(eventSrc: FlinkSource[ProjectedEvent],
       .getProperty("buffering_output_policy", props, topicInfo)
       .map(MegaTileEmissionPolicy.fromString)
       .getOrElse(MegaTileEmissionPolicy.Default)
+  private val gigaTileBufferingOutputTimeMillis =
+    FlinkUtils.gigaTileBufferingOutputTimeMillis(bufferingOutputTimeMillis, bufferingOutputPolicy)
 
   // The source of our Flink application is a  topic
   val topic: String = groupByServingInfoParsed.groupBy.streamingSource.get.topic
@@ -152,7 +154,14 @@ class FlinkGroupByStreamingJob(eventSrc: FlinkSource[ProjectedEvent],
     logger.info(f"Running Giga Tiled (push) Flink job for groupByName=${groupByName}, Topic=${topic}.")
     val preparedStream = buildSourceStream(env)
     val batchIrStream = BatchIrSourceBuilder.build(env, groupByServingInfoParsed, props)
-    buildGigaTiledTail(preparedStream, batchIrStream, inputSchema, parallelism, sinkFn, kvStoreCapacity, enableDebug)
+    buildGigaTiledTail(preparedStream,
+                       batchIrStream,
+                       inputSchema,
+                       parallelism,
+                       sinkFn,
+                       kvStoreCapacity,
+                       enableDebug,
+                       gigaTileBufferingOutputTimeMillis)
   }
 
   private def buildSourceStream(env: StreamExecutionEnvironment): DataStream[ProjectedEvent] = {

--- a/flink/src/main/scala/ai/chronon/flink/FlinkGroupByStreamingJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkGroupByStreamingJob.scala
@@ -7,7 +7,7 @@ import ai.chronon.flink.deser.ProjectedEvent
 import ai.chronon.flink.source.FlinkSource
 import ai.chronon.flink.source.BatchIrSourceBuilder
 import ai.chronon.flink.types.{AvroCodecOutput, WriteResponse}
-import ai.chronon.flink.window.MegaTileEmissionPolicy
+import ai.chronon.flink.window.{GigaTileProcessFunction, MegaTileEmissionPolicy}
 import ai.chronon.online.{GroupByServingInfoParsed, TopicInfo}
 import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
@@ -51,6 +51,8 @@ class FlinkGroupByStreamingJob(eventSrc: FlinkSource[ProjectedEvent],
     FlinkUtils.getNonNegativeLongProperty("buffering_output_time_millis", props, topicInfo)
   private val bufferingOutputJitterMillis =
     FlinkUtils.getNonNegativeLongProperty("buffering_output_jitter_millis", props, topicInfo)
+  private val firstSeenKeyGraceMillis =
+    FlinkUtils.getNonNegativeLongProperty(GigaTileProcessFunction.FirstSeenKeyGraceMillisConfig, props, topicInfo)
   private val bufferingOutputPolicy =
     FlinkUtils
       .getProperty("buffering_output_policy", props, topicInfo)
@@ -153,7 +155,10 @@ class FlinkGroupByStreamingJob(eventSrc: FlinkSource[ProjectedEvent],
   override def runGigaTiledGroupByJob(env: StreamExecutionEnvironment): DataStream[WriteResponse] = {
     logger.info(f"Running Giga Tiled (push) Flink job for groupByName=${groupByName}, Topic=${topic}.")
     val preparedStream = buildSourceStream(env)
-    val batchIrStream = BatchIrSourceBuilder.build(env, groupByServingInfoParsed, props)
+    val batchIrStream = BatchIrSourceBuilder.build(env,
+                                                   groupByServingInfoParsed,
+                                                   props,
+                                                   requireConfiguredBatchSource = firstSeenKeyGraceMillis > 0L)
     buildGigaTiledTail(preparedStream,
                        batchIrStream,
                        inputSchema,
@@ -161,7 +166,8 @@ class FlinkGroupByStreamingJob(eventSrc: FlinkSource[ProjectedEvent],
                        sinkFn,
                        kvStoreCapacity,
                        enableDebug,
-                       gigaTileBufferingOutputTimeMillis)
+                       gigaTileBufferingOutputTimeMillis,
+                       firstSeenKeyGraceMillis)
   }
 
   private def buildSourceStream(env: StreamExecutionEnvironment): DataStream[ProjectedEvent] = {

--- a/flink/src/main/scala/ai/chronon/flink/FlinkGroupByStreamingJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkGroupByStreamingJob.scala
@@ -5,6 +5,7 @@ import ai.chronon.api.DataType
 import ai.chronon.flink.FlinkJob.watermarkStrategy
 import ai.chronon.flink.deser.ProjectedEvent
 import ai.chronon.flink.source.FlinkSource
+import ai.chronon.flink.source.BatchIrSourceBuilder
 import ai.chronon.flink.types.{AvroCodecOutput, WriteResponse}
 import ai.chronon.flink.window.MegaTileEmissionPolicy
 import ai.chronon.online.{GroupByServingInfoParsed, TopicInfo}
@@ -150,7 +151,8 @@ class FlinkGroupByStreamingJob(eventSrc: FlinkSource[ProjectedEvent],
   override def runGigaTiledGroupByJob(env: StreamExecutionEnvironment): DataStream[WriteResponse] = {
     logger.info(f"Running Giga Tiled (push) Flink job for groupByName=${groupByName}, Topic=${topic}.")
     val preparedStream = buildSourceStream(env)
-    buildGigaTiledTail(preparedStream, inputSchema, parallelism, sinkFn, kvStoreCapacity, enableDebug)
+    val batchIrStream = BatchIrSourceBuilder.build(env, groupByServingInfoParsed, props)
+    buildGigaTiledTail(preparedStream, batchIrStream, inputSchema, parallelism, sinkFn, kvStoreCapacity, enableDebug)
   }
 
   private def buildSourceStream(env: StreamExecutionEnvironment): DataStream[ProjectedEvent] = {

--- a/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
@@ -283,9 +283,13 @@ object FlinkJob {
 
   val CatchupWatermarkLagSlackMillis: Long = 30 * 1000L
 
-  // The event-source watermark intentionally trails the newest observed event by
-  // AllowedOutOfOrderness. Publication is safe once only that expected lag plus a small
-  // operational slack remains; aggregation hop sizes do not describe source readiness.
+  // The event-source watermark already trails the newest observed event by AllowedOutOfOrderness
+  // (Flink emits maxEventTs - ooo - 1). Because this tolerance also includes AllowedOutOfOrderness,
+  // that term cancels in the Live check `processingTime > watermark + tolerance`: publication flips
+  // to Live once the true ingestion lag beyond the ooo-trailing is within CatchupWatermarkLagSlackMillis.
+  // AllowedOutOfOrderness is therefore included only to offset the watermark's own trailing, not as an
+  // independent readiness knob; only the slack governs the gate. Aggregation hop sizes do not describe
+  // source readiness.
   val LiveWatermarkLagToleranceMillis: Long =
     AllowedOutOfOrderness.toMillis + CatchupWatermarkLagSlackMillis
 

--- a/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
@@ -9,7 +9,7 @@ import ai.chronon.flink.{AsyncKVStoreWriter, FlinkGroupByStreamingJob}
 import ai.chronon.flink.deser.{DeserializationSchemaBuilder, FlinkSerDeProvider, ProjectedEvent, SourceProjection}
 import ai.chronon.flink.chaining.ChainedGroupByJob
 import ai.chronon.flink.source.FlinkSourceProvider
-import ai.chronon.flink.types.{AvroCodecOutput, TimestampedTile, WriteResponse}
+import ai.chronon.flink.types.{AvroCodecOutput, BatchIrRow, TimestampedTile, WriteResponse}
 import ai.chronon.flink.validation.ValidationFlinkJob
 import ai.chronon.flink.window.{
   AlwaysFireOnElementTrigger,
@@ -169,19 +169,29 @@ abstract class BaseFlinkJob {
     AsyncKVStoreWriter.withUnorderedWaits(putRecordDS, sinkFn, groupByName, capacity = kvStoreCapacity)
   }
 
-  /** Shared tail for giga tiled pipeline: keyBy → GigaTileProcessFunction → giga tile codec → KV write.
+  /** Shared tail for giga tiled pipeline: connect event + batch streams → GigaTileProcessFunction → codec → KV write.
     * Emits finalized feature vectors with plain entity keys.
+    *
+    * @param batchIrStream batch IR rows from Iceberg upload table (keyed by entity).
+    *                      Use an idle/empty stream if Iceberg source is not yet configured.
     */
   protected def buildGigaTiledTail(
       preparedStream: DataStream[ProjectedEvent],
+      batchIrStream: DataStream[BatchIrRow],
       schema: Seq[(String, DataType)],
       parallelism: Int,
       sinkFn: RichAsyncFunction[AvroCodecOutput, WriteResponse],
       kvStoreCapacity: Int,
       enableDebug: Boolean
   ): DataStream[WriteResponse] = {
+    val eventKeySelector = KeySelectorBuilder.build(groupByServingInfoParsed.groupBy)
+    val batchKeySelector = new org.apache.flink.api.java.functions.KeySelector[BatchIrRow, java.util.List[Any]] {
+      override def getKey(row: BatchIrRow): java.util.List[Any] = row.entityKeys
+    }
+
     val gigaTileDS = preparedStream
-      .keyBy(KeySelectorBuilder.build(groupByServingInfoParsed.groupBy))
+      .connect(batchIrStream)
+      .keyBy(eventKeySelector, batchKeySelector)
       .process(new GigaTileProcessFunction(groupByServingInfoParsed.groupBy, schema, enableDebug))
       .uid(s"giga-tiling-$groupByName")
       .name(s"Giga Tiling for $groupByName")

--- a/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
@@ -275,6 +275,12 @@ object FlinkJob {
 
   val CatchupWatermarkLagSlackMillis: Long = 30 * 1000L
 
+  // The event-source watermark intentionally trails the newest observed event by
+  // AllowedOutOfOrderness. Publication is safe once only that expected lag plus a small
+  // operational slack remains; aggregation hop sizes do not describe source readiness.
+  val LiveWatermarkLagToleranceMillis: Long =
+    AllowedOutOfOrderness.toMillis + CatchupWatermarkLagSlackMillis
+
   // Set an idleness timeout to keep time moving in case of very low traffic event streams as well as late events during
   // large backlog catchups
   val IdlenessTimeout: Duration = Duration.ofSeconds(30)

--- a/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
@@ -398,7 +398,7 @@ object FlinkJob {
 
     val groupByOpsVal = new GroupByOps(flinkJob.groupByServingInfoParsed.groupBy)
     val jobDatastream =
-      if (groupByOpsVal.isGigaTilingEnabled) flinkJob.runGigaTiledGroupByJob(env)
+      if (groupByOpsVal.isPushEnabled) flinkJob.runGigaTiledGroupByJob(env)
       else if (groupByOpsVal.isMegaTilingEnabled) flinkJob.runMegaTiledGroupByJob(env)
       else flinkJob.runTiledGroupByJob(env)
 

--- a/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
@@ -196,7 +196,8 @@ abstract class BaseFlinkJob {
       sinkFn: RichAsyncFunction[AvroCodecOutput, WriteResponse],
       kvStoreCapacity: Int,
       enableDebug: Boolean,
-      bufferingOutputTimeMillis: Long
+      bufferingOutputTimeMillis: Long,
+      firstSeenKeyGraceMillis: Long
   ): DataStream[WriteResponse] = {
     val eventKeySelector = KeySelectorBuilder.build(groupByServingInfoParsed.groupBy)
     val batchKeySelector = new org.apache.flink.api.java.functions.KeySelector[BatchIrRow, java.util.List[Any]] {
@@ -206,11 +207,13 @@ abstract class BaseFlinkJob {
     val gigaTileDS = preparedStream
       .connect(batchIrStream)
       .keyBy(eventKeySelector, batchKeySelector)
-      .process(
-        new GigaTileProcessFunction(groupByServingInfoParsed.groupBy,
-                                    schema,
-                                    enableDebug = enableDebug,
-                                    bufferingOutputTimeMillis = bufferingOutputTimeMillis))
+      .process(new GigaTileProcessFunction(
+        groupByServingInfoParsed.groupBy,
+        schema,
+        enableDebug = enableDebug,
+        bufferingOutputTimeMillis = bufferingOutputTimeMillis,
+        firstSeenKeyGraceMillis = firstSeenKeyGraceMillis
+      ))
       .uid(s"giga-tiling-$groupByName")
       .name(s"Giga Tiling for $groupByName")
       .setParallelism(parallelism)

--- a/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
@@ -351,7 +351,10 @@ object FlinkJob {
       maybeServingInfo
         .map { servingInfo =>
           // create the groupby dataset on the KV store if it doesn't exist prior to starting up the job
-          kvStore.create(servingInfo.groupBy.streamingDataset)
+          if (new GroupByOps(servingInfo.groupBy).isPushEnabled)
+            kvStore.create(servingInfo.groupByOps.pushDataset)
+          else
+            kvStore.create(servingInfo.groupBy.streamingDataset)
           buildFlinkJob(groupByName, props, api, servingInfo, enableDebug, jobArgs.topicOverride.toOption)
         }
         .recover { case e: Exception =>

--- a/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
@@ -195,7 +195,8 @@ abstract class BaseFlinkJob {
       parallelism: Int,
       sinkFn: RichAsyncFunction[AvroCodecOutput, WriteResponse],
       kvStoreCapacity: Int,
-      enableDebug: Boolean
+      enableDebug: Boolean,
+      bufferingOutputTimeMillis: Long
   ): DataStream[WriteResponse] = {
     val eventKeySelector = KeySelectorBuilder.build(groupByServingInfoParsed.groupBy)
     val batchKeySelector = new org.apache.flink.api.java.functions.KeySelector[BatchIrRow, java.util.List[Any]] {
@@ -205,7 +206,11 @@ abstract class BaseFlinkJob {
     val gigaTileDS = preparedStream
       .connect(batchIrStream)
       .keyBy(eventKeySelector, batchKeySelector)
-      .process(new GigaTileProcessFunction(groupByServingInfoParsed.groupBy, schema, enableDebug))
+      .process(
+        new GigaTileProcessFunction(groupByServingInfoParsed.groupBy,
+                                    schema,
+                                    enableDebug = enableDebug,
+                                    bufferingOutputTimeMillis = bufferingOutputTimeMillis))
       .uid(s"giga-tiling-$groupByName")
       .name(s"Giga Tiling for $groupByName")
       .setParallelism(parallelism)

--- a/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
@@ -16,6 +16,7 @@ import ai.chronon.flink.window.{
   BufferedProcessingTimeTrigger,
   FlinkRowAggProcessFunction,
   FlinkRowAggregationFunction,
+  GigaTileProcessFunction,
   KeySelectorBuilder,
   MegaTileEmissionPolicy,
   MegaTileProcessFunction
@@ -64,6 +65,11 @@ abstract class BaseFlinkJob {
     * Default delegates to buildMegaTiledTail. Subclasses must provide source setup.
     */
   def runMegaTiledGroupByJob(env: StreamExecutionEnvironment): DataStream[WriteResponse]
+
+  /** Run the streaming job with giga tiling (push-based) enabled.
+    * Emits finalized feature vectors — fetcher does a single point get.
+    */
+  def runGigaTiledGroupByJob(env: StreamExecutionEnvironment): DataStream[WriteResponse]
 
   /** Shared tail for tiled pipeline: keyBy → window aggregate → tile codec → KV write.
     * Both FlinkGroupByStreamingJob and ChainedGroupByJob use this with their respective
@@ -158,6 +164,33 @@ abstract class BaseFlinkJob {
       .flatMap(MegaTileAvroCodecFn(groupByServingInfoParsed, enableDebug))
       .uid(s"mega-avro-conversion-$groupByName")
       .name(s"Mega Tile Avro conversion for $groupByName")
+      .setParallelism(parallelism)
+
+    AsyncKVStoreWriter.withUnorderedWaits(putRecordDS, sinkFn, groupByName, capacity = kvStoreCapacity)
+  }
+
+  /** Shared tail for giga tiled pipeline: keyBy → GigaTileProcessFunction → giga tile codec → KV write.
+    * Emits finalized feature vectors with plain entity keys.
+    */
+  protected def buildGigaTiledTail(
+      preparedStream: DataStream[ProjectedEvent],
+      schema: Seq[(String, DataType)],
+      parallelism: Int,
+      sinkFn: RichAsyncFunction[AvroCodecOutput, WriteResponse],
+      kvStoreCapacity: Int,
+      enableDebug: Boolean
+  ): DataStream[WriteResponse] = {
+    val gigaTileDS = preparedStream
+      .keyBy(KeySelectorBuilder.build(groupByServingInfoParsed.groupBy))
+      .process(new GigaTileProcessFunction(groupByServingInfoParsed.groupBy, schema, enableDebug))
+      .uid(s"giga-tiling-$groupByName")
+      .name(s"Giga Tiling for $groupByName")
+      .setParallelism(parallelism)
+
+    val putRecordDS = gigaTileDS
+      .flatMap(GigaTileAvroCodecFn(groupByServingInfoParsed, enableDebug))
+      .uid(s"giga-avro-conversion-$groupByName")
+      .name(s"Giga Tile Avro conversion for $groupByName")
       .setParallelism(parallelism)
 
     AsyncKVStoreWriter.withUnorderedWaits(putRecordDS, sinkFn, groupByName, capacity = kvStoreCapacity)
@@ -353,9 +386,10 @@ object FlinkJob {
       FlinkJob.runWriteInternalManifestJob(env, jobArgs.streamingManifestPath(), maybeParentJobId.get, groupByName)
     }
 
-    val isMegaTiling = new GroupByOps(flinkJob.groupByServingInfoParsed.groupBy).isMegaTilingEnabled
+    val groupByOpsVal = new GroupByOps(flinkJob.groupByServingInfoParsed.groupBy)
     val jobDatastream =
-      if (isMegaTiling) flinkJob.runMegaTiledGroupByJob(env)
+      if (groupByOpsVal.isGigaTilingEnabled) flinkJob.runGigaTiledGroupByJob(env)
+      else if (groupByOpsVal.isMegaTilingEnabled) flinkJob.runMegaTiledGroupByJob(env)
       else flinkJob.runTiledGroupByJob(env)
 
     jobDatastream

--- a/flink/src/main/scala/ai/chronon/flink/FlinkUtils.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkUtils.scala
@@ -1,5 +1,6 @@
 package ai.chronon.flink
 
+import ai.chronon.flink.window.MegaTileEmissionPolicy
 import ai.chronon.online.TopicInfo
 
 import scala.concurrent.ExecutionContext
@@ -63,6 +64,12 @@ object FlinkUtils {
       }
       .getOrElse(0L)
   }
+
+  def gigaTileBufferingOutputTimeMillis(
+      configuredMillis: Long,
+      emissionPolicy: MegaTileEmissionPolicy
+  ): Long =
+    if (emissionPolicy == MegaTileEmissionPolicy.WallClockCadence) configuredMillis else 0L
 }
 
 /** This was moved to flink-rpc-akka in Flink 1.16 and made private, so we reproduce the direct execution context here

--- a/flink/src/main/scala/ai/chronon/flink/GigaTileAvroCodecFn.scala
+++ b/flink/src/main/scala/ai/chronon/flink/GigaTileAvroCodecFn.scala
@@ -15,6 +15,7 @@ import org.slf4j.{Logger, LoggerFactory}
 /** Converts giga tile output (TimestampedTile with finalized vector bytes) to KV PutRequests.
   * Key: plain entity key bytes (no TileKey wrapper, no day suffix).
   * Value: finalized feature vector bytes (passthrough).
+  * Dataset: pushDataset (*_PUSH) — simple key→value, no time-series sort key.
   */
 case class GigaTileAvroCodecFn(groupByServingInfoParsed: GroupByServingInfoParsed, enableDebug: Boolean = false)
     extends RichFlatMapFunction[TimestampedTile, AvroCodecOutput] {
@@ -23,9 +24,10 @@ case class GigaTileAvroCodecFn(groupByServingInfoParsed: GroupByServingInfoParse
   @transient private var avroConversionErrorCounter: Counter = _
   @transient private var eventProcessingErrorCounter: Counter = _
 
-  private lazy val streamingDataset: String = groupByServingInfoParsed.groupBy.streamingDataset
-  private lazy val keyColumns: Array[String] =
-    SparkExpressionEval.buildKeyValueEventTimeColumns(groupByServingInfoParsed.groupBy)._1
+  // Use pushDataset (*_PUSH) — not streamingDataset (*_STREAMING).
+  // _STREAMING tables in DynamoDB have a sort key (timestamp) causing GetItem failures
+  // on plain entity keys. _PUSH tables are simple key→value stores.
+  private lazy val dataset: String = groupByServingInfoParsed.groupByOps.pushDataset
   private lazy val keyToBytes: Any => Array[Byte] = {
     val keyZSchema: ChrononStructType = groupByServingInfoParsed.keyChrononSchema
     AvroConversions.encodeBytes(keyZSchema,
@@ -46,24 +48,21 @@ case class GigaTileAvroCodecFn(groupByServingInfoParsed: GroupByServingInfoParse
 
   override def flatMap(value: TimestampedTile, out: Collector[AvroCodecOutput]): Unit =
     try {
-      val tsMills = value.latestTsMillis
       val entityKeyBytes = keyToBytes(value.keys.toArray)
 
       if (enableDebug) {
         logger.info(
-          s"Giga tile PutRequest: groupBy=${groupByServingInfoParsed.groupBy.getMetaData.getName} " +
-            s"tsMills=$tsMills valueBytes=${value.tileBytes.length} bytes")
+          s"Push PutRequest: groupBy=${groupByServingInfoParsed.groupBy.getMetaData.getName} " +
+            s"valueBytes=${value.tileBytes.length} bytes")
       }
 
-      // Plain entity key — no TileKey wrapper. Single entry per entity.
-      // Fixed timestamp (0L) ensures KV stores that version by timestamp (BigTable cells,
-      // DynamoDB sort keys) overwrite instead of append. Without this, every event creates
-      // a new version, defeating the single-get promise.
-      out.collect(new AvroCodecOutput(entityKeyBytes, value.tileBytes, streamingDataset, 0L,
-        value.startProcessingTime))
+      // Plain entity key, simple key→value dataset, current time as write timestamp.
+      // _PUSH tables have no sort key, so each write overwrites the previous value.
+      out.collect(new AvroCodecOutput(entityKeyBytes, value.tileBytes, dataset,
+        value.latestTsMillis, value.startProcessingTime))
     } catch {
       case e: Exception =>
-        logger.error("Error converting giga tile to PutRequest", e)
+        logger.error("Error converting push tile to PutRequest", e)
         eventProcessingErrorCounter.inc()
         avroConversionErrorCounter.inc()
     }

--- a/flink/src/main/scala/ai/chronon/flink/GigaTileAvroCodecFn.scala
+++ b/flink/src/main/scala/ai/chronon/flink/GigaTileAvroCodecFn.scala
@@ -1,0 +1,67 @@
+package ai.chronon.flink
+
+import ai.chronon.api.Extensions.GroupByOps
+import ai.chronon.api.ScalaJavaConversions._
+import ai.chronon.api.{StructType => ChrononStructType}
+import ai.chronon.flink.types.{AvroCodecOutput, TimestampedTile}
+import ai.chronon.online.GroupByServingInfoParsed
+import ai.chronon.online.serde.AvroConversions
+import org.apache.flink.api.common.functions.RichFlatMapFunction
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.metrics.Counter
+import org.apache.flink.util.Collector
+import org.slf4j.{Logger, LoggerFactory}
+
+/** Converts giga tile output (TimestampedTile with finalized vector bytes) to KV PutRequests.
+  * Key: plain entity key bytes (no TileKey wrapper, no day suffix).
+  * Value: finalized feature vector bytes (passthrough).
+  */
+case class GigaTileAvroCodecFn(groupByServingInfoParsed: GroupByServingInfoParsed, enableDebug: Boolean = false)
+    extends RichFlatMapFunction[TimestampedTile, AvroCodecOutput] {
+
+  @transient lazy val logger: Logger = LoggerFactory.getLogger(getClass)
+  @transient private var avroConversionErrorCounter: Counter = _
+  @transient private var eventProcessingErrorCounter: Counter = _
+
+  private lazy val streamingDataset: String = groupByServingInfoParsed.groupBy.streamingDataset
+  private lazy val keyColumns: Array[String] =
+    SparkExpressionEval.buildKeyValueEventTimeColumns(groupByServingInfoParsed.groupBy)._1
+  private lazy val keyToBytes: Any => Array[Byte] = {
+    val keyZSchema: ChrononStructType = groupByServingInfoParsed.keyChrononSchema
+    AvroConversions.encodeBytes(keyZSchema,
+                                {
+                                  case x: Map[_, _] if x.keys.forall(_.isInstanceOf[String]) =>
+                                    x.toArray.flatMap { case (key, value) => Array(key, value) }
+                                })
+  }
+
+  override def open(configuration: Configuration): Unit = {
+    super.open(configuration)
+    val metricsGroup = getRuntimeContext.getMetricGroup
+      .addGroup("chronon")
+      .addGroup("feature_group", groupByServingInfoParsed.groupBy.getMetaData.getName)
+    avroConversionErrorCounter = metricsGroup.counter("avro_conversion_errors")
+    eventProcessingErrorCounter = metricsGroup.counter("event_processing_error")
+  }
+
+  override def flatMap(value: TimestampedTile, out: Collector[AvroCodecOutput]): Unit =
+    try {
+      val tsMills = value.latestTsMillis
+      val entityKeyBytes = keyToBytes(value.keys.toArray)
+
+      if (enableDebug) {
+        logger.info(
+          s"Giga tile PutRequest: groupBy=${groupByServingInfoParsed.groupBy.getMetaData.getName} " +
+            s"tsMills=$tsMills valueBytes=${value.tileBytes.length} bytes")
+      }
+
+      // Plain entity key — no TileKey wrapper. Single entry per entity, overwritten on every emit.
+      out.collect(new AvroCodecOutput(entityKeyBytes, value.tileBytes, streamingDataset, tsMills,
+        value.startProcessingTime))
+    } catch {
+      case e: Exception =>
+        logger.error("Error converting giga tile to PutRequest", e)
+        eventProcessingErrorCounter.inc()
+        avroConversionErrorCounter.inc()
+    }
+}

--- a/flink/src/main/scala/ai/chronon/flink/GigaTileAvroCodecFn.scala
+++ b/flink/src/main/scala/ai/chronon/flink/GigaTileAvroCodecFn.scala
@@ -55,8 +55,11 @@ case class GigaTileAvroCodecFn(groupByServingInfoParsed: GroupByServingInfoParse
             s"tsMills=$tsMills valueBytes=${value.tileBytes.length} bytes")
       }
 
-      // Plain entity key — no TileKey wrapper. Single entry per entity, overwritten on every emit.
-      out.collect(new AvroCodecOutput(entityKeyBytes, value.tileBytes, streamingDataset, tsMills,
+      // Plain entity key — no TileKey wrapper. Single entry per entity.
+      // Fixed timestamp (0L) ensures KV stores that version by timestamp (BigTable cells,
+      // DynamoDB sort keys) overwrite instead of append. Without this, every event creates
+      // a new version, defeating the single-get promise.
+      out.collect(new AvroCodecOutput(entityKeyBytes, value.tileBytes, streamingDataset, 0L,
         value.startProcessingTime))
     } catch {
       case e: Exception =>

--- a/flink/src/main/scala/ai/chronon/flink/chaining/ChainedGroupByJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/chaining/ChainedGroupByJob.scala
@@ -6,7 +6,7 @@ import ai.chronon.api._
 import ai.chronon.flink.{AsyncKVStoreWriter, BaseFlinkJob, FlinkUtils}
 import ai.chronon.flink.FlinkJob.watermarkStrategy
 import ai.chronon.flink.deser.ProjectedEvent
-import ai.chronon.flink.source.FlinkSource
+import ai.chronon.flink.source.{BatchIrSourceBuilder, FlinkSource}
 import ai.chronon.flink.types.{AvroCodecOutput, WriteResponse}
 import ai.chronon.flink.window.MegaTileEmissionPolicy
 import ai.chronon.online.{Api, GroupByServingInfoParsed, TopicInfo}
@@ -115,7 +115,8 @@ class ChainedGroupByJob(eventSrc: FlinkSource[ProjectedEvent],
       s"Building giga tiled (push) Flink streaming job for groupBy: $groupByName that chains join: " +
         s"${joinSource.getJoin.getMetaData.getName} using topic: $topic")
     val (processedStream, schema) = buildEnrichedStream(env)
-    buildGigaTiledTail(processedStream, schema, parallelism, sinkFn, kvStoreCapacity, enableDebug)
+    val batchIrStream = BatchIrSourceBuilder.build(env, groupByServingInfoParsed, props)
+    buildGigaTiledTail(processedStream, batchIrStream, schema, parallelism, sinkFn, kvStoreCapacity, enableDebug)
   }
 
   /** Build the source → watermark → enrichment → query transform pipeline.

--- a/flink/src/main/scala/ai/chronon/flink/chaining/ChainedGroupByJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/chaining/ChainedGroupByJob.scala
@@ -110,6 +110,14 @@ class ChainedGroupByJob(eventSrc: FlinkSource[ProjectedEvent],
                        bufferingOutputPolicy)
   }
 
+  override def runGigaTiledGroupByJob(env: StreamExecutionEnvironment): DataStream[WriteResponse] = {
+    logger.info(
+      s"Building giga tiled (push) Flink streaming job for groupBy: $groupByName that chains join: " +
+        s"${joinSource.getJoin.getMetaData.getName} using topic: $topic")
+    val (processedStream, schema) = buildEnrichedStream(env)
+    buildGigaTiledTail(processedStream, schema, parallelism, sinkFn, kvStoreCapacity, enableDebug)
+  }
+
   /** Build the source → watermark → enrichment → query transform pipeline.
     * Returns the prepared stream and its post-transformation schema.
     */

--- a/flink/src/main/scala/ai/chronon/flink/chaining/ChainedGroupByJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/chaining/ChainedGroupByJob.scala
@@ -76,6 +76,8 @@ class ChainedGroupByJob(eventSrc: FlinkSource[ProjectedEvent],
       .getProperty("buffering_output_policy", props, topicInfo)
       .map(MegaTileEmissionPolicy.fromString)
       .getOrElse(MegaTileEmissionPolicy.Default)
+  private val gigaTileBufferingOutputTimeMillis =
+    FlinkUtils.gigaTileBufferingOutputTimeMillis(bufferingOutputTimeMillis, bufferingOutputPolicy)
 
   /** Build the tiled version of the Flink GroupBy job that chains features using a JoinSource.
     *  The operators are structured as follows:
@@ -116,7 +118,14 @@ class ChainedGroupByJob(eventSrc: FlinkSource[ProjectedEvent],
         s"${joinSource.getJoin.getMetaData.getName} using topic: $topic")
     val (processedStream, schema) = buildEnrichedStream(env)
     val batchIrStream = BatchIrSourceBuilder.build(env, groupByServingInfoParsed, props)
-    buildGigaTiledTail(processedStream, batchIrStream, schema, parallelism, sinkFn, kvStoreCapacity, enableDebug)
+    buildGigaTiledTail(processedStream,
+                       batchIrStream,
+                       schema,
+                       parallelism,
+                       sinkFn,
+                       kvStoreCapacity,
+                       enableDebug,
+                       gigaTileBufferingOutputTimeMillis)
   }
 
   /** Build the source → watermark → enrichment → query transform pipeline.

--- a/flink/src/main/scala/ai/chronon/flink/chaining/ChainedGroupByJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/chaining/ChainedGroupByJob.scala
@@ -8,7 +8,7 @@ import ai.chronon.flink.FlinkJob.watermarkStrategy
 import ai.chronon.flink.deser.ProjectedEvent
 import ai.chronon.flink.source.{BatchIrSourceBuilder, FlinkSource}
 import ai.chronon.flink.types.{AvroCodecOutput, WriteResponse}
-import ai.chronon.flink.window.MegaTileEmissionPolicy
+import ai.chronon.flink.window.{GigaTileProcessFunction, MegaTileEmissionPolicy}
 import ai.chronon.online.{Api, GroupByServingInfoParsed, TopicInfo}
 
 import java.util.concurrent.TimeUnit
@@ -71,6 +71,8 @@ class ChainedGroupByJob(eventSrc: FlinkSource[ProjectedEvent],
     FlinkUtils.getNonNegativeLongProperty("buffering_output_time_millis", props, topicInfo)
   private val bufferingOutputJitterMillis =
     FlinkUtils.getNonNegativeLongProperty("buffering_output_jitter_millis", props, topicInfo)
+  private val firstSeenKeyGraceMillis =
+    FlinkUtils.getNonNegativeLongProperty(GigaTileProcessFunction.FirstSeenKeyGraceMillisConfig, props, topicInfo)
   private val bufferingOutputPolicy =
     FlinkUtils
       .getProperty("buffering_output_policy", props, topicInfo)
@@ -117,7 +119,10 @@ class ChainedGroupByJob(eventSrc: FlinkSource[ProjectedEvent],
       s"Building giga tiled (push) Flink streaming job for groupBy: $groupByName that chains join: " +
         s"${joinSource.getJoin.getMetaData.getName} using topic: $topic")
     val (processedStream, schema) = buildEnrichedStream(env)
-    val batchIrStream = BatchIrSourceBuilder.build(env, groupByServingInfoParsed, props)
+    val batchIrStream = BatchIrSourceBuilder.build(env,
+                                                   groupByServingInfoParsed,
+                                                   props,
+                                                   requireConfiguredBatchSource = firstSeenKeyGraceMillis > 0L)
     buildGigaTiledTail(processedStream,
                        batchIrStream,
                        schema,
@@ -125,7 +130,8 @@ class ChainedGroupByJob(eventSrc: FlinkSource[ProjectedEvent],
                        sinkFn,
                        kvStoreCapacity,
                        enableDebug,
-                       gigaTileBufferingOutputTimeMillis)
+                       gigaTileBufferingOutputTimeMillis,
+                       firstSeenKeyGraceMillis)
   }
 
   /** Build the source → watermark → enrichment → query transform pipeline.

--- a/flink/src/main/scala/ai/chronon/flink/source/BatchIrSourceBuilder.scala
+++ b/flink/src/main/scala/ai/chronon/flink/source/BatchIrSourceBuilder.scala
@@ -109,7 +109,10 @@ object BatchIrSourceBuilder {
   }
 }
 
-/** Decodes Iceberg RowData (key_bytes, value_bytes, ...) into BatchIrRow. */
+/** Decodes Iceberg RowData (key_bytes, value_bytes, key_json, value_json, ds) into BatchIrRow.
+  * batchEnd is derived from the ds partition column — NOT from the static servingInfo.batchEndTsMillis.
+  * Each new partition (ds=2026-03-29) produces a fresh batchEnd, ensuring onBatchUpdate accepts it.
+  */
 class BatchIrRowDecoder(servingInfo: GroupByServingInfoParsed)
     extends RichFlatMapFunction[RowData, BatchIrRow] {
 
@@ -128,15 +131,32 @@ class BatchIrRowDecoder(servingInfo: GroupByServingInfoParsed)
     }
   }
 
+  @transient private lazy val dsParser: String => Long = {
+    val fmt = new java.text.SimpleDateFormat(servingInfo.groupByServingInfo.getDateFormat)
+    fmt.setTimeZone(java.util.TimeZone.getTimeZone("UTC"))
+    ds: String => fmt.parse(ds).getTime
+  }
+
+  // Upload table columns: key_bytes(0), value_bytes(1), key_json(2), value_json(3), ds(4)
+  private val DsColumnIndex = 4
+
   override def flatMap(row: RowData, out: Collector[BatchIrRow]): Unit = {
     try {
-      // Upload table schema: key_bytes (col 0), value_bytes (col 1)
       val keyBytes = row.getBinary(0)
       val valueBytes = row.getBinary(1)
       if (keyBytes == null || valueBytes == null) return
 
       val entityKeys = keyDecoder(keyBytes)
-      val batchEnd = servingInfo.batchEndTsMillis
+
+      // Derive batchEnd from the ds partition column. Each new upload partition
+      // (e.g., ds=2026-03-29) produces batchEnd = Mar 29 00:00 UTC, which advances
+      // past the previous partition's batchEnd. Without this, onBatchUpdate rejects
+      // all updates after the first as stale (newBatchEnd <= oldBatchEnd).
+      val batchEnd = if (row.getArity > DsColumnIndex && !row.isNullAt(DsColumnIndex)) {
+        dsParser(row.getString(DsColumnIndex).toString)
+      } else {
+        servingInfo.batchEndTsMillis
+      }
 
       out.collect(new BatchIrRow(entityKeys, valueBytes, batchEnd))
     } catch {

--- a/flink/src/main/scala/ai/chronon/flink/source/BatchIrSourceBuilder.scala
+++ b/flink/src/main/scala/ai/chronon/flink/source/BatchIrSourceBuilder.scala
@@ -1,0 +1,147 @@
+package ai.chronon.flink.source
+
+import ai.chronon.api.Extensions.{GroupByOps, MetadataOps}
+import ai.chronon.flink.types.BatchIrRow
+import ai.chronon.online.GroupByServingInfoParsed
+import ai.chronon.online.serde.AvroConversions
+import org.apache.flink.api.common.eventtime.WatermarkStrategy
+import org.apache.flink.api.common.functions.RichFlatMapFunction
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+import org.apache.flink.table.data.RowData
+import org.apache.flink.util.Collector
+import org.slf4j.LoggerFactory
+
+import java.time.Duration
+
+/** Builds a DataStream[BatchIrRow] from the GroupBy's upload Iceberg table.
+  *
+  * The Iceberg source operates in streaming monitor mode: it scans the latest partition
+  * on startup, then monitors for new snapshots every `monitorInterval`.
+  *
+  * Configuration via props:
+  *   - `iceberg.catalog.warehouse`: warehouse path (required for Iceberg source)
+  *   - `iceberg.catalog.uri`: metastore URI (for hive catalog)
+  *   - `iceberg.monitor.interval.minutes`: snapshot monitor interval (default: 30)
+  *
+  * Falls back to an idle (empty) stream if Iceberg is not configured.
+  */
+object BatchIrSourceBuilder {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  def build(env: StreamExecutionEnvironment,
+            servingInfo: GroupByServingInfoParsed,
+            props: Map[String, String]): DataStream[BatchIrRow] = {
+
+    val warehouse = props.getOrElse("iceberg.catalog.warehouse", "")
+    val monitorIntervalMin = props.getOrElse("iceberg.monitor.interval.minutes", "30").toLong
+
+    if (warehouse.isEmpty) {
+      logger.warn(s"No iceberg.catalog.warehouse configured for ${servingInfo.groupByOps.metaData.getName}. " +
+        s"Returning idle batch IR stream (batch loading disabled).")
+      return buildIdleStream(env, servingInfo.groupByOps.metaData.getName)
+    }
+
+    try {
+      buildIcebergStream(env, servingInfo, props, warehouse, monitorIntervalMin)
+    } catch {
+      case e: Exception =>
+        logger.error(s"Failed to create Iceberg source. Falling back to idle stream.", e)
+        buildIdleStream(env, servingInfo.groupByOps.metaData.getName)
+    }
+  }
+
+  private def buildIcebergStream(env: StreamExecutionEnvironment,
+                                  servingInfo: GroupByServingInfoParsed,
+                                  props: Map[String, String],
+                                  warehouse: String,
+                                  monitorIntervalMin: Long): DataStream[BatchIrRow] = {
+    import org.apache.iceberg.catalog.TableIdentifier
+    import org.apache.iceberg.flink.{CatalogLoader, TableLoader}
+    import org.apache.iceberg.flink.source.IcebergSource
+
+    val uploadTable = servingInfo.groupByOps.metaData.uploadTable
+    val groupByName = servingInfo.groupByOps.metaData.getName
+    val catalogProps = new java.util.HashMap[String, String]()
+    catalogProps.put("type", props.getOrElse("iceberg.catalog.type", "hadoop"))
+    catalogProps.put("warehouse", warehouse)
+    props.get("iceberg.catalog.uri").foreach(catalogProps.put("uri", _))
+
+    val catalogLoader = CatalogLoader.hadoop("chronon_catalog",
+      new org.apache.hadoop.conf.Configuration(), catalogProps)
+    val tableId = TableIdentifier.parse(uploadTable)
+    val tableLoader = TableLoader.fromCatalog(catalogLoader, tableId)
+
+    val icebergSource = IcebergSource
+      .forRowData()
+      .tableLoader(tableLoader)
+      .streaming(true)
+      .monitorInterval(Duration.ofMinutes(monitorIntervalMin))
+      .build()
+
+    // Iceberg source with idleness — prevents stalling the global watermark
+    val batchWatermark = WatermarkStrategy
+      .noWatermarks[RowData]()
+      .withIdleness(Duration.ofMinutes(monitorIntervalMin + 5))
+
+    val rawStream = env
+      .fromSource(icebergSource, batchWatermark, s"Iceberg batch source for $uploadTable")
+      .uid(s"iceberg-batch-source-$groupByName")
+      .setParallelism(1)
+
+    rawStream
+      .flatMap(new BatchIrRowDecoder(servingInfo))
+      .uid(s"batch-ir-decode-$groupByName")
+      .name(s"Decode batch IR for $groupByName")
+      .setParallelism(1)
+  }
+
+  /** Returns an empty stream that completes immediately. Used as fallback when Iceberg is not configured. */
+  private def buildIdleStream(env: StreamExecutionEnvironment, groupByName: String): DataStream[BatchIrRow] = {
+    env
+      .fromElements(new BatchIrRow())
+      .filter(_ => false)
+      .uid(s"idle-batch-ir-source-$groupByName")
+      .name(s"Idle batch IR source for $groupByName")
+      .setParallelism(1)
+      .returns(classOf[BatchIrRow])
+  }
+}
+
+/** Decodes Iceberg RowData (key_bytes, value_bytes, ...) into BatchIrRow. */
+class BatchIrRowDecoder(servingInfo: GroupByServingInfoParsed)
+    extends RichFlatMapFunction[RowData, BatchIrRow] {
+
+  @transient private lazy val logger = LoggerFactory.getLogger(getClass)
+
+  @transient private lazy val keyDecoder: Array[Byte] => java.util.List[Any] = {
+    val keySchema = servingInfo.keyChrononSchema
+    val converter = AvroConversions.genericRecordToChrononRowConverter(keySchema)
+    val codec = servingInfo.keyCodec
+    bytes: Array[Byte] => {
+      val record = codec.decode(bytes)
+      val decoded = converter(record)
+      val keys = new java.util.ArrayList[Any](decoded.length)
+      decoded.foreach(keys.add)
+      keys
+    }
+  }
+
+  override def flatMap(row: RowData, out: Collector[BatchIrRow]): Unit = {
+    try {
+      // Upload table schema: key_bytes (col 0), value_bytes (col 1)
+      val keyBytes = row.getBinary(0)
+      val valueBytes = row.getBinary(1)
+      if (keyBytes == null || valueBytes == null) return
+
+      val entityKeys = keyDecoder(keyBytes)
+      val batchEnd = servingInfo.batchEndTsMillis
+
+      out.collect(new BatchIrRow(entityKeys, valueBytes, batchEnd))
+    } catch {
+      case e: Exception =>
+        logger.error("Error decoding batch IR row from Iceberg", e)
+    }
+  }
+}

--- a/flink/src/main/scala/ai/chronon/flink/source/BatchIrSourceBuilder.scala
+++ b/flink/src/main/scala/ai/chronon/flink/source/BatchIrSourceBuilder.scala
@@ -148,12 +148,13 @@ class BatchIrRowDecoder(servingInfo: GroupByServingInfoParsed)
 
       val entityKeys = keyDecoder(keyBytes)
 
-      // Derive batchEnd from the ds partition column. Each new upload partition
-      // (e.g., ds=2026-03-29) produces batchEnd = Mar 29 00:00 UTC, which advances
-      // past the previous partition's batchEnd. Without this, onBatchUpdate rejects
-      // all updates after the first as stale (newBatchEnd <= oldBatchEnd).
+      // Derive batchEnd from the ds partition column. Chronon convention:
+      // batchEnd = after(ds) = ds + 1 day. Batch for ds=2026-03-28 covers
+      // [Mar 28 00:00, Mar 29 00:00), so batchEnd = Mar 29 00:00.
+      // See GroupByUpload: batchEndDate = partitionSpec.after(endDs).
+      val DayMillis = 24 * 3600 * 1000L
       val batchEnd = if (row.getArity > DsColumnIndex && !row.isNullAt(DsColumnIndex)) {
-        dsParser(row.getString(DsColumnIndex).toString)
+        dsParser(row.getString(DsColumnIndex).toString) + DayMillis
       } else {
         servingInfo.batchEndTsMillis
       }

--- a/flink/src/main/scala/ai/chronon/flink/source/BatchIrSourceBuilder.scala
+++ b/flink/src/main/scala/ai/chronon/flink/source/BatchIrSourceBuilder.scala
@@ -1,6 +1,7 @@
 package ai.chronon.flink.source
 
 import ai.chronon.api.Extensions.{GroupByOps, MetadataOps}
+import ai.chronon.api.Constants
 import ai.chronon.flink.types.BatchIrRow
 import ai.chronon.online.GroupByServingInfoParsed
 import ai.chronon.online.serde.AvroConversions
@@ -12,6 +13,7 @@ import org.apache.flink.table.data.RowData
 import org.apache.flink.util.Collector
 import org.slf4j.LoggerFactory
 
+import java.text.{ParseException, ParsePosition}
 import java.time.Duration
 
 /** Builds a DataStream[BatchIrRow] from the GroupBy's upload Iceberg table.
@@ -24,7 +26,8 @@ import java.time.Duration
   *   - `iceberg.catalog.uri`: metastore URI (for hive catalog)
   *   - `iceberg.monitor.interval.minutes`: snapshot monitor interval (default: 30)
   *
-  * Falls back to an idle (empty) stream if Iceberg is not configured.
+  * Falls back to an idle (empty) stream if Iceberg is not configured unless the caller has
+  * explicitly enabled behavior that depends on distinguishing an absent batch row.
   */
 object BatchIrSourceBuilder {
 
@@ -32,31 +35,46 @@ object BatchIrSourceBuilder {
 
   def build(env: StreamExecutionEnvironment,
             servingInfo: GroupByServingInfoParsed,
-            props: Map[String, String]): DataStream[BatchIrRow] = {
+            props: Map[String, String],
+            requireConfiguredBatchSource: Boolean = false): DataStream[BatchIrRow] = {
 
     val warehouse = props.getOrElse("iceberg.catalog.warehouse", "")
-    val monitorIntervalMin = props.getOrElse("iceberg.monitor.interval.minutes", "30").toLong
+    val groupByName = servingInfo.groupByOps.metaData.getName
 
     if (warehouse.isEmpty) {
-      logger.warn(s"No iceberg.catalog.warehouse configured for ${servingInfo.groupByOps.metaData.getName}. " +
-        s"Returning idle batch IR stream (batch loading disabled).")
-      return buildIdleStream(env, servingInfo.groupByOps.metaData.getName)
+      val message = s"No iceberg.catalog.warehouse configured for $groupByName"
+      if (requireConfiguredBatchSource) {
+        throw new IllegalArgumentException(
+          s"$message; a configured batch source is required when gigatile_first_seen_key_grace_millis is enabled")
+      }
+      logger.warn(s"$message. Returning idle batch IR stream (batch loading disabled).")
+      return buildIdleStream(env, groupByName)
     }
 
     try {
-      buildIcebergStream(env, servingInfo, props, warehouse, monitorIntervalMin)
+      val monitorIntervalMin = props.getOrElse("iceberg.monitor.interval.minutes", "30").toLong
+      buildIcebergStream(env,
+                         servingInfo,
+                         props,
+                         warehouse,
+                         monitorIntervalMin,
+                         failOnDecodeError = requireConfiguredBatchSource)
     } catch {
       case e: Exception =>
-        logger.error(s"Failed to create Iceberg source. Falling back to idle stream.", e)
-        buildIdleStream(env, servingInfo.groupByOps.metaData.getName)
+        if (requireConfiguredBatchSource) {
+          throw new IllegalStateException(s"Failed to create required Iceberg source for $groupByName", e)
+        }
+        logger.error(s"Failed to create Iceberg source for $groupByName. Falling back to idle stream.", e)
+        buildIdleStream(env, groupByName)
     }
   }
 
   private def buildIcebergStream(env: StreamExecutionEnvironment,
-                                  servingInfo: GroupByServingInfoParsed,
-                                  props: Map[String, String],
-                                  warehouse: String,
-                                  monitorIntervalMin: Long): DataStream[BatchIrRow] = {
+                                 servingInfo: GroupByServingInfoParsed,
+                                 props: Map[String, String],
+                                 warehouse: String,
+                                 monitorIntervalMin: Long,
+                                 failOnDecodeError: Boolean): DataStream[BatchIrRow] = {
     import org.apache.iceberg.catalog.TableIdentifier
     import org.apache.iceberg.flink.{CatalogLoader, TableLoader}
     import org.apache.iceberg.flink.source.IcebergSource
@@ -68,8 +86,8 @@ object BatchIrSourceBuilder {
     catalogProps.put("warehouse", warehouse)
     props.get("iceberg.catalog.uri").foreach(catalogProps.put("uri", _))
 
-    val catalogLoader = CatalogLoader.hadoop("chronon_catalog",
-      new org.apache.hadoop.conf.Configuration(), catalogProps)
+    val catalogLoader =
+      CatalogLoader.hadoop("chronon_catalog", new org.apache.hadoop.conf.Configuration(), catalogProps)
     val tableId = TableIdentifier.parse(uploadTable)
     val tableLoader = TableLoader.fromCatalog(catalogLoader, tableId)
 
@@ -91,7 +109,7 @@ object BatchIrSourceBuilder {
       .setParallelism(1)
 
     rawStream
-      .flatMap(new BatchIrRowDecoder(servingInfo))
+      .flatMap(new BatchIrRowDecoder(servingInfo, failOnDecodeError))
       .uid(s"batch-ir-decode-$groupByName")
       .name(s"Decode batch IR for $groupByName")
       .setParallelism(1)
@@ -113,7 +131,7 @@ object BatchIrSourceBuilder {
   * batchEnd is derived from the ds partition column — NOT from the static servingInfo.batchEndTsMillis.
   * Each new partition (ds=2026-03-29) produces a fresh batchEnd, ensuring onBatchUpdate accepts it.
   */
-class BatchIrRowDecoder(servingInfo: GroupByServingInfoParsed)
+class BatchIrRowDecoder(servingInfo: GroupByServingInfoParsed, failOnDecodeError: Boolean = false)
     extends RichFlatMapFunction[RowData, BatchIrRow] {
 
   @transient private lazy val logger = LoggerFactory.getLogger(getClass)
@@ -134,17 +152,37 @@ class BatchIrRowDecoder(servingInfo: GroupByServingInfoParsed)
   @transient private lazy val dsParser: String => Long = {
     val fmt = new java.text.SimpleDateFormat(servingInfo.groupByServingInfo.getDateFormat)
     fmt.setTimeZone(java.util.TimeZone.getTimeZone("UTC"))
-    ds: String => fmt.parse(ds).getTime
+    fmt.setLenient(false)
+    ds: String => {
+      val position = new ParsePosition(0)
+      val parsed = fmt.parse(ds, position)
+      if (parsed == null || position.getIndex != ds.length) {
+        val errorOffset = math.max(position.getErrorIndex, position.getIndex)
+        throw new ParseException(s"Invalid ds partition value: $ds", errorOffset)
+      }
+      parsed.getTime
+    }
   }
 
   // Upload table columns: key_bytes(0), value_bytes(1), key_json(2), value_json(3), ds(4)
+  private val KeyJsonColumnIndex = 2
   private val DsColumnIndex = 4
 
   override def flatMap(row: RowData, out: Collector[BatchIrRow]): Unit = {
     try {
+      // GroupByUpload appends one metadata row to every upload partition and filters it by
+      // key_json in its own reload path. It is not an entity BatchIrRow, even in strict mode.
+      if (
+        row.getArity > KeyJsonColumnIndex && !row.isNullAt(KeyJsonColumnIndex) &&
+        row.getString(KeyJsonColumnIndex).toString == Constants.GroupByServingInfoKey
+      ) return
+
       val keyBytes = row.getBinary(0)
       val valueBytes = row.getBinary(1)
-      if (keyBytes == null || valueBytes == null) return
+      if (keyBytes == null || valueBytes == null) {
+        if (failOnDecodeError) throw new IllegalArgumentException("Batch IR row has null key_bytes or value_bytes")
+        return
+      }
 
       val entityKeys = keyDecoder(keyBytes)
 
@@ -153,16 +191,20 @@ class BatchIrRowDecoder(servingInfo: GroupByServingInfoParsed)
       // [Mar 28 00:00, Mar 29 00:00), so batchEnd = Mar 29 00:00.
       // See GroupByUpload: batchEndDate = partitionSpec.after(endDs).
       val DayMillis = 24 * 3600 * 1000L
-      val batchEnd = if (row.getArity > DsColumnIndex && !row.isNullAt(DsColumnIndex)) {
-        dsParser(row.getString(DsColumnIndex).toString) + DayMillis
-      } else {
-        servingInfo.batchEndTsMillis
-      }
+      val batchEnd =
+        if (row.getArity > DsColumnIndex && !row.isNullAt(DsColumnIndex)) {
+          Math.addExact(dsParser(row.getString(DsColumnIndex).toString), DayMillis)
+        } else if (failOnDecodeError) {
+          throw new IllegalArgumentException("Batch IR row is missing required ds partition value")
+        } else {
+          servingInfo.batchEndTsMillis
+        }
 
       out.collect(new BatchIrRow(entityKeys, valueBytes, batchEnd))
     } catch {
       case e: Exception =>
         logger.error("Error decoding batch IR row from Iceberg", e)
+        if (failOnDecodeError) throw e
     }
   }
 }

--- a/flink/src/main/scala/ai/chronon/flink/types/FlinkTypes.scala
+++ b/flink/src/main/scala/ai/chronon/flink/types/FlinkTypes.scala
@@ -146,3 +146,30 @@ class WriteResponse(var keyBytes: Array[Byte],
       case _ => false
     }
 }
+
+/** Batch IR row from the Iceberg upload table.
+  * Carries decoded entity keys and raw value bytes for a single entity's batch IR.
+  * Used as the second input to GigaTileProcessFunction (CoProcessFunction).
+  */
+class BatchIrRow(var entityKeys: util.List[Any],
+                 var valueBytes: Array[Byte],
+                 var batchEndTs: Long) {
+  def this() = this(new util.ArrayList[Any](), Array(), 0L)
+
+  override def hashCode(): Int =
+    Objects.hash(
+      util.Arrays.deepToString(entityKeys.toArray.asInstanceOf[Array[AnyRef]]),
+      valueBytes,
+      batchEndTs.asInstanceOf[java.lang.Long]
+    )
+
+  override def equals(other: Any): Boolean =
+    other match {
+      case o: BatchIrRow =>
+        util.Arrays.deepEquals(entityKeys.toArray.asInstanceOf[Array[AnyRef]],
+                               o.entityKeys.toArray.asInstanceOf[Array[AnyRef]]) &&
+        util.Arrays.equals(valueBytes, o.valueBytes) &&
+        batchEndTs == o.batchEndTs
+      case _ => false
+    }
+}

--- a/flink/src/main/scala/ai/chronon/flink/window/ChrononClockMode.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/ChrononClockMode.scala
@@ -1,0 +1,113 @@
+package ai.chronon.flink.window
+
+import ai.chronon.api.TsUtils
+
+/** Chooses replay-safe aggregation horizons for the GigaTile operator. */
+private[flink] object ChrononClockMode {
+  sealed trait Mode
+  case object NoWatermark extends Mode
+  case object Catchup extends Mode
+  case object Live extends Mode
+
+  final case class Horizons(largeWindowAsOfMillis: Long, smallWindowAsOfMillis: Long)
+
+  def classify(
+      processingTimeMillis: Long,
+      eventTimeWatermarkMillis: Long,
+      sourceOutOfOrdernessMillis: Long,
+      liveWatermarkLagToleranceMillis: Long
+  ): Mode = {
+    require(sourceOutOfOrdernessMillis >= 0L, "source out-of-orderness must be non-negative")
+    require(liveWatermarkLagToleranceMillis >= sourceOutOfOrdernessMillis,
+            "live watermark tolerance must cover source out-of-orderness")
+    if (eventTimeWatermarkMillis == Long.MinValue) NoWatermark
+    // Flink emits bounded-out-of-order watermarks as maxEventTs - outOfOrderness - 1.
+    // Equality therefore implies that the source has already observed a future event.
+    else if (watermarkImpliesFutureEvent(processingTimeMillis, eventTimeWatermarkMillis, sourceOutOfOrdernessMillis))
+      NoWatermark
+    else if (watermarkIsBehind(processingTimeMillis, eventTimeWatermarkMillis, liveWatermarkLagToleranceMillis)) Catchup
+    else Live
+  }
+
+  def allowsPublication(mode: Mode): Boolean = mode == Live
+
+  def dayAdvanceAsOfMillis(
+      mode: Mode,
+      processingTimeMillis: Long,
+      eventTimeWatermarkMillis: Long
+  ): Option[Long] =
+    mode match {
+      case NoWatermark => None
+      case Catchup     => Some(eventTimeWatermarkMillis)
+      case Live        => Some(processingTimeMillis)
+    }
+
+  def streamEventHorizons(
+      mode: Mode,
+      eventTimeMillis: Long,
+      processingTimeMillis: Long,
+      eventTimeWatermarkMillis: Long,
+      smallestHopMillis: Long
+  ): Horizons = {
+    val asOfMillis = mode match {
+      case NoWatermark => eventTimeMillis
+      case Catchup     => eventTimeWatermarkMillis
+      case Live        => processingTimeMillis
+    }
+    horizons(asOfMillis, smallestHopMillis)
+  }
+
+  def batchUpdateHorizons(
+      mode: Mode,
+      batchEndMillis: Long,
+      currentDayStartMillis: Long,
+      processingTimeMillis: Long,
+      eventTimeWatermarkMillis: Long,
+      smallestHopMillis: Long
+  ): Horizons = {
+    val asOfMillis = mode match {
+      case NoWatermark => if (currentDayStartMillis >= 0L) currentDayStartMillis else batchEndMillis
+      case Catchup     => eventTimeWatermarkMillis
+      case Live        => processingTimeMillis
+    }
+    horizons(asOfMillis, smallestHopMillis)
+  }
+
+  def processingTimerHorizons(
+      mode: Mode,
+      processingTimeMillis: Long,
+      eventTimeWatermarkMillis: Long,
+      smallestHopMillis: Long
+  ): Option[Horizons] =
+    mode match {
+      case NoWatermark => None
+      case Catchup     => Some(horizons(eventTimeWatermarkMillis, smallestHopMillis))
+      case Live        => Some(horizons(processingTimeMillis, smallestHopMillis))
+    }
+
+  private def horizons(asOfMillis: Long, smallestHopMillis: Long): Horizons =
+    Horizons(asOfMillis, adjustExclusiveUpperBound(asOfMillis, smallestHopMillis))
+
+  private def adjustExclusiveUpperBound(asOfMillis: Long, hopMillis: Long): Long =
+    if (asOfMillis < Long.MaxValue && asOfMillis == TsUtils.round(asOfMillis, hopMillis)) asOfMillis + 1L
+    else asOfMillis
+
+  private def watermarkIsBehind(
+      processingTimeMillis: Long,
+      eventTimeWatermarkMillis: Long,
+      liveWatermarkLagToleranceMillis: Long
+  ): Boolean =
+    processingTimeMillis > saturatingAdd(eventTimeWatermarkMillis, liveWatermarkLagToleranceMillis)
+
+  private def watermarkImpliesFutureEvent(
+      processingTimeMillis: Long,
+      eventTimeWatermarkMillis: Long,
+      sourceOutOfOrdernessMillis: Long
+  ): Boolean =
+    saturatingAdd(eventTimeWatermarkMillis, sourceOutOfOrdernessMillis) >= processingTimeMillis
+
+  private def saturatingAdd(value: Long, nonNegativeDelta: Long): Long = {
+    require(nonNegativeDelta >= 0L, "clock delta must be non-negative")
+    if (value > Long.MaxValue - nonNegativeDelta) Long.MaxValue else value + nonNegativeDelta
+  }
+}

--- a/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
@@ -1,0 +1,348 @@
+package ai.chronon.flink.window
+
+import ai.chronon.aggregator.windowing.{FinalBatchIr, GigaTileStore, GigaTileStreamProcessor, MegaTileAggregator}
+import ai.chronon.api.{Constants, DataType, GroupBy, TsUtils}
+import ai.chronon.api.ScalaJavaConversions.IteratorOps
+import ai.chronon.flink.SparkExpressionEval
+import ai.chronon.flink.deser.ProjectedEvent
+import ai.chronon.flink.types.TimestampedTile
+import ai.chronon.online.{GigaTileCodec, MegaTileCodec}
+import ai.chronon.online.serde.ArrayRow
+import org.apache.flink.api.common.state.{MapState, MapStateDescriptor, ValueState, ValueStateDescriptor}
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.metrics.Counter
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction
+import org.apache.flink.util.Collector
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.util.{Failure, Success, Try}
+
+/** Flink KeyedProcessFunction for the GigaTile pipeline.
+  *
+  * Delegates all aggregation logic to GigaTileStreamProcessor.
+  * Emits finalized feature vectors (not windowed IRs) to the KV store.
+  *
+  * For batch IR loading: call loadBatchIr() externally (e.g., from an Iceberg source
+  * via a connected stream or broadcast). Currently handles events only — batch IR
+  * integration requires upgrading to a CoProcessFunction (follow-up PR).
+  */
+class GigaTileProcessFunction(
+    groupBy: GroupBy,
+    inputSchema: Seq[(String, DataType)],
+    enableDebug: Boolean = false
+) extends KeyedProcessFunction[java.util.List[Any], ProjectedEvent, TimestampedTile] {
+
+  @transient lazy val logger: Logger = LoggerFactory.getLogger(getClass)
+
+  @transient private var processor: GigaTileStreamProcessor = _
+  @transient private var gigaTileCodec: GigaTileCodec = _
+  @transient private var megaTileCodec: MegaTileCodec = _
+  @transient private var flinkStore: FlinkGigaTileStore = _
+
+  @transient private var eventProcessingErrorCounter: Counter = _
+  @transient private var lastKey: java.util.List[Any] = _
+
+  private val valueColumns: Array[String] = inputSchema.map(_._1).toArray
+  private val timeColumnAlias: String = Constants.TimeColumn
+
+  // Flink managed state (mega tile state)
+  private var tileState: MapState[String, Array[Byte]] = _
+  private var megaTileIrState: ValueState[Array[Byte]] = _
+  private var largeTodayIrState: ValueState[Array[Byte]] = _
+  private var largeYesterdayIrState: ValueState[Array[Byte]] = _
+  private var currentDayStartState: ValueState[java.lang.Long] = _
+  private var earliestTileStartState: ValueState[java.lang.Long] = _
+
+  // Giga tile additional state
+  private var batchIrState: ValueState[Array[Byte]] = _
+  private var batchEndTsState: ValueState[java.lang.Long] = _
+  private var runningLargeIrState: ValueState[Array[Byte]] = _
+
+  override def open(parameters: Configuration): Unit = {
+    super.open(parameters)
+
+    val metricsGroup = getRuntimeContext.getMetricGroup
+      .addGroup("chronon")
+      .addGroup("feature_group", groupBy.getMetaData.getName)
+    eventProcessingErrorCounter = metricsGroup.counter("event_processing_error")
+
+    tileState = getRuntimeContext.getMapState(
+      new MapStateDescriptor[String, Array[Byte]]("giga-tile-tiles", classOf[String], classOf[Array[Byte]]))
+    megaTileIrState =
+      getRuntimeContext.getState(new ValueStateDescriptor[Array[Byte]]("giga-tile-ir", classOf[Array[Byte]]))
+    largeTodayIrState =
+      getRuntimeContext.getState(new ValueStateDescriptor[Array[Byte]]("giga-tile-large-today", classOf[Array[Byte]]))
+    largeYesterdayIrState = getRuntimeContext.getState(
+      new ValueStateDescriptor[Array[Byte]]("giga-tile-large-yesterday", classOf[Array[Byte]]))
+    currentDayStartState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Long]("giga-tile-day-start", classOf[java.lang.Long]))
+    earliestTileStartState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Long]("giga-tile-earliest-tile", classOf[java.lang.Long]))
+
+    batchIrState =
+      getRuntimeContext.getState(new ValueStateDescriptor[Array[Byte]]("giga-tile-batch-ir", classOf[Array[Byte]]))
+    batchEndTsState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Long]("giga-tile-batch-end", classOf[java.lang.Long]))
+    runningLargeIrState = getRuntimeContext.getState(
+      new ValueStateDescriptor[Array[Byte]]("giga-tile-running-large", classOf[Array[Byte]]))
+
+    initializeTransients()
+  }
+
+  private def initializeTransients(): Unit = {
+    val inputCols = inputSchema.map { case (name, dt) => (name, dt) }
+    val megaTileAgg = new MegaTileAggregator(groupBy.getAggregations.iterator().toScala.toSeq, inputCols)
+    gigaTileCodec = new GigaTileCodec(groupBy, inputCols)
+    megaTileCodec = new MegaTileCodec(groupBy, inputCols)
+    flinkStore = new FlinkGigaTileStore(megaTileAgg, megaTileCodec, gigaTileCodec)
+
+    // Mismatch check: serialize-and-compare-bytes
+    val irEqual: (Array[Any], Array[Any]) => Boolean = { (a, b) =>
+      java.util.Arrays.equals(gigaTileCodec.encodeWindowedIr(a), gigaTileCodec.encodeWindowedIr(b))
+    }
+
+    processor = new GigaTileStreamProcessor(megaTileAgg, flinkStore, irEqual)
+  }
+
+  override def processElement(
+      event: ProjectedEvent,
+      ctx: KeyedProcessFunction[java.util.List[Any], ProjectedEvent, TimestampedTile]#Context,
+      out: Collector[TimestampedTile]
+  ): Unit = {
+    try {
+      if (processor == null) initializeTransients()
+
+      val element = event.fields
+      val tsMills = Try(element(timeColumnAlias).asInstanceOf[Long])
+        .getOrElse(element(timeColumnAlias).asInstanceOf[Double].toLong)
+      val values: Array[Any] = valueColumns.map(element(_))
+      val row = new ArrayRow(values, tsMills)
+
+      val currentKey = ctx.getCurrentKey
+      if (lastKey == null || !lastKey.equals(currentKey)) {
+        lastKey = currentKey
+        flinkStore.bindFlinkState(
+          tileState,
+          megaTileIrState,
+          largeTodayIrState,
+          largeYesterdayIrState,
+          currentDayStartState,
+          earliestTileStartState,
+          batchIrState,
+          batchEndTsState,
+          runningLargeIrState
+        )
+      }
+
+      processor.advanceWatermark(ctx.timerService().currentWatermark())
+      val result = processor.onEvent(row, tsMills)
+
+      if (result.finalizedVector != null) {
+        out.collect(
+          new TimestampedTile(ctx.getCurrentKey,
+                              gigaTileCodec.encodeOutput(result.finalizedVector),
+                              tsMills,
+                              event.startProcessingTimeMillis))
+      }
+
+      // Register eviction timer
+      val nextEviction = TsUtils.round(tsMills, processor.minEvictionInterval) + processor.minEvictionInterval
+      ctx.timerService().registerEventTimeTimer(nextEviction)
+    } catch {
+      case e: Exception =>
+        logger.error(s"Error processing giga tile event for groupBy=${groupBy.getMetaData.getName}", e)
+        eventProcessingErrorCounter.inc()
+    }
+  }
+
+  override def onTimer(
+      timestamp: Long,
+      ctx: KeyedProcessFunction[java.util.List[Any], ProjectedEvent, TimestampedTile]#OnTimerContext,
+      out: Collector[TimestampedTile]
+  ): Unit = {
+    try {
+      if (processor == null) initializeTransients()
+
+      val currentKey = ctx.getCurrentKey
+      if (lastKey == null || !lastKey.equals(currentKey)) {
+        lastKey = currentKey
+        flinkStore.bindFlinkState(
+          tileState,
+          megaTileIrState,
+          largeTodayIrState,
+          largeYesterdayIrState,
+          currentDayStartState,
+          earliestTileStartState,
+          batchIrState,
+          batchEndTsState,
+          runningLargeIrState
+        )
+      }
+
+      processor.advanceWatermark(ctx.timerService().currentWatermark())
+      val result = processor.onEviction(timestamp)
+
+      if (result.finalizedVector != null) {
+        out.collect(
+          new TimestampedTile(ctx.getCurrentKey,
+                              gigaTileCodec.encodeOutput(result.finalizedVector),
+                              timestamp,
+                              System.currentTimeMillis()))
+      }
+
+      // Re-register eviction timer
+      ctx.timerService().registerEventTimeTimer(timestamp + processor.minEvictionInterval)
+    } catch {
+      case e: Exception =>
+        logger.error(s"Error in giga tile eviction for groupBy=${groupBy.getMetaData.getName}", e)
+        eventProcessingErrorCounter.inc()
+    }
+  }
+}
+
+/** TileStore backed by Flink state for GigaTile. Extends the mega tile state with batch IR storage. */
+class FlinkGigaTileStore(megaTileAgg: MegaTileAggregator, codec: MegaTileCodec, gigaCodec: GigaTileCodec)
+    extends GigaTileStore {
+  private val windowedAgg = megaTileAgg.windowedAggregator
+
+  private var tileState: MapState[String, Array[Byte]] = _
+  private var megaTileIrState: ValueState[Array[Byte]] = _
+  private var largeTodayIrState: ValueState[Array[Byte]] = _
+  private var largeYesterdayIrState: ValueState[Array[Byte]] = _
+  private var currentDayStartState: ValueState[java.lang.Long] = _
+  private var earliestTileStartState: ValueState[java.lang.Long] = _
+  private var batchIrState: ValueState[Array[Byte]] = _
+  private var batchEndTsState: ValueState[java.lang.Long] = _
+  private var runningLargeIrState: ValueState[Array[Byte]] = _
+
+  // Decode cache (invalidated on key switch)
+  private var cachedSmallDecoded: Array[Any] = _
+  private var cachedSmallValid: Boolean = false
+  private var largeTodayDecoded: Array[Any] = _
+  private var largeTodayValid: Boolean = false
+  private var largeYesterdayDecoded: Array[Any] = _
+  private var largeYesterdayValid: Boolean = false
+  private var batchIrDecoded: FinalBatchIr = _
+  private var batchIrValid: Boolean = false
+  private var runningLargeDecoded: Array[Any] = _
+  private var runningLargeValid: Boolean = false
+
+  def bindFlinkState(tiles: MapState[String, Array[Byte]],
+                     megaTileIr: ValueState[Array[Byte]],
+                     largeToday: ValueState[Array[Byte]],
+                     largeYesterday: ValueState[Array[Byte]],
+                     dayStart: ValueState[java.lang.Long],
+                     earliest: ValueState[java.lang.Long],
+                     batchIr: ValueState[Array[Byte]],
+                     batchEndTs: ValueState[java.lang.Long],
+                     runningLarge: ValueState[Array[Byte]]): Unit = {
+    tileState = tiles
+    megaTileIrState = megaTileIr
+    largeTodayIrState = largeToday
+    largeYesterdayIrState = largeYesterday
+    currentDayStartState = dayStart
+    earliestTileStartState = earliest
+    batchIrState = batchIr
+    batchEndTsState = batchEndTs
+    runningLargeIrState = runningLarge
+    // Invalidate all caches
+    cachedSmallValid = false
+    largeTodayValid = false
+    largeYesterdayValid = false
+    batchIrValid = false
+    runningLargeValid = false
+  }
+
+  private def tileKey(hopSize: Long, tileStart: Long): String = s"$hopSize:$tileStart"
+
+  override def getTile(hopSize: Long, tileStart: Long): Array[Any] = {
+    val bytes = tileState.get(tileKey(hopSize, tileStart))
+    if (bytes != null) codec.decodeBaseIr(bytes) else null
+  }
+  override def putTile(hopSize: Long, tileStart: Long, ir: Array[Any]): Unit =
+    tileState.put(tileKey(hopSize, tileStart), codec.encodeBaseIr(ir))
+  override def removeTile(hopSize: Long, tileStart: Long): Unit =
+    tileState.remove(tileKey(hopSize, tileStart))
+  override def tileIterator: Iterator[(Long, Long, Array[Any])] = {
+    val iter = tileState.iterator()
+    new Iterator[(Long, Long, Array[Any])] {
+      override def hasNext: Boolean = iter.hasNext
+      override def next(): (Long, Long, Array[Any]) = {
+        val entry = iter.next()
+        val parts = entry.getKey.split(":")
+        (parts(0).toLong, parts(1).toLong, codec.decodeBaseIr(entry.getValue))
+      }
+    }
+  }
+
+  private def decodeWindowedIr(state: ValueState[Array[Byte]]): Array[Any] = {
+    val bytes = state.value()
+    if (bytes != null) codec.decode(bytes) else windowedAgg.init
+  }
+
+  override def getCachedSmallWindowIr: Array[Any] = {
+    if (!cachedSmallValid) { cachedSmallDecoded = decodeWindowedIr(megaTileIrState); cachedSmallValid = true }
+    cachedSmallDecoded
+  }
+  override def putCachedSmallWindowIr(ir: Array[Any]): Unit = {
+    megaTileIrState.update(codec.encode(ir))
+    cachedSmallDecoded = ir; cachedSmallValid = true
+  }
+
+  override def getLargeTodayIr: Array[Any] = {
+    if (!largeTodayValid) { largeTodayDecoded = decodeWindowedIr(largeTodayIrState); largeTodayValid = true }
+    largeTodayDecoded
+  }
+  override def putLargeTodayIr(ir: Array[Any]): Unit = {
+    largeTodayIrState.update(codec.encode(ir))
+    largeTodayDecoded = ir; largeTodayValid = true
+  }
+
+  override def getLargeYesterdayIr: Array[Any] = {
+    if (!largeYesterdayValid) {
+      largeYesterdayDecoded = decodeWindowedIr(largeYesterdayIrState); largeYesterdayValid = true
+    }
+    largeYesterdayDecoded
+  }
+  override def putLargeYesterdayIr(ir: Array[Any]): Unit = {
+    largeYesterdayIrState.update(codec.encode(ir))
+    largeYesterdayDecoded = ir; largeYesterdayValid = true
+  }
+
+  override def getCurrentDayStart: Long = Option(currentDayStartState.value()).map(_.longValue()).getOrElse(-1L)
+  override def putCurrentDayStart(ts: Long): Unit = currentDayStartState.update(ts)
+
+  override def getEarliestTileStart: Long =
+    Option(earliestTileStartState.value()).map(_.longValue()).getOrElse(Long.MaxValue)
+  override def putEarliestTileStart(ts: Long): Unit = earliestTileStartState.update(ts)
+
+  // --- GigaTileStore batch state ---
+
+  override def getBatchIr: FinalBatchIr = {
+    if (!batchIrValid) {
+      val bytes = batchIrState.value()
+      batchIrDecoded = if (bytes != null) gigaCodec.decodeBatchIr(bytes) else null
+      batchIrValid = true
+    }
+    batchIrDecoded
+  }
+  override def putBatchIr(ir: FinalBatchIr): Unit = {
+    batchIrState.update(gigaCodec.encodeBatchIr(ir))
+    batchIrDecoded = ir; batchIrValid = true
+  }
+
+  override def getBatchEndTs: Long = Option(batchEndTsState.value()).map(_.longValue()).getOrElse(-1L)
+  override def putBatchEndTs(ts: Long): Unit = batchEndTsState.update(ts)
+
+  override def getRunningLargeIr: Array[Any] = {
+    if (!runningLargeValid) {
+      runningLargeDecoded = decodeWindowedIr(runningLargeIrState)
+      runningLargeValid = true
+    }
+    runningLargeDecoded
+  }
+  override def putRunningLargeIr(ir: Array[Any]): Unit = {
+    runningLargeIrState.update(codec.encode(ir))
+    runningLargeDecoded = ir; runningLargeValid = true
+  }
+}

--- a/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
@@ -5,32 +5,32 @@ import ai.chronon.api.{Constants, DataType, GroupBy, TsUtils}
 import ai.chronon.api.ScalaJavaConversions.IteratorOps
 import ai.chronon.flink.SparkExpressionEval
 import ai.chronon.flink.deser.ProjectedEvent
-import ai.chronon.flink.types.TimestampedTile
+import ai.chronon.flink.types.{BatchIrRow, TimestampedTile}
 import ai.chronon.online.{GigaTileCodec, MegaTileCodec}
 import ai.chronon.online.serde.ArrayRow
 import org.apache.flink.api.common.state.{MapState, MapStateDescriptor, ValueState, ValueStateDescriptor}
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.metrics.Counter
-import org.apache.flink.streaming.api.functions.KeyedProcessFunction
+import org.apache.flink.streaming.api.functions.co.KeyedCoProcessFunction
 import org.apache.flink.util.Collector
 import org.slf4j.{Logger, LoggerFactory}
 
-import scala.util.{Failure, Success, Try}
+import scala.util.Try
 
-/** Flink KeyedProcessFunction for the GigaTile pipeline.
+/** Flink CoProcessFunction for the GigaTile pipeline.
+  *
+  * Two inputs:
+  *   - Stream 1 (processElement1): Kafka events (ProjectedEvent)
+  *   - Stream 2 (processElement2): Batch IR rows from Iceberg upload table (BatchIrRow)
   *
   * Delegates all aggregation logic to GigaTileStreamProcessor.
   * Emits finalized feature vectors (not windowed IRs) to the KV store.
-  *
-  * For batch IR loading: call loadBatchIr() externally (e.g., from an Iceberg source
-  * via a connected stream or broadcast). Currently handles events only — batch IR
-  * integration requires upgrading to a CoProcessFunction (follow-up PR).
   */
 class GigaTileProcessFunction(
     groupBy: GroupBy,
     inputSchema: Seq[(String, DataType)],
     enableDebug: Boolean = false
-) extends KeyedProcessFunction[java.util.List[Any], ProjectedEvent, TimestampedTile] {
+) extends KeyedCoProcessFunction[java.util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile] {
 
   @transient lazy val logger: Logger = LoggerFactory.getLogger(getClass)
 
@@ -40,20 +40,19 @@ class GigaTileProcessFunction(
   @transient private var flinkStore: FlinkGigaTileStore = _
 
   @transient private var eventProcessingErrorCounter: Counter = _
+  @transient private var batchUpdateCounter: Counter = _
   @transient private var lastKey: java.util.List[Any] = _
 
   private val valueColumns: Array[String] = inputSchema.map(_._1).toArray
   private val timeColumnAlias: String = Constants.TimeColumn
 
-  // Flink managed state (mega tile state)
+  // Flink managed state
   private var tileState: MapState[String, Array[Byte]] = _
   private var megaTileIrState: ValueState[Array[Byte]] = _
   private var largeTodayIrState: ValueState[Array[Byte]] = _
   private var largeYesterdayIrState: ValueState[Array[Byte]] = _
   private var currentDayStartState: ValueState[java.lang.Long] = _
   private var earliestTileStartState: ValueState[java.lang.Long] = _
-
-  // Giga tile additional state
   private var batchIrState: ValueState[Array[Byte]] = _
   private var batchEndTsState: ValueState[java.lang.Long] = _
   private var runningLargeIrState: ValueState[Array[Byte]] = _
@@ -65,6 +64,7 @@ class GigaTileProcessFunction(
       .addGroup("chronon")
       .addGroup("feature_group", groupBy.getMetaData.getName)
     eventProcessingErrorCounter = metricsGroup.counter("event_processing_error")
+    batchUpdateCounter = metricsGroup.counter("batch_update_count")
 
     tileState = getRuntimeContext.getMapState(
       new MapStateDescriptor[String, Array[Byte]]("giga-tile-tiles", classOf[String], classOf[Array[Byte]]))
@@ -78,7 +78,6 @@ class GigaTileProcessFunction(
       new ValueStateDescriptor[java.lang.Long]("giga-tile-day-start", classOf[java.lang.Long]))
     earliestTileStartState = getRuntimeContext.getState(
       new ValueStateDescriptor[java.lang.Long]("giga-tile-earliest-tile", classOf[java.lang.Long]))
-
     batchIrState =
       getRuntimeContext.getState(new ValueStateDescriptor[Array[Byte]]("giga-tile-batch-ir", classOf[Array[Byte]]))
     batchEndTsState = getRuntimeContext.getState(
@@ -96,7 +95,6 @@ class GigaTileProcessFunction(
     megaTileCodec = new MegaTileCodec(groupBy, inputCols)
     flinkStore = new FlinkGigaTileStore(megaTileAgg, megaTileCodec, gigaTileCodec)
 
-    // Mismatch check: serialize-and-compare-bytes
     val irEqual: (Array[Any], Array[Any]) => Boolean = { (a, b) =>
       java.util.Arrays.equals(gigaTileCodec.encodeWindowedIr(a), gigaTileCodec.encodeWindowedIr(b))
     }
@@ -104,9 +102,21 @@ class GigaTileProcessFunction(
     processor = new GigaTileStreamProcessor(megaTileAgg, flinkStore, irEqual)
   }
 
-  override def processElement(
+  private def ensureStateBound(currentKey: java.util.List[Any]): Unit = {
+    if (lastKey == null || !lastKey.equals(currentKey)) {
+      lastKey = currentKey
+      flinkStore.bindFlinkState(
+        tileState, megaTileIrState, largeTodayIrState, largeYesterdayIrState,
+        currentDayStartState, earliestTileStartState,
+        batchIrState, batchEndTsState, runningLargeIrState
+      )
+    }
+  }
+
+  /** Process a Kafka event (stream 1). */
+  override def processElement1(
       event: ProjectedEvent,
-      ctx: KeyedProcessFunction[java.util.List[Any], ProjectedEvent, TimestampedTile]#Context,
+      ctx: KeyedCoProcessFunction[java.util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#Context,
       out: Collector[TimestampedTile]
   ): Unit = {
     try {
@@ -118,22 +128,7 @@ class GigaTileProcessFunction(
       val values: Array[Any] = valueColumns.map(element(_))
       val row = new ArrayRow(values, tsMills)
 
-      val currentKey = ctx.getCurrentKey
-      if (lastKey == null || !lastKey.equals(currentKey)) {
-        lastKey = currentKey
-        flinkStore.bindFlinkState(
-          tileState,
-          megaTileIrState,
-          largeTodayIrState,
-          largeYesterdayIrState,
-          currentDayStartState,
-          earliestTileStartState,
-          batchIrState,
-          batchEndTsState,
-          runningLargeIrState
-        )
-      }
-
+      ensureStateBound(ctx.getCurrentKey)
       processor.advanceWatermark(ctx.timerService().currentWatermark())
       val result = processor.onEvent(row, tsMills)
 
@@ -145,7 +140,6 @@ class GigaTileProcessFunction(
                               event.startProcessingTimeMillis))
       }
 
-      // Register eviction timer
       val nextEviction = TsUtils.round(tsMills, processor.minEvictionInterval) + processor.minEvictionInterval
       ctx.timerService().registerEventTimeTimer(nextEviction)
     } catch {
@@ -155,30 +149,53 @@ class GigaTileProcessFunction(
     }
   }
 
-  override def onTimer(
-      timestamp: Long,
-      ctx: KeyedProcessFunction[java.util.List[Any], ProjectedEvent, TimestampedTile]#OnTimerContext,
+  /** Process a batch IR row from Iceberg (stream 2). */
+  override def processElement2(
+      batchRow: BatchIrRow,
+      ctx: KeyedCoProcessFunction[java.util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#Context,
       out: Collector[TimestampedTile]
   ): Unit = {
     try {
       if (processor == null) initializeTransients()
 
-      val currentKey = ctx.getCurrentKey
-      if (lastKey == null || !lastKey.equals(currentKey)) {
-        lastKey = currentKey
-        flinkStore.bindFlinkState(
-          tileState,
-          megaTileIrState,
-          largeTodayIrState,
-          largeYesterdayIrState,
-          currentDayStartState,
-          earliestTileStartState,
-          batchIrState,
-          batchEndTsState,
-          runningLargeIrState
-        )
+      ensureStateBound(ctx.getCurrentKey)
+      processor.advanceWatermark(ctx.timerService().currentWatermark())
+
+      val batchIr = gigaTileCodec.decodeBatchIr(batchRow.valueBytes)
+      val result = processor.onBatchUpdate(batchIr, batchRow.batchEndTs,
+        ctx.timerService().currentWatermark())
+
+      batchUpdateCounter.inc()
+
+      if (result.finalizedVector != null) {
+        out.collect(
+          new TimestampedTile(ctx.getCurrentKey,
+                              gigaTileCodec.encodeOutput(result.finalizedVector),
+                              batchRow.batchEndTs,
+                              System.currentTimeMillis()))
       }
 
+      if (result.needsEvictionTimer) {
+        val nextEviction = TsUtils.round(ctx.timerService().currentWatermark(),
+          processor.minEvictionInterval) + processor.minEvictionInterval
+        ctx.timerService().registerEventTimeTimer(nextEviction)
+      }
+    } catch {
+      case e: Exception =>
+        logger.error(s"Error processing batch IR for groupBy=${groupBy.getMetaData.getName}", e)
+        eventProcessingErrorCounter.inc()
+    }
+  }
+
+  override def onTimer(
+      timestamp: Long,
+      ctx: KeyedCoProcessFunction[java.util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#OnTimerContext,
+      out: Collector[TimestampedTile]
+  ): Unit = {
+    try {
+      if (processor == null) initializeTransients()
+
+      ensureStateBound(ctx.getCurrentKey)
       processor.advanceWatermark(ctx.timerService().currentWatermark())
       val result = processor.onEviction(timestamp)
 
@@ -190,7 +207,6 @@ class GigaTileProcessFunction(
                               System.currentTimeMillis()))
       }
 
-      // Re-register eviction timer
       ctx.timerService().registerEventTimeTimer(timestamp + processor.minEvictionInterval)
     } catch {
       case e: Exception =>
@@ -245,7 +261,6 @@ class FlinkGigaTileStore(megaTileAgg: MegaTileAggregator, codec: MegaTileCodec, 
     batchIrState = batchIr
     batchEndTsState = batchEndTs
     runningLargeIrState = runningLarge
-    // Invalidate all caches
     cachedSmallValid = false
     largeTodayValid = false
     largeYesterdayValid = false
@@ -315,8 +330,6 @@ class FlinkGigaTileStore(megaTileAgg: MegaTileAggregator, codec: MegaTileCodec, 
   override def getEarliestTileStart: Long =
     Option(earliestTileStartState.value()).map(_.longValue()).getOrElse(Long.MaxValue)
   override def putEarliestTileStart(ts: Long): Unit = earliestTileStartState.update(ts)
-
-  // --- GigaTileStore batch state ---
 
   override def getBatchIr: FinalBatchIr = {
     if (!batchIrValid) {

--- a/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
@@ -207,7 +207,9 @@ class GigaTileProcessFunction(
                               System.currentTimeMillis()))
       }
 
-      ctx.timerService().registerEventTimeTimer(timestamp + processor.minEvictionInterval)
+      // Don't re-register from onTimer. Each event in processElement1 registers the next
+      // eviction timer. Without new events, there's nothing to correct (sawtooth doesn't
+      // grow). This also prevents an infinite timer loop at end-of-stream when watermark = MAX.
     } catch {
       case e: Exception =>
         logger.error(s"Error in giga tile eviction for groupBy=${groupBy.getMetaData.getName}", e)

--- a/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
@@ -26,6 +26,11 @@ import org.slf4j.{Logger, LoggerFactory}
 
 import scala.util.Try
 
+object GigaTileProcessFunction {
+  val FirstSeenKeyGraceMillisConfig: String = "gigatile_first_seen_key_grace_millis"
+  val DefaultFirstSeenKeyGraceMillis: Long = 0L
+}
+
 /** Flink CoProcessFunction for the GigaTile pipeline.
   *
   * Two inputs:
@@ -39,10 +44,12 @@ class GigaTileProcessFunction(
     groupBy: GroupBy,
     inputSchema: Seq[(String, DataType)],
     enableDebug: Boolean = false,
-    bufferingOutputTimeMillis: Long = 0L
+    bufferingOutputTimeMillis: Long = 0L,
+    firstSeenKeyGraceMillis: Long = GigaTileProcessFunction.DefaultFirstSeenKeyGraceMillis
 ) extends KeyedCoProcessFunction[java.util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile] {
 
   require(bufferingOutputTimeMillis >= 0L, "GigaTile output buffer must be non-negative")
+  require(firstSeenKeyGraceMillis >= 0L, "GigaTile first-seen key grace must be non-negative")
 
   @transient lazy val logger: Logger = LoggerFactory.getLogger(getClass)
 
@@ -55,6 +62,9 @@ class GigaTileProcessFunction(
   @transient private var batchUpdateCounter: Counter = _
   @transient private var futureEventDropCounter: Counter = _
   @transient private var lastKey: java.util.List[Any] = _
+  // Deliberately operator-local and not checkpointed. Recovery starts a fresh delay on its first
+  // keyed callback before an unseen batch row can be treated as empty history.
+  @transient private var emptyBatchBaselineSafeAfterMillis: java.lang.Long = _
 
   private val valueColumns: Array[String] = inputSchema.map(_._1).toArray
   private val timeColumnAlias: String = Constants.TimeColumn
@@ -78,6 +88,9 @@ class GigaTileProcessFunction(
   private var pendingPublicationActivationTimerState: ValueState[java.lang.Long] = _
   private var bufferedWriteLatestTsState: ValueState[java.lang.Long] = _
   private var nextBufferedWriteTimerState: ValueState[java.lang.Long] = _
+  private var pendingEmptyBatchBaselineState: ValueState[java.lang.Boolean] = _
+  private var syntheticEmptyBatchBaselineState: ValueState[java.lang.Boolean] = _
+  private var syntheticRollbackCorrectionState: ValueState[java.lang.Boolean] = _
 
   private val publicationRetryDelayMillis = math.max(1L, 2L * FlinkJob.AutoWatermarkInterval)
   private val activationCooldownDelayMillis =
@@ -132,6 +145,13 @@ class GigaTileProcessFunction(
       new ValueStateDescriptor[java.lang.Long]("giga-tile-buffered-write-latest-ts", classOf[java.lang.Long]))
     nextBufferedWriteTimerState = getRuntimeContext.getState(
       new ValueStateDescriptor[java.lang.Long]("giga-tile-next-emit-pt-timer", classOf[java.lang.Long]))
+    pendingEmptyBatchBaselineState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Boolean]("giga-tile-pending-empty-batch", classOf[java.lang.Boolean]))
+    syntheticEmptyBatchBaselineState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Boolean]("giga-tile-synthetic-empty-batch", classOf[java.lang.Boolean]))
+    syntheticRollbackCorrectionState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Boolean]("giga-tile-synthetic-rollback-correction",
+                                                  classOf[java.lang.Boolean]))
 
     initializeTransients()
   }
@@ -163,7 +183,8 @@ class GigaTileProcessFunction(
         batchEndTsState,
         runningLargeIrState,
         cachedSmallWindowAsOfTsState,
-        lastLargeRecomputeAsOfTsState
+        lastLargeRecomputeAsOfTsState,
+        syntheticEmptyBatchBaselineState
       )
     }
   }
@@ -173,6 +194,65 @@ class GigaTileProcessFunction(
                               eventTimeWatermark,
                               FlinkJob.AllowedOutOfOrderness.toMillis,
                               FlinkJob.LiveWatermarkLagToleranceMillis)
+
+  private def firstSeenKeyGraceEnabled: Boolean = firstSeenKeyGraceMillis > 0L
+
+  private def startEmptyBatchGrace(currentProcessingTime: Long): Unit = {
+    if (!firstSeenKeyGraceEnabled) {
+      // Synthetic availability lives outside the legacy batch-IR descriptor so both a config
+      // rollback and an older binary return to the normal null fence. Keep the legacy pending
+      // publication marker armed so the next callback retracts any synthetic value already
+      // handed to KV.
+      emptyBatchBaselineSafeAfterMillis = null
+      pendingEmptyBatchBaselineState.clear()
+      flinkStore.clearSyntheticBatchIr()
+      syntheticRollbackCorrectionState.clear()
+    } else if (emptyBatchBaselineSafeAfterMillis == null) {
+      // A pre-fallback binary understands pendingPublicationState but not the two synthetic
+      // markers. If it cleared pending state, it already handed off the null-fenced correction;
+      // do not resurrect synthetic availability when rolling forward again. The correction
+      // marker may itself be clear when the rollback checkpoint captured a newer fenced update.
+      if (flinkStore.hasSyntheticBatchIr && !hasRawPendingPublication) {
+        flinkStore.clearSyntheticBatchIr()
+        syntheticRollbackCorrectionState.clear()
+      }
+      emptyBatchBaselineSafeAfterMillis =
+        if (currentProcessingTime > Long.MaxValue - firstSeenKeyGraceMillis) Long.MaxValue
+        else currentProcessingTime + firstSeenKeyGraceMillis
+    }
+  }
+
+  private def hasPendingEmptyBatchBaseline: Boolean =
+    firstSeenKeyGraceEnabled && java.lang.Boolean.TRUE.equals(pendingEmptyBatchBaselineState.value())
+
+  private def markEmptyBatchBaselinePendingIfNeeded(): Unit = {
+    if (firstSeenKeyGraceEnabled && processor.hasBatchBackedColumns && flinkStore.getBatchIr == null) {
+      pendingEmptyBatchBaselineState.update(java.lang.Boolean.TRUE)
+    }
+  }
+
+  private def initializeEmptyBatchBaselineIfReady(
+      currentProcessingTime: Long,
+      largeWindowAsOfMillis: Long
+  ): Option[GigaEmitResult] = {
+    if (!firstSeenKeyGraceEnabled) {
+      pendingEmptyBatchBaselineState.clear()
+      return None
+    }
+
+    val safeAfterMillis = emptyBatchBaselineSafeAfterMillis
+    if (
+      !hasPendingEmptyBatchBaseline || safeAfterMillis == null ||
+      currentProcessingTime < safeAfterMillis.longValue()
+    ) {
+      None
+    } else {
+      val result = processor.initializeEmptyBatchIr(largeWindowAsOfMillis,
+                                                    emptyBatchIr => flinkStore.putSyntheticBatchIr(emptyBatchIr))
+      pendingEmptyBatchBaselineState.clear()
+      if (result.finalizedVector != null) Some(result) else None
+    }
+  }
 
   private def bufferingEnabled: Boolean = bufferingOutputTimeMillis > 0L
 
@@ -191,7 +271,7 @@ class GigaTileProcessFunction(
     ) {
       // An older binary can consume a cadence timer without understanding these keyed
       // markers. Recreate logical/physical ownership on the first later callback.
-      pendingPublicationState.update(java.lang.Boolean.TRUE)
+      markPublicationPending()
       nextBufferedWriteTimestamp(lastKey, currentProcessingTime) match {
         case Some(nextEmit) =>
           // Register the replacement before moving the keyed marker. If registration
@@ -252,8 +332,32 @@ class GigaTileProcessFunction(
   private def isFutureEvent(eventTime: Long, currentProcessingTime: Long): Boolean =
     eventTime > currentProcessingTime
 
+  private def hasRawPendingPublication: Boolean =
+    java.lang.Boolean.TRUE.equals(pendingPublicationState.value())
+
+  private def hasSyntheticRollbackCorrection: Boolean =
+    java.lang.Boolean.TRUE.equals(syntheticRollbackCorrectionState.value())
+
   private def hasPendingPublication: Boolean =
-    java.lang.Boolean.TRUE.equals(pendingPublicationState.value()) && pendingVersionCollisionState.value() == null
+    hasRawPendingPublication && !hasSyntheticRollbackCorrection && pendingVersionCollisionState.value() == null
+
+  private def markPublicationPending(): Unit = {
+    syntheticRollbackCorrectionState.clear()
+    pendingPublicationState.update(java.lang.Boolean.TRUE)
+  }
+
+  private def completePublicationHandoff(): Unit = {
+    if (flinkStore.hasSyntheticBatchIr) {
+      // A marker-blind binary still understands pendingPublicationState. Keeping that legacy
+      // marker armed lets its next eligible callback hand off the null-fenced rollback value.
+      // Rollback must remain serving-fenced until that correction is verified.
+      pendingPublicationState.update(java.lang.Boolean.TRUE)
+      syntheticRollbackCorrectionState.update(java.lang.Boolean.TRUE)
+    } else {
+      pendingPublicationState.clear()
+      syntheticRollbackCorrectionState.clear()
+    }
+  }
 
   private def hasDeferredPublication: Boolean =
     hasPendingPublication &&
@@ -462,7 +566,7 @@ class GigaTileProcessFunction(
     if (!shouldPublish(mode, horizons, currentProcessingTime)) {
       val publicationPending = result.finalizedVector != null || result.needsEvictionTimer || hasPendingPublication
       if (publicationPending) {
-        pendingPublicationState.update(java.lang.Boolean.TRUE)
+        markPublicationPending()
         if (scheduleWatermarkRetry) schedulePublicationRetryIfNeeded(timerService, currentProcessingTime)
       }
       return
@@ -477,13 +581,13 @@ class GigaTileProcessFunction(
       // This tracks ownership through cadence buffering, encoding, and Collector handoff. The
       // downstream async KV result is outside this keyed operator and cannot acknowledge or
       // retry through this state.
-      pendingPublicationState.update(java.lang.Boolean.TRUE)
+      markPublicationPending()
       try {
         emitOrBuffer(finalizedVector, currentKey, currentProcessingTime, startProcessingTime, timerService, out)
         // A buffered value has not reached the collector yet. Keep the legacy pending
         // marker until cadence/collision publication succeeds so an older binary restored
         // from this checkpoint can rebuild it on the normal eviction timer.
-        if (!hasBufferedWrite && pendingVersionCollisionState.value() == null) pendingPublicationState.clear()
+        if (!hasBufferedWrite && pendingVersionCollisionState.value() == null) completePublicationHandoff()
         // Cadence or collision state owns any deferred write from here.
         clearPublicationWakeupMarkers()
       } catch {
@@ -683,7 +787,7 @@ class GigaTileProcessFunction(
       // cannot schedule and publish the same value again.
       bufferedWriteLatestTsState.clear()
       nextBufferedWriteTimerState.clear()
-      pendingPublicationState.clear()
+      completePublicationHandoff()
       clearPublicationWakeupMarkers()
     } catch {
       case e: Exception =>
@@ -698,7 +802,7 @@ class GigaTileProcessFunction(
   private def parkBufferedWrite(): Unit = {
     nextBufferedWriteTimerState.clear()
     if (hasBufferedWrite) {
-      pendingPublicationState.update(java.lang.Boolean.TRUE)
+      markPublicationPending()
     }
   }
 
@@ -712,7 +816,7 @@ class GigaTileProcessFunction(
     nextBufferedWriteTimerState.clear()
     if (bufferedVersion == null) return
 
-    pendingPublicationState.update(java.lang.Boolean.TRUE)
+    markPublicationPending()
     try {
       emitOrCoalesceVersionCollision(timerService,
                                      processor.packAndFinalize(),
@@ -721,7 +825,7 @@ class GigaTileProcessFunction(
                                      System.currentTimeMillis(),
                                      out)
       bufferedWriteLatestTsState.clear()
-      if (pendingVersionCollisionState.value() == null) pendingPublicationState.clear()
+      if (pendingVersionCollisionState.value() == null) completePublicationHandoff()
       clearPublicationWakeupMarkers()
     } catch {
       case e: Exception =>
@@ -751,6 +855,7 @@ class GigaTileProcessFunction(
       ensureStateBound(ctx.getCurrentKey)
       val timerService = ctx.timerService()
       val currentProcessingTime = timerService.currentProcessingTime()
+      startEmptyBatchGrace(currentProcessingTime)
       repairExpiredProcessingTimerMarkers(timerService, currentProcessingTime, None)
       repairStaleBufferedWriteTimerIfNeeded(timerService, currentProcessingTime, None)
       if (isFutureEvent(tsMills, currentProcessingTime)) {
@@ -758,6 +863,7 @@ class GigaTileProcessFunction(
         return
       }
       clearExpiredPublicationRetryMarker(currentProcessingTime, None)
+      markEmptyBatchBaselinePendingIfNeeded()
       val eventTimeWatermark = timerService.currentWatermark()
       val mode = currentClockMode(currentProcessingTime, eventTimeWatermark)
       val horizons = ChrononClockMode.streamEventHorizons(mode,
@@ -774,7 +880,13 @@ class GigaTileProcessFunction(
                                           tsMills,
                                           largeWindowAsOfTs = horizons.largeWindowAsOfMillis,
                                           smallWindowAsOfTs = horizons.smallWindowAsOfMillis)
-      val result = preferLatestResult(eventResult, pendingRebuild.getOrElse(rolloverResult))
+      val callbackResult = preferLatestResult(eventResult, pendingRebuild.getOrElse(rolloverResult))
+      val result =
+        if (mode == NoWatermark) callbackResult
+        else
+          initializeEmptyBatchBaselineIfReady(currentProcessingTime, horizons.largeWindowAsOfMillis)
+            .map(preferLatestResult(_, callbackResult))
+            .getOrElse(callbackResult)
 
       scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
       emitOrDefer(mode,
@@ -806,6 +918,7 @@ class GigaTileProcessFunction(
       ensureStateBound(ctx.getCurrentKey)
       val timerService = ctx.timerService()
       val currentProcessingTime = timerService.currentProcessingTime()
+      startEmptyBatchGrace(currentProcessingTime)
       repairExpiredProcessingTimerMarkers(timerService, currentProcessingTime, None)
       repairStaleBufferedWriteTimerIfNeeded(timerService, currentProcessingTime, None)
       clearExpiredPublicationRetryMarker(currentProcessingTime, None)
@@ -825,6 +938,10 @@ class GigaTileProcessFunction(
                                                 batchRow.batchEndTs,
                                                 largeWindowAsOfTs = horizons.largeWindowAsOfMillis,
                                                 smallWindowAsOfTs = horizons.smallWindowAsOfMillis)
+      // A real row supersedes the synthetic rollback assertion. If that assertion kept the
+      // legacy pending marker armed, let this callback publish and clear it normally.
+      syntheticRollbackCorrectionState.clear()
+      pendingEmptyBatchBaselineState.clear()
       val result = preferLatestResult(batchResult, pendingRebuild.getOrElse(rolloverResult))
 
       batchUpdateCounter.inc()
@@ -846,6 +963,7 @@ class GigaTileProcessFunction(
       case e: Exception =>
         logger.error(s"Error processing batch IR for groupBy=${groupBy.getMetaData.getName}", e)
         eventProcessingErrorCounter.inc()
+        if (firstSeenKeyGraceEnabled) throw e
     }
   }
 
@@ -871,6 +989,7 @@ class GigaTileProcessFunction(
       val currentTimerCallback = Some(ctx.timeDomain() -> timestamp)
       timerServiceOnFailure = timerService
       processingTimeOnFailure = currentProcessingTime
+      startEmptyBatchGrace(currentProcessingTime)
       repairExpiredProcessingTimerMarkers(timerService, currentProcessingTime, currentTimerCallback)
 
       // Checkpoints written by the former event-time implementation may still contain
@@ -880,6 +999,7 @@ class GigaTileProcessFunction(
         val isPublicationActivationTimer = isCurrentPublicationActivationTimer(timestamp)
         publicationActivationTimerFired = isPublicationActivationTimer
         if (isPublicationActivationTimer) pendingPublicationActivationTimerState.clear()
+        markEmptyBatchBaselinePendingIfNeeded()
         scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
         if (isPublicationActivationTimer) {
           if (hasDeferredPublication) {
@@ -895,7 +1015,10 @@ class GigaTileProcessFunction(
                 val rolloverResult = advanceDayForMode(Live, currentProcessingTime, eventTimeWatermark)
                 val retryResult = rebuildPendingAtCurrentTime(Live, horizons, currentProcessingTime)
                   .getOrElse(GigaEmitResult(null))
-                val result = preferLatestResult(retryResult, rolloverResult)
+                val callbackResult = preferLatestResult(retryResult, rolloverResult)
+                val result = initializeEmptyBatchBaselineIfReady(currentProcessingTime, horizons.largeWindowAsOfMillis)
+                  .map(preferLatestResult(_, callbackResult))
+                  .getOrElse(callbackResult)
                 emitOrDefer(Live,
                             horizons,
                             result,
@@ -949,6 +1072,8 @@ class GigaTileProcessFunction(
         !expiredPublicationRetryMarkerCleared
       ) return
 
+      markEmptyBatchBaselinePendingIfNeeded()
+
       // The physical retry timer has fired. Clear only its logical role before running all
       // coincident roles, then arm one watermark-driven wake-up if publication remains fenced.
       if (isPublicationRetryTimer) clearPublicationRetryMarker()
@@ -968,7 +1093,7 @@ class GigaTileProcessFunction(
             // The active batch input holds the connected watermark at MIN while it scans.
             // Keep consuming records, but do not age or roll keyed state from wall clock.
             val snapshot = processor.currentSnapshot
-            if (!snapshot.isEmpty) pendingPublicationState.update(java.lang.Boolean.TRUE)
+            if (!snapshot.isEmpty) markPublicationPending()
             GigaEmitResult(null, needsEvictionTimer = snapshot.needsEvictionTimer, isEmpty = snapshot.isEmpty)
           case _ =>
             val horizons = timerHorizons.get
@@ -978,13 +1103,19 @@ class GigaTileProcessFunction(
             val evictionResult = pendingRebuild.getOrElse(
               processor.onEviction(EvictionTimes(timerTs = horizons.largeWindowAsOfMillis,
                                                  smallWindowAsOfTs = horizons.smallWindowAsOfMillis)))
-            preferLatestResult(evictionResult, rolloverResult)
+            val callbackResult = preferLatestResult(evictionResult, rolloverResult)
+            initializeEmptyBatchBaselineIfReady(currentProcessingTime, horizons.largeWindowAsOfMillis)
+              .map(preferLatestResult(_, callbackResult))
+              .getOrElse(callbackResult)
         }
         timerResult = Some(result)
 
         // Keep normal decay live while state or a deferred publication remains. A coincident
         // collision flush rearms itself on failure, so it does not need a speculative timer.
-        if (!result.isEmpty || result.needsEvictionTimer || hasPendingPublication || hasBufferedWrite) {
+        if (
+          !result.isEmpty || result.needsEvictionTimer || hasPendingPublication || hasBufferedWrite ||
+          hasPendingEmptyBatchBaseline
+        ) {
           scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
         }
       }
@@ -1011,7 +1142,7 @@ class GigaTileProcessFunction(
         }
       }
 
-      if (hasPendingPublication) {
+      if (hasPendingPublication || hasPendingEmptyBatchBaseline) {
         scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
       }
 
@@ -1049,10 +1180,10 @@ class GigaTileProcessFunction(
           case Some(horizons) if shouldPublish(mode, horizons, currentProcessingTime) =>
             // Eviction runs first when both markers share a timestamp, so this is one
             // post-eviction snapshot with a strictly newer version.
-            pendingPublicationState.update(java.lang.Boolean.TRUE)
+            markPublicationPending()
             flushVersionCollision(timerService, currentProcessingTime, currentTimerCallback, ctx.getCurrentKey, out)
           case _ =>
-            pendingPublicationState.update(java.lang.Boolean.TRUE)
+            markPublicationPending()
             scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
             postponeVersionCollision(timerService, currentProcessingTime, currentTimerCallback)
         }
@@ -1167,6 +1298,7 @@ class FlinkGigaTileStore(megaTileAgg: MegaTileAggregator, codec: MegaTileCodec, 
   private var runningLargeIrState: ValueState[Array[Byte]] = _
   private var cachedSmallWindowAsOfTsState: ValueState[java.lang.Long] = _
   private var lastLargeRecomputeAsOfTsState: ValueState[java.lang.Long] = _
+  private var syntheticEmptyBatchBaselineState: ValueState[java.lang.Boolean] = _
 
   // Decode cache invalidated on key switch. Keeping per-day decoded values in an off-heap
   // mutable map would defeat the idea of per-key Flink state, so we just memoize the values
@@ -1187,7 +1319,8 @@ class FlinkGigaTileStore(megaTileAgg: MegaTileAggregator, codec: MegaTileCodec, 
                      batchEndTs: ValueState[java.lang.Long],
                      runningLarge: ValueState[Array[Byte]],
                      cachedSmallWindowAsOfTs: ValueState[java.lang.Long],
-                     lastLargeRecomputeAsOfTs: ValueState[java.lang.Long]): Unit = {
+                     lastLargeRecomputeAsOfTs: ValueState[java.lang.Long],
+                     syntheticEmptyBatchBaseline: ValueState[java.lang.Boolean]): Unit = {
     tileState = tiles
     megaTileIrState = megaTileIr
     dailyLargeIrState = dailyLargeIr
@@ -1198,6 +1331,7 @@ class FlinkGigaTileStore(megaTileAgg: MegaTileAggregator, codec: MegaTileCodec, 
     runningLargeIrState = runningLarge
     cachedSmallWindowAsOfTsState = cachedSmallWindowAsOfTs
     lastLargeRecomputeAsOfTsState = lastLargeRecomputeAsOfTs
+    syntheticEmptyBatchBaselineState = syntheticEmptyBatchBaseline
     cachedSmallValid = false
     batchIrValid = false
     runningLargeValid = false
@@ -1286,15 +1420,35 @@ class FlinkGigaTileStore(megaTileAgg: MegaTileAggregator, codec: MegaTileCodec, 
   override def getBatchIr: FinalBatchIr = {
     if (!batchIrValid) {
       val bytes = batchIrState.value()
-      batchIrDecoded = if (bytes != null) gigaCodec.decodeBatchIr(bytes) else null
+      batchIrDecoded =
+        if (bytes != null) gigaCodec.decodeBatchIr(bytes)
+        else if (java.lang.Boolean.TRUE.equals(syntheticEmptyBatchBaselineState.value()))
+          megaTileAgg.finalizeSnapshot(megaTileAgg.init)
+        else null
       batchIrValid = true
     }
     batchIrDecoded
   }
   override def putBatchIr(ir: FinalBatchIr): Unit = {
     batchIrState.update(gigaCodec.encodeBatchIr(ir))
+    syntheticEmptyBatchBaselineState.clear()
     batchIrDecoded = ir; batchIrValid = true
   }
+
+  def putSyntheticBatchIr(ir: FinalBatchIr): Unit = {
+    syntheticEmptyBatchBaselineState.update(java.lang.Boolean.TRUE)
+    batchIrDecoded = ir; batchIrValid = true
+  }
+
+  def clearSyntheticBatchIr(): Unit = {
+    if (java.lang.Boolean.TRUE.equals(syntheticEmptyBatchBaselineState.value())) {
+      syntheticEmptyBatchBaselineState.clear()
+      batchIrDecoded = null; batchIrValid = false
+    }
+  }
+
+  def hasSyntheticBatchIr: Boolean =
+    java.lang.Boolean.TRUE.equals(syntheticEmptyBatchBaselineState.value())
 
   override def getBatchEndTs: Long = Option(batchEndTsState.value()).map(_.longValue()).getOrElse(-1L)
   override def putBatchEndTs(ts: Long): Unit = batchEndTsState.update(ts)

--- a/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
@@ -207,18 +207,29 @@ class GigaTileProcessFunction(
       pendingEmptyBatchBaselineState.clear()
       flinkStore.clearSyntheticBatchIr()
       syntheticRollbackCorrectionState.clear()
-    } else if (emptyBatchBaselineSafeAfterMillis == null) {
+    } else {
       // A pre-fallback binary understands pendingPublicationState but not the two synthetic
       // markers. If it cleared pending state, it already handed off the null-fenced correction;
       // do not resurrect synthetic availability when rolling forward again. The correction
       // marker may itself be clear when the rollback checkpoint captured a newer fenced update.
+      //
+      // This reconciliation reads only per-key state, so it must run for every key on the
+      // subtask, not just the first callback that seeds the operator-wide grace clock below.
+      // While synthetic availability is present, this binary keeps the pending marker armed
+      // (completePublicationHandoff), so `hasSyntheticBatchIr && !hasRawPendingPublication` is
+      // reachable only via an external marker-blind binary — making it safe to check every call.
       if (flinkStore.hasSyntheticBatchIr && !hasRawPendingPublication) {
         flinkStore.clearSyntheticBatchIr()
         syntheticRollbackCorrectionState.clear()
       }
-      emptyBatchBaselineSafeAfterMillis =
-        if (currentProcessingTime > Long.MaxValue - firstSeenKeyGraceMillis) Long.MaxValue
-        else currentProcessingTime + firstSeenKeyGraceMillis
+      // The grace clock is deliberately operator-local (see field docs) and seeded once per
+      // restore, so a fresh delay covers every key before an unseen batch row is treated as
+      // empty history.
+      if (emptyBatchBaselineSafeAfterMillis == null) {
+        emptyBatchBaselineSafeAfterMillis =
+          if (currentProcessingTime > Long.MaxValue - firstSeenKeyGraceMillis) Long.MaxValue
+          else currentProcessingTime + firstSeenKeyGraceMillis
+      }
     }
   }
 

--- a/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
@@ -38,8 +38,11 @@ import scala.util.Try
 class GigaTileProcessFunction(
     groupBy: GroupBy,
     inputSchema: Seq[(String, DataType)],
-    enableDebug: Boolean = false
+    enableDebug: Boolean = false,
+    bufferingOutputTimeMillis: Long = 0L
 ) extends KeyedCoProcessFunction[java.util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile] {
+
+  require(bufferingOutputTimeMillis >= 0L, "GigaTile output buffer must be non-negative")
 
   @transient lazy val logger: Logger = LoggerFactory.getLogger(getClass)
 
@@ -73,6 +76,8 @@ class GigaTileProcessFunction(
   private var pendingPublicationState: ValueState[java.lang.Boolean] = _
   private var pendingPublicationRetryTimerState: ValueState[java.lang.Long] = _
   private var pendingPublicationActivationTimerState: ValueState[java.lang.Long] = _
+  private var bufferedWriteLatestTsState: ValueState[java.lang.Long] = _
+  private var nextBufferedWriteTimerState: ValueState[java.lang.Long] = _
 
   private val publicationRetryDelayMillis = math.max(1L, 2L * FlinkJob.AutoWatermarkInterval)
   private val activationCooldownDelayMillis =
@@ -123,6 +128,10 @@ class GigaTileProcessFunction(
     pendingPublicationActivationTimerState = getRuntimeContext.getState(
       new ValueStateDescriptor[java.lang.Long]("giga-tile-pending-publication-activation-et-timer",
                                                classOf[java.lang.Long]))
+    bufferedWriteLatestTsState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Long]("giga-tile-buffered-write-latest-ts", classOf[java.lang.Long]))
+    nextBufferedWriteTimerState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Long]("giga-tile-next-emit-pt-timer", classOf[java.lang.Long]))
 
     initializeTransients()
   }
@@ -165,11 +174,90 @@ class GigaTileProcessFunction(
                               FlinkJob.AllowedOutOfOrderness.toMillis,
                               FlinkJob.LiveWatermarkLagToleranceMillis)
 
+  private def bufferingEnabled: Boolean = bufferingOutputTimeMillis > 0L
+
+  private def hasBufferedWrite: Boolean = bufferedWriteLatestTsState.value() != null
+
+  private def repairStaleBufferedWriteTimerIfNeeded(
+      timerService: TimerService,
+      currentProcessingTime: Long,
+      currentTimerCallback: Option[(TimeDomain, Long)]
+  ): Unit = {
+    val bufferedVersion = bufferedWriteLatestTsState.value()
+    val bufferedTimer = nextBufferedWriteTimerState.value()
+    if (
+      bufferedVersion != null && bufferedTimer != null &&
+      processingTimerMarkerIsExpired(bufferedTimer.longValue(), currentProcessingTime, currentTimerCallback)
+    ) {
+      // An older binary can consume a cadence timer without understanding these keyed
+      // markers. Recreate logical/physical ownership on the first later callback.
+      pendingPublicationState.update(java.lang.Boolean.TRUE)
+      nextBufferedWriteTimestamp(lastKey, currentProcessingTime) match {
+        case Some(nextEmit) =>
+          // Register the replacement before moving the keyed marker. If registration
+          // fails, the restored stale marker remains visible for a later repair attempt.
+          timerService.registerProcessingTimeTimer(nextEmit)
+          nextBufferedWriteTimerState.update(nextEmit)
+        case None =>
+          nextBufferedWriteTimerState.clear()
+      }
+    }
+  }
+
+  private def stableBufferedWritePhaseMillis(key: java.util.List[Any]): Long =
+    Math.floorMod((groupBy.getMetaData.getName :: key.iterator().toScala.toList).hashCode().toLong,
+                  bufferingOutputTimeMillis)
+
+  private def nextBufferedWriteTimestamp(
+      key: java.util.List[Any],
+      currentProcessingTime: Long
+  ): Option[Long] = {
+    if (!bufferingEnabled) return None
+
+    val phase = stableBufferedWritePhaseMillis(key)
+    val currentPhase = Math.floorMod(currentProcessingTime, bufferingOutputTimeMillis)
+    val elapsedSincePhase = Math.floorMod(currentPhase - phase, bufferingOutputTimeMillis)
+    val delay =
+      if (elapsedSincePhase == 0L) bufferingOutputTimeMillis
+      else bufferingOutputTimeMillis - elapsedSincePhase
+    if (currentProcessingTime <= Long.MaxValue - delay) Some(currentProcessingTime + delay) else None
+  }
+
+  private def scheduleBufferedWriteTimerIfNeeded(
+      timerService: TimerService,
+      currentProcessingTime: Long
+  ): Unit = {
+    if (bufferingEnabled && nextBufferedWriteTimerState.value() == null) {
+      nextBufferedWriteTimestamp(lastKey, currentProcessingTime).foreach { nextEmit =>
+        timerService.registerProcessingTimeTimer(nextEmit)
+        nextBufferedWriteTimerState.update(nextEmit)
+      }
+    }
+  }
+
+  private def isCurrentBufferedWriteTimer(timestamp: Long): Boolean =
+    Option(nextBufferedWriteTimerState.value()).exists(_.longValue() == timestamp)
+
+  private def bufferLatestWrite(
+      timerService: TimerService,
+      versionMillis: Long
+  ): Unit = {
+    val previousVersion = bufferedWriteLatestTsState.value()
+    if (previousVersion == null || versionMillis > previousVersion.longValue()) {
+      bufferedWriteLatestTsState.update(versionMillis)
+    }
+    scheduleBufferedWriteTimerIfNeeded(timerService, versionMillis)
+  }
+
   private def isFutureEvent(eventTime: Long, currentProcessingTime: Long): Boolean =
     eventTime > currentProcessingTime
 
   private def hasPendingPublication: Boolean =
     java.lang.Boolean.TRUE.equals(pendingPublicationState.value()) && pendingVersionCollisionState.value() == null
+
+  private def hasDeferredPublication: Boolean =
+    hasPendingPublication &&
+      (!hasBufferedWrite || nextBufferedWriteTimerState.value() == null)
 
   private def schedulePublicationRetryIfNeeded(
       timerService: TimerService,
@@ -182,7 +270,7 @@ class GigaTileProcessFunction(
       currentProcessingTime: Long,
       delayMillis: Long
   ): Unit = {
-    if (!hasPublicationWakeupTimer && currentProcessingTime <= Long.MaxValue - delayMillis) {
+    if (hasDeferredPublication && !hasPublicationWakeupTimer && currentProcessingTime <= Long.MaxValue - delayMillis) {
       val retryTimestamp = currentProcessingTime + delayMillis
       timerService.registerProcessingTimeTimer(retryTimestamp)
       pendingPublicationRetryTimerState.update(retryTimestamp)
@@ -194,7 +282,7 @@ class GigaTileProcessFunction(
       currentProcessingTime: Long,
       retryTimestamp: Long
   ): Unit = {
-    if (!hasPublicationWakeupTimer && retryTimestamp > currentProcessingTime) {
+    if (hasDeferredPublication && !hasPublicationWakeupTimer && retryTimestamp > currentProcessingTime) {
       timerService.registerProcessingTimeTimer(retryTimestamp)
       pendingPublicationRetryTimerState.update(retryTimestamp)
     }
@@ -223,7 +311,7 @@ class GigaTileProcessFunction(
       currentProcessingTime: Long,
       eventTimeWatermark: Long
   ): Unit = {
-    if (!hasPublicationWakeupTimer) {
+    if (hasDeferredPublication && !hasPublicationWakeupTimer) {
       nextPublicationActivationWatermark(currentProcessingTime)
         .filter(_ > eventTimeWatermark)
         .foreach { activationWatermark =>
@@ -314,13 +402,51 @@ class GigaTileProcessFunction(
       horizons: Horizons,
       currentProcessingTime: Long
   ): Option[GigaEmitResult] =
-    if (hasPendingPublication && shouldPublish(mode, horizons, currentProcessingTime)) {
+    if (hasDeferredPublication && shouldPublish(mode, horizons, currentProcessingTime)) {
       Some(
         processor.onEviction(
           EvictionTimes(timerTs = horizons.largeWindowAsOfMillis, smallWindowAsOfTs = horizons.smallWindowAsOfMillis)))
     } else {
       None
     }
+
+  private def emitOrBuffer(
+      finalizedVector: Array[Any],
+      currentKey: java.util.List[Any],
+      currentProcessingTime: Long,
+      startProcessingTime: Long,
+      timerService: TimerService,
+      out: Collector[TimestampedTile]
+  ): Unit = {
+    if (!bufferingEnabled) {
+      // A checkpoint may have been written with buffering enabled. The first immediate
+      // callback supersedes that buffered snapshot; leave its physical timer in Flink and
+      // clear only the logical markers so the restored callback becomes a no-op.
+      bufferedWriteLatestTsState.clear()
+      nextBufferedWriteTimerState.clear()
+      emitOrCoalesceVersionCollision(timerService,
+                                     finalizedVector,
+                                     currentKey,
+                                     currentProcessingTime,
+                                     startProcessingTime,
+                                     out)
+      return
+    }
+
+    bufferLatestWrite(timerService, currentProcessingTime)
+    // Only the timestamp is buffered; the value is rebuilt from keyed state at the cadence
+    // boundary. If no later timestamp can be represented, fall back to the normal path so a
+    // value is not stranded at the end of the processing-time range.
+    if (nextBufferedWriteTimerState.value() == null) {
+      emitOrCoalesceVersionCollision(timerService,
+                                     finalizedVector,
+                                     currentKey,
+                                     currentProcessingTime,
+                                     startProcessingTime,
+                                     out)
+      bufferedWriteLatestTsState.clear()
+    }
+  }
 
   private def emitOrDefer(
       mode: Mode,
@@ -344,21 +470,21 @@ class GigaTileProcessFunction(
 
     val finalizedVector =
       if (result.finalizedVector != null) result.finalizedVector
-      else if (hasPendingPublication) processor.currentSnapshot.finalizedVector
+      else if (hasDeferredPublication) processor.currentSnapshot.finalizedVector
       else null
 
     if (finalizedVector != null) {
-      // This covers encoding and Collector handoff only. The downstream async KV result is
-      // outside this keyed operator and cannot acknowledge or retry through this state.
+      // This tracks ownership through cadence buffering, encoding, and Collector handoff. The
+      // downstream async KV result is outside this keyed operator and cannot acknowledge or
+      // retry through this state.
       pendingPublicationState.update(java.lang.Boolean.TRUE)
       try {
-        emitOrCoalesceVersionCollision(timerService,
-                                       finalizedVector,
-                                       currentKey,
-                                       currentProcessingTime,
-                                       startProcessingTime,
-                                       out)
-        if (pendingVersionCollisionState.value() == null) pendingPublicationState.clear()
+        emitOrBuffer(finalizedVector, currentKey, currentProcessingTime, startProcessingTime, timerService, out)
+        // A buffered value has not reached the collector yet. Keep the legacy pending
+        // marker until cadence/collision publication succeeds so an older binary restored
+        // from this checkpoint can rebuild it on the normal eviction timer.
+        if (!hasBufferedWrite && pendingVersionCollisionState.value() == null) pendingPublicationState.clear()
+        // Cadence or collision state owns any deferred write from here.
         clearPublicationWakeupMarkers()
       } catch {
         case e: Exception =>
@@ -545,9 +671,18 @@ class GigaTileProcessFunction(
 
       val snapshot = processor.currentSnapshot
       val encoded = gigaTileCodec.encodeOutput(snapshot.finalizedVector)
-      out.collect(new TimestampedTile(currentKey, encoded, pendingVersion.longValue(), System.currentTimeMillis()))
-      lastEmittedVersionState.update(pendingVersion)
+      val bufferedVersion = bufferedWriteLatestTsState.value()
+      val outputVersion =
+        if (bufferedVersion != null && bufferedVersion.longValue() > pendingVersion.longValue()) bufferedVersion
+        else pendingVersion
+      out.collect(new TimestampedTile(currentKey, encoded, outputVersion.longValue(), System.currentTimeMillis()))
+      lastEmittedVersionState.update(outputVersion)
       pendingVersionCollisionState.clear()
+      // The collision snapshot includes every mutation represented by the buffered
+      // cadence state. Relinquish that logical timer ownership so its physical callback
+      // cannot schedule and publish the same value again.
+      bufferedWriteLatestTsState.clear()
+      nextBufferedWriteTimerState.clear()
       pendingPublicationState.clear()
       clearPublicationWakeupMarkers()
     } catch {
@@ -556,6 +691,44 @@ class GigaTileProcessFunction(
         // the failure so a transient encoding/collection error cannot strand the latest value.
         scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
         postponeVersionCollision(timerService, currentProcessingTime, currentTimerCallback)
+        throw e
+    }
+  }
+
+  private def parkBufferedWrite(): Unit = {
+    nextBufferedWriteTimerState.clear()
+    if (hasBufferedWrite) {
+      pendingPublicationState.update(java.lang.Boolean.TRUE)
+    }
+  }
+
+  private def flushBufferedWrite(
+      timerService: TimerService,
+      currentProcessingTime: Long,
+      currentKey: java.util.List[Any],
+      out: Collector[TimestampedTile]
+  ): Unit = {
+    val bufferedVersion = bufferedWriteLatestTsState.value()
+    nextBufferedWriteTimerState.clear()
+    if (bufferedVersion == null) return
+
+    pendingPublicationState.update(java.lang.Boolean.TRUE)
+    try {
+      emitOrCoalesceVersionCollision(timerService,
+                                     processor.packAndFinalize(),
+                                     currentKey,
+                                     bufferedVersion.longValue(),
+                                     System.currentTimeMillis(),
+                                     out)
+      bufferedWriteLatestTsState.clear()
+      if (pendingVersionCollisionState.value() == null) pendingPublicationState.clear()
+      clearPublicationWakeupMarkers()
+    } catch {
+      case e: Exception =>
+        // The fired cadence timer was the only write trigger. Re-arm it before the outer
+        // handler records the failure so a transient encoding/collection error cannot strand
+        // the latest keyed value.
+        scheduleBufferedWriteTimerIfNeeded(timerService, currentProcessingTime)
         throw e
     }
   }
@@ -579,6 +752,7 @@ class GigaTileProcessFunction(
       val timerService = ctx.timerService()
       val currentProcessingTime = timerService.currentProcessingTime()
       repairExpiredProcessingTimerMarkers(timerService, currentProcessingTime, None)
+      repairStaleBufferedWriteTimerIfNeeded(timerService, currentProcessingTime, None)
       if (isFutureEvent(tsMills, currentProcessingTime)) {
         futureEventDropCounter.inc()
         return
@@ -633,6 +807,7 @@ class GigaTileProcessFunction(
       val timerService = ctx.timerService()
       val currentProcessingTime = timerService.currentProcessingTime()
       repairExpiredProcessingTimerMarkers(timerService, currentProcessingTime, None)
+      repairStaleBufferedWriteTimerIfNeeded(timerService, currentProcessingTime, None)
       clearExpiredPublicationRetryMarker(currentProcessingTime, None)
       val eventTimeWatermark = timerService.currentWatermark()
       val mode = currentClockMode(currentProcessingTime, eventTimeWatermark)
@@ -682,6 +857,7 @@ class GigaTileProcessFunction(
     var timerServiceOnFailure: TimerService = null
     var processingTimeOnFailure = Long.MinValue
     var evictionTimerFired = false
+    var bufferedWriteTimerFired = false
     var versionCollisionTimerFired = false
     var publicationRetryTimerFired = false
     var publicationActivationTimerFired = false
@@ -706,7 +882,7 @@ class GigaTileProcessFunction(
         if (isPublicationActivationTimer) pendingPublicationActivationTimerState.clear()
         scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
         if (isPublicationActivationTimer) {
-          if (hasPendingPublication) {
+          if (hasDeferredPublication) {
             val eventTimeWatermark = timerService.currentWatermark()
             currentClockMode(currentProcessingTime, eventTimeWatermark) match {
               case Live =>
@@ -747,18 +923,29 @@ class GigaTileProcessFunction(
         return
       }
 
-      val isEvictionTimer = isCurrentProcessingEvictionTimer(timestamp)
+      // One physical Flink timer can represent several logical triggers. Snapshot every role
+      // before clearing any marker, then mutate state before publication work.
+      val isTrackedEvictionTimer = isCurrentProcessingEvictionTimer(timestamp)
+      val isBufferedWriteTimer = isCurrentBufferedWriteTimer(timestamp)
+      bufferedWriteTimerFired = isBufferedWriteTimer
       val isVersionCollisionTimer = isCurrentVersionCollisionTimer(timestamp)
-      val isPublicationRetryTimer = isCurrentPublicationRetryTimer(timestamp)
-      evictionTimerFired = isEvictionTimer
       versionCollisionTimerFired = isVersionCollisionTimer
+      val isPublicationRetryTimer = isCurrentPublicationRetryTimer(timestamp)
       publicationRetryTimerFired = isPublicationRetryTimer
+      val isLegacyEvictionTimer =
+        !isTrackedEvictionTimer && !isBufferedWriteTimer && !isVersionCollisionTimer && !isPublicationRetryTimer &&
+          isUnmarkedLegacyEvictionTimer(timestamp)
+      val isEvictionTimer = isTrackedEvictionTimer || isLegacyEvictionTimer
+      evictionTimerFired = isEvictionTimer
+
+      repairStaleBufferedWriteTimerIfNeeded(timerService, currentProcessingTime, currentTimerCallback)
       if (!isPublicationRetryTimer) {
         expiredPublicationRetryMarkerCleared =
           clearExpiredPublicationRetryMarker(currentProcessingTime, currentTimerCallback)
       }
+
       if (
-        !isEvictionTimer && !isVersionCollisionTimer && !isPublicationRetryTimer &&
+        !isEvictionTimer && !isBufferedWriteTimer && !isVersionCollisionTimer && !isPublicationRetryTimer &&
         !expiredPublicationRetryMarkerCleared
       ) return
 
@@ -772,32 +959,45 @@ class GigaTileProcessFunction(
                                                                    eventTimeWatermark,
                                                                    processor.minSmallWindowTileSize)
 
-      var result = GigaEmitResult(null)
+      var timerResult: Option[GigaEmitResult] = None
+      var rebuiltPendingPublication = false
       if (isEvictionTimer) {
         nextProcessingEvictionTimerState.clear()
-        mode match {
+        val result = mode match {
           case NoWatermark =>
             // The active batch input holds the connected watermark at MIN while it scans.
             // Keep consuming records, but do not age or roll keyed state from wall clock.
             val snapshot = processor.currentSnapshot
             if (!snapshot.isEmpty) pendingPublicationState.update(java.lang.Boolean.TRUE)
-            result = GigaEmitResult(null, needsEvictionTimer = snapshot.needsEvictionTimer, isEmpty = snapshot.isEmpty)
+            GigaEmitResult(null, needsEvictionTimer = snapshot.needsEvictionTimer, isEmpty = snapshot.isEmpty)
           case _ =>
             val horizons = timerHorizons.get
             val rolloverResult = advanceDayForMode(mode, currentProcessingTime, eventTimeWatermark)
-            val evictionResult = rebuildPendingAtCurrentTime(mode, horizons, currentProcessingTime)
-              .getOrElse(
-                processor.onEviction(EvictionTimes(timerTs = horizons.largeWindowAsOfMillis,
-                                                   smallWindowAsOfTs = horizons.smallWindowAsOfMillis)))
-            result = preferLatestResult(evictionResult, rolloverResult)
+            val pendingRebuild = rebuildPendingAtCurrentTime(mode, horizons, currentProcessingTime)
+            rebuiltPendingPublication = pendingRebuild.nonEmpty
+            val evictionResult = pendingRebuild.getOrElse(
+              processor.onEviction(EvictionTimes(timerTs = horizons.largeWindowAsOfMillis,
+                                                 smallWindowAsOfTs = horizons.smallWindowAsOfMillis)))
+            preferLatestResult(evictionResult, rolloverResult)
         }
+        timerResult = Some(result)
 
         // Keep normal decay live while state or a deferred publication remains. A coincident
         // collision flush rearms itself on failure, so it does not need a speculative timer.
-        if (!result.isEmpty || result.needsEvictionTimer || hasPendingPublication) {
+        if (!result.isEmpty || result.needsEvictionTimer || hasPendingPublication || hasBufferedWrite) {
           scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
         }
+      }
 
+      if (isPublicationRetryTimer && !isEvictionTimer && hasDeferredPublication) {
+        timerHorizons.foreach { horizons =>
+          val pendingRebuild = rebuildPendingAtCurrentTime(mode, horizons, currentProcessingTime)
+          rebuiltPendingPublication = pendingRebuild.nonEmpty
+          timerResult = Some(pendingRebuild.getOrElse(GigaEmitResult(null)))
+        }
+      }
+
+      timerResult.foreach { result =>
         timerHorizons.foreach { horizons =>
           emitOrDefer(mode,
                       horizons,
@@ -811,22 +1011,39 @@ class GigaTileProcessFunction(
         }
       }
 
-      if (isPublicationRetryTimer && !isEvictionTimer && hasPendingPublication) {
-        timerHorizons.foreach { horizons =>
-          val retryResult = rebuildPendingAtCurrentTime(mode, horizons, currentProcessingTime)
-            .getOrElse(GigaEmitResult(null))
-          emitOrDefer(mode,
-                      horizons,
-                      retryResult,
-                      ctx.getCurrentKey,
-                      currentProcessingTime,
-                      System.currentTimeMillis(),
-                      timerService,
-                      out,
-                      scheduleWatermarkRetry = false)
+      if (hasPendingPublication) {
+        scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
+      }
+
+      if (isBufferedWriteTimer) {
+        timerHorizons match {
+          case Some(horizons) if shouldPublish(mode, horizons, currentProcessingTime) =>
+            if (!rebuiltPendingPublication && hasDeferredPublication) {
+              rebuildPendingAtCurrentTime(mode, horizons, currentProcessingTime).foreach { rebuildResult =>
+                emitOrDefer(mode,
+                            horizons,
+                            rebuildResult,
+                            ctx.getCurrentKey,
+                            currentProcessingTime,
+                            System.currentTimeMillis(),
+                            timerService,
+                            out,
+                            scheduleWatermarkRetry = false)
+              }
+            }
+            flushBufferedWrite(timerService, currentProcessingTime, ctx.getCurrentKey, out)
+          case _ =>
+            // Park cadence ownership while fenced. The watermark/future-time wakeup is the
+            // primary resume path; normal eviction remains a state-decay fallback.
+            parkBufferedWrite()
+            if (hasPendingPublication) {
+              scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
+            }
         }
       }
 
+      // Version collision is always last so a shared callback emits only the post-mutation,
+      // post-cadence snapshot with a strictly newer version.
       if (isVersionCollisionTimer) {
         timerHorizons match {
           case Some(horizons) if shouldPublish(mode, horizons, currentProcessingTime) =>
@@ -841,7 +1058,10 @@ class GigaTileProcessFunction(
         }
       }
 
-      if ((isPublicationRetryTimer || expiredPublicationRetryMarkerCleared) && hasPendingPublication) {
+      if (
+        (isPublicationRetryTimer || expiredPublicationRetryMarkerCleared || isBufferedWriteTimer) &&
+        hasDeferredPublication
+      ) {
         scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
         scheduleFencedPublicationWakeupIfNeeded(timerService, currentProcessingTime, eventTimeWatermark, mode)
       }
@@ -856,27 +1076,28 @@ class GigaTileProcessFunction(
             nextProcessingEvictionTimerState.clear()
             scheduleProcessingEvictionTimerIfNeeded(timerServiceOnFailure, processingTimeOnFailure)
           }
+          val trackedBufferedWrite = nextBufferedWriteTimerState.value()
+          if (
+            bufferedWriteTimerFired && hasBufferedWrite &&
+            (trackedBufferedWrite == null || trackedBufferedWrite.longValue() <= timestamp)
+          ) {
+            nextBufferedWriteTimerState.clear()
+            scheduleBufferedWriteTimerIfNeeded(timerServiceOnFailure, processingTimeOnFailure)
+          }
           val pendingCollision = pendingVersionCollisionState.value()
           if (
             versionCollisionTimerFired && pendingCollision != null &&
             pendingCollision.longValue() <= timestamp && processingTimeOnFailure < Long.MaxValue
           ) {
-            // A shared callback must preserve eviction-before-publication ordering. If
-            // eviction failed, park the collision on the re-armed eviction timer instead
-            // of publishing the stale pre-eviction snapshot one millisecond later.
-            val retryVersion =
-              if (evictionTimerFired) {
-                Option(nextProcessingEvictionTimerState.value())
-                  .map(_.longValue())
-                  .filter(_ > timestamp)
-                  .getOrElse(processingTimeOnFailure + 1L)
-              } else {
-                processingTimeOnFailure + 1L
-              }
-            timerServiceOnFailure.registerProcessingTimeTimer(retryVersion)
-            pendingVersionCollisionState.update(retryVersion)
+            scheduleProcessingEvictionTimerIfNeeded(timerServiceOnFailure, processingTimeOnFailure)
+            postponeVersionCollision(timerServiceOnFailure,
+                                     processingTimeOnFailure,
+                                     Some(TimeDomain.PROCESSING_TIME -> timestamp))
           }
-          if ((publicationRetryTimerFired || expiredPublicationRetryMarkerCleared) && hasPendingPublication) {
+          if (
+            (publicationRetryTimerFired || expiredPublicationRetryMarkerCleared || bufferedWriteTimerFired) &&
+            hasDeferredPublication
+          ) {
             val eventTimeWatermark = timerServiceOnFailure.currentWatermark()
             currentClockMode(processingTimeOnFailure, eventTimeWatermark) match {
               case Live => schedulePublicationRetryIfNeeded(timerServiceOnFailure, processingTimeOnFailure)
@@ -887,7 +1108,7 @@ class GigaTileProcessFunction(
                                                         mode)
             }
           }
-          if (publicationActivationTimerFired && hasPendingPublication) {
+          if (publicationActivationTimerFired && hasDeferredPublication) {
             schedulePublicationRetryAfterIfNeeded(timerServiceOnFailure,
                                                   processingTimeOnFailure,
                                                   activationCooldownDelayMillis)
@@ -900,6 +1121,11 @@ class GigaTileProcessFunction(
 
   private def isCurrentProcessingEvictionTimer(timestamp: Long): Boolean =
     Option(nextProcessingEvictionTimerState.value()).exists(_.longValue() == timestamp)
+
+  private def isUnmarkedLegacyEvictionTimer(timestamp: Long): Boolean = {
+    val interval = processor.minEvictionInterval
+    nextProcessingEvictionTimerState.value() == null && interval > 0L && timestamp == TsUtils.round(timestamp, interval)
+  }
 
   private def nextProcessingEvictionTimestamp(currentProcessingTime: Long): Option[Long] = {
     val interval = processor.minEvictionInterval

--- a/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
@@ -3,15 +3,17 @@ package ai.chronon.flink.window
 import ai.chronon.aggregator.windowing.{
   EvictionTimes,
   FinalBatchIr,
+  GigaEmitResult,
   GigaTileStore,
   GigaTileStreamProcessor,
   MegaTileAggregator
 }
 import ai.chronon.api.{Constants, DataType, GroupBy, TsUtils}
 import ai.chronon.api.ScalaJavaConversions.IteratorOps
-import ai.chronon.flink.SparkExpressionEval
+import ai.chronon.flink.{FlinkJob, SparkExpressionEval}
 import ai.chronon.flink.deser.ProjectedEvent
 import ai.chronon.flink.types.{BatchIrRow, TimestampedTile}
+import ai.chronon.flink.window.ChrononClockMode.{Catchup, Horizons, Live, Mode, NoWatermark}
 import ai.chronon.online.{GigaTileCodec, MegaTileCodec}
 import ai.chronon.online.serde.ArrayRow
 import org.apache.flink.api.common.state.{MapState, MapStateDescriptor, ValueState, ValueStateDescriptor}
@@ -48,6 +50,7 @@ class GigaTileProcessFunction(
 
   @transient private var eventProcessingErrorCounter: Counter = _
   @transient private var batchUpdateCounter: Counter = _
+  @transient private var futureEventDropCounter: Counter = _
   @transient private var lastKey: java.util.List[Any] = _
 
   private val valueColumns: Array[String] = inputSchema.map(_._1).toArray
@@ -67,6 +70,13 @@ class GigaTileProcessFunction(
   private var lastLargeRecomputeAsOfTsState: ValueState[java.lang.Long] = _
   private var lastEmittedVersionState: ValueState[java.lang.Long] = _
   private var pendingVersionCollisionState: ValueState[java.lang.Long] = _
+  private var pendingPublicationState: ValueState[java.lang.Boolean] = _
+  private var pendingPublicationRetryTimerState: ValueState[java.lang.Long] = _
+  private var pendingPublicationActivationTimerState: ValueState[java.lang.Long] = _
+
+  private val publicationRetryDelayMillis = math.max(1L, 2L * FlinkJob.AutoWatermarkInterval)
+  private val activationCooldownDelayMillis =
+    math.max(publicationRetryDelayMillis, FlinkJob.CatchupWatermarkLagSlackMillis / 2L)
 
   override def open(parameters: Configuration): Unit = {
     super.open(parameters)
@@ -76,6 +86,7 @@ class GigaTileProcessFunction(
       .addGroup("feature_group", groupBy.getMetaData.getName)
     eventProcessingErrorCounter = metricsGroup.counter("event_processing_error")
     batchUpdateCounter = metricsGroup.counter("batch_update_count")
+    futureEventDropCounter = metricsGroup.counter("future_event_drop_count")
 
     tileState = getRuntimeContext.getMapState(
       new MapStateDescriptor[String, Array[Byte]]("giga-tile-tiles", classOf[String], classOf[Array[Byte]]))
@@ -105,6 +116,13 @@ class GigaTileProcessFunction(
       new ValueStateDescriptor[java.lang.Long]("giga-tile-last-emitted-version", classOf[java.lang.Long]))
     pendingVersionCollisionState = getRuntimeContext.getState(
       new ValueStateDescriptor[java.lang.Long]("giga-tile-pending-version-collision", classOf[java.lang.Long]))
+    pendingPublicationState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Boolean]("giga-tile-pending-publication", classOf[java.lang.Boolean]))
+    pendingPublicationRetryTimerState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Long]("giga-tile-pending-publication-retry-pt-timer", classOf[java.lang.Long]))
+    pendingPublicationActivationTimerState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Long]("giga-tile-pending-publication-activation-et-timer",
+                                               classOf[java.lang.Long]))
 
     initializeTransients()
   }
@@ -141,11 +159,214 @@ class GigaTileProcessFunction(
     }
   }
 
-  // Small-window ranges use an exclusive upper bound. At an exact hop, nudge only that
-  // horizon so the just-opened tile remains visible; large windows keep the real time.
-  private def adjustedSmallWindowAsOfTs(asOfTs: Long): Long =
-    if (asOfTs < Long.MaxValue && asOfTs == TsUtils.round(asOfTs, processor.minSmallWindowTileSize)) asOfTs + 1L
-    else asOfTs
+  private def currentClockMode(currentProcessingTime: Long, eventTimeWatermark: Long): Mode =
+    ChrononClockMode.classify(currentProcessingTime,
+                              eventTimeWatermark,
+                              FlinkJob.AllowedOutOfOrderness.toMillis,
+                              FlinkJob.LiveWatermarkLagToleranceMillis)
+
+  private def isFutureEvent(eventTime: Long, currentProcessingTime: Long): Boolean =
+    eventTime > currentProcessingTime
+
+  private def hasPendingPublication: Boolean =
+    java.lang.Boolean.TRUE.equals(pendingPublicationState.value()) && pendingVersionCollisionState.value() == null
+
+  private def schedulePublicationRetryIfNeeded(
+      timerService: TimerService,
+      currentProcessingTime: Long
+  ): Unit =
+    schedulePublicationRetryAfterIfNeeded(timerService, currentProcessingTime, publicationRetryDelayMillis)
+
+  private def schedulePublicationRetryAfterIfNeeded(
+      timerService: TimerService,
+      currentProcessingTime: Long,
+      delayMillis: Long
+  ): Unit = {
+    if (!hasPublicationWakeupTimer && currentProcessingTime <= Long.MaxValue - delayMillis) {
+      val retryTimestamp = currentProcessingTime + delayMillis
+      timerService.registerProcessingTimeTimer(retryTimestamp)
+      pendingPublicationRetryTimerState.update(retryTimestamp)
+    }
+  }
+
+  private def schedulePublicationRetryAtIfNeeded(
+      timerService: TimerService,
+      currentProcessingTime: Long,
+      retryTimestamp: Long
+  ): Unit = {
+    if (!hasPublicationWakeupTimer && retryTimestamp > currentProcessingTime) {
+      timerService.registerProcessingTimeTimer(retryTimestamp)
+      pendingPublicationRetryTimerState.update(retryTimestamp)
+    }
+  }
+
+  private def hasPublicationWakeupTimer: Boolean =
+    pendingPublicationRetryTimerState.value() != null || pendingPublicationActivationTimerState.value() != null
+
+  private def nextPublicationActivationWatermark(currentProcessingTime: Long): Option[Long] = {
+    val liveWatermarkLagMillis = FlinkJob.LiveWatermarkLagToleranceMillis
+    if (currentProcessingTime < Long.MinValue + liveWatermarkLagMillis) None
+    else Some(currentProcessingTime - liveWatermarkLagMillis)
+  }
+
+  private def firstSafeProcessingTimeAfterFutureWatermark(eventTimeWatermark: Long): Option[Long] = {
+    val outOfOrdernessMillis = FlinkJob.AllowedOutOfOrderness.toMillis
+    if (eventTimeWatermark > Long.MaxValue - outOfOrdernessMillis) None
+    else {
+      val lastUnsafeProcessingTime = eventTimeWatermark + outOfOrdernessMillis
+      if (lastUnsafeProcessingTime == Long.MaxValue) None else Some(lastUnsafeProcessingTime + 1L)
+    }
+  }
+
+  private def schedulePublicationActivationIfNeeded(
+      timerService: TimerService,
+      currentProcessingTime: Long,
+      eventTimeWatermark: Long
+  ): Unit = {
+    if (!hasPublicationWakeupTimer) {
+      nextPublicationActivationWatermark(currentProcessingTime)
+        .filter(_ > eventTimeWatermark)
+        .foreach { activationWatermark =>
+          timerService.registerEventTimeTimer(activationWatermark)
+          pendingPublicationActivationTimerState.update(activationWatermark)
+        }
+    }
+  }
+
+  private def scheduleFencedPublicationWakeupIfNeeded(
+      timerService: TimerService,
+      currentProcessingTime: Long,
+      eventTimeWatermark: Long,
+      mode: Mode
+  ): Unit =
+    mode match {
+      case Catchup =>
+        schedulePublicationActivationIfNeeded(timerService, currentProcessingTime, eventTimeWatermark)
+      case NoWatermark if eventTimeWatermark == Long.MinValue =>
+        schedulePublicationActivationIfNeeded(timerService, currentProcessingTime, eventTimeWatermark)
+      case NoWatermark =>
+        // Watermarks never move backward. A future-poisoned watermark becomes safe at one
+        // exact wall-clock boundary, so avoid polling every pending key while time catches up.
+        firstSafeProcessingTimeAfterFutureWatermark(eventTimeWatermark)
+          .foreach { retryTimestamp =>
+            schedulePublicationRetryAtIfNeeded(timerService, currentProcessingTime, retryTimestamp)
+          }
+      case Live => ()
+    }
+
+  private def clearPublicationRetryMarker(): Unit =
+    pendingPublicationRetryTimerState.clear()
+
+  private def clearExpiredPublicationRetryMarker(
+      currentProcessingTime: Long,
+      currentTimerCallback: Option[(TimeDomain, Long)]
+  ): Boolean = {
+    val retryTimestamp = pendingPublicationRetryTimerState.value()
+    if (
+      retryTimestamp != null && processingTimerMarkerIsExpired(retryTimestamp.longValue(),
+                                                               currentProcessingTime,
+                                                               currentTimerCallback)
+    ) {
+      pendingPublicationRetryTimerState.clear()
+      true
+    } else {
+      false
+    }
+  }
+
+  private def clearPublicationWakeupMarkers(): Unit = {
+    pendingPublicationRetryTimerState.clear()
+    pendingPublicationActivationTimerState.clear()
+  }
+
+  private def isCurrentPublicationRetryTimer(timestamp: Long): Boolean =
+    Option(pendingPublicationRetryTimerState.value()).exists(_.longValue() == timestamp)
+
+  private def isCurrentPublicationActivationTimer(timestamp: Long): Boolean =
+    Option(pendingPublicationActivationTimerState.value()).exists(_.longValue() == timestamp)
+
+  private def shouldPublish(
+      mode: Mode,
+      horizons: Horizons,
+      currentProcessingTime: Long
+  ): Boolean = {
+    val currentDayStart = flinkStore.getCurrentDayStart
+    ChrononClockMode.allowsPublication(mode) &&
+    horizons.largeWindowAsOfMillis == currentProcessingTime &&
+    !(currentDayStart >= 0L && flinkStore.getBatchEndTs > currentDayStart)
+  }
+
+  private def advanceDayForMode(
+      mode: Mode,
+      currentProcessingTime: Long,
+      eventTimeWatermark: Long
+  ): GigaEmitResult =
+    ChrononClockMode
+      .dayAdvanceAsOfMillis(mode, currentProcessingTime, eventTimeWatermark)
+      .map(processor.advanceDayAsOf)
+      .getOrElse(GigaEmitResult(null))
+
+  private def preferLatestResult(primary: GigaEmitResult, fallback: GigaEmitResult): GigaEmitResult =
+    if (primary.finalizedVector != null || fallback.finalizedVector == null) primary else fallback
+
+  private def rebuildPendingAtCurrentTime(
+      mode: Mode,
+      horizons: Horizons,
+      currentProcessingTime: Long
+  ): Option[GigaEmitResult] =
+    if (hasPendingPublication && shouldPublish(mode, horizons, currentProcessingTime)) {
+      Some(
+        processor.onEviction(
+          EvictionTimes(timerTs = horizons.largeWindowAsOfMillis, smallWindowAsOfTs = horizons.smallWindowAsOfMillis)))
+    } else {
+      None
+    }
+
+  private def emitOrDefer(
+      mode: Mode,
+      horizons: Horizons,
+      result: GigaEmitResult,
+      currentKey: java.util.List[Any],
+      currentProcessingTime: Long,
+      startProcessingTime: Long,
+      timerService: TimerService,
+      out: Collector[TimestampedTile],
+      scheduleWatermarkRetry: Boolean
+  ): Unit = {
+    if (!shouldPublish(mode, horizons, currentProcessingTime)) {
+      val publicationPending = result.finalizedVector != null || result.needsEvictionTimer || hasPendingPublication
+      if (publicationPending) {
+        pendingPublicationState.update(java.lang.Boolean.TRUE)
+        if (scheduleWatermarkRetry) schedulePublicationRetryIfNeeded(timerService, currentProcessingTime)
+      }
+      return
+    }
+
+    val finalizedVector =
+      if (result.finalizedVector != null) result.finalizedVector
+      else if (hasPendingPublication) processor.currentSnapshot.finalizedVector
+      else null
+
+    if (finalizedVector != null) {
+      // This covers encoding and Collector handoff only. The downstream async KV result is
+      // outside this keyed operator and cannot acknowledge or retry through this state.
+      pendingPublicationState.update(java.lang.Boolean.TRUE)
+      try {
+        emitOrCoalesceVersionCollision(timerService,
+                                       finalizedVector,
+                                       currentKey,
+                                       currentProcessingTime,
+                                       startProcessingTime,
+                                       out)
+        if (pendingVersionCollisionState.value() == null) pendingPublicationState.clear()
+        clearPublicationWakeupMarkers()
+      } catch {
+        case e: Exception =>
+          logger.error(s"Error emitting giga tile for groupBy=${groupBy.getMetaData.getName}", e)
+          eventProcessingErrorCounter.inc()
+      }
+    }
+  }
 
   /** Processing-time callbacks can share a millisecond. Coalesce later same-millisecond updates
     * behind a timer so emitted versions are strictly increasing before async sink handoff.
@@ -285,9 +506,36 @@ class GigaTileProcessFunction(
     }
   }
 
+  private def postponeVersionCollision(
+      timerService: TimerService,
+      currentProcessingTime: Long,
+      currentTimerCallback: Option[(TimeDomain, Long)]
+  ): Unit = {
+    if (pendingVersionCollisionState.value() != null) {
+      val trackedEviction = nextProcessingEvictionTimerState.value()
+      val retryVersion =
+        if (
+          trackedEviction != null && !processingTimerMarkerIsExpired(trackedEviction.longValue(),
+                                                                     currentProcessingTime,
+                                                                     currentTimerCallback)
+        ) {
+          Some(trackedEviction.longValue())
+        } else {
+          nextProcessingEvictionTimestamp(currentProcessingTime)
+        }
+      retryVersion.foreach { version =>
+        // This normally shares the tracked eviction timer; registering the same keyed
+        // timestamp is idempotent and avoids a separate hot retry loop while fenced.
+        timerService.registerProcessingTimeTimer(version)
+        pendingVersionCollisionState.update(version)
+      }
+    }
+  }
+
   private def flushVersionCollision(
       timerService: TimerService,
       currentProcessingTime: Long,
+      currentTimerCallback: Option[(TimeDomain, Long)],
       currentKey: java.util.List[Any],
       out: Collector[TimestampedTile]
   ): Unit = {
@@ -300,15 +548,14 @@ class GigaTileProcessFunction(
       out.collect(new TimestampedTile(currentKey, encoded, pendingVersion.longValue(), System.currentTimeMillis()))
       lastEmittedVersionState.update(pendingVersion)
       pendingVersionCollisionState.clear()
+      pendingPublicationState.clear()
+      clearPublicationWakeupMarkers()
     } catch {
       case e: Exception =>
         // The fired timer was the only flush trigger. Re-arm before the outer handler records
         // the failure so a transient encoding/collection error cannot strand the latest value.
-        if (currentProcessingTime < Long.MaxValue) {
-          val retryVersion = currentProcessingTime + 1L
-          timerService.registerProcessingTimeTimer(retryVersion)
-          pendingVersionCollisionState.update(retryVersion)
-        }
+        scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
+        postponeVersionCollision(timerService, currentProcessingTime, currentTimerCallback)
         throw e
     }
   }
@@ -332,20 +579,39 @@ class GigaTileProcessFunction(
       val timerService = ctx.timerService()
       val currentProcessingTime = timerService.currentProcessingTime()
       repairExpiredProcessingTimerMarkers(timerService, currentProcessingTime, None)
-      val rolloverResult = processor.advanceWatermark(currentProcessingTime)
+      if (isFutureEvent(tsMills, currentProcessingTime)) {
+        futureEventDropCounter.inc()
+        return
+      }
+      clearExpiredPublicationRetryMarker(currentProcessingTime, None)
+      val eventTimeWatermark = timerService.currentWatermark()
+      val mode = currentClockMode(currentProcessingTime, eventTimeWatermark)
+      val horizons = ChrononClockMode.streamEventHorizons(mode,
+                                                          tsMills,
+                                                          currentProcessingTime,
+                                                          eventTimeWatermark,
+                                                          processor.minSmallWindowTileSize)
+
+      val rolloverResult =
+        if (mode == NoWatermark) processor.advanceDayAsOf(tsMills)
+        else advanceDayForMode(mode, currentProcessingTime, eventTimeWatermark)
+      val pendingRebuild = rebuildPendingAtCurrentTime(mode, horizons, currentProcessingTime)
       val eventResult = processor.onEvent(row,
                                           tsMills,
-                                          largeWindowAsOfTs = currentProcessingTime,
-                                          smallWindowAsOfTs = adjustedSmallWindowAsOfTs(currentProcessingTime))
-      val result = if (eventResult.finalizedVector != null) eventResult else rolloverResult
+                                          largeWindowAsOfTs = horizons.largeWindowAsOfMillis,
+                                          smallWindowAsOfTs = horizons.smallWindowAsOfMillis)
+      val result = preferLatestResult(eventResult, pendingRebuild.getOrElse(rolloverResult))
 
       scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
-      emitOrCoalesceVersionCollision(timerService,
-                                     result.finalizedVector,
-                                     ctx.getCurrentKey,
-                                     currentProcessingTime,
-                                     event.startProcessingTimeMillis,
-                                     out)
+      emitOrDefer(mode,
+                  horizons,
+                  result,
+                  ctx.getCurrentKey,
+                  currentProcessingTime,
+                  event.startProcessingTimeMillis,
+                  timerService,
+                  out,
+                  scheduleWatermarkRetry = true)
 
     } catch {
       case e: Exception =>
@@ -367,26 +633,40 @@ class GigaTileProcessFunction(
       val timerService = ctx.timerService()
       val currentProcessingTime = timerService.currentProcessingTime()
       repairExpiredProcessingTimerMarkers(timerService, currentProcessingTime, None)
-      val rolloverResult = processor.advanceWatermark(currentProcessingTime)
+      clearExpiredPublicationRetryMarker(currentProcessingTime, None)
+      val eventTimeWatermark = timerService.currentWatermark()
+      val mode = currentClockMode(currentProcessingTime, eventTimeWatermark)
+      val horizons = ChrononClockMode.batchUpdateHorizons(mode,
+                                                          batchRow.batchEndTs,
+                                                          flinkStore.getCurrentDayStart,
+                                                          currentProcessingTime,
+                                                          eventTimeWatermark,
+                                                          processor.minSmallWindowTileSize)
 
+      val rolloverResult = advanceDayForMode(mode, currentProcessingTime, eventTimeWatermark)
+      val pendingRebuild = rebuildPendingAtCurrentTime(mode, horizons, currentProcessingTime)
       val batchIr = gigaTileCodec.decodeBatchIr(batchRow.valueBytes)
       val batchResult = processor.onBatchUpdate(batchIr,
                                                 batchRow.batchEndTs,
-                                                largeWindowAsOfTs = currentProcessingTime,
-                                                smallWindowAsOfTs = adjustedSmallWindowAsOfTs(currentProcessingTime))
-      val result = if (batchResult.finalizedVector != null) batchResult else rolloverResult
+                                                largeWindowAsOfTs = horizons.largeWindowAsOfMillis,
+                                                smallWindowAsOfTs = horizons.smallWindowAsOfMillis)
+      val result = preferLatestResult(batchResult, pendingRebuild.getOrElse(rolloverResult))
 
       batchUpdateCounter.inc()
 
-      if (batchResult.needsEvictionTimer) {
+      emitOrDefer(mode,
+                  horizons,
+                  result,
+                  ctx.getCurrentKey,
+                  currentProcessingTime,
+                  System.currentTimeMillis(),
+                  timerService,
+                  out,
+                  scheduleWatermarkRetry = true)
+
+      if (batchResult.needsEvictionTimer || hasPendingPublication) {
         scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
       }
-      emitOrCoalesceVersionCollision(timerService,
-                                     result.finalizedVector,
-                                     ctx.getCurrentKey,
-                                     currentProcessingTime,
-                                     System.currentTimeMillis(),
-                                     out)
     } catch {
       case e: Exception =>
         logger.error(s"Error processing batch IR for groupBy=${groupBy.getMetaData.getName}", e)
@@ -403,21 +683,63 @@ class GigaTileProcessFunction(
     var processingTimeOnFailure = Long.MinValue
     var evictionTimerFired = false
     var versionCollisionTimerFired = false
+    var publicationRetryTimerFired = false
+    var publicationActivationTimerFired = false
+    var expiredPublicationRetryMarkerCleared = false
     try {
       if (processor == null) initializeTransients()
 
       ensureStateBound(ctx.getCurrentKey)
       val timerService = ctx.timerService()
       val currentProcessingTime = timerService.currentProcessingTime()
+      val currentTimerCallback = Some(ctx.timeDomain() -> timestamp)
       timerServiceOnFailure = timerService
       processingTimeOnFailure = currentProcessingTime
-      repairExpiredProcessingTimerMarkers(timerService, currentProcessingTime, Some(ctx.timeDomain() -> timestamp))
+      repairExpiredProcessingTimerMarkers(timerService, currentProcessingTime, currentTimerCallback)
 
-      // Checkpoints written by the event-time implementation may still contain several
-      // event-time eviction timers per key. Let those callbacks migrate the key to one
-      // processing-time timer, but do not publish from both timer domains.
+      // Checkpoints written by the former event-time implementation may still contain
+      // eviction timers. Only the explicitly tracked activation timer may publish from this
+      // domain; untracked legacy timers remain migration-only.
       if (ctx.timeDomain() == TimeDomain.EVENT_TIME) {
+        val isPublicationActivationTimer = isCurrentPublicationActivationTimer(timestamp)
+        publicationActivationTimerFired = isPublicationActivationTimer
+        if (isPublicationActivationTimer) pendingPublicationActivationTimerState.clear()
         scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
+        if (isPublicationActivationTimer) {
+          if (hasPendingPublication) {
+            val eventTimeWatermark = timerService.currentWatermark()
+            currentClockMode(currentProcessingTime, eventTimeWatermark) match {
+              case Live =>
+                val horizons = ChrononClockMode
+                  .processingTimerHorizons(Live,
+                                           currentProcessingTime,
+                                           eventTimeWatermark,
+                                           processor.minSmallWindowTileSize)
+                  .get
+                val rolloverResult = advanceDayForMode(Live, currentProcessingTime, eventTimeWatermark)
+                val retryResult = rebuildPendingAtCurrentTime(Live, horizons, currentProcessingTime)
+                  .getOrElse(GigaEmitResult(null))
+                val result = preferLatestResult(retryResult, rolloverResult)
+                emitOrDefer(Live,
+                            horizons,
+                            result,
+                            ctx.getCurrentKey,
+                            currentProcessingTime,
+                            System.currentTimeMillis(),
+                            timerService,
+                            out,
+                            scheduleWatermarkRetry = false)
+              case Catchup =>
+                // If callback delivery consumed the Live slack, separate retries from source
+                // watermark cadence before installing a new activation boundary.
+                schedulePublicationRetryAfterIfNeeded(timerService,
+                                                      currentProcessingTime,
+                                                      activationCooldownDelayMillis)
+              case mode =>
+                scheduleFencedPublicationWakeupIfNeeded(timerService, currentProcessingTime, eventTimeWatermark, mode)
+            }
+          }
+        }
         return
       }
 
@@ -427,37 +749,101 @@ class GigaTileProcessFunction(
 
       val isEvictionTimer = isCurrentProcessingEvictionTimer(timestamp)
       val isVersionCollisionTimer = isCurrentVersionCollisionTimer(timestamp)
+      val isPublicationRetryTimer = isCurrentPublicationRetryTimer(timestamp)
       evictionTimerFired = isEvictionTimer
       versionCollisionTimerFired = isVersionCollisionTimer
-      if (!isEvictionTimer && !isVersionCollisionTimer) return
+      publicationRetryTimerFired = isPublicationRetryTimer
+      if (!isPublicationRetryTimer) {
+        expiredPublicationRetryMarkerCleared =
+          clearExpiredPublicationRetryMarker(currentProcessingTime, currentTimerCallback)
+      }
+      if (
+        !isEvictionTimer && !isVersionCollisionTimer && !isPublicationRetryTimer &&
+        !expiredPublicationRetryMarkerCleared
+      ) return
 
-      var finalizedVector: Array[Any] = null
+      // The physical retry timer has fired. Clear only its logical role before running all
+      // coincident roles, then arm one watermark-driven wake-up if publication remains fenced.
+      if (isPublicationRetryTimer) clearPublicationRetryMarker()
+      val eventTimeWatermark = timerService.currentWatermark()
+      val mode = currentClockMode(currentProcessingTime, eventTimeWatermark)
+      val timerHorizons = ChrononClockMode.processingTimerHorizons(mode,
+                                                                   currentProcessingTime,
+                                                                   eventTimeWatermark,
+                                                                   processor.minSmallWindowTileSize)
+
+      var result = GigaEmitResult(null)
       if (isEvictionTimer) {
         nextProcessingEvictionTimerState.clear()
-        val rolloverResult = processor.advanceWatermark(currentProcessingTime)
-        val evictionResult = processor.onEviction(
-          EvictionTimes(timerTs = currentProcessingTime,
-                        smallWindowAsOfTs = adjustedSmallWindowAsOfTs(currentProcessingTime)))
-        finalizedVector =
-          if (evictionResult.finalizedVector != null) evictionResult.finalizedVector else rolloverResult.finalizedVector
+        mode match {
+          case NoWatermark =>
+            // The active batch input holds the connected watermark at MIN while it scans.
+            // Keep consuming records, but do not age or roll keyed state from wall clock.
+            val snapshot = processor.currentSnapshot
+            if (!snapshot.isEmpty) pendingPublicationState.update(java.lang.Boolean.TRUE)
+            result = GigaEmitResult(null, needsEvictionTimer = snapshot.needsEvictionTimer, isEmpty = snapshot.isEmpty)
+          case _ =>
+            val horizons = timerHorizons.get
+            val rolloverResult = advanceDayForMode(mode, currentProcessingTime, eventTimeWatermark)
+            val evictionResult = rebuildPendingAtCurrentTime(mode, horizons, currentProcessingTime)
+              .getOrElse(
+                processor.onEviction(EvictionTimes(timerTs = horizons.largeWindowAsOfMillis,
+                                                   smallWindowAsOfTs = horizons.smallWindowAsOfMillis)))
+            result = preferLatestResult(evictionResult, rolloverResult)
+        }
 
-        // Re-register before a coincident collision flush: if encoding the flush fails, both
-        // the retry and normal eviction cadence remain live.
-        if (!evictionResult.isEmpty || evictionResult.needsEvictionTimer) {
+        // Keep normal decay live while state or a deferred publication remains. A coincident
+        // collision flush rearms itself on failure, so it does not need a speculative timer.
+        if (!result.isEmpty || result.needsEvictionTimer || hasPendingPublication) {
           scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
+        }
+
+        timerHorizons.foreach { horizons =>
+          emitOrDefer(mode,
+                      horizons,
+                      result,
+                      ctx.getCurrentKey,
+                      currentProcessingTime,
+                      System.currentTimeMillis(),
+                      timerService,
+                      out,
+                      scheduleWatermarkRetry = false)
+        }
+      }
+
+      if (isPublicationRetryTimer && !isEvictionTimer && hasPendingPublication) {
+        timerHorizons.foreach { horizons =>
+          val retryResult = rebuildPendingAtCurrentTime(mode, horizons, currentProcessingTime)
+            .getOrElse(GigaEmitResult(null))
+          emitOrDefer(mode,
+                      horizons,
+                      retryResult,
+                      ctx.getCurrentKey,
+                      currentProcessingTime,
+                      System.currentTimeMillis(),
+                      timerService,
+                      out,
+                      scheduleWatermarkRetry = false)
         }
       }
 
       if (isVersionCollisionTimer) {
-        // Eviction wins when both timers share a timestamp; publish one post-eviction snapshot.
-        flushVersionCollision(timerService, currentProcessingTime, ctx.getCurrentKey, out)
-      } else {
-        emitOrCoalesceVersionCollision(timerService,
-                                       finalizedVector,
-                                       ctx.getCurrentKey,
-                                       currentProcessingTime,
-                                       System.currentTimeMillis(),
-                                       out)
+        timerHorizons match {
+          case Some(horizons) if shouldPublish(mode, horizons, currentProcessingTime) =>
+            // Eviction runs first when both markers share a timestamp, so this is one
+            // post-eviction snapshot with a strictly newer version.
+            pendingPublicationState.update(java.lang.Boolean.TRUE)
+            flushVersionCollision(timerService, currentProcessingTime, currentTimerCallback, ctx.getCurrentKey, out)
+          case _ =>
+            pendingPublicationState.update(java.lang.Boolean.TRUE)
+            scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
+            postponeVersionCollision(timerService, currentProcessingTime, currentTimerCallback)
+        }
+      }
+
+      if ((isPublicationRetryTimer || expiredPublicationRetryMarkerCleared) && hasPendingPublication) {
+        scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
+        scheduleFencedPublicationWakeupIfNeeded(timerService, currentProcessingTime, eventTimeWatermark, mode)
       }
     } catch {
       case e: Exception =>
@@ -489,6 +875,22 @@ class GigaTileProcessFunction(
               }
             timerServiceOnFailure.registerProcessingTimeTimer(retryVersion)
             pendingVersionCollisionState.update(retryVersion)
+          }
+          if ((publicationRetryTimerFired || expiredPublicationRetryMarkerCleared) && hasPendingPublication) {
+            val eventTimeWatermark = timerServiceOnFailure.currentWatermark()
+            currentClockMode(processingTimeOnFailure, eventTimeWatermark) match {
+              case Live => schedulePublicationRetryIfNeeded(timerServiceOnFailure, processingTimeOnFailure)
+              case mode =>
+                scheduleFencedPublicationWakeupIfNeeded(timerServiceOnFailure,
+                                                        processingTimeOnFailure,
+                                                        eventTimeWatermark,
+                                                        mode)
+            }
+          }
+          if (publicationActivationTimerFired && hasPendingPublication) {
+            schedulePublicationRetryAfterIfNeeded(timerServiceOnFailure,
+                                                  processingTimeOnFailure,
+                                                  activationCooldownDelayMillis)
           }
         }
         logger.error(s"Error in giga tile eviction for groupBy=${groupBy.getMetaData.getName}", e)
@@ -523,7 +925,7 @@ class GigaTileProcessFunction(
 
 /** TileStore backed by Flink state for GigaTile. Extends the mega tile state with batch IR
   * storage and a per-day large-IR map (keyed by day-start) sized to bridge any retained gap
-  * between batchEndDay and the watermark day.
+  * between batchEndDay and the current materialized day.
   */
 class FlinkGigaTileStore(megaTileAgg: MegaTileAggregator, codec: MegaTileCodec, gigaCodec: GigaTileCodec)
     extends GigaTileStore {

--- a/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
@@ -197,7 +197,7 @@ class GigaTileProcessFunction(
 
       ensureStateBound(ctx.getCurrentKey)
       processor.advanceWatermark(ctx.timerService().currentWatermark())
-      val result = processor.onEviction(timestamp)
+      val result = processor.onScheduledEviction(timestamp)
 
       if (result.finalizedVector != null) {
         out.collect(

--- a/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
@@ -321,12 +321,14 @@ class FlinkGigaTileStore(megaTileAgg: MegaTileAggregator, codec: MegaTileCodec, 
   override def getLargeYesterdayIr: Array[Any] = windowedAgg.init
   override def putLargeYesterdayIr(ir: Array[Any]): Unit = ()
 
+  // Daily slot IRs are base-aggregator-shaped (one column per (op, input)) — fanned out
+  // to per-window columns at recompute time via baseIrIndices.
   override def getDailyLargeIr(dayStart: Long): Array[Any] = {
     val bytes = dailyLargeIrState.get(dayStart)
-    if (bytes != null) codec.decode(bytes) else null
+    if (bytes != null) codec.decodeBaseIr(bytes) else null
   }
   override def putDailyLargeIr(dayStart: Long, ir: Array[Any]): Unit =
-    dailyLargeIrState.put(dayStart, codec.encode(ir))
+    dailyLargeIrState.put(dayStart, codec.encodeBaseIr(ir))
   override def removeDailyLargeIr(dayStart: Long): Unit =
     dailyLargeIrState.remove(dayStart)
   override def dailyLargeIrIterator: Iterator[(Long, Array[Any])] = {
@@ -335,7 +337,7 @@ class FlinkGigaTileStore(megaTileAgg: MegaTileAggregator, codec: MegaTileCodec, 
       override def hasNext: Boolean = iter.hasNext
       override def next(): (Long, Array[Any]) = {
         val entry = iter.next()
-        (entry.getKey.longValue(), codec.decode(entry.getValue))
+        (entry.getKey.longValue(), codec.decodeBaseIr(entry.getValue))
       }
     }
   }

--- a/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
@@ -207,9 +207,20 @@ class GigaTileProcessFunction(
                               System.currentTimeMillis()))
       }
 
-      // Don't re-register from onTimer. Each event in processElement1 registers the next
-      // eviction timer. Without new events, there's nothing to correct (sawtooth doesn't
-      // grow). This also prevents an infinite timer loop at end-of-stream when watermark = MAX.
+      // Re-register the next eviction timer so idle keys keep decaying without waiting for
+      // a new event. The natural termination is `result.isEmpty`: once every column has
+      // decayed to null there's nothing more to correct, and no new timer is needed until a
+      // fresh event arrives. Without re-registration, an entity that goes silent serves the
+      // last emit forever — even after every event has aged out of every window.
+      if (!result.isEmpty) {
+        val interval = processor.minEvictionInterval
+        // Guard against integer overflow at end-of-stream (watermark = Long.MaxValue): if
+        // the next timer would wrap into the negative range, skip — Flink would either
+        // refuse the registration or fire it immediately, looping forever.
+        if (timestamp <= Long.MaxValue - interval) {
+          ctx.timerService().registerEventTimeTimer(timestamp + interval)
+        }
+      }
     } catch {
       case e: Exception =>
         logger.error(s"Error in giga tile eviction for groupBy=${groupBy.getMetaData.getName}", e)

--- a/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
@@ -49,8 +49,7 @@ class GigaTileProcessFunction(
   // Flink managed state
   private var tileState: MapState[String, Array[Byte]] = _
   private var megaTileIrState: ValueState[Array[Byte]] = _
-  private var largeTodayIrState: ValueState[Array[Byte]] = _
-  private var largeYesterdayIrState: ValueState[Array[Byte]] = _
+  private var dailyLargeIrState: MapState[java.lang.Long, Array[Byte]] = _
   private var currentDayStartState: ValueState[java.lang.Long] = _
   private var earliestTileStartState: ValueState[java.lang.Long] = _
   private var batchIrState: ValueState[Array[Byte]] = _
@@ -70,10 +69,11 @@ class GigaTileProcessFunction(
       new MapStateDescriptor[String, Array[Byte]]("giga-tile-tiles", classOf[String], classOf[Array[Byte]]))
     megaTileIrState =
       getRuntimeContext.getState(new ValueStateDescriptor[Array[Byte]]("giga-tile-ir", classOf[Array[Byte]]))
-    largeTodayIrState =
-      getRuntimeContext.getState(new ValueStateDescriptor[Array[Byte]]("giga-tile-large-today", classOf[Array[Byte]]))
-    largeYesterdayIrState = getRuntimeContext.getState(
-      new ValueStateDescriptor[Array[Byte]]("giga-tile-large-yesterday", classOf[Array[Byte]]))
+    dailyLargeIrState = getRuntimeContext.getMapState(
+      new MapStateDescriptor[java.lang.Long, Array[Byte]](
+        "giga-tile-large-daily",
+        classOf[java.lang.Long],
+        classOf[Array[Byte]]))
     currentDayStartState = getRuntimeContext.getState(
       new ValueStateDescriptor[java.lang.Long]("giga-tile-day-start", classOf[java.lang.Long]))
     earliestTileStartState = getRuntimeContext.getState(
@@ -106,7 +106,7 @@ class GigaTileProcessFunction(
     if (lastKey == null || !lastKey.equals(currentKey)) {
       lastKey = currentKey
       flinkStore.bindFlinkState(
-        tileState, megaTileIrState, largeTodayIrState, largeYesterdayIrState,
+        tileState, megaTileIrState, dailyLargeIrState,
         currentDayStartState, earliestTileStartState,
         batchIrState, batchEndTsState, runningLargeIrState
       )
@@ -218,28 +218,28 @@ class GigaTileProcessFunction(
   }
 }
 
-/** TileStore backed by Flink state for GigaTile. Extends the mega tile state with batch IR storage. */
+/** TileStore backed by Flink state for GigaTile. Extends the mega tile state with batch IR
+  * storage and a per-day large-IR map (keyed by day-start) sized to bridge any retained gap
+  * between batchEndDay and the watermark day.
+  */
 class FlinkGigaTileStore(megaTileAgg: MegaTileAggregator, codec: MegaTileCodec, gigaCodec: GigaTileCodec)
     extends GigaTileStore {
   private val windowedAgg = megaTileAgg.windowedAggregator
 
   private var tileState: MapState[String, Array[Byte]] = _
   private var megaTileIrState: ValueState[Array[Byte]] = _
-  private var largeTodayIrState: ValueState[Array[Byte]] = _
-  private var largeYesterdayIrState: ValueState[Array[Byte]] = _
+  private var dailyLargeIrState: MapState[java.lang.Long, Array[Byte]] = _
   private var currentDayStartState: ValueState[java.lang.Long] = _
   private var earliestTileStartState: ValueState[java.lang.Long] = _
   private var batchIrState: ValueState[Array[Byte]] = _
   private var batchEndTsState: ValueState[java.lang.Long] = _
   private var runningLargeIrState: ValueState[Array[Byte]] = _
 
-  // Decode cache (invalidated on key switch)
+  // Decode cache invalidated on key switch. Keeping per-day decoded values in an off-heap
+  // mutable map would defeat the idea of per-key Flink state, so we just memoize the values
+  // we read inside one event (typically getDailyLargeIr is called once per slot per recompute).
   private var cachedSmallDecoded: Array[Any] = _
   private var cachedSmallValid: Boolean = false
-  private var largeTodayDecoded: Array[Any] = _
-  private var largeTodayValid: Boolean = false
-  private var largeYesterdayDecoded: Array[Any] = _
-  private var largeYesterdayValid: Boolean = false
   private var batchIrDecoded: FinalBatchIr = _
   private var batchIrValid: Boolean = false
   private var runningLargeDecoded: Array[Any] = _
@@ -247,8 +247,7 @@ class FlinkGigaTileStore(megaTileAgg: MegaTileAggregator, codec: MegaTileCodec, 
 
   def bindFlinkState(tiles: MapState[String, Array[Byte]],
                      megaTileIr: ValueState[Array[Byte]],
-                     largeToday: ValueState[Array[Byte]],
-                     largeYesterday: ValueState[Array[Byte]],
+                     dailyLargeIr: MapState[java.lang.Long, Array[Byte]],
                      dayStart: ValueState[java.lang.Long],
                      earliest: ValueState[java.lang.Long],
                      batchIr: ValueState[Array[Byte]],
@@ -256,16 +255,13 @@ class FlinkGigaTileStore(megaTileAgg: MegaTileAggregator, codec: MegaTileCodec, 
                      runningLarge: ValueState[Array[Byte]]): Unit = {
     tileState = tiles
     megaTileIrState = megaTileIr
-    largeTodayIrState = largeToday
-    largeYesterdayIrState = largeYesterday
+    dailyLargeIrState = dailyLargeIr
     currentDayStartState = dayStart
     earliestTileStartState = earliest
     batchIrState = batchIr
     batchEndTsState = batchEndTs
     runningLargeIrState = runningLarge
     cachedSmallValid = false
-    largeTodayValid = false
-    largeYesterdayValid = false
     batchIrValid = false
     runningLargeValid = false
   }
@@ -306,24 +302,31 @@ class FlinkGigaTileStore(megaTileAgg: MegaTileAggregator, codec: MegaTileCodec, 
     cachedSmallDecoded = ir; cachedSmallValid = true
   }
 
-  override def getLargeTodayIr: Array[Any] = {
-    if (!largeTodayValid) { largeTodayDecoded = decodeWindowedIr(largeTodayIrState); largeTodayValid = true }
-    largeTodayDecoded
-  }
-  override def putLargeTodayIr(ir: Array[Any]): Unit = {
-    largeTodayIrState.update(codec.encode(ir))
-    largeTodayDecoded = ir; largeTodayValid = true
-  }
+  // Today/yesterday accessors required by the parent TileStore trait but unused in GigaTile —
+  // routing happens through the per-day map below. Stubbed to safe defaults so a misroute is
+  // detectable downstream (empty IRs / no-op writes) instead of throwing inside Flink.
+  override def getLargeTodayIr: Array[Any] = windowedAgg.init
+  override def putLargeTodayIr(ir: Array[Any]): Unit = ()
+  override def getLargeYesterdayIr: Array[Any] = windowedAgg.init
+  override def putLargeYesterdayIr(ir: Array[Any]): Unit = ()
 
-  override def getLargeYesterdayIr: Array[Any] = {
-    if (!largeYesterdayValid) {
-      largeYesterdayDecoded = decodeWindowedIr(largeYesterdayIrState); largeYesterdayValid = true
-    }
-    largeYesterdayDecoded
+  override def getDailyLargeIr(dayStart: Long): Array[Any] = {
+    val bytes = dailyLargeIrState.get(dayStart)
+    if (bytes != null) codec.decode(bytes) else null
   }
-  override def putLargeYesterdayIr(ir: Array[Any]): Unit = {
-    largeYesterdayIrState.update(codec.encode(ir))
-    largeYesterdayDecoded = ir; largeYesterdayValid = true
+  override def putDailyLargeIr(dayStart: Long, ir: Array[Any]): Unit =
+    dailyLargeIrState.put(dayStart, codec.encode(ir))
+  override def removeDailyLargeIr(dayStart: Long): Unit =
+    dailyLargeIrState.remove(dayStart)
+  override def dailyLargeIrIterator: Iterator[(Long, Array[Any])] = {
+    val iter = dailyLargeIrState.iterator()
+    new Iterator[(Long, Array[Any])] {
+      override def hasNext: Boolean = iter.hasNext
+      override def next(): (Long, Array[Any]) = {
+        val entry = iter.next()
+        (entry.getKey.longValue(), codec.decode(entry.getValue))
+      }
+    }
   }
 
   override def getCurrentDayStart: Long = Option(currentDayStartState.value()).map(_.longValue()).getOrElse(-1L)

--- a/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
@@ -1,6 +1,12 @@
 package ai.chronon.flink.window
 
-import ai.chronon.aggregator.windowing.{FinalBatchIr, GigaTileStore, GigaTileStreamProcessor, MegaTileAggregator}
+import ai.chronon.aggregator.windowing.{
+  EvictionTimes,
+  FinalBatchIr,
+  GigaTileStore,
+  GigaTileStreamProcessor,
+  MegaTileAggregator
+}
 import ai.chronon.api.{Constants, DataType, GroupBy, TsUtils}
 import ai.chronon.api.ScalaJavaConversions.IteratorOps
 import ai.chronon.flink.SparkExpressionEval
@@ -57,6 +63,8 @@ class GigaTileProcessFunction(
   private var batchEndTsState: ValueState[java.lang.Long] = _
   private var runningLargeIrState: ValueState[Array[Byte]] = _
   private var nextProcessingEvictionTimerState: ValueState[java.lang.Long] = _
+  private var cachedSmallWindowAsOfTsState: ValueState[java.lang.Long] = _
+  private var lastLargeRecomputeAsOfTsState: ValueState[java.lang.Long] = _
   private var lastEmittedVersionState: ValueState[java.lang.Long] = _
   private var pendingVersionCollisionState: ValueState[java.lang.Long] = _
 
@@ -89,6 +97,10 @@ class GigaTileProcessFunction(
       getRuntimeContext.getState(new ValueStateDescriptor[Array[Byte]]("giga-tile-running-large", classOf[Array[Byte]]))
     nextProcessingEvictionTimerState = getRuntimeContext.getState(
       new ValueStateDescriptor[java.lang.Long]("giga-tile-next-evict-pt-timer", classOf[java.lang.Long]))
+    cachedSmallWindowAsOfTsState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Long]("giga-tile-cached-small-window-as-of-ts", classOf[java.lang.Long]))
+    lastLargeRecomputeAsOfTsState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Long]("giga-tile-last-large-recompute-as-of-ts", classOf[java.lang.Long]))
     lastEmittedVersionState = getRuntimeContext.getState(
       new ValueStateDescriptor[java.lang.Long]("giga-tile-last-emitted-version", classOf[java.lang.Long]))
     pendingVersionCollisionState = getRuntimeContext.getState(
@@ -122,10 +134,18 @@ class GigaTileProcessFunction(
         earliestTileStartState,
         batchIrState,
         batchEndTsState,
-        runningLargeIrState
+        runningLargeIrState,
+        cachedSmallWindowAsOfTsState,
+        lastLargeRecomputeAsOfTsState
       )
     }
   }
+
+  // Small-window ranges use an exclusive upper bound. At an exact hop, nudge only that
+  // horizon so the just-opened tile remains visible; large windows keep the real time.
+  private def adjustedSmallWindowAsOfTs(asOfTs: Long): Long =
+    if (asOfTs < Long.MaxValue && asOfTs == TsUtils.round(asOfTs, processor.minSmallWindowTileSize)) asOfTs + 1L
+    else asOfTs
 
   /** Processing-time callbacks can share a millisecond. Coalesce later same-millisecond updates
     * behind a timer so emitted versions are strictly increasing before async sink handoff.
@@ -313,7 +333,10 @@ class GigaTileProcessFunction(
       val currentProcessingTime = timerService.currentProcessingTime()
       repairExpiredProcessingTimerMarkers(timerService, currentProcessingTime, None)
       val rolloverResult = processor.advanceWatermark(currentProcessingTime)
-      val eventResult = processor.onEvent(row, tsMills, currentProcessingTime)
+      val eventResult = processor.onEvent(row,
+                                          tsMills,
+                                          largeWindowAsOfTs = currentProcessingTime,
+                                          smallWindowAsOfTs = adjustedSmallWindowAsOfTs(currentProcessingTime))
       val result = if (eventResult.finalizedVector != null) eventResult else rolloverResult
 
       scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
@@ -347,7 +370,10 @@ class GigaTileProcessFunction(
       val rolloverResult = processor.advanceWatermark(currentProcessingTime)
 
       val batchIr = gigaTileCodec.decodeBatchIr(batchRow.valueBytes)
-      val batchResult = processor.onBatchUpdate(batchIr, batchRow.batchEndTs, currentProcessingTime)
+      val batchResult = processor.onBatchUpdate(batchIr,
+                                                batchRow.batchEndTs,
+                                                largeWindowAsOfTs = currentProcessingTime,
+                                                smallWindowAsOfTs = adjustedSmallWindowAsOfTs(currentProcessingTime))
       val result = if (batchResult.finalizedVector != null) batchResult else rolloverResult
 
       batchUpdateCounter.inc()
@@ -409,13 +435,15 @@ class GigaTileProcessFunction(
       if (isEvictionTimer) {
         nextProcessingEvictionTimerState.clear()
         val rolloverResult = processor.advanceWatermark(currentProcessingTime)
-        val evictionResult = processor.onScheduledEviction(currentProcessingTime)
+        val evictionResult = processor.onEviction(
+          EvictionTimes(timerTs = currentProcessingTime,
+                        smallWindowAsOfTs = adjustedSmallWindowAsOfTs(currentProcessingTime)))
         finalizedVector =
           if (evictionResult.finalizedVector != null) evictionResult.finalizedVector else rolloverResult.finalizedVector
 
         // Re-register before a coincident collision flush: if encoding the flush fails, both
         // the retry and normal eviction cadence remain live.
-        if (!evictionResult.isEmpty) {
+        if (!evictionResult.isEmpty || evictionResult.needsEvictionTimer) {
           scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
         }
       }
@@ -509,6 +537,8 @@ class FlinkGigaTileStore(megaTileAgg: MegaTileAggregator, codec: MegaTileCodec, 
   private var batchIrState: ValueState[Array[Byte]] = _
   private var batchEndTsState: ValueState[java.lang.Long] = _
   private var runningLargeIrState: ValueState[Array[Byte]] = _
+  private var cachedSmallWindowAsOfTsState: ValueState[java.lang.Long] = _
+  private var lastLargeRecomputeAsOfTsState: ValueState[java.lang.Long] = _
 
   // Decode cache invalidated on key switch. Keeping per-day decoded values in an off-heap
   // mutable map would defeat the idea of per-key Flink state, so we just memoize the values
@@ -527,7 +557,9 @@ class FlinkGigaTileStore(megaTileAgg: MegaTileAggregator, codec: MegaTileCodec, 
                      earliest: ValueState[java.lang.Long],
                      batchIr: ValueState[Array[Byte]],
                      batchEndTs: ValueState[java.lang.Long],
-                     runningLarge: ValueState[Array[Byte]]): Unit = {
+                     runningLarge: ValueState[Array[Byte]],
+                     cachedSmallWindowAsOfTs: ValueState[java.lang.Long],
+                     lastLargeRecomputeAsOfTs: ValueState[java.lang.Long]): Unit = {
     tileState = tiles
     megaTileIrState = megaTileIr
     dailyLargeIrState = dailyLargeIr
@@ -536,6 +568,8 @@ class FlinkGigaTileStore(megaTileAgg: MegaTileAggregator, codec: MegaTileCodec, 
     batchIrState = batchIr
     batchEndTsState = batchEndTs
     runningLargeIrState = runningLarge
+    cachedSmallWindowAsOfTsState = cachedSmallWindowAsOfTs
+    lastLargeRecomputeAsOfTsState = lastLargeRecomputeAsOfTs
     cachedSmallValid = false
     batchIrValid = false
     runningLargeValid = false
@@ -576,6 +610,14 @@ class FlinkGigaTileStore(megaTileAgg: MegaTileAggregator, codec: MegaTileCodec, 
     megaTileIrState.update(codec.encode(ir))
     cachedSmallDecoded = ir; cachedSmallValid = true
   }
+
+  override def getCachedSmallWindowAsOfTs: Long =
+    Option(cachedSmallWindowAsOfTsState.value()).map(_.longValue()).getOrElse(-1L)
+  override def putCachedSmallWindowAsOfTs(ts: Long): Unit = cachedSmallWindowAsOfTsState.update(ts)
+
+  override def getLastLargeRecomputeAsOfTs: Long =
+    Option(lastLargeRecomputeAsOfTsState.value()).map(_.longValue()).getOrElse(Long.MinValue)
+  override def putLastLargeRecomputeAsOfTs(ts: Long): Unit = lastLargeRecomputeAsOfTsState.update(ts)
 
   // Today/yesterday accessors required by the parent TileStore trait but unused in GigaTile —
   // routing happens through the per-day map below. Stubbed to safe defaults so a misroute is

--- a/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
@@ -11,6 +11,7 @@ import ai.chronon.online.serde.ArrayRow
 import org.apache.flink.api.common.state.{MapState, MapStateDescriptor, ValueState, ValueStateDescriptor}
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.metrics.Counter
+import org.apache.flink.streaming.api.{TimeDomain, TimerService}
 import org.apache.flink.streaming.api.functions.co.KeyedCoProcessFunction
 import org.apache.flink.util.Collector
 import org.slf4j.{Logger, LoggerFactory}
@@ -55,6 +56,9 @@ class GigaTileProcessFunction(
   private var batchIrState: ValueState[Array[Byte]] = _
   private var batchEndTsState: ValueState[java.lang.Long] = _
   private var runningLargeIrState: ValueState[Array[Byte]] = _
+  private var nextProcessingEvictionTimerState: ValueState[java.lang.Long] = _
+  private var lastEmittedVersionState: ValueState[java.lang.Long] = _
+  private var pendingVersionCollisionState: ValueState[java.lang.Long] = _
 
   override def open(parameters: Configuration): Unit = {
     super.open(parameters)
@@ -70,10 +74,9 @@ class GigaTileProcessFunction(
     megaTileIrState =
       getRuntimeContext.getState(new ValueStateDescriptor[Array[Byte]]("giga-tile-ir", classOf[Array[Byte]]))
     dailyLargeIrState = getRuntimeContext.getMapState(
-      new MapStateDescriptor[java.lang.Long, Array[Byte]](
-        "giga-tile-large-daily",
-        classOf[java.lang.Long],
-        classOf[Array[Byte]]))
+      new MapStateDescriptor[java.lang.Long, Array[Byte]]("giga-tile-large-daily",
+                                                          classOf[java.lang.Long],
+                                                          classOf[Array[Byte]]))
     currentDayStartState = getRuntimeContext.getState(
       new ValueStateDescriptor[java.lang.Long]("giga-tile-day-start", classOf[java.lang.Long]))
     earliestTileStartState = getRuntimeContext.getState(
@@ -82,8 +85,14 @@ class GigaTileProcessFunction(
       getRuntimeContext.getState(new ValueStateDescriptor[Array[Byte]]("giga-tile-batch-ir", classOf[Array[Byte]]))
     batchEndTsState = getRuntimeContext.getState(
       new ValueStateDescriptor[java.lang.Long]("giga-tile-batch-end", classOf[java.lang.Long]))
-    runningLargeIrState = getRuntimeContext.getState(
-      new ValueStateDescriptor[Array[Byte]]("giga-tile-running-large", classOf[Array[Byte]]))
+    runningLargeIrState =
+      getRuntimeContext.getState(new ValueStateDescriptor[Array[Byte]]("giga-tile-running-large", classOf[Array[Byte]]))
+    nextProcessingEvictionTimerState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Long]("giga-tile-next-evict-pt-timer", classOf[java.lang.Long]))
+    lastEmittedVersionState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Long]("giga-tile-last-emitted-version", classOf[java.lang.Long]))
+    pendingVersionCollisionState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Long]("giga-tile-pending-version-collision", classOf[java.lang.Long]))
 
     initializeTransients()
   }
@@ -106,10 +115,181 @@ class GigaTileProcessFunction(
     if (lastKey == null || !lastKey.equals(currentKey)) {
       lastKey = currentKey
       flinkStore.bindFlinkState(
-        tileState, megaTileIrState, dailyLargeIrState,
-        currentDayStartState, earliestTileStartState,
-        batchIrState, batchEndTsState, runningLargeIrState
+        tileState,
+        megaTileIrState,
+        dailyLargeIrState,
+        currentDayStartState,
+        earliestTileStartState,
+        batchIrState,
+        batchEndTsState,
+        runningLargeIrState
       )
+    }
+  }
+
+  /** Processing-time callbacks can share a millisecond. Coalesce later same-millisecond updates
+    * behind a timer so emitted versions are strictly increasing before async sink handoff.
+    */
+  private def emitOrCoalesceVersionCollision(
+      timerService: TimerService,
+      finalizedVector: Array[Any],
+      currentKey: java.util.List[Any],
+      versionMillis: Long,
+      startProcessingTimeMillis: Long,
+      out: Collector[TimestampedTile]
+  ): Unit = {
+    if (finalizedVector == null) return
+
+    val lastEmittedVersion = lastEmittedVersionState.value()
+    if (
+      pendingVersionCollisionState.value() != null ||
+      (lastEmittedVersion != null && versionMillis <= lastEmittedVersion.longValue())
+    ) {
+      scheduleVersionCollisionFlushIfNeeded(timerService, lastEmittedVersion)
+    } else {
+      try {
+        out.collect(
+          new TimestampedTile(currentKey,
+                              gigaTileCodec.encodeOutput(finalizedVector),
+                              versionMillis,
+                              startProcessingTimeMillis))
+        lastEmittedVersionState.update(versionMillis)
+      } catch {
+        case e: Exception =>
+          // State was already mutated. Retry the current snapshot on a future timer so a
+          // transient first-write failure cannot leave the key unpublished.
+          scheduleVersionCollisionFlushIfNeeded(timerService, lastEmittedVersion)
+          throw e
+      }
+    }
+  }
+
+  private def scheduleVersionCollisionFlushIfNeeded(
+      timerService: TimerService,
+      lastEmittedVersion: java.lang.Long
+  ): Unit = {
+    val currentProcessingTime = timerService.currentProcessingTime()
+    if (
+      pendingVersionCollisionState.value() == null && currentProcessingTime < Long.MaxValue &&
+      (lastEmittedVersion == null || lastEmittedVersion.longValue() < Long.MaxValue)
+    ) {
+      val flushVersion =
+        if (lastEmittedVersion == null) currentProcessingTime + 1L
+        else math.max(lastEmittedVersion.longValue() + 1L, currentProcessingTime + 1L)
+      timerService.registerProcessingTimeTimer(flushVersion)
+      pendingVersionCollisionState.update(flushVersion)
+    }
+  }
+
+  private def isCurrentVersionCollisionTimer(timestamp: Long): Boolean =
+    Option(pendingVersionCollisionState.value()).exists(_.longValue() == timestamp)
+
+  private def processingTimerMarkerIsExpired(
+      markerTimestamp: Long,
+      currentProcessingTime: Long,
+      currentTimerCallback: Option[(TimeDomain, Long)]
+  ): Boolean =
+    currentTimerCallback match {
+      case None => markerTimestamp <= currentProcessingTime
+      // Flink exposes the jump target as currentProcessingTime while draining every due
+      // timer in timestamp order. A later marker is still physically queued; only a marker
+      // before this callback can have been consumed without clearing its ownership state.
+      case Some((TimeDomain.PROCESSING_TIME, callbackTimestamp)) => markerTimestamp < callbackTimestamp
+      case Some((TimeDomain.EVENT_TIME, _))                      => false
+    }
+
+  private def isCurrentProcessingTimerCallback(
+      timestamp: Long,
+      currentTimerCallback: Option[(TimeDomain, Long)]
+  ): Boolean =
+    currentTimerCallback.contains(TimeDomain.PROCESSING_TIME -> timestamp)
+
+  /** An older binary can consume additive processing-time timers without clearing their
+    * keyed ownership markers. Repair expired ownership on the next keyed callback. This
+    * cannot repair a completely idle key because a KeyedCoProcessFunction cannot enumerate
+    * keyed state during open; rolling back below this timer-aware layer still requires a
+    * retained compatible checkpoint or a state migration.
+    */
+  private def repairExpiredProcessingTimerMarkers(
+      timerService: TimerService,
+      currentProcessingTime: Long,
+      currentTimerCallback: Option[(TimeDomain, Long)]
+  ): Unit = {
+    val trackedEviction = nextProcessingEvictionTimerState.value()
+    if (
+      trackedEviction != null && processingTimerMarkerIsExpired(trackedEviction.longValue(),
+                                                                currentProcessingTime,
+                                                                currentTimerCallback)
+    ) {
+      nextProcessingEvictionTimestamp(currentProcessingTime) match {
+        case Some(nextEviction) =>
+          // Register first. If registration fails, leave the stale marker visible so a later
+          // callback can retry instead of recording ownership with no physical timer.
+          timerService.registerProcessingTimeTimer(nextEviction)
+          nextProcessingEvictionTimerState.update(nextEviction)
+        case None => nextProcessingEvictionTimerState.clear()
+      }
+    }
+
+    val trackedCollision = pendingVersionCollisionState.value()
+    if (
+      trackedCollision != null && processingTimerMarkerIsExpired(trackedCollision.longValue(),
+                                                                 currentProcessingTime,
+                                                                 currentTimerCallback)
+    ) {
+      val sharedEviction = Option(nextProcessingEvictionTimerState.value())
+        .map(_.longValue())
+        .filterNot(processingTimerMarkerIsExpired(_, currentProcessingTime, currentTimerCallback))
+      val nextCollision = sharedEviction.orElse {
+        val lastEmittedVersion = lastEmittedVersionState.value()
+        if (
+          currentProcessingTime == Long.MaxValue ||
+          (lastEmittedVersion != null && lastEmittedVersion.longValue() == Long.MaxValue)
+        ) None
+        else {
+          val afterLast = if (lastEmittedVersion == null) Long.MinValue else lastEmittedVersion.longValue() + 1L
+          Some(math.max(currentProcessingTime + 1L, afterLast))
+        }
+      }
+      nextCollision match {
+        case Some(timestamp) =>
+          // If the collision joins the callback currently being drained, role discovery below
+          // will consume it in this invocation. Re-registering that timestamp would enqueue an
+          // unnecessary immediate duplicate after Flink has removed the physical timer.
+          if (!isCurrentProcessingTimerCallback(timestamp, currentTimerCallback)) {
+            timerService.registerProcessingTimeTimer(timestamp)
+          }
+          pendingVersionCollisionState.update(timestamp)
+        case None => pendingVersionCollisionState.clear()
+      }
+    }
+  }
+
+  private def flushVersionCollision(
+      timerService: TimerService,
+      currentProcessingTime: Long,
+      currentKey: java.util.List[Any],
+      out: Collector[TimestampedTile]
+  ): Unit = {
+    try {
+      val pendingVersion = pendingVersionCollisionState.value()
+      if (pendingVersion == null) return
+
+      val snapshot = processor.currentSnapshot
+      val encoded = gigaTileCodec.encodeOutput(snapshot.finalizedVector)
+      out.collect(new TimestampedTile(currentKey, encoded, pendingVersion.longValue(), System.currentTimeMillis()))
+      lastEmittedVersionState.update(pendingVersion)
+      pendingVersionCollisionState.clear()
+    } catch {
+      case e: Exception =>
+        // The fired timer was the only flush trigger. Re-arm before the outer handler records
+        // the failure so a transient encoding/collection error cannot strand the latest value.
+        if (currentProcessingTime < Long.MaxValue) {
+          val retryVersion = currentProcessingTime + 1L
+          timerService.registerProcessingTimeTimer(retryVersion)
+          pendingVersionCollisionState.update(retryVersion)
+        }
+        throw e
     }
   }
 
@@ -129,19 +309,21 @@ class GigaTileProcessFunction(
       val row = new ArrayRow(values, tsMills)
 
       ensureStateBound(ctx.getCurrentKey)
-      processor.advanceWatermark(ctx.timerService().currentWatermark())
-      val result = processor.onEvent(row, tsMills)
+      val timerService = ctx.timerService()
+      val currentProcessingTime = timerService.currentProcessingTime()
+      repairExpiredProcessingTimerMarkers(timerService, currentProcessingTime, None)
+      val rolloverResult = processor.advanceWatermark(currentProcessingTime)
+      val eventResult = processor.onEvent(row, tsMills, currentProcessingTime)
+      val result = if (eventResult.finalizedVector != null) eventResult else rolloverResult
 
-      if (result.finalizedVector != null) {
-        out.collect(
-          new TimestampedTile(ctx.getCurrentKey,
-                              gigaTileCodec.encodeOutput(result.finalizedVector),
-                              tsMills,
-                              event.startProcessingTimeMillis))
-      }
+      scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
+      emitOrCoalesceVersionCollision(timerService,
+                                     result.finalizedVector,
+                                     ctx.getCurrentKey,
+                                     currentProcessingTime,
+                                     event.startProcessingTimeMillis,
+                                     out)
 
-      val nextEviction = TsUtils.round(tsMills, processor.minEvictionInterval) + processor.minEvictionInterval
-      ctx.timerService().registerEventTimeTimer(nextEviction)
     } catch {
       case e: Exception =>
         logger.error(s"Error processing giga tile event for groupBy=${groupBy.getMetaData.getName}", e)
@@ -159,27 +341,26 @@ class GigaTileProcessFunction(
       if (processor == null) initializeTransients()
 
       ensureStateBound(ctx.getCurrentKey)
-      processor.advanceWatermark(ctx.timerService().currentWatermark())
+      val timerService = ctx.timerService()
+      val currentProcessingTime = timerService.currentProcessingTime()
+      repairExpiredProcessingTimerMarkers(timerService, currentProcessingTime, None)
+      val rolloverResult = processor.advanceWatermark(currentProcessingTime)
 
       val batchIr = gigaTileCodec.decodeBatchIr(batchRow.valueBytes)
-      val result = processor.onBatchUpdate(batchIr, batchRow.batchEndTs,
-        ctx.timerService().currentWatermark())
+      val batchResult = processor.onBatchUpdate(batchIr, batchRow.batchEndTs, currentProcessingTime)
+      val result = if (batchResult.finalizedVector != null) batchResult else rolloverResult
 
       batchUpdateCounter.inc()
 
-      if (result.finalizedVector != null) {
-        out.collect(
-          new TimestampedTile(ctx.getCurrentKey,
-                              gigaTileCodec.encodeOutput(result.finalizedVector),
-                              batchRow.batchEndTs,
-                              System.currentTimeMillis()))
+      if (batchResult.needsEvictionTimer) {
+        scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
       }
-
-      if (result.needsEvictionTimer) {
-        val nextEviction = TsUtils.round(ctx.timerService().currentWatermark(),
-          processor.minEvictionInterval) + processor.minEvictionInterval
-        ctx.timerService().registerEventTimeTimer(nextEviction)
-      }
+      emitOrCoalesceVersionCollision(timerService,
+                                     result.finalizedVector,
+                                     ctx.getCurrentKey,
+                                     currentProcessingTime,
+                                     System.currentTimeMillis(),
+                                     out)
     } catch {
       case e: Exception =>
         logger.error(s"Error processing batch IR for groupBy=${groupBy.getMetaData.getName}", e)
@@ -192,39 +373,122 @@ class GigaTileProcessFunction(
       ctx: KeyedCoProcessFunction[java.util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#OnTimerContext,
       out: Collector[TimestampedTile]
   ): Unit = {
+    var timerServiceOnFailure: TimerService = null
+    var processingTimeOnFailure = Long.MinValue
+    var evictionTimerFired = false
+    var versionCollisionTimerFired = false
     try {
       if (processor == null) initializeTransients()
 
       ensureStateBound(ctx.getCurrentKey)
-      processor.advanceWatermark(ctx.timerService().currentWatermark())
-      val result = processor.onScheduledEviction(timestamp)
+      val timerService = ctx.timerService()
+      val currentProcessingTime = timerService.currentProcessingTime()
+      timerServiceOnFailure = timerService
+      processingTimeOnFailure = currentProcessingTime
+      repairExpiredProcessingTimerMarkers(timerService, currentProcessingTime, Some(ctx.timeDomain() -> timestamp))
 
-      if (result.finalizedVector != null) {
-        out.collect(
-          new TimestampedTile(ctx.getCurrentKey,
-                              gigaTileCodec.encodeOutput(result.finalizedVector),
-                              timestamp,
-                              System.currentTimeMillis()))
+      // Checkpoints written by the event-time implementation may still contain several
+      // event-time eviction timers per key. Let those callbacks migrate the key to one
+      // processing-time timer, but do not publish from both timer domains.
+      if (ctx.timeDomain() == TimeDomain.EVENT_TIME) {
+        scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
+        return
       }
 
-      // Re-register the next eviction timer so idle keys keep decaying without waiting for
-      // a new event. The natural termination is `result.isEmpty`: once every column has
-      // decayed to null there's nothing more to correct, and no new timer is needed until a
-      // fresh event arrives. Without re-registration, an entity that goes silent serves the
-      // last emit forever — even after every event has aged out of every window.
-      if (!result.isEmpty) {
-        val interval = processor.minEvictionInterval
-        // Guard against integer overflow at end-of-stream (watermark = Long.MaxValue): if
-        // the next timer would wrap into the negative range, skip — Flink would either
-        // refuse the registration or fire it immediately, looping forever.
-        if (timestamp <= Long.MaxValue - interval) {
-          ctx.timerService().registerEventTimeTimer(timestamp + interval)
+      if (ctx.timeDomain() != TimeDomain.PROCESSING_TIME) {
+        return
+      }
+
+      val isEvictionTimer = isCurrentProcessingEvictionTimer(timestamp)
+      val isVersionCollisionTimer = isCurrentVersionCollisionTimer(timestamp)
+      evictionTimerFired = isEvictionTimer
+      versionCollisionTimerFired = isVersionCollisionTimer
+      if (!isEvictionTimer && !isVersionCollisionTimer) return
+
+      var finalizedVector: Array[Any] = null
+      if (isEvictionTimer) {
+        nextProcessingEvictionTimerState.clear()
+        val rolloverResult = processor.advanceWatermark(currentProcessingTime)
+        val evictionResult = processor.onScheduledEviction(currentProcessingTime)
+        finalizedVector =
+          if (evictionResult.finalizedVector != null) evictionResult.finalizedVector else rolloverResult.finalizedVector
+
+        // Re-register before a coincident collision flush: if encoding the flush fails, both
+        // the retry and normal eviction cadence remain live.
+        if (!evictionResult.isEmpty) {
+          scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
         }
+      }
+
+      if (isVersionCollisionTimer) {
+        // Eviction wins when both timers share a timestamp; publish one post-eviction snapshot.
+        flushVersionCollision(timerService, currentProcessingTime, ctx.getCurrentKey, out)
+      } else {
+        emitOrCoalesceVersionCollision(timerService,
+                                       finalizedVector,
+                                       ctx.getCurrentKey,
+                                       currentProcessingTime,
+                                       System.currentTimeMillis(),
+                                       out)
       }
     } catch {
       case e: Exception =>
+        if (timerServiceOnFailure != null) {
+          val trackedEviction = nextProcessingEvictionTimerState.value()
+          if (
+            evictionTimerFired &&
+            (trackedEviction == null || trackedEviction.longValue() <= timestamp)
+          ) {
+            nextProcessingEvictionTimerState.clear()
+            scheduleProcessingEvictionTimerIfNeeded(timerServiceOnFailure, processingTimeOnFailure)
+          }
+          val pendingCollision = pendingVersionCollisionState.value()
+          if (
+            versionCollisionTimerFired && pendingCollision != null &&
+            pendingCollision.longValue() <= timestamp && processingTimeOnFailure < Long.MaxValue
+          ) {
+            // A shared callback must preserve eviction-before-publication ordering. If
+            // eviction failed, park the collision on the re-armed eviction timer instead
+            // of publishing the stale pre-eviction snapshot one millisecond later.
+            val retryVersion =
+              if (evictionTimerFired) {
+                Option(nextProcessingEvictionTimerState.value())
+                  .map(_.longValue())
+                  .filter(_ > timestamp)
+                  .getOrElse(processingTimeOnFailure + 1L)
+              } else {
+                processingTimeOnFailure + 1L
+              }
+            timerServiceOnFailure.registerProcessingTimeTimer(retryVersion)
+            pendingVersionCollisionState.update(retryVersion)
+          }
+        }
         logger.error(s"Error in giga tile eviction for groupBy=${groupBy.getMetaData.getName}", e)
         eventProcessingErrorCounter.inc()
+    }
+  }
+
+  private def isCurrentProcessingEvictionTimer(timestamp: Long): Boolean =
+    Option(nextProcessingEvictionTimerState.value()).exists(_.longValue() == timestamp)
+
+  private def nextProcessingEvictionTimestamp(currentProcessingTime: Long): Option[Long] = {
+    val interval = processor.minEvictionInterval
+    if (currentProcessingTime <= Long.MaxValue - interval) {
+      Some(TsUtils.round(currentProcessingTime, interval) + interval)
+    } else {
+      None
+    }
+  }
+
+  private def scheduleProcessingEvictionTimerIfNeeded(
+      timerService: TimerService,
+      currentProcessingTime: Long
+  ): Unit = {
+    if (nextProcessingEvictionTimerState.value() == null) {
+      nextProcessingEvictionTimestamp(currentProcessingTime).foreach { nextEviction =>
+        timerService.registerProcessingTimeTimer(nextEviction)
+        nextProcessingEvictionTimerState.update(nextEviction)
+      }
     }
   }
 }

--- a/flink/src/test/scala/ai/chronon/flink/test/AllowedLatenessConfigTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/AllowedLatenessConfigTest.scala
@@ -1,6 +1,7 @@
 package ai.chronon.flink.test
 
 import ai.chronon.flink.FlinkUtils
+import ai.chronon.flink.window.MegaTileEmissionPolicy
 import ai.chronon.online.TopicInfo
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -155,5 +156,10 @@ class AllowedLatenessConfigTest extends AnyFlatSpec with Matchers {
       FlinkUtils.getNonNegativeLongProperty("buffering_output_jitter_millis", props, topicInfo)
     }
     exception.getMessage should include("invalid buffering_output_jitter_millis value")
+  }
+
+  "GigaTile output buffering" should "require the wall-clock cadence policy" in {
+    FlinkUtils.gigaTileBufferingOutputTimeMillis(1000L, MegaTileEmissionPolicy.Default) shouldBe 0L
+    FlinkUtils.gigaTileBufferingOutputTimeMillis(1000L, MegaTileEmissionPolicy.WallClockCadence) shouldBe 1000L
   }
 }

--- a/flink/src/test/scala/ai/chronon/flink/test/AllowedLatenessConfigTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/AllowedLatenessConfigTest.scala
@@ -162,4 +162,14 @@ class AllowedLatenessConfigTest extends AnyFlatSpec with Matchers {
     FlinkUtils.gigaTileBufferingOutputTimeMillis(1000L, MegaTileEmissionPolicy.Default) shouldBe 0L
     FlinkUtils.gigaTileBufferingOutputTimeMillis(1000L, MegaTileEmissionPolicy.WallClockCadence) shouldBe 1000L
   }
+
+  "gigatile first-seen grace config" should "be opt-in for missing zero and negative values" in {
+    val key = "gigatile_first_seen_key_grace_millis"
+    val topicInfo = TopicInfo("test-topic", "kafka", Map.empty)
+
+    FlinkUtils.getNonNegativeLongProperty(key, Map.empty, topicInfo) shouldBe 0L
+    FlinkUtils.getNonNegativeLongProperty(key, Map(key -> "0"), topicInfo) shouldBe 0L
+    FlinkUtils.getNonNegativeLongProperty(key, Map(key -> "-1"), topicInfo) shouldBe 0L
+    FlinkUtils.getNonNegativeLongProperty(key, Map(key -> "3600000"), topicInfo) shouldBe 3600000L
+  }
 }

--- a/flink/src/test/scala/ai/chronon/flink/test/BaseFlinkJobMegaTileDefaultTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/BaseFlinkJobMegaTileDefaultTest.scala
@@ -14,6 +14,7 @@ import org.scalatest.matchers.should.Matchers
 private class LegacyOnlyFlinkJob(val groupByName: String) extends BaseFlinkJob {
   override def groupByServingInfoParsed: GroupByServingInfoParsed = null
   override def runTiledGroupByJob(env: StreamExecutionEnvironment): DataStream[WriteResponse] = null
+  override def runGigaTiledGroupByJob(env: StreamExecutionEnvironment): DataStream[WriteResponse] = null
 }
 
 class BaseFlinkJobMegaTileDefaultTest extends AnyFlatSpec with Matchers {
@@ -35,6 +36,7 @@ class BaseFlinkJobMegaTileDefaultTest extends AnyFlatSpec with Matchers {
       override def groupByServingInfoParsed: GroupByServingInfoParsed = null
       override def runTiledGroupByJob(env: StreamExecutionEnvironment): DataStream[WriteResponse] = sentinel
       override def runMegaTiledGroupByJob(env: StreamExecutionEnvironment): DataStream[WriteResponse] = sentinel
+      override def runGigaTiledGroupByJob(env: StreamExecutionEnvironment): DataStream[WriteResponse] = sentinel
     }
     noException should be thrownBy job.runMegaTiledGroupByJob(StreamExecutionEnvironment.getExecutionEnvironment)
   }

--- a/flink/src/test/scala/ai/chronon/flink/test/BatchIrRowDecoderTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/BatchIrRowDecoderTest.scala
@@ -1,0 +1,133 @@
+package ai.chronon.flink.test
+
+import ai.chronon.api._
+import ai.chronon.api.Extensions.GroupByOps
+import ai.chronon.flink.source.BatchIrRowDecoder
+import ai.chronon.flink.types.BatchIrRow
+import ai.chronon.online.GroupByServingInfoParsed
+import ai.chronon.online.serde.AvroConversions
+import org.apache.flink.table.data.{GenericRowData, StringData}
+import org.apache.flink.util.Collector
+import org.junit.Assert._
+import org.scalatest.flatspec.AnyFlatSpec
+
+import java.util
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+/** Tests BatchIrRowDecoder's batchEnd derivation from the ds partition column.
+  * Verifies the +1 day convention: ds=2026-03-28 → batchEnd = Mar 29 00:00 UTC.
+  */
+class BatchIrRowDecoderTest extends AnyFlatSpec {
+
+  val DayMillis: Long = 24 * 3600 * 1000L
+
+  private def makeServingInfo(batchEndDate: String = "2026-03-29",
+                               dateFormat: String = "yyyy-MM-dd"): GroupByServingInfoParsed = {
+    val gb = new GroupBy()
+    gb.setAggregations(Seq(
+      Builders.Aggregation(Operation.COUNT, "num", Seq(new Window(1, TimeUnit.DAYS)))
+    ).asJava)
+    val meta = new MetaData()
+    meta.setName("test_batch_ir_decoder")
+    gb.setMetaData(meta)
+    gb.setSources(new java.util.ArrayList(util.Arrays.asList(
+      Builders.Source.events(
+        table = "db.events",
+        topic = "events_topic",
+        query = Builders.Query(selects = Map("num" -> "num"), timeColumn = "ts")
+      )
+    )))
+    gb.setKeyColumns(new java.util.ArrayList(util.Arrays.asList("entity_id")))
+
+    val keySchema = StructType("Key", Array(StructField("entity_id", StringType)))
+    val inputSchema = StructType("Input", Array(
+      StructField("entity_id", StringType),
+      StructField("num", LongType),
+      StructField("ts", LongType)
+    ))
+    val selectedSchema = StructType("Selected", Array(
+      StructField("num", LongType),
+      StructField("ts", LongType)
+    ))
+
+    val servingInfo = new GroupByServingInfo()
+    servingInfo.setGroupBy(gb)
+    servingInfo.setBatchEndDate(batchEndDate)
+    servingInfo.setDateFormat(dateFormat)
+    servingInfo.setKeyAvroSchema(AvroConversions.fromChrononSchema(keySchema).toString(true))
+    servingInfo.setInputAvroSchema(AvroConversions.fromChrononSchema(inputSchema).toString(true))
+    servingInfo.setSelectedAvroSchema(AvroConversions.fromChrononSchema(selectedSchema).toString(true))
+    new GroupByServingInfoParsed(servingInfo)
+  }
+
+  /** Builds a mock RowData with 5 columns: key_bytes, value_bytes, key_json, value_json, ds. */
+  private def makeRowData(keyBytes: Array[Byte], valueBytes: Array[Byte], ds: String): GenericRowData = {
+    val row = new GenericRowData(5)
+    row.setField(0, keyBytes)
+    row.setField(1, valueBytes)
+    row.setField(2, StringData.fromString(""))   // key_json
+    row.setField(3, StringData.fromString(""))   // value_json
+    row.setField(4, StringData.fromString(ds))
+    row
+  }
+
+  /** Collecting Collector that captures emitted BatchIrRows. */
+  class CollectingCollector extends Collector[BatchIrRow] {
+    val collected: mutable.ArrayBuffer[BatchIrRow] = mutable.ArrayBuffer.empty
+    override def collect(record: BatchIrRow): Unit = collected += record
+    override def close(): Unit = {}
+  }
+
+  it should "derive batchEnd = ds + 1 day (not ds) matching after(endDs) convention" in {
+    val servingInfo = makeServingInfo(batchEndDate = "2026-03-29")
+    val decoder = new BatchIrRowDecoder(servingInfo)
+
+    val keyEncoder = AvroConversions.encodeBytes(servingInfo.keyChrononSchema, null)
+    val keyBytes = keyEncoder(Array[Any]("user_123"))
+    val valueBytes = Array[Byte](1, 2, 3) // dummy batch IR bytes
+
+    val collector = new CollectingCollector()
+
+    // ds=2026-03-28 → batchEnd should be Mar 29 00:00 (ds + 1 day)
+    val row1 = makeRowData(keyBytes, valueBytes, "2026-03-28")
+    decoder.flatMap(row1, collector)
+    assertEquals("should emit one row", 1, collector.collected.size)
+
+    val fmt = new java.text.SimpleDateFormat("yyyy-MM-dd")
+    fmt.setTimeZone(java.util.TimeZone.getTimeZone("UTC"))
+    val expectedBatchEnd1 = fmt.parse("2026-03-28").getTime + DayMillis // Mar 29 00:00
+    assertEquals("ds=2026-03-28 → batchEnd should be Mar 29 00:00", expectedBatchEnd1, collector.collected(0).batchEndTs)
+
+    // ds=2026-03-29 → batchEnd should be Mar 30 00:00
+    val row2 = makeRowData(keyBytes, valueBytes, "2026-03-29")
+    decoder.flatMap(row2, collector)
+    assertEquals("should emit two rows", 2, collector.collected.size)
+
+    val expectedBatchEnd2 = fmt.parse("2026-03-29").getTime + DayMillis // Mar 30 00:00
+    assertEquals("ds=2026-03-29 → batchEnd should be Mar 30 00:00", expectedBatchEnd2, collector.collected(1).batchEndTs)
+
+    // Verify the two batchEnds are different (sequential updates won't be rejected as stale)
+    assertTrue("second batchEnd should be > first", collector.collected(1).batchEndTs > collector.collected(0).batchEndTs)
+  }
+
+  it should "fall back to servingInfo.batchEndTsMillis when ds column is missing" in {
+    val servingInfo = makeServingInfo(batchEndDate = "2026-03-29")
+    val decoder = new BatchIrRowDecoder(servingInfo)
+
+    val keyEncoder = AvroConversions.encodeBytes(servingInfo.keyChrononSchema, null)
+    val keyBytes = keyEncoder(Array[Any]("user_123"))
+    val valueBytes = Array[Byte](1, 2, 3)
+
+    // Row with only 2 columns (no ds)
+    val row = new GenericRowData(2)
+    row.setField(0, keyBytes)
+    row.setField(1, valueBytes)
+
+    val collector = new CollectingCollector()
+    decoder.flatMap(row, collector)
+    assertEquals("should emit one row", 1, collector.collected.size)
+    assertEquals("should use servingInfo.batchEndTsMillis",
+                  servingInfo.batchEndTsMillis, collector.collected(0).batchEndTs)
+  }
+}

--- a/flink/src/test/scala/ai/chronon/flink/test/BatchIrRowDecoderTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/BatchIrRowDecoderTest.scala
@@ -2,11 +2,12 @@ package ai.chronon.flink.test
 
 import ai.chronon.api._
 import ai.chronon.api.Extensions.GroupByOps
-import ai.chronon.flink.source.BatchIrRowDecoder
+import ai.chronon.flink.source.{BatchIrRowDecoder, BatchIrSourceBuilder}
 import ai.chronon.flink.types.BatchIrRow
 import ai.chronon.online.GroupByServingInfoParsed
 import ai.chronon.online.serde.AvroConversions
 import org.apache.flink.table.data.{GenericRowData, StringData}
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.util.Collector
 import org.junit.Assert._
 import org.scalatest.flatspec.AnyFlatSpec
@@ -62,13 +63,16 @@ class BatchIrRowDecoderTest extends AnyFlatSpec {
   }
 
   /** Builds a mock RowData with 5 columns: key_bytes, value_bytes, key_json, value_json, ds. */
-  private def makeRowData(keyBytes: Array[Byte], valueBytes: Array[Byte], ds: String): GenericRowData = {
+  private def makeRowData(keyBytes: Array[Byte],
+                          valueBytes: Array[Byte],
+                          ds: String,
+                          keyJson: String = ""): GenericRowData = {
     val row = new GenericRowData(5)
     row.setField(0, keyBytes)
     row.setField(1, valueBytes)
-    row.setField(2, StringData.fromString(""))   // key_json
+    row.setField(2, if (keyJson == null) null else StringData.fromString(keyJson)) // key_json
     row.setField(3, StringData.fromString(""))   // value_json
-    row.setField(4, StringData.fromString(ds))
+    row.setField(4, if (ds == null) null else StringData.fromString(ds))
     row
   }
 
@@ -129,5 +133,118 @@ class BatchIrRowDecoderTest extends AnyFlatSpec {
     assertEquals("should emit one row", 1, collector.collected.size)
     assertEquals("should use servingInfo.batchEndTsMillis",
                   servingInfo.batchEndTsMillis, collector.collected(0).batchEndTs)
+  }
+
+  it should "fail malformed rows closed only when an absent-row fallback requires them" in {
+    val servingInfo = makeServingInfo()
+    val malformed = makeRowData(Array[Byte](1, 2, 3), Array[Byte](4, 5, 6), "2026-03-28")
+
+    val bestEffortCollector = new CollectingCollector()
+    new BatchIrRowDecoder(servingInfo).flatMap(malformed, bestEffortCollector)
+    assertTrue(bestEffortCollector.collected.isEmpty)
+
+    val requiredCollector = new CollectingCollector()
+    intercept[Exception] {
+      new BatchIrRowDecoder(servingInfo, failOnDecodeError = true).flatMap(malformed, requiredCollector)
+    }
+    assertTrue(requiredCollector.collected.isEmpty)
+  }
+
+  it should "skip the upload metadata row even when strict decoding is enabled" in {
+    val decoder = new BatchIrRowDecoder(makeServingInfo(), failOnDecodeError = true)
+    val collector = new CollectingCollector()
+    val metadataRow = makeRowData(Constants.GroupByServingInfoKey.getBytes(Constants.UTF8),
+                                  Array[Byte](1, 2, 3),
+                                  "2026-03-28",
+                                  keyJson = Constants.GroupByServingInfoKey)
+
+    decoder.flatMap(metadataRow, collector)
+
+    assertTrue(collector.collected.isEmpty)
+  }
+
+  it should "reject null key or value bytes when an absent-row fallback requires them" in {
+    val decoder = new BatchIrRowDecoder(makeServingInfo(), failOnDecodeError = true)
+
+    val error = intercept[IllegalArgumentException] {
+      decoder.flatMap(makeRowData(null, Array[Byte](1), "2026-03-28"), new CollectingCollector())
+    }
+    assertTrue(error.getMessage.contains("null key_bytes or value_bytes"))
+  }
+
+  it should "require a ds partition value when the absent-row fallback is enabled" in {
+    val servingInfo = makeServingInfo()
+    val decoder = new BatchIrRowDecoder(servingInfo, failOnDecodeError = true)
+    val keyEncoder = AvroConversions.encodeBytes(servingInfo.keyChrononSchema, null)
+    val keyBytes = keyEncoder(Array[Any]("user_123"))
+    val valueBytes = Array[Byte](1, 2, 3)
+
+    val missingDs = new GenericRowData(2)
+    missingDs.setField(0, keyBytes)
+    missingDs.setField(1, valueBytes)
+    val missingError = intercept[IllegalArgumentException] {
+      decoder.flatMap(missingDs, new CollectingCollector())
+    }
+    assertTrue(missingError.getMessage.contains("missing required ds"))
+
+    val nullError = intercept[IllegalArgumentException] {
+      decoder.flatMap(makeRowData(keyBytes, valueBytes, null), new CollectingCollector())
+    }
+    assertTrue(nullError.getMessage.contains("missing required ds"))
+  }
+
+  it should "reject invalid or partially parsed ds values when the absent-row fallback is enabled" in {
+    val servingInfo = makeServingInfo()
+    val decoder = new BatchIrRowDecoder(servingInfo, failOnDecodeError = true)
+    val keyEncoder = AvroConversions.encodeBytes(servingInfo.keyChrononSchema, null)
+    val keyBytes = keyEncoder(Array[Any]("user_123"))
+    val valueBytes = Array[Byte](1, 2, 3)
+
+    Seq("2026-02-31", "2026-03-28-junk").foreach { ds =>
+      val error = intercept[java.text.ParseException] {
+        decoder.flatMap(makeRowData(keyBytes, valueBytes, ds), new CollectingCollector())
+      }
+      assertTrue(error.getMessage.contains("Invalid ds partition value"))
+    }
+  }
+
+  "BatchIrSourceBuilder" should "preserve the idle fallback when no batch source is required" in {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val stream = BatchIrSourceBuilder.build(env, makeServingInfo(), Map.empty)
+
+    assertEquals("Idle batch IR source for test_batch_ir_decoder", stream.getTransformation.getName)
+  }
+
+  it should "reject a missing warehouse when an absent-row fallback requires the batch source" in {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+
+    val error = intercept[IllegalArgumentException] {
+      BatchIrSourceBuilder.build(env,
+                                 makeServingInfo(),
+                                 Map.empty,
+                                 requireConfiguredBatchSource = true)
+    }
+    assertTrue(error.getMessage.contains("gigatile_first_seen_key_grace_millis"))
+  }
+
+  it should "fail closed on source construction errors only when the batch source is required" in {
+    val props = Map(
+      "iceberg.catalog.warehouse" -> "/tmp/unused-warehouse",
+      "iceberg.monitor.interval.minutes" -> "not-a-number"
+    )
+
+    val fallbackEnv = StreamExecutionEnvironment.getExecutionEnvironment
+    val fallback = BatchIrSourceBuilder.build(fallbackEnv, makeServingInfo(), props)
+    assertEquals("Idle batch IR source for test_batch_ir_decoder", fallback.getTransformation.getName)
+
+    val requiredEnv = StreamExecutionEnvironment.getExecutionEnvironment
+    val error = intercept[IllegalStateException] {
+      BatchIrSourceBuilder.build(requiredEnv,
+                                 makeServingInfo(),
+                                 props,
+                                 requireConfiguredBatchSource = true)
+    }
+    assertTrue(error.getMessage.contains("Failed to create required Iceberg source"))
+    assertTrue(error.getCause.isInstanceOf[NumberFormatException])
   }
 }

--- a/flink/src/test/scala/ai/chronon/flink/test/GigaTilePushFlinkIntegrationTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/GigaTilePushFlinkIntegrationTest.scala
@@ -1,0 +1,260 @@
+package ai.chronon.flink.test
+
+import ai.chronon.api._
+import ai.chronon.api.Extensions.GroupByOps
+import ai.chronon.api.ScalaJavaConversions._
+import ai.chronon.flink.{GigaTileAvroCodecFn, SparkExpressionEval, SparkExpressionEvalFn}
+import ai.chronon.flink.types.{BatchIrRow, TimestampedTile, WriteResponse}
+import ai.chronon.flink.window.GigaTileProcessFunction
+import ai.chronon.online.{Api, GigaTileCodec, GroupByServingInfoParsed}
+import ai.chronon.online.serde.SparkConversions
+import org.apache.flink.api.common.eventtime.WatermarkStrategy
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+import org.apache.flink.streaming.api.functions.source.SourceFunction
+import org.apache.flink.test.util.MiniClusterWithClientResource
+import org.apache.spark.sql.Encoders
+import org.mockito.Mockito.withSettings
+import org.scalatest.BeforeAndAfter
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers._
+import org.scalatestplus.mockito.MockitoSugar.mock
+
+import java.time.Duration
+import java.util
+
+/** Flink MiniCluster integration test for the PUSH (giga tile) pipeline.
+  *
+  * Exercises the full Flink wiring that isn't covered by aggregator-level tests:
+  * - GigaTileProcessFunction (CoProcessFunction) with connected streams
+  * - FlinkGigaTileStore with real Flink keyed state (ValueState/MapState)
+  * - Key switching across entities
+  * - Timer registration and event-time eviction
+  * - GigaTileAvroCodecFn output encoding
+  *
+  * Does NOT test Iceberg source (requires a real Iceberg catalog).
+  */
+class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
+
+  val flinkCluster = new MiniClusterWithClientResource(
+    new MiniClusterResourceConfiguration.Builder()
+      .setNumberSlotsPerTaskManager(8)
+      .setNumberTaskManagers(1)
+      .build)
+
+  before {
+    flinkCluster.before()
+    CollectSink.values.clear()
+  }
+
+  after {
+    flinkCluster.after()
+    CollectSink.values.clear()
+  }
+
+  /** Like FlinkTestUtils.makeTestGroupByServingInfoParsed but sets batchEndDate/dateFormat
+    * BEFORE constructing GroupByServingInfoParsed (needed by outputCodec → aggregator → batchEndTsMillis).
+    */
+  private def makePushGroupByServingInfoParsed(groupBy: GroupBy,
+                                                inputSchema: org.apache.spark.sql.types.StructType,
+                                                outputSchema: org.apache.spark.sql.types.StructType): GroupByServingInfoParsed = {
+    import ai.chronon.online.Extensions.StructTypeOps
+    val servingInfo = new GroupByServingInfo()
+    servingInfo.setGroupBy(groupBy)
+    servingInfo.setBatchEndDate("2023-11-08")
+    servingInfo.setDateFormat("yyyy-MM-dd")
+    servingInfo.setInputAvroSchema(inputSchema.toAvroSchema("Input").toString(true))
+    servingInfo.setKeyAvroSchema(
+      org.apache.spark.sql.types.StructType(
+        groupBy.keyColumns.toScala.map(col => outputSchema.fields.find(_.name == col).get))
+        .toAvroSchema("Key").toString(true))
+    val aggInputCols = groupBy.aggregations.toScala.map(_.inputColumn).toList
+    servingInfo.setSelectedAvroSchema(
+      org.apache.spark.sql.types.StructType(outputSchema.fields.filter(f => aggInputCols.contains(f.name)))
+        .toAvroSchema("Value").toString(true))
+    new GroupByServingInfoParsed(servingInfo)
+  }
+
+  private def makePushGroupBy(keyColumns: Seq[String]): GroupBy = {
+    val gb = FlinkTestUtils.makeGroupBy(keyColumns)
+    gb.setOnlineStrategy(OnlineStrategy.PUSH)
+    gb
+  }
+
+  private def buildPushPipeline(groupBy: GroupBy, elements: Seq[E2ETestEvent])(
+      implicit env: StreamExecutionEnvironment
+  ): (DataStream[WriteResponse], GroupByServingInfoParsed) = {
+    val query = SparkExpressionEval.queryFromGroupBy(groupBy)
+    val sparkExprEvalFn =
+      new SparkExpressionEvalFn(Encoders.product[E2ETestEvent], query, groupBy.metaData.name, groupBy.dataModel)
+    val source = new WatermarkedE2EEventSource(elements, sparkExprEvalFn)
+
+    val encoder = Encoders.product[E2ETestEvent]
+    val outputSchema =
+      new SparkExpressionEval(encoder, query, groupBy.getMetaData.getName, groupBy.dataModel).getOutputSchema
+    val outputSchemaDataTypes = outputSchema.fields.map { field =>
+      (field.name, SparkConversions.toChrononType(field.name, field.dataType))
+    }
+
+    val groupByServingInfoParsed =
+      makePushGroupByServingInfoParsed(groupBy, encoder.schema, outputSchema)
+
+    // Event stream with watermarks
+    val preparedStream = source
+      .getDataStream("test-topic", groupBy.metaData.name)(env, 2)
+      .uid(s"source-${groupBy.metaData.name}")
+
+    // Empty batch stream: completes immediately (so env.execute returns),
+    // watermark goes to MAX on completion (doesn't stall event stream's watermark).
+    val batchStream: DataStream[BatchIrRow] = env
+      .addSource(new EmptyBatchIrSource())
+      .uid(s"empty-batch-${groupBy.metaData.name}")
+
+    // Connect event + batch streams, key by entity, process
+    val eventKeySelector =
+      ai.chronon.flink.window.KeySelectorBuilder.build(groupBy)
+    val batchKeySelector =
+      new org.apache.flink.api.java.functions.KeySelector[BatchIrRow, java.util.List[Any]] {
+        override def getKey(row: BatchIrRow): java.util.List[Any] = row.entityKeys
+      }
+
+    val gigaTileDS: DataStream[TimestampedTile] = preparedStream
+      .connect(batchStream)
+      .keyBy(eventKeySelector, batchKeySelector)
+      .process(new GigaTileProcessFunction(groupBy, outputSchemaDataTypes, enableDebug = true))
+      .uid(s"push-process-${groupBy.metaData.name}")
+      .setParallelism(2)
+
+    // Skip the AsyncKVStoreWriter — collect TimestampedTile directly as WriteResponse
+    // to isolate the CoProcessFunction from async I/O hangs.
+    val writeDS: DataStream[WriteResponse] = gigaTileDS
+      .flatMap(GigaTileAvroCodecFn(groupByServingInfoParsed, enableDebug = true))
+      .uid(s"push-codec-${groupBy.metaData.name}")
+      .setParallelism(2)
+      .map { codec: ai.chronon.flink.types.AvroCodecOutput =>
+        new WriteResponse(codec.keyBytes, codec.valueBytes, codec.dataset,
+          codec.tsMillis, true, codec.startProcessingTime)
+      }
+      .uid(s"push-to-response-${groupBy.metaData.name}")
+
+    (writeDS, groupByServingInfoParsed)
+  }
+
+  it should "process events through GigaTileProcessFunction and emit finalized vectors" in {
+    implicit val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment
+
+    // 3 events across 2 entities. Each entity should produce at least one finalized vector.
+    val elements = Seq(
+      E2ETestEvent("test1", 12, 1.5, 1699366993123L),
+      E2ETestEvent("test2", 13, 1.6, 1699366993124L),
+      E2ETestEvent("test1", 14, 2.5, 1699366993125L)
+    )
+
+    val groupBy = makePushGroupBy(Seq("id"))
+    val (writeDS, servingInfo) = buildPushPipeline(groupBy, elements)
+    writeDS.addSink(new CollectSink)
+
+    env.execute("PushFlinkIntegrationTest")
+
+    val results = CollectSink.values.toScala
+
+    // Each event should trigger an emit (finalized vector)
+    results.size should be >= elements.size
+
+    // All writes should succeed
+    results.forall(_.status) shouldBe true
+
+    // Both entities should have output
+    val keyBytes = results.map(_.keyBytes).distinct
+    keyBytes.size should be >= 2
+
+    // Value bytes should be non-empty (finalized vector encoded)
+    results.foreach { wr =>
+      wr.valueBytes should not be empty
+    }
+  }
+
+  it should "produce decodable finalized vectors" in {
+    implicit val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment
+
+    // Single entity, known values
+    val elements = Seq(
+      E2ETestEvent("entity1", 10, 5.0, 1699366993100L),
+      E2ETestEvent("entity1", 20, 3.0, 1699366993200L)
+    )
+
+    val groupBy = makePushGroupBy(Seq("id"))
+    val (writeDS, servingInfo) = buildPushPipeline(groupBy, elements)
+    writeDS.addSink(new CollectSink)
+
+    env.execute("PushFlinkDecodableTest")
+
+    val results = CollectSink.values.toScala
+    results should not be empty
+    results.forall(_.status) shouldBe true
+
+    // Decode the finalized vector using the output codec
+    val latestResult = results.maxBy(_.tsMillis)
+    val decoded = servingInfo.outputCodec.decodeMap(latestResult.valueBytes)
+
+    // Should have the output field for SUM(double_val, 1d)
+    decoded should not be null
+    decoded should not be empty
+
+    // The SUM should be the sum of all double_val events (5.0 + 3.0 = 8.0)
+    val sumFieldName = decoded.keys.find(_.contains("double_val")).get
+    val sumValue = decoded(sumFieldName)
+    sumValue should not be null
+    sumValue.asInstanceOf[Double] shouldBe 8.0
+  }
+
+  it should "handle multiple entities with correct key isolation" in {
+    implicit val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment
+
+    // Two entities with different values — verify state isolation
+    val elements = Seq(
+      E2ETestEvent("alice", 1, 10.0, 1699366993100L),
+      E2ETestEvent("bob", 2, 20.0, 1699366993200L),
+      E2ETestEvent("alice", 3, 5.0, 1699366993300L)
+    )
+
+    val groupBy = makePushGroupBy(Seq("id"))
+    val (writeDS, servingInfo) = buildPushPipeline(groupBy, elements)
+    writeDS.addSink(new CollectSink)
+
+    env.execute("PushFlinkKeyIsolationTest")
+
+    val results = CollectSink.values.toScala
+    results should not be empty
+    results.forall(_.status) shouldBe true
+
+    // Group by key and pick the latest write per entity
+    val latestPerKey = results
+      .groupBy(r => util.Arrays.hashCode(r.keyBytes))
+      .map { case (_, writes) => writes.maxBy(_.tsMillis) }
+
+    // Each entity should have output
+    latestPerKey.size shouldBe 2
+
+    // Decode each and verify distinct values
+    val sums = latestPerKey.map { wr =>
+      val decoded = servingInfo.outputCodec.decodeMap(wr.valueBytes)
+      val sumField = decoded.keys.find(_.contains("double_val")).get
+      decoded(sumField).asInstanceOf[Double]
+    }.toSet
+
+    // Alice: 10.0 + 5.0 = 15.0, Bob: 20.0
+    sums shouldBe Set(15.0, 20.0)
+  }
+}
+
+/** SourceFunction that completes immediately, emitting zero elements.
+  * When a bounded source completes, Flink sets its watermark to Long.MAX_VALUE.
+  * The CoProcessFunction's combined watermark becomes min(eventWm, MAX) = eventWm,
+  * so the event stream drives watermark progression normally.
+  */
+class EmptyBatchIrSource extends SourceFunction[BatchIrRow] {
+  override def run(ctx: SourceFunction.SourceContext[BatchIrRow]): Unit = {}
+  override def cancel(): Unit = {}
+}

--- a/flink/src/test/scala/ai/chronon/flink/test/GigaTilePushFlinkIntegrationTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/GigaTilePushFlinkIntegrationTest.scala
@@ -194,19 +194,18 @@ class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
     results should not be empty
     results.forall(_.status) shouldBe true
 
-    // Decode the finalized vector using the output codec
-    val latestResult = results.maxBy(_.tsMillis)
-    val decoded = servingInfo.outputCodec.decodeMap(latestResult.valueBytes)
-
-    // Should have the output field for SUM(double_val, 1d)
-    decoded should not be null
-    decoded should not be empty
-
-    // The SUM should be the sum of all double_val events (5.0 + 3.0 = 8.0)
-    val sumFieldName = decoded.keys.find(_.contains("double_val")).get
-    val sumValue = decoded(sumFieldName)
-    sumValue should not be null
-    sumValue.asInstanceOf[Double] shouldBe 8.0
+    // The pipeline now decays idle entities via re-registered eviction timers, so the
+    // tsMillis-latest emit at end-of-stream is a tombstone (all-null). Pick the latest
+    // emit whose SUM is non-null to verify the aggregation itself is correct.
+    val sumFieldName = servingInfo.outputCodec.decodeMap(results.head.valueBytes).keys
+      .find(_.contains("double_val")).get
+    val nonEmpty = results.toSeq.flatMap { wr =>
+      val decoded = servingInfo.outputCodec.decodeMap(wr.valueBytes)
+      Option(decoded(sumFieldName)).map(v => (wr.tsMillis, v.asInstanceOf[Double]))
+    }
+    nonEmpty should not be empty
+    val (_, latestSum) = nonEmpty.maxBy(_._1)
+    latestSum shouldBe 8.0
   }
 
   it should "handle multiple entities with correct key isolation" in {
@@ -229,23 +228,25 @@ class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
     results should not be empty
     results.forall(_.status) shouldBe true
 
-    // Group by key and pick the latest write per entity
-    val latestPerKey = results
+    // Group by key and pick the latest non-empty write per entity. Idle decay timers fire
+    // at end-of-stream and tombstone each key with an all-null vector after 1d window
+    // expiration; the test verifies the SUM aggregation, not the decay, so filter to non-
+    // null sums per key.
+    val sumFieldName = servingInfo.outputCodec.decodeMap(results.head.valueBytes).keys
+      .find(_.contains("double_val")).get
+    val latestSumPerKey: Set[Double] = results
       .groupBy(r => util.Arrays.hashCode(r.keyBytes))
-      .map { case (_, writes) => writes.maxBy(_.tsMillis) }
-
-    // Each entity should have output
-    latestPerKey.size shouldBe 2
-
-    // Decode each and verify distinct values
-    val sums = latestPerKey.map { wr =>
-      val decoded = servingInfo.outputCodec.decodeMap(wr.valueBytes)
-      val sumField = decoded.keys.find(_.contains("double_val")).get
-      decoded(sumField).asInstanceOf[Double]
-    }.toSet
-
+      .values
+      .flatMap { writes =>
+        val nonEmpty = writes.toSeq.flatMap { wr =>
+          val decoded = servingInfo.outputCodec.decodeMap(wr.valueBytes)
+          Option(decoded(sumFieldName)).map(v => (wr.tsMillis, v.asInstanceOf[Double]))
+        }
+        if (nonEmpty.isEmpty) None else Some(nonEmpty.maxBy(_._1)._2)
+      }
+      .toSet
     // Alice: 10.0 + 5.0 = 15.0, Bob: 20.0
-    sums shouldBe Set(15.0, 20.0)
+    latestSumPerKey shouldBe Set(15.0, 20.0)
   }
 }
 

--- a/flink/src/test/scala/ai/chronon/flink/test/GigaTilePushFlinkIntegrationTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/GigaTilePushFlinkIntegrationTest.scala
@@ -30,7 +30,7 @@ import java.util
   * - GigaTileProcessFunction (CoProcessFunction) with connected streams
   * - FlinkGigaTileStore with real Flink keyed state (ValueState/MapState)
   * - Key switching across entities
-  * - Timer registration and event-time eviction
+  * - Timer registration and processing-time eviction
   * - GigaTileAvroCodecFn output encoding
   *
   * Does NOT test Iceberg source (requires a real Iceberg catalog).
@@ -143,12 +143,13 @@ class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
 
   it should "process events through GigaTileProcessFunction and emit finalized vectors" in {
     implicit val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment
+    val now = System.currentTimeMillis()
 
     // 3 events across 2 entities. Each entity should produce at least one finalized vector.
     val elements = Seq(
-      E2ETestEvent("test1", 12, 1.5, 1699366993123L),
-      E2ETestEvent("test2", 13, 1.6, 1699366993124L),
-      E2ETestEvent("test1", 14, 2.5, 1699366993125L)
+      E2ETestEvent("test1", 12, 1.5, now - 3000L),
+      E2ETestEvent("test2", 13, 1.6, now - 2000L),
+      E2ETestEvent("test1", 14, 2.5, now - 1000L)
     )
 
     val groupBy = makePushGroupBy(Seq("id"))
@@ -159,15 +160,12 @@ class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
 
     val results = CollectSink.values.toScala
 
-    // Each event should trigger an emit (finalized vector)
-    results.size should be >= elements.size
-
     // All writes should succeed
     results.forall(_.status) shouldBe true
 
-    // Both entities should have output
-    val keyBytes = results.map(_.keyBytes).distinct
-    keyBytes.size should be >= 2
+    // Same-millisecond updates may be coalesced, but every entity must publish final state.
+    val keyHashes = results.map(result => util.Arrays.hashCode(result.keyBytes)).distinct
+    keyHashes.size shouldBe 2
 
     // Value bytes should be non-empty (finalized vector encoded)
     results.foreach { wr =>
@@ -177,11 +175,12 @@ class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
 
   it should "produce decodable finalized vectors" in {
     implicit val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment
+    val now = System.currentTimeMillis()
 
     // Single entity, known values
     val elements = Seq(
-      E2ETestEvent("entity1", 10, 5.0, 1699366993100L),
-      E2ETestEvent("entity1", 20, 3.0, 1699366993200L)
+      E2ETestEvent("entity1", 10, 5.0, now - 2000L),
+      E2ETestEvent("entity1", 20, 3.0, now - 1000L)
     )
 
     val groupBy = makePushGroupBy(Seq("id"))
@@ -194,9 +193,8 @@ class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
     results should not be empty
     results.forall(_.status) shouldBe true
 
-    // The pipeline now decays idle entities via re-registered eviction timers, so the
-    // tsMillis-latest emit at end-of-stream is a tombstone (all-null). Pick the latest
-    // emit whose SUM is non-null to verify the aggregation itself is correct.
+    // Processing-time freshness gates events against the current wall clock, so these test
+    // rows are intentionally recent rather than fixed historical timestamps.
     val sumFieldName = servingInfo.outputCodec.decodeMap(results.head.valueBytes).keys
       .find(_.contains("double_val")).get
     val nonEmpty = results.toSeq.flatMap { wr =>
@@ -210,12 +208,13 @@ class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
 
   it should "handle multiple entities with correct key isolation" in {
     implicit val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment
+    val now = System.currentTimeMillis()
 
     // Two entities with different values — verify state isolation
     val elements = Seq(
-      E2ETestEvent("alice", 1, 10.0, 1699366993100L),
-      E2ETestEvent("bob", 2, 20.0, 1699366993200L),
-      E2ETestEvent("alice", 3, 5.0, 1699366993300L)
+      E2ETestEvent("alice", 1, 10.0, now - 3000L),
+      E2ETestEvent("bob", 2, 20.0, now - 2000L),
+      E2ETestEvent("alice", 3, 5.0, now - 1000L)
     )
 
     val groupBy = makePushGroupBy(Seq("id"))
@@ -228,10 +227,7 @@ class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
     results should not be empty
     results.forall(_.status) shouldBe true
 
-    // Group by key and pick the latest non-empty write per entity. Idle decay timers fire
-    // at end-of-stream and tombstone each key with an all-null vector after 1d window
-    // expiration; the test verifies the SUM aggregation, not the decay, so filter to non-
-    // null sums per key.
+    // Group by key and pick the latest non-empty write per entity.
     val sumFieldName = servingInfo.outputCodec.decodeMap(results.head.valueBytes).keys
       .find(_.contains("double_val")).get
     val latestSumPerKey: Set[Double] = results

--- a/flink/src/test/scala/ai/chronon/flink/test/GigaTilePushFlinkIntegrationTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/GigaTilePushFlinkIntegrationTest.scala
@@ -3,16 +3,18 @@ package ai.chronon.flink.test
 import ai.chronon.api._
 import ai.chronon.api.Extensions.GroupByOps
 import ai.chronon.api.ScalaJavaConversions._
-import ai.chronon.flink.{GigaTileAvroCodecFn, SparkExpressionEval, SparkExpressionEvalFn}
+import ai.chronon.flink.deser.ProjectedEvent
+import ai.chronon.flink.{FlinkJob, GigaTileAvroCodecFn, SparkExpressionEval, SparkExpressionEvalFn}
 import ai.chronon.flink.types.{BatchIrRow, TimestampedTile, WriteResponse}
 import ai.chronon.flink.window.GigaTileProcessFunction
 import ai.chronon.online.{Api, GigaTileCodec, GroupByServingInfoParsed}
-import ai.chronon.online.serde.SparkConversions
-import org.apache.flink.api.common.eventtime.WatermarkStrategy
+import ai.chronon.online.serde.{AvroCodec, SparkConversions}
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration
 import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+import org.apache.flink.streaming.api.functions.sink.SinkFunction
 import org.apache.flink.streaming.api.functions.source.SourceFunction
+import org.apache.flink.streaming.api.watermark.Watermark
 import org.apache.flink.test.util.MiniClusterWithClientResource
 import org.apache.spark.sql.Encoders
 import org.mockito.Mockito.withSettings
@@ -21,8 +23,8 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 import org.scalatestplus.mockito.MockitoSugar.mock
 
-import java.time.Duration
 import java.util
+import java.util.concurrent.{CountDownLatch, TimeUnit}
 
 /** Flink MiniCluster integration test for the PUSH (giga tile) pipeline.
   *
@@ -46,6 +48,7 @@ class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
   before {
     flinkCluster.before()
     CollectSink.values.clear()
+    GigaTilePushIntegrationSourceGate.reset()
   }
 
   after {
@@ -88,8 +91,6 @@ class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
     val query = SparkExpressionEval.queryFromGroupBy(groupBy)
     val sparkExprEvalFn =
       new SparkExpressionEvalFn(Encoders.product[E2ETestEvent], query, groupBy.metaData.name, groupBy.dataModel)
-    val source = new WatermarkedE2EEventSource(elements, sparkExprEvalFn)
-
     val encoder = Encoders.product[E2ETestEvent]
     val outputSchema =
       new SparkExpressionEval(encoder, query, groupBy.getMetaData.getName, groupBy.dataModel).getOutputSchema
@@ -100,10 +101,14 @@ class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
     val groupByServingInfoParsed =
       makePushGroupByServingInfoParsed(groupBy, encoder.schema, outputSchema)
 
-    // Event stream with watermarks
-    val preparedStream = source
-      .getDataStream("test-topic", groupBy.metaData.name)(env, 2)
+    // The production sources are unbounded, but this fixture is bounded and would otherwise
+    // finish before a periodic watermark or processing-time timer can flush fenced state.
+    // Establish a finite watermark before records after the empty batch input is ready.
+    val preparedStream = env
+      .addSource(new LiveWatermarkedE2EEventSource(elements))
       .uid(s"source-${groupBy.metaData.name}")
+      .flatMap(sparkExprEvalFn)
+      .map(e => ProjectedEvent(e, System.currentTimeMillis()))
 
     // Empty batch stream: completes immediately (so env.execute returns),
     // watermark goes to MAX on completion (doesn't stall event stream's watermark).
@@ -154,7 +159,7 @@ class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
 
     val groupBy = makePushGroupBy(Seq("id"))
     val (writeDS, servingInfo) = buildPushPipeline(groupBy, elements)
-    writeDS.addSink(new CollectSink)
+    writeDS.addSink(new GigaTileCollectSink(expectedKeyCount = 2))
 
     env.execute("PushFlinkIntegrationTest")
 
@@ -163,7 +168,8 @@ class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
     // All writes should succeed
     results.forall(_.status) shouldBe true
 
-    // Same-millisecond updates may be coalesced, but every entity must publish final state.
+    // Same-millisecond coalescing and replay fencing may emit fewer writes, but every entity
+    // must publish final state.
     val keyHashes = results.map(result => util.Arrays.hashCode(result.keyBytes)).distinct
     keyHashes.size shouldBe 2
 
@@ -185,7 +191,7 @@ class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
 
     val groupBy = makePushGroupBy(Seq("id"))
     val (writeDS, servingInfo) = buildPushPipeline(groupBy, elements)
-    writeDS.addSink(new CollectSink)
+    writeDS.addSink(new GigaTileCollectSink(servingInfo.outputCodec, Set(8.0)))
 
     env.execute("PushFlinkDecodableTest")
 
@@ -219,7 +225,7 @@ class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
 
     val groupBy = makePushGroupBy(Seq("id"))
     val (writeDS, servingInfo) = buildPushPipeline(groupBy, elements)
-    writeDS.addSink(new CollectSink)
+    writeDS.addSink(new GigaTileCollectSink(servingInfo.outputCodec, Set(15.0, 20.0)))
 
     env.execute("PushFlinkKeyIsolationTest")
 
@@ -252,6 +258,105 @@ class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
   * so the event stream drives watermark progression normally.
   */
 class EmptyBatchIrSource extends SourceFunction[BatchIrRow] {
-  override def run(ctx: SourceFunction.SourceContext[BatchIrRow]): Unit = {}
+  override def run(ctx: SourceFunction.SourceContext[BatchIrRow]): Unit = {
+    ctx.emitWatermark(new Watermark(Long.MaxValue))
+    GigaTilePushIntegrationSourceGate.batchInputReady()
+  }
   override def cancel(): Unit = {}
+}
+
+/** Bounded event source that establishes a near-live watermark before emitting records. */
+class LiveWatermarkedE2EEventSource(elements: Seq[E2ETestEvent]) extends SourceFunction[E2ETestEvent] {
+  @volatile private var running = true
+
+  private def boundedOutOfOrdernessWatermark(maxEventTime: Long): Long = {
+    val delta = FlinkJob.AllowedOutOfOrderness.toMillis + 1L
+    if (maxEventTime < Long.MinValue + delta) Long.MinValue else maxEventTime - delta
+  }
+
+  override def run(ctx: SourceFunction.SourceContext[E2ETestEvent]): Unit = {
+    if (!GigaTilePushIntegrationSourceGate.awaitBatchInput()) {
+      throw new IllegalStateException("Timed out waiting for the empty batch input")
+    }
+
+    val sourceStartTime = System.currentTimeMillis()
+    val latestOriginalEventTime = elements.map(_.created).reduceOption((left, right) => math.max(left, right))
+      .getOrElse(sourceStartTime)
+    val rebasedElements = elements.map { event =>
+      event.copy(created = sourceStartTime - (latestOriginalEventTime - event.created))
+    }
+    val lock = ctx.getCheckpointLock
+    rebasedElements.headOption.foreach { firstEvent =>
+      val initialWatermark = boundedOutOfOrdernessWatermark(firstEvent.created)
+      lock.synchronized(ctx.emitWatermark(new Watermark(initialWatermark)))
+    }
+
+    var maxEventTime = Long.MinValue
+    rebasedElements.iterator.takeWhile(_ => running).foreach { event =>
+      lock.synchronized {
+        maxEventTime = math.max(maxEventTime, event.created)
+        ctx.collectWithTimestamp(event, event.created)
+        ctx.emitWatermark(new Watermark(boundedOutOfOrdernessWatermark(maxEventTime)))
+      }
+    }
+
+    if (running && !GigaTilePushIntegrationSourceGate.awaitOutput()) {
+      throw new IllegalStateException("Timed out waiting for GigaTile output")
+    }
+  }
+
+  override def cancel(): Unit = running = false
+}
+
+private object GigaTilePushIntegrationSourceGate {
+  @volatile private var batchReady = new CountDownLatch(1)
+  @volatile private var outputReady = new CountDownLatch(1)
+
+  def reset(): Unit = {
+    batchReady = new CountDownLatch(1)
+    outputReady = new CountDownLatch(1)
+  }
+
+  def batchInputReady(): Unit = batchReady.countDown()
+
+  def awaitBatchInput(): Boolean = batchReady.await(10, TimeUnit.SECONDS)
+
+  def outputObserved(): Unit = outputReady.countDown()
+
+  def awaitOutput(): Boolean = outputReady.await(30, TimeUnit.SECONDS)
+}
+
+private class GigaTileCollectSink(
+    outputCodec: AvroCodec = null,
+    expectedFinalSums: Set[Double] = Set.empty,
+    expectedKeyCount: Int = 1)
+    extends SinkFunction[WriteResponse] {
+
+  private def completionObserved: Boolean = {
+    val results = CollectSink.values.synchronized(CollectSink.values.toScala.toSeq)
+    if (expectedFinalSums.nonEmpty) {
+      val sumFieldName = outputCodec.decodeMap(results.head.valueBytes).keys
+        .find(_.contains("double_val"))
+        .get
+      val latestSumPerKey = results
+        .groupBy(result => util.Arrays.hashCode(result.keyBytes))
+        .values
+        .flatMap { writes =>
+          val nonEmpty = writes.flatMap { write =>
+            val decoded = outputCodec.decodeMap(write.valueBytes)
+            Option(decoded(sumFieldName)).map(value => (write.tsMillis, value.asInstanceOf[Double]))
+          }
+          if (nonEmpty.isEmpty) None else Some(nonEmpty.maxBy(_._1)._2)
+        }
+        .toSet
+      latestSumPerKey == expectedFinalSums
+    } else {
+      results.map(result => util.Arrays.hashCode(result.keyBytes)).distinct.size >= expectedKeyCount
+    }
+  }
+
+  override def invoke(value: WriteResponse, context: SinkFunction.Context): Unit = {
+    CollectSink.values.add(value)
+    if (completionObserved) GigaTilePushIntegrationSourceGate.outputObserved()
+  }
 }

--- a/flink/src/test/scala/ai/chronon/flink/test/window/ChrononClockModeTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/window/ChrononClockModeTest.scala
@@ -1,0 +1,98 @@
+package ai.chronon.flink.test.window
+
+import ai.chronon.flink.FlinkJob
+import ai.chronon.flink.window.ChrononClockMode
+import ai.chronon.flink.window.ChrononClockMode.{Catchup, Live, NoWatermark}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ChrononClockModeTest extends AnyFlatSpec with Matchers {
+  private val hopMillis = 5 * 60 * 1000L
+  private val exactHop = 10 * hopMillis
+  private val sourceOutOfOrderness = FlinkJob.AllowedOutOfOrderness.toMillis
+  private val liveBoundary = FlinkJob.LiveWatermarkLagToleranceMillis
+  private val aggregationHops = Seq(hopMillis, 60 * 60 * 1000L, 24 * 60 * 60 * 1000L)
+
+  "ChrononClockMode" should "fence an uninitialized connected watermark without timer horizons" in {
+    val mode = ChrononClockMode.classify(exactHop, Long.MinValue, sourceOutOfOrderness, liveBoundary)
+
+    mode shouldBe NoWatermark
+    ChrononClockMode.allowsPublication(mode) shouldBe false
+    ChrononClockMode.dayAdvanceAsOfMillis(mode, exactHop, Long.MinValue) shouldBe None
+    ChrononClockMode.processingTimerHorizons(mode, exactHop, Long.MinValue, hopMillis) shouldBe None
+    ChrononClockMode.streamEventHorizons(mode, exactHop, exactHop, Long.MinValue, hopMillis) shouldBe
+      ChrononClockMode.Horizons(exactHop, exactHop + 1L)
+  }
+
+  it should "keep every key fenced while the global watermark is behind" in {
+    val processingTime = exactHop + liveBoundary + 1L
+    val mode = ChrononClockMode.classify(processingTime, exactHop, sourceOutOfOrderness, liveBoundary)
+
+    mode shouldBe Catchup
+    ChrononClockMode.allowsPublication(mode) shouldBe false
+    ChrononClockMode.dayAdvanceAsOfMillis(mode, processingTime, exactHop) shouldBe Some(exactHop)
+    ChrononClockMode.processingTimerHorizons(mode, processingTime, exactHop, hopMillis) shouldBe
+      Some(ChrononClockMode.Horizons(exactHop, exactHop + 1L))
+  }
+
+  it should "use one source-readiness tolerance for every aggregation hop" in {
+    val processingTime = 20L * aggregationHops.last
+    val justBehind = processingTime - liveBoundary - 1L
+    val atBoundary = processingTime - liveBoundary
+
+    aggregationHops.foreach { aggregationHop =>
+      ChrononClockMode.classify(processingTime, justBehind, sourceOutOfOrderness, liveBoundary) shouldBe Catchup
+      ChrononClockMode.classify(processingTime, atBoundary, sourceOutOfOrderness, liveBoundary) shouldBe Live
+      ChrononClockMode.processingTimerHorizons(Live, processingTime, atBoundary, aggregationHop) shouldBe
+        Some(ChrononClockMode.Horizons(processingTime, processingTime + 1L))
+    }
+  }
+
+  it should "be live at the lag boundary and preserve separate exact-hop horizons" in {
+    val processingTime = exactHop
+    val watermark = processingTime - liveBoundary
+    val mode = ChrononClockMode.classify(processingTime, watermark, sourceOutOfOrderness, liveBoundary)
+
+    mode shouldBe Live
+    ChrononClockMode.allowsPublication(mode) shouldBe true
+    ChrononClockMode.streamEventHorizons(mode, watermark, processingTime, watermark, hopMillis) shouldBe
+      ChrononClockMode.Horizons(processingTime, processingTime + 1L)
+  }
+
+  it should "leave non-hop small horizons unchanged" in {
+    val processingTime = exactHop + sourceOutOfOrderness + 17L
+    val watermark = processingTime - sourceOutOfOrderness - 1L
+    val mode = ChrononClockMode.classify(processingTime, watermark, sourceOutOfOrderness, liveBoundary)
+
+    ChrononClockMode.streamEventHorizons(mode, processingTime, processingTime, watermark, hopMillis) shouldBe
+      ChrononClockMode.Horizons(processingTime, processingTime)
+  }
+
+  it should "fence a watermark that implies a future source timestamp" in {
+    val processingTime = exactHop + sourceOutOfOrderness
+    val healthyWatermark = processingTime - sourceOutOfOrderness - 1L
+    val futureWatermark = healthyWatermark + 1L
+
+    ChrononClockMode.classify(processingTime,
+                              healthyWatermark,
+                              sourceOutOfOrderness,
+                              liveBoundary) shouldBe Live
+    ChrononClockMode.classify(processingTime,
+                              futureWatermark,
+                              sourceOutOfOrderness,
+                              liveBoundary) shouldBe NoWatermark
+    ChrononClockMode.classify(processingTime,
+                              Long.MaxValue,
+                              sourceOutOfOrderness,
+                              liveBoundary) shouldBe NoWatermark
+  }
+
+  it should "avoid overflow near the end of the timestamp range" in {
+    val watermark = Long.MaxValue - sourceOutOfOrderness - 1L
+    val mode = ChrononClockMode.classify(Long.MaxValue, watermark, sourceOutOfOrderness, liveBoundary)
+
+    mode shouldBe Live
+    ChrononClockMode.processingTimerHorizons(mode, Long.MaxValue, watermark, hopMillis) shouldBe
+      Some(ChrononClockMode.Horizons(Long.MaxValue, Long.MaxValue))
+  }
+}

--- a/flink/src/test/scala/ai/chronon/flink/test/window/GigaTileFirstSeenKeyGraceTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/window/GigaTileFirstSeenKeyGraceTest.scala
@@ -1,0 +1,867 @@
+package ai.chronon.flink.test.window
+
+import ai.chronon.aggregator.windowing.{GigaEmitResult, SawtoothOnlineAggregator}
+import ai.chronon.api._
+import ai.chronon.api.Extensions.WindowOps
+import ai.chronon.flink.FlinkJob
+import ai.chronon.flink.deser.ProjectedEvent
+import ai.chronon.flink.types.{BatchIrRow, TimestampedTile}
+import ai.chronon.flink.window.GigaTileProcessFunction
+import ai.chronon.online.GigaTileCodec
+import ai.chronon.online.serde.{ArrayRow, AvroCodec}
+import org.apache.flink.api.common.state.{ValueState, ValueStateDescriptor}
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.functions.KeySelector
+import org.apache.flink.runtime.state.KeyedStateBackend
+import org.apache.flink.streaming.api.functions.co.KeyedCoProcessFunction
+import org.apache.flink.streaming.api.operators.co.KeyedCoProcessOperator
+import org.apache.flink.streaming.api.watermark.Watermark
+import org.apache.flink.streaming.util.KeyedTwoInputStreamOperatorTestHarness
+import org.apache.flink.util.Collector
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.util
+import scala.collection.JavaConverters._
+
+class GigaTileFirstSeenKeyGraceTest extends AnyFlatSpec with Matchers {
+  import GigaTileFirstSeenKeyGraceTest._
+
+  "GigaTileProcessFunction first-seen grace" should "initialize during catch-up but remain fenced until Live" in {
+    val graceMillis = 1000L
+    val function = new GigaTileProcessFunction(batchBackedGroupBy,
+                                               inputSchema,
+                                               firstSeenKeyGraceMillis = graceMillis)
+    val testHarness = harness(function)
+    val startProcessingTime = tenDays + oneHour
+    val catchupWatermark = startProcessingTime - 3L * dayMillis
+    val eventTime = catchupWatermark - 1000L
+    val graceTimer = nextDay(startProcessingTime)
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(startProcessingTime)
+      advanceConnectedWatermark(testHarness, catchupWatermark)
+      testHarness.processElement1(event(DefaultEntity, eventTime, 5L), eventTime)
+
+      testHarness.setProcessingTime(graceTimer)
+      testHarness.extractOutputValues() shouldBe empty
+      setCurrentKey(testHarness, entityKey(DefaultEntity))
+      state[Array[Byte]](function, "batchIrState").value() shouldBe null
+      state[java.lang.Boolean](function, "syntheticEmptyBatchBaselineState").value() shouldEqual
+        java.lang.Boolean.TRUE
+      state[java.lang.Boolean](function, "pendingEmptyBatchBaselineState").value() shouldBe null
+
+      val liveProcessingTime = graceTimer + 1000L
+      testHarness.setProcessingTime(liveProcessingTime)
+      advanceConnectedHealthyLiveWatermark(testHarness, liveProcessingTime)
+      testHarness.processElement1(event(DefaultEntity, liveProcessingTime - 1L, 0L), liveProcessingTime - 1L)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0), batchBackedGroupBy) shouldEqual 5L
+    } finally testHarness.close()
+  }
+
+  it should "not initialize, age, or publish from a NoWatermark processing timer" in {
+    val graceMillis = dayMillis + oneHour
+    val function = new GigaTileProcessFunction(batchBackedGroupBy,
+                                               inputSchema,
+                                               firstSeenKeyGraceMillis = graceMillis)
+    val testHarness = harness(function)
+    val startProcessingTime = tenDays + oneHour
+    val eventTime = startProcessingTime - 1000L
+    val eventDay = TsUtils.round(eventTime, dayMillis)
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(startProcessingTime)
+      testHarness.processElement1(event(DefaultEntity, eventTime, 5L), eventTime)
+
+      // This crosses two daily processing timers, including one after the grace expires.
+      testHarness.setProcessingTime(startProcessingTime + 2L * dayMillis)
+
+      testHarness.extractOutputValues() shouldBe empty
+      setCurrentKey(testHarness, entityKey(DefaultEntity))
+      state[Array[Byte]](function, "batchIrState").value() shouldBe null
+      state[java.lang.Boolean](function, "pendingEmptyBatchBaselineState").value() shouldEqual java.lang.Boolean.TRUE
+      state[java.lang.Long](function, "currentDayStartState").value().longValue() shouldEqual eventDay
+    } finally testHarness.close()
+  }
+
+  it should "not initialize from a NoWatermark event after grace" in {
+    val graceMillis = 1000L
+    val function = new GigaTileProcessFunction(
+      batchBackedGroupBy,
+      inputSchema,
+      firstSeenKeyGraceMillis = graceMillis)
+    val testHarness = harness(function)
+    val startProcessingTime = tenDays + oneHour
+    val firstEventTime = startProcessingTime - 1000L
+    val afterGraceProcessingTime = startProcessingTime + graceMillis + 1L
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(startProcessingTime)
+      testHarness.processElement1(event(DefaultEntity, firstEventTime, 5L), firstEventTime)
+
+      testHarness.setProcessingTime(afterGraceProcessingTime)
+      testHarness.processElement1(event(DefaultEntity, firstEventTime + 1L, 7L), firstEventTime + 1L)
+
+      testHarness.extractOutputValues() shouldBe empty
+      setCurrentKey(testHarness, entityKey(DefaultEntity))
+      state[Array[Byte]](function, "batchIrState").value() shouldBe null
+      state[java.lang.Boolean](function, "pendingEmptyBatchBaselineState").value() shouldEqual java.lang.Boolean.TRUE
+    } finally testHarness.close()
+  }
+
+  it should "let a real batch row win during the grace" in {
+    val graceMillis = 2000L
+    val function = new GigaTileProcessFunction(batchBackedGroupBy,
+                                               inputSchema,
+                                               firstSeenKeyGraceMillis = graceMillis)
+    val testHarness = harness(function)
+    val startProcessingTime = tenDays + oneHour
+    val eventTime = startProcessingTime - 1000L
+    val batchEnd = tenDays
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(startProcessingTime)
+      advanceConnectedHealthyLiveWatermark(testHarness, startProcessingTime)
+      testHarness.processElement1(event(DefaultEntity, eventTime, 5L), eventTime)
+      decodeSum(testHarness.extractOutputValues().get(0), batchBackedGroupBy) shouldBe null
+
+      val batchProcessingTime = startProcessingTime + graceMillis / 2L
+      testHarness.setProcessingTime(batchProcessingTime)
+      advanceConnectedHealthyLiveWatermark(testHarness, batchProcessingTime)
+      testHarness.processElement2(batchRow(DefaultEntity, batchBackedGroupBy, batchEnd, 7L), batchEnd)
+
+      val outputs = testHarness.extractOutputValues()
+      decodeSum(outputs.get(outputs.size() - 1), batchBackedGroupBy) shouldEqual 12L
+      setCurrentKey(testHarness, entityKey(DefaultEntity))
+      state[java.lang.Boolean](function, "pendingEmptyBatchBaselineState").value() shouldBe null
+      state[java.lang.Long](function, "batchEndTsState").value().longValue() shouldEqual batchEnd
+    } finally testHarness.close()
+  }
+
+  it should "let a real batch row replace a synthetic empty baseline" in {
+    val function = new GigaTileProcessFunction(batchBackedGroupBy,
+                                               inputSchema,
+                                               firstSeenKeyGraceMillis = 1L)
+    val testHarness = harness(function)
+    val startProcessingTime = tenDays + oneHour
+    val eventTime = startProcessingTime - 1000L
+    val batchEnd = tenDays
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(startProcessingTime)
+      advanceConnectedHealthyLiveWatermark(testHarness, startProcessingTime)
+      testHarness.processElement1(event(DefaultEntity, eventTime, 5L), eventTime)
+      decodeSum(testHarness.extractOutputValues().get(0), batchBackedGroupBy) shouldBe null
+
+      val baselineProcessingTime = startProcessingTime + 1L
+      testHarness.setProcessingTime(baselineProcessingTime)
+      advanceConnectedHealthyLiveWatermark(testHarness, baselineProcessingTime)
+      testHarness.processElement1(event(DefaultEntity, eventTime + 1L, 0L), eventTime + 1L)
+      val baselineOutputs = testHarness.extractOutputValues()
+      decodeSum(baselineOutputs.get(baselineOutputs.size() - 1), batchBackedGroupBy) shouldEqual 5L
+
+      setCurrentKey(testHarness, entityKey(DefaultEntity))
+      state[Array[Byte]](function, "batchIrState").value() shouldBe null
+      state[java.lang.Boolean](function, "syntheticEmptyBatchBaselineState").value() shouldEqual
+        java.lang.Boolean.TRUE
+      state[java.lang.Long](function, "batchEndTsState").value() shouldBe null
+
+      testHarness.processElement2(batchRow(DefaultEntity, batchBackedGroupBy, batchEnd, 7L), batchEnd)
+      // The event and batch callbacks share one processing-time millisecond, so the
+      // monotonic publisher flushes the authoritative batch result at the next millisecond.
+      testHarness.setProcessingTime(baselineProcessingTime + 1L)
+      val outputs = testHarness.extractOutputValues()
+      decodeSum(outputs.get(outputs.size() - 1), batchBackedGroupBy) shouldEqual 12L
+      state[Array[Byte]](function, "batchIrState").value() should not be null
+      state[java.lang.Boolean](function, "syntheticEmptyBatchBaselineState").value() shouldBe null
+      state[java.lang.Long](function, "batchEndTsState").value().longValue() shouldEqual batchEnd
+    } finally testHarness.close()
+  }
+
+  it should "fail batch value decoding closed when the fallback is enabled" in {
+    val function = new GigaTileProcessFunction(batchBackedGroupBy,
+                                               inputSchema,
+                                               firstSeenKeyGraceMillis = 1L)
+    val testHarness = harness(function)
+    val startProcessingTime = tenDays + oneHour
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(startProcessingTime)
+      advanceConnectedHealthyLiveWatermark(testHarness, startProcessingTime)
+
+      an[Exception] should be thrownBy testHarness.processElement2(
+        new BatchIrRow(entityKey(DefaultEntity), Array[Byte](1, 2, 3), tenDays),
+        tenDays)
+    } finally testHarness.close()
+  }
+
+  it should "ignore a stale pending fallback when batch state already exists" in {
+    val function = new GigaTileProcessFunction(batchBackedGroupBy,
+                                               inputSchema,
+                                               firstSeenKeyGraceMillis = 1L)
+    val testHarness = harness(function)
+    val startProcessingTime = tenDays + oneHour
+    val batchEnd = tenDays
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(startProcessingTime)
+      advanceConnectedHealthyLiveWatermark(testHarness, startProcessingTime)
+      testHarness.processElement2(batchRow(DefaultEntity, batchBackedGroupBy, batchEnd, 7L), batchEnd)
+
+      setCurrentKey(testHarness, entityKey(DefaultEntity))
+      state[java.lang.Boolean](function, "pendingEmptyBatchBaselineState").update(java.lang.Boolean.TRUE)
+
+      val noOpInitialization = initializeEmptyBatchBaseline(function,
+                                                            startProcessingTime + 1L,
+                                                            startProcessingTime)
+      noOpInitialization shouldBe None
+      state[java.lang.Boolean](function, "pendingEmptyBatchBaselineState").value() shouldBe null
+
+      // A no-op initialization must not replace callback metadata. This is the shape used
+      // by batch callbacks that need to retain the normal eviction schedule without emitting.
+      val callbackResult = GigaEmitResult(null, needsEvictionTimer = true)
+      val mergedResult = noOpInitialization.getOrElse(callbackResult)
+      mergedResult.finalizedVector shouldBe null
+      mergedResult.needsEvictionTimer shouldBe true
+
+      // Exercise the same coexistence through the normal event path and retain its value.
+      state[java.lang.Boolean](function, "pendingEmptyBatchBaselineState").update(java.lang.Boolean.TRUE)
+      val eventProcessingTime = startProcessingTime + 1L
+      testHarness.setProcessingTime(eventProcessingTime)
+      advanceConnectedHealthyLiveWatermark(testHarness, eventProcessingTime)
+      testHarness.processElement1(event(DefaultEntity, eventProcessingTime - 1L, 5L), eventProcessingTime - 1L)
+
+      val outputs = testHarness.extractOutputValues()
+      decodeSum(outputs.get(outputs.size() - 1), batchBackedGroupBy) shouldEqual 12L
+      state[java.lang.Boolean](function, "pendingEmptyBatchBaselineState").value() shouldBe null
+    } finally testHarness.close()
+  }
+
+  it should "restore pending grace and cadence state without bypassing a fresh grace" in {
+    val graceMillis = 1000L
+    val cadenceMillis = 100L
+    val startProcessingTime = tenDays + oneHour
+    val eventTime = startProcessingTime - 1000L
+    val firstCadence = nextBufferedWriteTick(batchBackedGroupBy,
+                                             entityKey(DefaultEntity),
+                                             startProcessingTime,
+                                             cadenceMillis)
+    val originalFunction = new GigaTileProcessFunction(batchBackedGroupBy,
+                                                       inputSchema,
+                                                       bufferingOutputTimeMillis = cadenceMillis,
+                                                       firstSeenKeyGraceMillis = graceMillis)
+    val originalHarness = harness(originalFunction)
+
+    originalHarness.open()
+    originalHarness.setProcessingTime(startProcessingTime)
+    advanceConnectedHealthyLiveWatermark(originalHarness, startProcessingTime)
+    originalHarness.processElement1(event(DefaultEntity, eventTime, 5L), eventTime)
+    val snapshot = originalHarness.snapshot(31L, startProcessingTime)
+    originalHarness.close()
+
+    val restoredFunction = new GigaTileProcessFunction(batchBackedGroupBy,
+                                                       inputSchema,
+                                                       bufferingOutputTimeMillis = cadenceMillis,
+                                                       firstSeenKeyGraceMillis = graceMillis)
+    val restoredHarness = harness(restoredFunction)
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(snapshot)
+      restoredHarness.open()
+      restoredHarness.setProcessingTime(startProcessingTime)
+      advanceConnectedHealthyLiveWatermark(restoredHarness, startProcessingTime)
+
+      // The restored cadence can flush the pre-grace null value, but must not install
+      // synthetic history or clear the keyed pending-grace marker.
+      restoredHarness.setProcessingTime(firstCadence)
+      setCurrentKey(restoredHarness, entityKey(DefaultEntity))
+      state[Array[Byte]](restoredFunction, "batchIrState").value() shouldBe null
+      state[java.lang.Boolean](restoredFunction, "pendingEmptyBatchBaselineState").value() shouldEqual
+        java.lang.Boolean.TRUE
+
+      val readyProcessingTime = firstCadence + graceMillis
+      restoredHarness.setProcessingTime(readyProcessingTime)
+      advanceConnectedHealthyLiveWatermark(restoredHarness, readyProcessingTime)
+      restoredHarness.processElement1(event(DefaultEntity, readyProcessingTime - 1L, 0L), readyProcessingTime - 1L)
+      val finalCadence = nextBufferedWriteTick(batchBackedGroupBy,
+                                               entityKey(DefaultEntity),
+                                               readyProcessingTime,
+                                               cadenceMillis)
+      restoredHarness.setProcessingTime(finalCadence)
+
+      val outputs = restoredHarness.extractOutputValues()
+      decodeSum(outputs.get(outputs.size() - 1), batchBackedGroupBy) shouldEqual 5L
+      state[Array[Byte]](restoredFunction, "batchIrState").value() shouldBe null
+      state[java.lang.Boolean](restoredFunction, "syntheticEmptyBatchBaselineState").value() shouldEqual
+        java.lang.Boolean.TRUE
+      state[java.lang.Boolean](restoredFunction, "pendingPublicationState").value() shouldEqual
+        java.lang.Boolean.TRUE
+      state[java.lang.Boolean](restoredFunction, "syntheticRollbackCorrectionState").value() shouldEqual
+        java.lang.Boolean.TRUE
+    } finally restoredHarness.close()
+  }
+
+  it should "remove a restored synthetic baseline when the option is disabled" in {
+    val graceMillis = 1000L
+    val startProcessingTime = tenDays + oneHour
+    val eventTime = startProcessingTime - 1000L
+    val originalFunction = new GigaTileProcessFunction(batchBackedGroupBy,
+                                                       inputSchema,
+                                                       firstSeenKeyGraceMillis = graceMillis)
+    val originalHarness = harness(originalFunction)
+
+    originalHarness.open()
+    originalHarness.setProcessingTime(startProcessingTime)
+    advanceConnectedHealthyLiveWatermark(originalHarness, startProcessingTime)
+    originalHarness.processElement1(event(DefaultEntity, eventTime, 5L), eventTime)
+    val baselineProcessingTime = startProcessingTime + graceMillis + 1L
+    originalHarness.setProcessingTime(baselineProcessingTime)
+    advanceConnectedHealthyLiveWatermark(originalHarness, baselineProcessingTime)
+    originalHarness.processElement1(event(DefaultEntity, eventTime + 1L, 0L), eventTime + 1L)
+    decodeSum(originalHarness.extractOutputValues().asScala.last, batchBackedGroupBy) shouldEqual 5L
+    setCurrentKey(originalHarness, entityKey(DefaultEntity))
+    state[Array[Byte]](originalFunction, "batchIrState").value() shouldBe null
+    state[java.lang.Boolean](originalFunction, "syntheticEmptyBatchBaselineState").value() shouldEqual
+      java.lang.Boolean.TRUE
+    state[java.lang.Boolean](originalFunction, "pendingPublicationState").value() shouldEqual
+      java.lang.Boolean.TRUE
+    state[java.lang.Boolean](originalFunction, "syntheticRollbackCorrectionState").value() shouldEqual
+      java.lang.Boolean.TRUE
+    val firstCorrectionTimer =
+      state[java.lang.Long](originalFunction, "nextProcessingEvictionTimerState").value().longValue()
+    val snapshot = originalHarness.snapshot(32L, baselineProcessingTime)
+    originalHarness.close()
+
+    val restoredFunction = new GigaTileProcessFunction(batchBackedGroupBy, inputSchema)
+    val restoredHarness = harness(restoredFunction)
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(snapshot)
+      restoredHarness.open()
+      // No new event arrives. The first restored timer disables synthetic availability while
+      // the connected watermark is still catching up; the next live timer must publish the
+      // null-fenced correction so a C4 rollback cannot leave the old KV value serving.
+      restoredHarness.setProcessingTime(firstCorrectionTimer)
+      advanceConnectedHealthyLiveWatermark(restoredHarness, firstCorrectionTimer)
+      setCurrentKey(restoredHarness, entityKey(DefaultEntity))
+      state[java.lang.Boolean](restoredFunction, "syntheticEmptyBatchBaselineState").value() shouldBe null
+      state[java.lang.Boolean](restoredFunction, "syntheticRollbackCorrectionState").value() shouldBe null
+      state[java.lang.Boolean](restoredFunction, "pendingPublicationState").value() shouldEqual
+        java.lang.Boolean.TRUE
+      val liveCorrectionTimer =
+        state[java.lang.Long](restoredFunction, "nextProcessingEvictionTimerState").value().longValue()
+      liveCorrectionTimer should be > firstCorrectionTimer
+      restoredHarness.setProcessingTime(liveCorrectionTimer - 1L)
+      advanceConnectedHealthyLiveWatermark(restoredHarness, liveCorrectionTimer)
+      restoredHarness.setProcessingTime(liveCorrectionTimer)
+
+      val corrections = restoredHarness.extractOutputValues().asScala
+      corrections should have size 1
+      decodeSum(corrections.head, batchBackedGroupBy) shouldBe null
+      setCurrentKey(restoredHarness, entityKey(DefaultEntity))
+      state[Array[Byte]](restoredFunction, "batchIrState").value() shouldBe null
+      state[java.lang.Boolean](restoredFunction, "pendingEmptyBatchBaselineState").value() shouldBe null
+      state[java.lang.Boolean](restoredFunction, "syntheticEmptyBatchBaselineState").value() shouldBe null
+      state[java.lang.Boolean](restoredFunction, "pendingPublicationState").value() shouldBe null
+      state[java.lang.Boolean](restoredFunction, "syntheticRollbackCorrectionState").value() shouldBe null
+    } finally restoredHarness.close()
+  }
+
+  it should "not resurrect a synthetic baseline after a marker-blind rollback checkpoint" in {
+    val graceMillis = 1L
+    val startProcessingTime = tenDays + oneHour
+    val eventTime = startProcessingTime - 1000L
+    val originalFunction = new GigaTileProcessFunction(batchBackedGroupBy,
+                                                       inputSchema,
+                                                       firstSeenKeyGraceMillis = graceMillis)
+    val originalHarness = harness(originalFunction)
+    originalHarness.open()
+    originalHarness.setProcessingTime(startProcessingTime)
+    advanceConnectedHealthyLiveWatermark(originalHarness, startProcessingTime)
+    originalHarness.processElement1(event(DefaultEntity, eventTime, 5L), eventTime)
+    val baselineProcessingTime = startProcessingTime + graceMillis + 1L
+    originalHarness.setProcessingTime(baselineProcessingTime)
+    advanceConnectedHealthyLiveWatermark(originalHarness, baselineProcessingTime)
+    originalHarness.processElement1(event(DefaultEntity, eventTime + 1L, 0L), eventTime + 1L)
+    setCurrentKey(originalHarness, entityKey(DefaultEntity))
+    state[Array[Byte]](originalFunction, "batchIrState").value() shouldBe null
+    state[java.lang.Boolean](originalFunction, "syntheticEmptyBatchBaselineState").value() shouldEqual
+      java.lang.Boolean.TRUE
+    state[java.lang.Boolean](originalFunction, "syntheticRollbackCorrectionState").value() shouldEqual
+      java.lang.Boolean.TRUE
+    state[java.lang.Boolean](originalFunction, "pendingPublicationState").value() shouldEqual
+      java.lang.Boolean.TRUE
+    val correctionTimer =
+      state[java.lang.Long](originalFunction, "nextProcessingEvictionTimerState").value().longValue()
+    val originalSnapshot = originalHarness.snapshot(40L, baselineProcessingTime)
+    originalHarness.close()
+
+    val markerBlindFunction = new MarkerBlindCorrectionConsumer(expectedTimer = Some(correctionTimer))
+    val markerBlindHarness = harness(markerBlindFunction)
+    markerBlindHarness.setup()
+    markerBlindHarness.initializeState(originalSnapshot)
+    markerBlindHarness.open()
+    markerBlindHarness.setProcessingTime(correctionTimer)
+    markerBlindFunction.correctionConsumed shouldBe true
+    val markerBlindSnapshot = markerBlindHarness.snapshot(41L, correctionTimer)
+    markerBlindHarness.close()
+
+    val restoredFunction = new GigaTileProcessFunction(batchBackedGroupBy,
+                                                       inputSchema,
+                                                       firstSeenKeyGraceMillis = graceMillis)
+    val restoredHarness = harness(restoredFunction)
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(markerBlindSnapshot)
+      restoredHarness.open()
+      restoredHarness.setProcessingTime(correctionTimer)
+      restoredHarness.processElement1(event(DefaultEntity, eventTime + 2L, 0L), eventTime + 2L)
+
+      setCurrentKey(restoredHarness, entityKey(DefaultEntity))
+      state[Array[Byte]](restoredFunction, "batchIrState").value() shouldBe null
+      state[java.lang.Boolean](restoredFunction, "syntheticEmptyBatchBaselineState").value() shouldBe null
+      state[java.lang.Boolean](restoredFunction, "syntheticRollbackCorrectionState").value() shouldBe null
+      state[java.lang.Boolean](restoredFunction, "pendingEmptyBatchBaselineState").value() shouldEqual
+        java.lang.Boolean.TRUE
+    } finally restoredHarness.close()
+  }
+
+  it should "restart grace after marker-blind rollback consumes a newer fenced synthetic update" in {
+    val graceMillis = oneHour
+    val startProcessingTime = tenDays + oneHour
+    val eventTime = startProcessingTime - 1000L
+    val originalFunction = new GigaTileProcessFunction(batchBackedGroupBy,
+                                                       inputSchema,
+                                                       firstSeenKeyGraceMillis = graceMillis)
+    val originalHarness = harness(originalFunction)
+    originalHarness.open()
+    originalHarness.setProcessingTime(startProcessingTime)
+    advanceConnectedHealthyLiveWatermark(originalHarness, startProcessingTime)
+    originalHarness.processElement1(event(DefaultEntity, eventTime, 5L), eventTime)
+
+    val baselineProcessingTime = startProcessingTime + graceMillis + 1L
+    originalHarness.setProcessingTime(baselineProcessingTime)
+    advanceConnectedHealthyLiveWatermark(originalHarness, baselineProcessingTime)
+    originalHarness.processElement1(event(DefaultEntity, eventTime + 1L, 0L), eventTime + 1L)
+    setCurrentKey(originalHarness, entityKey(DefaultEntity))
+    state[java.lang.Boolean](originalFunction, "syntheticEmptyBatchBaselineState").value() shouldEqual
+      java.lang.Boolean.TRUE
+    state[java.lang.Boolean](originalFunction, "syntheticRollbackCorrectionState").value() shouldEqual
+      java.lang.Boolean.TRUE
+
+    // Let the connected watermark become stale, then mutate the synthetic view while fenced.
+    // This is the checkpoint shape that clears the correction marker but still owns a pending
+    // publication through the legacy descriptor.
+    val catchupProcessingTime = baselineProcessingTime + 10L * oneHour
+    originalHarness.setProcessingTime(catchupProcessingTime)
+    originalHarness.processElement1(event(DefaultEntity, eventTime + 2L, 7L), eventTime + 2L)
+    setCurrentKey(originalHarness, entityKey(DefaultEntity))
+    state[java.lang.Boolean](originalFunction, "syntheticEmptyBatchBaselineState").value() shouldEqual
+      java.lang.Boolean.TRUE
+    state[java.lang.Boolean](originalFunction, "pendingPublicationState").value() shouldEqual
+      java.lang.Boolean.TRUE
+    state[java.lang.Boolean](originalFunction, "syntheticRollbackCorrectionState").value() shouldBe null
+    val correctionTimer =
+      state[java.lang.Long](originalFunction, "nextProcessingEvictionTimerState").value().longValue()
+    val originalSnapshot = originalHarness.snapshot(42L, catchupProcessingTime)
+    originalHarness.close()
+
+    val markerBlindFunction = new MarkerBlindCorrectionConsumer(expectedTimer = Some(correctionTimer))
+    val markerBlindHarness = harness(markerBlindFunction)
+    markerBlindHarness.setup()
+    markerBlindHarness.initializeState(originalSnapshot)
+    markerBlindHarness.open()
+    markerBlindHarness.setProcessingTime(catchupProcessingTime)
+    markerBlindHarness.setProcessingTime(correctionTimer)
+    markerBlindFunction.correctionConsumed shouldBe true
+    val markerBlindSnapshot = markerBlindHarness.snapshot(43L, correctionTimer)
+    markerBlindHarness.close()
+
+    val restoredFunction = new GigaTileProcessFunction(batchBackedGroupBy,
+                                                       inputSchema,
+                                                       firstSeenKeyGraceMillis = graceMillis)
+    val restoredHarness = harness(restoredFunction)
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(markerBlindSnapshot)
+      restoredHarness.open()
+      restoredHarness.setProcessingTime(correctionTimer)
+      advanceConnectedHealthyLiveWatermark(restoredHarness, correctionTimer)
+      restoredHarness.processElement1(event(DefaultEntity, correctionTimer - 1L, 0L), correctionTimer - 1L)
+
+      restoredHarness.extractOutputValues().asScala.foreach { output =>
+        decodeSum(output, batchBackedGroupBy) shouldBe null
+      }
+      setCurrentKey(restoredHarness, entityKey(DefaultEntity))
+      state[java.lang.Boolean](restoredFunction, "syntheticEmptyBatchBaselineState").value() shouldBe null
+      state[java.lang.Boolean](restoredFunction, "syntheticRollbackCorrectionState").value() shouldBe null
+      state[java.lang.Boolean](restoredFunction, "pendingEmptyBatchBaselineState").value() shouldEqual
+        java.lang.Boolean.TRUE
+      transientLong(restoredFunction, "emptyBatchBaselineSafeAfterMillis") shouldEqual
+        correctionTimer + graceMillis
+    } finally restoredHarness.close()
+  }
+
+  it should "share the operator warm clock while isolating per-key baseline decisions" in {
+    val graceMillis = 1000L
+    val firstKey = "entity-a"
+    val secondKey = "entity-b"
+    val function = new GigaTileProcessFunction(batchBackedGroupBy,
+                                               inputSchema,
+                                               firstSeenKeyGraceMillis = graceMillis)
+    val testHarness = harness(function)
+    val startProcessingTime = tenDays + oneHour
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(startProcessingTime)
+      advanceConnectedHealthyLiveWatermark(testHarness, startProcessingTime)
+      testHarness.processElement1(event(firstKey, startProcessingTime - 1000L, 5L), startProcessingTime - 1000L)
+
+      val warmProcessingTime = startProcessingTime + graceMillis + 1L
+      testHarness.setProcessingTime(warmProcessingTime)
+      advanceConnectedHealthyLiveWatermark(testHarness, warmProcessingTime)
+      testHarness.processElement1(event(secondKey, warmProcessingTime - 1L, 7L), warmProcessingTime - 1L)
+
+      val secondKeyOutput = testHarness.extractOutputValues().asScala
+        .filter(_.keys.get(0).toString == secondKey)
+        .last
+      decodeSum(secondKeyOutput, batchBackedGroupBy) shouldEqual 7L
+
+      testHarness.processElement2(batchRow(firstKey, batchBackedGroupBy, tenDays, 11L), tenDays)
+
+      setCurrentKey(testHarness, entityKey(firstKey))
+      state[java.lang.Long](function, "batchEndTsState").value().longValue() shouldEqual tenDays
+      state[java.lang.Boolean](function, "pendingEmptyBatchBaselineState").value() shouldBe null
+      setCurrentKey(testHarness, entityKey(secondKey))
+      state[Array[Byte]](function, "batchIrState").value() shouldBe null
+      state[java.lang.Boolean](function, "syntheticEmptyBatchBaselineState").value() shouldEqual
+        java.lang.Boolean.TRUE
+      state[java.lang.Long](function, "batchEndTsState").value() shouldBe null
+    } finally testHarness.close()
+  }
+
+  it should "initialize before flushing a coincident eviction and cadence timer" in {
+    val cadenceMillis = 1L
+    val collisionTime = 11L * dayMillis
+    val eventProcessingTime = collisionTime - 1L
+    val function = new GigaTileProcessFunction(batchBackedGroupBy,
+                                               inputSchema,
+                                               bufferingOutputTimeMillis = cadenceMillis,
+                                               firstSeenKeyGraceMillis = 1L)
+    val testHarness = harness(function)
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(eventProcessingTime)
+      advanceConnectedHealthyLiveWatermark(testHarness, eventProcessingTime)
+      testHarness.processElement1(event(DefaultEntity, eventProcessingTime - 1000L, 5L), eventProcessingTime - 1000L)
+      testHarness.extractOutputValues() shouldBe empty
+
+      testHarness.setProcessingTime(collisionTime)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0), batchBackedGroupBy) shouldEqual 5L
+      outputs.get(0).latestTsMillis shouldEqual collisionTime
+    } finally testHarness.close()
+  }
+
+  it should "not initialize from collision-only or retry-only timers" in {
+    val collisionFunction = new GigaTileProcessFunction(batchBackedGroupBy,
+                                                        inputSchema,
+                                                        firstSeenKeyGraceMillis = 1L)
+    val collisionHarness = harness(collisionFunction)
+    val startProcessingTime = tenDays + oneHour
+    val eventTime = startProcessingTime - 1000L
+
+    try {
+      collisionHarness.open()
+      collisionHarness.setProcessingTime(startProcessingTime)
+      advanceConnectedHealthyLiveWatermark(collisionHarness, startProcessingTime)
+      collisionHarness.processElement1(event(DefaultEntity, eventTime, 5L), eventTime)
+      collisionHarness.processElement1(event(DefaultEntity, eventTime + 1L, 0L), eventTime + 1L)
+      collisionHarness.setProcessingTime(startProcessingTime + 1L)
+
+      setCurrentKey(collisionHarness, entityKey(DefaultEntity))
+      state[Array[Byte]](collisionFunction, "batchIrState").value() shouldBe null
+    } finally collisionHarness.close()
+
+    val retryDelay = math.max(1L, 2L * FlinkJob.AutoWatermarkInterval)
+    val retryFunction = new GigaTileProcessFunction(batchBackedGroupBy,
+                                                    inputSchema,
+                                                    firstSeenKeyGraceMillis = retryDelay)
+    val retryHarness = harness(retryFunction)
+    val catchupWatermark = startProcessingTime - 3L * dayMillis
+    try {
+      retryHarness.open()
+      retryHarness.setProcessingTime(startProcessingTime)
+      advanceConnectedWatermark(retryHarness, catchupWatermark)
+      retryHarness.processElement1(event(DefaultEntity, catchupWatermark - 1L, 5L), catchupWatermark - 1L)
+      retryHarness.setProcessingTime(startProcessingTime + retryDelay)
+
+      retryHarness.extractOutputValues() shouldBe empty
+      setCurrentKey(retryHarness, entityKey(DefaultEntity))
+      state[Array[Byte]](retryFunction, "batchIrState").value() shouldBe null
+    } finally retryHarness.close()
+  }
+
+  it should "leave a no-batch-only GroupBy outside the fallback path" in {
+    val function = new GigaTileProcessFunction(noBatchGroupBy,
+                                               inputSchema,
+                                               firstSeenKeyGraceMillis = 1L)
+    val testHarness = harness(function)
+    val startProcessingTime = tenDays + oneHour
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(startProcessingTime)
+      advanceConnectedHealthyLiveWatermark(testHarness, startProcessingTime)
+      testHarness.processElement1(event(DefaultEntity, startProcessingTime - 1000L, 5L), startProcessingTime - 1000L)
+
+      decodeSum(testHarness.extractOutputValues().get(0), noBatchGroupBy) shouldEqual 5L
+      setCurrentKey(testHarness, entityKey(DefaultEntity))
+      state[Array[Byte]](function, "batchIrState").value() shouldBe null
+      state[java.lang.Boolean](function, "pendingEmptyBatchBaselineState").value() shouldBe null
+    } finally testHarness.close()
+  }
+
+  it should "leave the fallback disabled by default" in {
+    GigaTileProcessFunction.DefaultFirstSeenKeyGraceMillis shouldEqual 0L
+    val function = new GigaTileProcessFunction(batchBackedGroupBy, inputSchema)
+    val testHarness = harness(function)
+    val startProcessingTime = tenDays + oneHour
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(startProcessingTime)
+      advanceConnectedHealthyLiveWatermark(testHarness, startProcessingTime)
+      testHarness.processElement1(event(DefaultEntity, startProcessingTime - 1000L, 5L), startProcessingTime - 1000L)
+
+      decodeSum(testHarness.extractOutputValues().get(0), batchBackedGroupBy) shouldBe null
+      setCurrentKey(testHarness, entityKey(DefaultEntity))
+      state[Array[Byte]](function, "batchIrState").value() shouldBe null
+      state[java.lang.Boolean](function, "pendingEmptyBatchBaselineState").value() shouldBe null
+    } finally testHarness.close()
+  }
+
+  it should "reject a negative grace at the operator boundary" in {
+    an[IllegalArgumentException] should be thrownBy new GigaTileProcessFunction(
+      batchBackedGroupBy,
+      inputSchema,
+      firstSeenKeyGraceMillis = -1L)
+  }
+
+  it should "saturate the operator grace deadline instead of overflowing" in {
+    val function = new GigaTileProcessFunction(batchBackedGroupBy,
+                                               inputSchema,
+                                               firstSeenKeyGraceMillis = 10L)
+    val testHarness = harness(function)
+    val eventTime = tenDays + oneHour
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(Long.MaxValue - 5L)
+      testHarness.processElement1(event(DefaultEntity, eventTime, 5L), eventTime)
+
+      transientLong(function, "emptyBatchBaselineSafeAfterMillis") shouldEqual Long.MaxValue
+      setCurrentKey(testHarness, entityKey(DefaultEntity))
+      state[Array[Byte]](function, "batchIrState").value() shouldBe null
+    } finally testHarness.close()
+  }
+}
+
+object GigaTileFirstSeenKeyGraceTest {
+  private val DefaultEntity = "entity-1"
+  private val dayMillis = new Window(1, TimeUnit.DAYS).millis
+  private val oneHour = new Window(1, TimeUnit.HOURS).millis
+  private val tenDays = 10L * dayMillis
+  private val inputSchema: Seq[(String, DataType)] =
+    Seq(Constants.TimeColumn -> LongType, "num" -> LongType)
+  private val batchBackedGroupBy = groupBy("gigatile-first-seen-batch-backed", new Window(7, TimeUnit.DAYS))
+  private val noBatchGroupBy = groupBy("gigatile-first-seen-no-batch", new Window(1, TimeUnit.HOURS))
+
+  private def groupBy(name: String, window: Window): GroupBy =
+    Builders.GroupBy(
+      metaData = Builders.MetaData(name = name),
+      aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(window))))
+
+  private def harness(
+      function: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]
+  ): KeyedTwoInputStreamOperatorTestHarness[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile] =
+    new KeyedTwoInputStreamOperatorTestHarness[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile](
+      new KeyedCoProcessOperator(function),
+      new KeySelector[ProjectedEvent, util.List[Any]] {
+        override def getKey(value: ProjectedEvent): util.List[Any] =
+          entityKey(value.fields.getOrElse("entity", DefaultEntity).toString)
+      },
+      new KeySelector[BatchIrRow, util.List[Any]] {
+        override def getKey(value: BatchIrRow): util.List[Any] = value.entityKeys
+      },
+      TypeInformation
+        .of(classOf[util.List[_]])
+        .asInstanceOf[TypeInformation[util.List[Any]]])
+
+  /** Models a rollback binary that binds only the legacy correction descriptors and
+    * checkpoints without knowing the additive synthetic markers.
+    */
+  private class MarkerBlindCorrectionConsumer(expectedTimer: Option[Long] = None)
+      extends KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile] {
+    @transient private var batchIrState: ValueState[Array[Byte]] = _
+    @transient private var pendingPublicationState: ValueState[java.lang.Boolean] = _
+    @transient private var nextEvictionTimerState: ValueState[java.lang.Long] = _
+    var correctionConsumed: Boolean = false
+
+    override def open(parameters: org.apache.flink.configuration.Configuration): Unit = {
+      batchIrState = getRuntimeContext.getState(
+        new ValueStateDescriptor[Array[Byte]]("giga-tile-batch-ir", classOf[Array[Byte]]))
+      pendingPublicationState = getRuntimeContext.getState(
+        new ValueStateDescriptor[java.lang.Boolean]("giga-tile-pending-publication", classOf[java.lang.Boolean]))
+      nextEvictionTimerState = getRuntimeContext.getState(
+        new ValueStateDescriptor[java.lang.Long]("giga-tile-next-evict-pt-timer", classOf[java.lang.Long]))
+    }
+
+    override def processElement1(
+        event: ProjectedEvent,
+        ctx: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#Context,
+        out: Collector[TimestampedTile]
+    ): Unit = ()
+
+    override def processElement2(
+        batchRow: BatchIrRow,
+        ctx: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#Context,
+        out: Collector[TimestampedTile]
+    ): Unit = ()
+
+    override def onTimer(
+        timestamp: Long,
+        ctx: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#OnTimerContext,
+        out: Collector[TimestampedTile]
+    ): Unit = {
+      if (expectedTimer.forall(_ == timestamp)) {
+        require(batchIrState.value() == null)
+        require(java.lang.Boolean.TRUE.equals(pendingPublicationState.value()))
+        pendingPublicationState.clear()
+        nextEvictionTimerState.clear()
+        correctionConsumed = true
+      }
+    }
+  }
+
+  private def event(entity: String, timestamp: Long, value: Long): ProjectedEvent =
+    ProjectedEvent(Map("entity" -> entity, Constants.TimeColumn -> timestamp, "num" -> value), timestamp)
+
+  private def entityKey(entity: String): util.List[Any] = {
+    val result = new util.ArrayList[Any](1)
+    result.add(entity)
+    result
+  }
+
+  private def batchRow(entity: String, targetGroupBy: GroupBy, batchEnd: Long, value: Long): BatchIrRow = {
+    val batchEventTime = batchEnd - 1000L
+    val aggregator = new SawtoothOnlineAggregator(
+      batchEnd,
+      targetGroupBy.getAggregations.asScala.toSeq,
+      inputSchema)
+    val batchIr = aggregator.update(
+      aggregator.init,
+      new ArrayRow(Array[Any](batchEventTime, value), batchEventTime))
+    val finalBatchIr = aggregator.denormalizeBatchIr(aggregator.normalizeBatchIr(batchIr))
+    val codec = new GigaTileCodec(targetGroupBy, inputSchema)
+    new BatchIrRow(entityKey(entity), codec.encodeBatchIr(finalBatchIr), batchEnd)
+  }
+
+  private def advanceConnectedWatermark(
+      testHarness: KeyedTwoInputStreamOperatorTestHarness[
+        util.List[Any],
+        ProjectedEvent,
+        BatchIrRow,
+        TimestampedTile],
+      watermark: Long
+  ): Unit = {
+    testHarness.processWatermark1(new Watermark(watermark))
+    testHarness.processWatermark2(new Watermark(watermark))
+  }
+
+  private def advanceConnectedHealthyLiveWatermark(
+      testHarness: KeyedTwoInputStreamOperatorTestHarness[
+        util.List[Any],
+        ProjectedEvent,
+        BatchIrRow,
+        TimestampedTile],
+      processingTime: Long
+  ): Unit =
+    advanceConnectedWatermark(testHarness,
+                              processingTime - FlinkJob.AllowedOutOfOrderness.toMillis - 1L)
+
+  private def nextDay(timestamp: Long): Long = TsUtils.round(timestamp, dayMillis) + dayMillis
+
+  private def nextBufferedWriteTick(
+      targetGroupBy: GroupBy,
+      key: util.List[Any],
+      currentProcessingTime: Long,
+      cadenceMillis: Long
+  ): Long = {
+    val phase =
+      Math.floorMod((targetGroupBy.getMetaData.getName :: key.iterator().asScala.toList).hashCode().toLong,
+                    cadenceMillis)
+    val elapsedSincePhase = Math.floorMod(Math.floorMod(currentProcessingTime, cadenceMillis) - phase, cadenceMillis)
+    val delay = if (elapsedSincePhase == 0L) cadenceMillis else cadenceMillis - elapsedSincePhase
+    currentProcessingTime + delay
+  }
+
+  private def setCurrentKey(
+      testHarness: KeyedTwoInputStreamOperatorTestHarness[
+        util.List[Any],
+        ProjectedEvent,
+        BatchIrRow,
+        TimestampedTile],
+      key: util.List[Any]
+  ): Unit =
+    testHarness.getOperator.getKeyedStateBackend
+      .asInstanceOf[KeyedStateBackend[util.List[Any]]]
+      .setCurrentKey(key)
+
+  private def state[T](function: GigaTileProcessFunction, fieldName: String): ValueState[T] = {
+    val field = classOf[GigaTileProcessFunction].getDeclaredField(fieldName)
+    field.setAccessible(true)
+    field.get(function).asInstanceOf[ValueState[T]]
+  }
+
+  private def transientLong(function: GigaTileProcessFunction, fieldName: String): Long = {
+    val field = classOf[GigaTileProcessFunction].getDeclaredField(fieldName)
+    field.setAccessible(true)
+    field.get(function).asInstanceOf[java.lang.Long].longValue()
+  }
+
+  private def initializeEmptyBatchBaseline(
+      function: GigaTileProcessFunction,
+      currentProcessingTime: Long,
+      largeWindowAsOfMillis: Long
+  ): Option[GigaEmitResult] = {
+    val method = classOf[GigaTileProcessFunction]
+      .getDeclaredMethod("initializeEmptyBatchBaselineIfReady", java.lang.Long.TYPE, java.lang.Long.TYPE)
+    method.setAccessible(true)
+    method
+      .invoke(function, Long.box(currentProcessingTime), Long.box(largeWindowAsOfMillis))
+      .asInstanceOf[Option[GigaEmitResult]]
+  }
+
+  private def decodeSum(tile: TimestampedTile, targetGroupBy: GroupBy): AnyRef = {
+    val outputCodec = new GigaTileCodec(targetGroupBy, inputSchema)
+    val fieldName = outputCodec.outputSchema.fields.head.name
+    AvroCodec
+      .of(ai.chronon.online.serde.AvroConversions.fromChrononSchema(outputCodec.outputSchema).toString)
+      .decodeMap(tile.tileBytes)(fieldName)
+  }
+}

--- a/flink/src/test/scala/ai/chronon/flink/test/window/GigaTileFirstSeenKeyGraceTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/window/GigaTileFirstSeenKeyGraceTest.scala
@@ -436,6 +436,83 @@ class GigaTileFirstSeenKeyGraceTest extends AnyFlatSpec with Matchers {
     } finally restoredHarness.close()
   }
 
+  it should "reconcile every key's synthetic baseline after a marker-blind rollback checkpoint" in {
+    // Regression: the per-key rollback reconciliation must run for every key on the subtask,
+    // not only the first callback that seeds the operator-wide grace clock. Two keys both hold a
+    // published synthetic baseline; a marker-blind binary serves the null correction for both and
+    // clears their pending markers; on roll-forward both must drop the stale synthetic baseline.
+    val graceMillis = 1L
+    val firstKey = "entity-a"
+    val secondKey = "entity-b"
+    val startProcessingTime = tenDays + oneHour
+    val eventTime = startProcessingTime - 1000L
+    val originalFunction = new GigaTileProcessFunction(batchBackedGroupBy,
+                                                       inputSchema,
+                                                       firstSeenKeyGraceMillis = graceMillis)
+    val originalHarness = harness(originalFunction)
+    originalHarness.open()
+    originalHarness.setProcessingTime(startProcessingTime)
+    advanceConnectedHealthyLiveWatermark(originalHarness, startProcessingTime)
+    originalHarness.processElement1(event(firstKey, eventTime, 5L), eventTime)
+    originalHarness.processElement1(event(secondKey, eventTime, 9L), eventTime)
+    val baselineProcessingTime = startProcessingTime + graceMillis + 1L
+    originalHarness.setProcessingTime(baselineProcessingTime)
+    advanceConnectedHealthyLiveWatermark(originalHarness, baselineProcessingTime)
+    originalHarness.processElement1(event(firstKey, eventTime + 1L, 0L), eventTime + 1L)
+    originalHarness.processElement1(event(secondKey, eventTime + 1L, 0L), eventTime + 1L)
+
+    Seq(firstKey, secondKey).foreach { key =>
+      setCurrentKey(originalHarness, entityKey(key))
+      state[java.lang.Boolean](originalFunction, "syntheticEmptyBatchBaselineState").value() shouldEqual
+        java.lang.Boolean.TRUE
+      state[java.lang.Boolean](originalFunction, "syntheticRollbackCorrectionState").value() shouldEqual
+        java.lang.Boolean.TRUE
+      state[java.lang.Boolean](originalFunction, "pendingPublicationState").value() shouldEqual
+        java.lang.Boolean.TRUE
+    }
+    // Both keys share the day-aligned eviction cadence, so their correction timers coincide.
+    setCurrentKey(originalHarness, entityKey(firstKey))
+    val correctionTimer =
+      state[java.lang.Long](originalFunction, "nextProcessingEvictionTimerState").value().longValue()
+    val originalSnapshot = originalHarness.snapshot(50L, baselineProcessingTime)
+    originalHarness.close()
+
+    val markerBlindFunction = new MarkerBlindCorrectionConsumer(expectedTimer = Some(correctionTimer))
+    val markerBlindHarness = harness(markerBlindFunction)
+    markerBlindHarness.setup()
+    markerBlindHarness.initializeState(originalSnapshot)
+    markerBlindHarness.open()
+    markerBlindHarness.setProcessingTime(correctionTimer)
+    markerBlindFunction.correctionConsumed shouldBe true
+    val markerBlindSnapshot = markerBlindHarness.snapshot(51L, correctionTimer)
+    markerBlindHarness.close()
+
+    val restoredFunction = new GigaTileProcessFunction(batchBackedGroupBy,
+                                                       inputSchema,
+                                                       firstSeenKeyGraceMillis = graceMillis)
+    val restoredHarness = harness(restoredFunction)
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(markerBlindSnapshot)
+      restoredHarness.open()
+      restoredHarness.setProcessingTime(correctionTimer)
+      advanceConnectedHealthyLiveWatermark(restoredHarness, correctionTimer)
+      restoredHarness.processElement1(event(firstKey, eventTime + 2L, 0L), eventTime + 2L)
+      restoredHarness.processElement1(event(secondKey, eventTime + 2L, 0L), eventTime + 2L)
+
+      Seq(firstKey, secondKey).foreach { key =>
+        setCurrentKey(restoredHarness, entityKey(key))
+        withClue(s"synthetic baseline for $key should be dropped after marker-blind rollback: ") {
+          state[Array[Byte]](restoredFunction, "batchIrState").value() shouldBe null
+          state[java.lang.Boolean](restoredFunction, "syntheticEmptyBatchBaselineState").value() shouldBe null
+          state[java.lang.Boolean](restoredFunction, "syntheticRollbackCorrectionState").value() shouldBe null
+          state[java.lang.Boolean](restoredFunction, "pendingEmptyBatchBaselineState").value() shouldEqual
+            java.lang.Boolean.TRUE
+        }
+      }
+    } finally restoredHarness.close()
+  }
+
   it should "restart grace after marker-blind rollback consumes a newer fenced synthetic update" in {
     val graceMillis = oneHour
     val startProcessingTime = tenDays + oneHour

--- a/flink/src/test/scala/ai/chronon/flink/test/window/GigaTileProcessFunctionTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/window/GigaTileProcessFunctionTest.scala
@@ -1,8 +1,11 @@
 package ai.chronon.flink.test.window
 
 import ai.chronon.aggregator.windowing.{
+  EvictionTimes,
   GigaEmitResult,
   GigaTileStreamProcessor,
+  InMemoryGigaTileStore,
+  MegaTileAggregator,
   SawtoothOnlineAggregator
 }
 import ai.chronon.api._
@@ -10,11 +13,12 @@ import ai.chronon.api.Extensions.WindowOps
 import ai.chronon.flink.deser.ProjectedEvent
 import ai.chronon.flink.types.{BatchIrRow, TimestampedTile}
 import ai.chronon.flink.window.GigaTileProcessFunction
-import ai.chronon.online.GigaTileCodec
+import ai.chronon.online.{GigaTileCodec, MegaTileCodec}
 import ai.chronon.online.serde.{ArrayRow, AvroCodec}
-import org.apache.flink.api.common.state.ValueState
+import org.apache.flink.api.common.state.{MapState, MapStateDescriptor, ValueState, ValueStateDescriptor}
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.functions.KeySelector
+import org.apache.flink.configuration.Configuration
 import org.apache.flink.runtime.state.KeyedStateBackend
 import org.apache.flink.streaming.api.functions.co.KeyedCoProcessFunction
 import org.apache.flink.streaming.api.operators.co.KeyedCoProcessOperator
@@ -144,6 +148,51 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
 
       testHarness.extractOutputValues().asScala shouldBe empty
       testHarness.numProcessingTimeTimers() shouldEqual 1
+    } finally testHarness.close()
+  }
+
+  it should "keep an empty key scheduled until a deferred future batch activates" in {
+    val dayMillis = new Window(1, TimeUnit.DAYS).millis
+    val hourMillis = new Window(1, TimeUnit.HOURS).millis
+    val batchGroupBy = Builders.GroupBy(
+      metaData = Builders.MetaData(name = "gigatile-process-function-future-batch-test"),
+      aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(7, TimeUnit.DAYS)))))
+    val testHarness = harness(new GigaTileProcessFunction(batchGroupBy, inputSchema))
+    val batchCodec = new GigaTileCodec(batchGroupBy, inputSchema)
+    val currentBatchEnd = 10 * dayMillis
+    val currentProcessingTs = currentBatchEnd + hourMillis
+    val futureBatchEnd = currentBatchEnd + dayMillis
+    val futureEventTs = futureBatchEnd - hourMillis
+    val batchAggregator =
+      new SawtoothOnlineAggregator(futureBatchEnd, batchGroupBy.getAggregations.asScala.toSeq, inputSchema)
+    val futureBatchIr = batchAggregator.update(
+      batchAggregator.init,
+      new ArrayRow(Array[Any](futureEventTs, 50L), futureEventTs))
+    val futureBatchRow = new BatchIrRow(
+      entityKey(),
+      batchCodec.encodeBatchIr(batchAggregator.denormalizeBatchIr(batchAggregator.normalizeBatchIr(futureBatchIr))),
+      futureBatchEnd)
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(currentProcessingTs)
+      testHarness.processElement2(emptyBatchRow(batchGroupBy, currentBatchEnd), currentBatchEnd)
+      testHarness.processElement2(futureBatchRow, futureBatchEnd)
+
+      testHarness.extractOutputValues().asScala shouldBe empty
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+
+      testHarness.setProcessingTime(currentProcessingTs + hourMillis)
+
+      testHarness.extractOutputValues().asScala shouldBe empty
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+
+      testHarness.setProcessingTime(futureBatchEnd + hourMillis)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs.size() shouldEqual 1
+      decodeSum(outputs.get(0), batchGroupBy) shouldEqual 50L
+      outputs.get(0).latestTsMillis shouldEqual futureBatchEnd + hourMillis
     } finally testHarness.close()
   }
 
@@ -446,7 +495,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
       testHarness.setProcessingTime(collisionProcessingTs)
       testHarness.processElement1(event(expiringEventTs, 5L), expiringEventTs)
       testHarness.processElement1(event(expiringEventTs, 7L), expiringEventTs)
-      failNextScheduledEviction(function)
+      failNextEviction(function)
 
       testHarness.setProcessingTime(evictionTs)
 
@@ -487,6 +536,89 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
         .toMap
       flushedByKey shouldEqual Map("campaign-1" -> 12L, "campaign-2" -> 24L)
     } finally testHarness.close()
+  }
+
+  it should "include an event that arrives exactly on a small-window hop" in {
+    val testHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    val hopMillis = new Window(5, TimeUnit.MINUTES).millis
+    val exactHopTs = 30 * hopMillis
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(exactHopTs)
+      testHarness.processElement1(event(exactHopTs, 5L), exactHopTs)
+
+      val output = testHarness.extractOutputValues().get(0)
+      decodeSum(output) shouldEqual 5L
+      output.latestTsMillis shouldEqual exactHopTs
+    } finally testHarness.close()
+  }
+
+  it should "restore state from before the horizon markers existed" in {
+    val eventTimestamp = 4 * new Window(1, TimeUnit.DAYS).millis + new Window(1, TimeUnit.HOURS).millis
+    val legacyHarness = harness(new LegacyHorizonStateFunction(groupBy, inputSchema))
+    legacyHarness.open()
+    legacyHarness.processElement1(event(eventTimestamp, 5L), eventTimestamp)
+    val snapshot = legacyHarness.snapshot(9L, eventTimestamp)
+    legacyHarness.close()
+
+    val restoredHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    val batchCallbackTs = eventTimestamp + new Window(2, TimeUnit.HOURS).millis
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(snapshot)
+      restoredHarness.open()
+      restoredHarness.setProcessingTime(batchCallbackTs)
+      restoredHarness.processElement2(emptyBatchRow(groupBy, batchEndTs = 0L), 0L)
+
+      val outputs = restoredHarness.extractOutputValues()
+      outputs.size() shouldEqual 1
+      decodeSum(outputs.get(0)) shouldBe null
+      outputs.get(0).latestTsMillis shouldEqual batchCallbackTs
+    } finally restoredHarness.close()
+  }
+
+  it should "rebuild large state when a restored checkpoint has no recompute marker" in {
+    val dayMillis = new Window(1, TimeUnit.DAYS).millis
+    val hourMillis = new Window(1, TimeUnit.HOURS).millis
+    val batchEndTs = 10 * dayMillis
+    val batchEventTs = batchEndTs - 48 * hourMillis
+    val beforeExpiry = batchEndTs + 59 * 60 * 1000L
+    val delayedCallbackTs = batchEndTs + 3 * hourMillis + 60 * 1000L
+    val batchGroupBy = Builders.GroupBy(
+      metaData = Builders.MetaData(name = "gigatile-process-function-legacy-large-marker-test"),
+      aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(49, TimeUnit.HOURS)))))
+    val batchAggregator =
+      new SawtoothOnlineAggregator(batchEndTs, batchGroupBy.getAggregations.asScala.toSeq, inputSchema)
+    val batchIr = batchAggregator.update(
+      batchAggregator.init,
+      new ArrayRow(Array[Any](batchEventTs, 5L), batchEventTs))
+    val finalBatchIr = batchAggregator.denormalizeBatchIr(batchAggregator.normalizeBatchIr(batchIr))
+    val batchRow = new BatchIrRow(
+      entityKey(),
+      new GigaTileCodec(batchGroupBy, inputSchema).encodeBatchIr(finalBatchIr),
+      batchEndTs)
+
+    val legacyHarness = harness(new LegacyHorizonStateFunction(batchGroupBy, inputSchema))
+    legacyHarness.open()
+    legacyHarness.setProcessingTime(beforeExpiry)
+    legacyHarness.processElement2(batchRow, batchEndTs)
+    val snapshot = legacyHarness.snapshot(10L, beforeExpiry)
+    legacyHarness.close()
+
+    val restoredHarness = harness(new GigaTileProcessFunction(batchGroupBy, inputSchema))
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(snapshot)
+      restoredHarness.open()
+      restoredHarness.setProcessingTime(delayedCallbackTs)
+      restoredHarness.processElement1(event(delayedCallbackTs - 1L, 7L), delayedCallbackTs - 1L)
+
+      val outputs = restoredHarness.extractOutputValues()
+      outputs.size() shouldEqual 1
+      decodeSum(outputs.get(0), batchGroupBy) shouldEqual 7L
+      outputs.get(0).latestTsMillis shouldEqual delayedCallbackTs
+    } finally restoredHarness.close()
   }
 }
 
@@ -601,7 +733,7 @@ object GigaTileProcessFunctionTest {
       })
   }
 
-  private def failNextScheduledEviction(function: GigaTileProcessFunction): Unit = {
+  private def failNextEviction(function: GigaTileProcessFunction): Unit = {
     val processorField = classOf[GigaTileProcessFunction].getDeclaredField("processor")
     processorField.setAccessible(true)
     val delegate = processorField.get(function).asInstanceOf[GigaTileStreamProcessor]
@@ -615,15 +747,22 @@ object GigaTileProcessFunctionTest {
       ) {
         private var shouldFail = true
 
-        override def onScheduledEviction(timerTs: Long): GigaEmitResult = {
+        override private[chronon] def onEviction(evictionTimes: EvictionTimes): GigaEmitResult = {
           if (shouldFail) {
             shouldFail = false
-            throw new RuntimeException("expected scheduled eviction failure")
+            throw new RuntimeException("expected eviction failure")
           }
-          delegate.onScheduledEviction(timerTs)
+          delegate.onEviction(evictionTimes)
         }
       }
     )
+  }
+
+  private def emptyBatchRow(batchGroupBy: GroupBy, batchEndTs: Long): BatchIrRow = {
+    val batchAggregator =
+      new SawtoothOnlineAggregator(batchEndTs, batchGroupBy.getAggregations.asScala.toSeq, inputSchema)
+    val emptyBatchIr = batchAggregator.denormalizeBatchIr(batchAggregator.normalizeBatchIr(batchAggregator.init))
+    new BatchIrRow(entityKey(), new GigaTileCodec(batchGroupBy, inputSchema).encodeBatchIr(emptyBatchIr), batchEndTs)
   }
 
   private class LegacyEventTimeTimerFunction(timerTimestamps: Seq[Long])
@@ -679,5 +818,82 @@ object GigaTileProcessFunctionTest {
         ctx: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#Context,
         out: Collector[TimestampedTile]
     ): Unit = ()
+  }
+
+  /** Seeds only descriptors that existed before the cached-as-of markers were introduced. */
+  private class LegacyHorizonStateFunction(groupBy: GroupBy, inputSchema: Seq[(String, DataType)])
+      extends KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile] {
+    private var tileState: MapState[String, Array[Byte]] = _
+    private var megaTileIrState: ValueState[Array[Byte]] = _
+    private var currentDayStartState: ValueState[java.lang.Long] = _
+    private var earliestTileStartState: ValueState[java.lang.Long] = _
+    private var batchIrState: ValueState[Array[Byte]] = _
+    private var batchEndTsState: ValueState[java.lang.Long] = _
+    private var runningLargeIrState: ValueState[Array[Byte]] = _
+    private var megaTileAgg: MegaTileAggregator = _
+    private var codec: MegaTileCodec = _
+    private var gigaCodec: GigaTileCodec = _
+
+    override def open(parameters: Configuration): Unit = {
+      super.open(parameters)
+      val aggregations = groupBy.getAggregations.asScala.toSeq
+      megaTileAgg = new MegaTileAggregator(aggregations, inputSchema)
+      codec = new MegaTileCodec(groupBy, inputSchema)
+      gigaCodec = new GigaTileCodec(groupBy, inputSchema)
+      tileState = getRuntimeContext.getMapState(
+        new MapStateDescriptor[String, Array[Byte]]("giga-tile-tiles", classOf[String], classOf[Array[Byte]]))
+      megaTileIrState = getRuntimeContext.getState(
+        new ValueStateDescriptor[Array[Byte]]("giga-tile-ir", classOf[Array[Byte]]))
+      currentDayStartState = getRuntimeContext.getState(
+        new ValueStateDescriptor[java.lang.Long]("giga-tile-day-start", classOf[java.lang.Long]))
+      earliestTileStartState = getRuntimeContext.getState(
+        new ValueStateDescriptor[java.lang.Long]("giga-tile-earliest-tile", classOf[java.lang.Long]))
+      batchIrState = getRuntimeContext.getState(
+        new ValueStateDescriptor[Array[Byte]]("giga-tile-batch-ir", classOf[Array[Byte]]))
+      batchEndTsState = getRuntimeContext.getState(
+        new ValueStateDescriptor[java.lang.Long]("giga-tile-batch-end", classOf[java.lang.Long]))
+      runningLargeIrState = getRuntimeContext.getState(
+        new ValueStateDescriptor[Array[Byte]]("giga-tile-running-large", classOf[Array[Byte]]))
+    }
+
+    override def processElement1(
+        event: ProjectedEvent,
+        ctx: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#Context,
+        out: Collector[TimestampedTile]
+    ): Unit = {
+      val timestamp = event.fields(Constants.TimeColumn).asInstanceOf[Long]
+      val row = new ArrayRow(inputSchema.map { case (name, _) => event.fields(name) }.toArray, timestamp)
+      val baseIr = megaTileAgg.baseAggregator.init
+      megaTileAgg.baseAggregator.update(baseIr, row)
+      val tileStarts = megaTileAgg.tileStartsForEvent(timestamp)
+      tileStarts.foreach { case (hopSize, tileStart) =>
+        tileState.put(s"$hopSize:$tileStart", codec.encodeBaseIr(baseIr))
+      }
+
+      val cachedIr = megaTileAgg.windowedAggregator.init
+      megaTileAgg.windowedAggregator.columnAggregators(0).update(cachedIr, row)
+      megaTileIrState.update(codec.encode(cachedIr))
+      currentDayStartState.update(TsUtils.round(timestamp, new Window(1, TimeUnit.DAYS).millis))
+      earliestTileStartState.update(tileStarts.map(_._2).min)
+    }
+
+    override def processElement2(
+        batchRow: BatchIrRow,
+        ctx: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#Context,
+        out: Collector[TimestampedTile]
+    ): Unit = {
+      val batchIr = gigaCodec.decodeBatchIr(batchRow.valueBytes)
+      val seedStore = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator)
+      val seedProcessor = new GigaTileStreamProcessor(megaTileAgg, seedStore)
+      seedProcessor.onBatchUpdate(
+        batchIr,
+        batchRow.batchEndTs,
+        ctx.timerService().currentProcessingTime())
+
+      batchIrState.update(gigaCodec.encodeBatchIr(seedStore.getBatchIr))
+      batchEndTsState.update(batchRow.batchEndTs)
+      runningLargeIrState.update(codec.encode(seedStore.getRunningLargeIr))
+      currentDayStartState.update(TsUtils.round(batchRow.batchEndTs, new Window(1, TimeUnit.DAYS).millis))
+    }
   }
 }

--- a/flink/src/test/scala/ai/chronon/flink/test/window/GigaTileProcessFunctionTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/window/GigaTileProcessFunctionTest.scala
@@ -166,7 +166,8 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     val batchGroupBy = Builders.GroupBy(
       metaData = Builders.MetaData(name = "gigatile-process-function-future-batch-test"),
       aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(7, TimeUnit.DAYS)))))
-    val testHarness = harness(new GigaTileProcessFunction(batchGroupBy, inputSchema))
+    val function = new GigaTileProcessFunction(batchGroupBy, inputSchema)
+    val testHarness = harness(function)
     val batchCodec = new GigaTileCodec(batchGroupBy, inputSchema)
     val currentBatchEnd = 10 * dayMillis
     val currentProcessingTs = currentBatchEnd + hourMillis
@@ -191,11 +192,12 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
       testHarness.extractOutputValues().asScala shouldBe empty
       // A short watermark retry and the normal eviction timer are both live initially.
       testHarness.numProcessingTimeTimers() shouldEqual 2
+      valueState[java.lang.Long](function, "nextProcessingEvictionTimerState").value() should not be null
 
       testHarness.setProcessingTime(currentProcessingTs + hourMillis)
 
       testHarness.extractOutputValues().asScala shouldBe empty
-      testHarness.numProcessingTimeTimers() shouldEqual 1
+      valueState[java.lang.Long](function, "nextProcessingEvictionTimerState").value() should not be null
 
       advanceToHealthyLiveWatermark(testHarness, futureBatchEnd + hourMillis)
       testHarness.setProcessingTime(futureBatchEnd + hourMillis)

--- a/flink/src/test/scala/ai/chronon/flink/test/window/GigaTileProcessFunctionTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/window/GigaTileProcessFunctionTest.scala
@@ -10,6 +10,7 @@ import ai.chronon.aggregator.windowing.{
 }
 import ai.chronon.api._
 import ai.chronon.api.Extensions.WindowOps
+import ai.chronon.flink.FlinkJob
 import ai.chronon.flink.deser.ProjectedEvent
 import ai.chronon.flink.types.{BatchIrRow, TimestampedTile}
 import ai.chronon.flink.window.GigaTileProcessFunction
@@ -23,6 +24,7 @@ import org.apache.flink.runtime.state.KeyedStateBackend
 import org.apache.flink.streaming.api.functions.co.KeyedCoProcessFunction
 import org.apache.flink.streaming.api.operators.co.KeyedCoProcessOperator
 import org.apache.flink.streaming.api.watermark.Watermark
+import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus
 import org.apache.flink.streaming.util.KeyedTwoInputStreamOperatorTestHarness
 import org.apache.flink.util.Collector
 import org.scalatest.flatspec.AnyFlatSpec
@@ -42,6 +44,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     try {
       testHarness.open()
       testHarness.setProcessingTime(processingTs)
+      advanceToHealthyLiveWatermark(testHarness, processingTs)
       testHarness.processElement1(
         ProjectedEvent(Map(Constants.TimeColumn -> retainedLateEventTs, "num" -> 5L), carriedProcessingTs),
         retainedLateEventTs)
@@ -64,7 +67,9 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     try {
       testHarness.open()
       testHarness.setProcessingTime(justBeforeExpiry)
+      advanceToHealthyLiveWatermark(testHarness, justBeforeExpiry)
       testHarness.processElement1(event(eventTs, 5L), eventTs)
+      advanceToHealthyLiveWatermark(testHarness, afterExpiry)
       testHarness.setProcessingTime(afterExpiry)
 
       val outputs = testHarness.extractOutputValues()
@@ -86,7 +91,9 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     try {
       testHarness.open()
       testHarness.setProcessingTime(beforeMidnightProcessingTs)
+      advanceToHealthyLiveWatermark(testHarness, beforeMidnightProcessingTs)
       testHarness.processElement1(event(initialEventTs, 5L), initialEventTs)
+      advanceToHealthyLiveWatermark(testHarness, afterMidnightProcessingTs)
       testHarness.setProcessingTime(afterMidnightProcessingTs)
       // Zipline suppresses redundant timer writes. Crossing midnight must still leave the
       // retained pre-midnight value available to the next event.
@@ -118,6 +125,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     try {
       testHarness.open()
       testHarness.setProcessingTime(processingTs)
+      advanceToHealthyLiveWatermark(testHarness, processingTs)
       testHarness.processElement2(
         new BatchIrRow(entityKey(), batchCodec.encodeBatchIr(finalBatchIr), batchEndTs),
         batchEndTs)
@@ -142,6 +150,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     try {
       testHarness.open()
       testHarness.setProcessingTime(processingTs)
+      advanceToHealthyLiveWatermark(testHarness, processingTs)
       testHarness.processElement2(
         new BatchIrRow(entityKey(), batchCodec.encodeBatchIr(emptyBatchIr), batchEndTs),
         batchEndTs)
@@ -180,19 +189,105 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
       testHarness.processElement2(futureBatchRow, futureBatchEnd)
 
       testHarness.extractOutputValues().asScala shouldBe empty
-      testHarness.numProcessingTimeTimers() shouldEqual 1
+      // A short watermark retry and the normal eviction timer are both live initially.
+      testHarness.numProcessingTimeTimers() shouldEqual 2
 
       testHarness.setProcessingTime(currentProcessingTs + hourMillis)
 
       testHarness.extractOutputValues().asScala shouldBe empty
       testHarness.numProcessingTimeTimers() shouldEqual 1
 
+      advanceToHealthyLiveWatermark(testHarness, futureBatchEnd + hourMillis)
       testHarness.setProcessingTime(futureBatchEnd + hourMillis)
 
       val outputs = testHarness.extractOutputValues()
       outputs.size() shouldEqual 1
       decodeSum(outputs.get(0), batchGroupBy) shouldEqual 50L
       outputs.get(0).latestTsMillis shouldEqual futureBatchEnd + hourMillis
+    } finally testHarness.close()
+  }
+
+  it should "drop a future event before it can poison batch-backed large-window state" in {
+    val dayMillis = new Window(1, TimeUnit.DAYS).millis
+    val batchGroupBy = Builders.GroupBy(
+      metaData = Builders.MetaData(name = "gigatile-process-function-future-event-test"),
+      aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(7, TimeUnit.DAYS)))))
+    val testHarness = harness(new GigaTileProcessFunction(batchGroupBy, inputSchema))
+    val currentProcessingTime = 10 * dayMillis + new Window(1, TimeUnit.HOURS).millis
+    val batchCallbackTime = currentProcessingTime - 2L
+    val batchEnd = 9 * dayMillis
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(batchCallbackTime)
+      advanceToHealthyLiveWatermark(testHarness, batchCallbackTime)
+      testHarness.processElement2(batchRow(batchGroupBy, batchEnd, batchEnd - 1000L, 3L), batchEnd)
+      decodeSum(testHarness.extractOutputValues().get(0), batchGroupBy) shouldEqual 3L
+
+      testHarness.setProcessingTime(currentProcessingTime)
+      advanceToHealthyLiveWatermark(testHarness, currentProcessingTime)
+      testHarness.processElement1(event(currentProcessingTime + 1L, 11L), currentProcessingTime + 1L)
+      testHarness.processElement1(event(currentProcessingTime - 1000L, 5L), currentProcessingTime - 1000L)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs.size() shouldEqual 2
+      decodeSum(outputs.get(1), batchGroupBy) shouldEqual 8L
+      outputs.get(1).latestTsMillis shouldEqual currentProcessingTime
+    } finally testHarness.close()
+  }
+
+  it should "stay fenced while a source watermark implies a future event" in {
+    val testHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    val futureEventTime = processingTs + 1L
+    val historicalEventTime = processingTs - 1000L
+    val poisonedWatermark = processingTs - FlinkJob.AllowedOutOfOrderness.toMillis
+    val retryTime = processingTs + 2L * FlinkJob.AutoWatermarkInterval
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      testHarness.processWatermarkStatus2(WatermarkStatus.IDLE)
+      testHarness.processElement1(event(futureEventTime, 11L), futureEventTime)
+      testHarness.processWatermark1(new Watermark(poisonedWatermark))
+      testHarness.processElement1(event(historicalEventTime, 5L), historicalEventTime)
+
+      testHarness.extractOutputValues() shouldBe empty
+      testHarness.setProcessingTime(retryTime)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldEqual 5L
+      outputs.get(0).latestTsMillis shouldEqual retryTime
+    } finally testHarness.close()
+  }
+
+  it should "wait once at the exact safe boundary for a finite future watermark" in {
+    val function = new GigaTileProcessFunction(groupBy, inputSchema)
+    val testHarness = harness(function)
+    val futureWatermark = processingTs + 1000L
+    val shortRetryTime = processingTs + 2L * FlinkJob.AutoWatermarkInterval
+    val safeProcessingTime = futureWatermark + FlinkJob.AllowedOutOfOrderness.toMillis + 1L
+    val eventTime = processingTs - 1000L
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      advanceToLiveWatermark(testHarness, futureWatermark)
+      testHarness.processElement1(event(eventTime, 5L), eventTime)
+
+      testHarness.extractOutputValues() shouldBe empty
+      testHarness.setProcessingTime(shortRetryTime)
+      publicationRetryTimestamp(function) shouldEqual safeProcessingTime
+
+      testHarness.setProcessingTime(shortRetryTime + FlinkJob.IdlenessTimeout.toMillis)
+      testHarness.extractOutputValues() shouldBe empty
+      publicationRetryTimestamp(function) shouldEqual safeProcessingTime
+
+      testHarness.setProcessingTime(safeProcessingTime)
+      val outputs = testHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldEqual 5L
+      outputs.get(0).latestTsMillis shouldEqual safeProcessingTime
     } finally testHarness.close()
   }
 
@@ -221,11 +316,567 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     } finally restoredHarness.close()
   }
 
-  it should "restore and flush same-millisecond updates with a strictly newer version" in {
+  it should "advance only by event time while the batch input holds the watermark at MIN" in {
+    val dayMillis = new Window(1, TimeUnit.DAYS).millis
+    val currentProcessingTime = 10 * dayMillis + new Window(1, TimeUnit.HOURS).millis
+    val firstEventTime = dayMillis + new Window(1, TimeUnit.HOURS).millis
+    val laterEventTime = 4 * dayMillis + new Window(1, TimeUnit.HOURS).millis
+    val firstFutureEventTime = currentProcessingTime + 1L
+    val farFutureEventTime = currentProcessingTime + 2 * dayMillis
+    val function = new GigaTileProcessFunction(groupBy, inputSchema)
+    val testHarness = harness(function)
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(currentProcessingTime)
+      // Input 2 remains active, so this input-1 watermark does not initialize the connected one.
+      testHarness.processWatermark1(new Watermark(currentProcessingTime))
+      testHarness.processElement1(event(firstEventTime, 5L), firstEventTime)
+      testHarness.processElement1(event(laterEventTime, 7L), laterEventTime)
+
+      testHarness.extractOutputValues() shouldBe empty
+      currentFinalizedSum(function) shouldEqual 7L
+      currentDayStart(function) shouldEqual 4 * dayMillis
+
+      // Any future event is rejected before it can mutate either small- or large-window state.
+      testHarness.processElement1(event(firstFutureEventTime, 11L), firstFutureEventTime)
+      testHarness.processElement1(event(farFutureEventTime, 11L), farFutureEventTime)
+      currentFinalizedSum(function) shouldEqual 7L
+      testHarness.setProcessingTime(nextEvictionHop(currentProcessingTime))
+      testHarness.extractOutputValues() shouldBe empty
+      currentDayStart(function) shouldEqual 4 * dayMillis
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+    } finally testHarness.close()
+  }
+
+  it should "remain fail-closed when both inputs idle before any finite watermark" in {
+    val batchGroupBy = Builders.GroupBy(
+      metaData = Builders.MetaData(name = "gigatile-process-function-idle-bootstrap-test"),
+      aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(7, TimeUnit.DAYS)))))
+    val function = new GigaTileProcessFunction(batchGroupBy, inputSchema)
+    val testHarness = harness(function)
+    val batchEnd = TsUtils.round(eventTs, new Window(1, TimeUnit.DAYS).millis)
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      testHarness.processElement2(batchRow(batchGroupBy, batchEnd, eventTs - 1000L, 3L), batchEnd)
+      testHarness.processWatermarkStatus1(WatermarkStatus.IDLE)
+      testHarness.processWatermarkStatus2(WatermarkStatus.IDLE)
+      testHarness.setProcessingTime(nextEvictionHop(processingTs))
+
+      // Marking both inputs idle does not synthesize a finite watermark. Without a previously
+      // observed finite event watermark, retain state rather than publish a partial row.
+      testHarness.extractOutputValues() shouldBe empty
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+    } finally testHarness.close()
+  }
+
+  it should "bound finite batch-backed state during a long replay with an uninitialized watermark" in {
+    val dayMillis = new Window(1, TimeUnit.DAYS).millis
+    val replayGroupBy = Builders.GroupBy(
+      metaData = Builders.MetaData(name = "gigatile-process-function-long-replay-test"),
+      aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(7, TimeUnit.DAYS)))))
+    val function = new GigaTileProcessFunction(replayGroupBy, inputSchema)
+    val testHarness = harness(function)
+    // Keep the serving horizon day-aligned so the daily large-IR boundary is exact.
+    val currentProcessingTime = 41 * dayMillis
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(currentProcessingTime)
+      testHarness.processElement2(emptyBatchRow(replayGroupBy, dayMillis), dayMillis)
+      (1 to 40).foreach { day =>
+        val eventTime = day * dayMillis + new Window(1, TimeUnit.HOURS).millis
+        testHarness.processElement1(event(eventTime, 1L), eventTime)
+      }
+
+      testHarness.extractOutputValues() shouldBe empty
+      currentDayStart(function) shouldEqual 40 * dayMillis
+      dailyLargeSlotCount(function) should be <= 8
+
+      val liveTimer = nextEvictionHop(currentProcessingTime)
+      advanceToHealthyLiveWatermark(testHarness, liveTimer)
+      testHarness.setProcessingTime(liveTimer)
+      val outputs = testHarness.extractOutputValues()
+      outputs should not be empty
+      decodeSum(outputs.get(outputs.size() - 1), replayGroupBy) shouldEqual 7L
+    } finally testHarness.close()
+  }
+
+  it should "use source watermark readiness across five-minute, hourly, and daily aggregation hops" in {
+    val hourMillis = new Window(1, TimeUnit.HOURS).millis
+    val dayMillis = new Window(1, TimeUnit.DAYS).millis
+    val staleWatermark = processingTs - 30 * 60 * 1000L
+    val liveWatermark = processingTs - FlinkJob.LiveWatermarkLagToleranceMillis
+    val cases = Seq(
+      ("five-minute", new Window(1, TimeUnit.HOURS), 5 * 60 * 1000L, false),
+      ("hourly", new Window(7, TimeUnit.DAYS), hourMillis, true),
+      ("daily", new Window(30, TimeUnit.DAYS), dayMillis, true)
+    )
+
+    cases.foreach { case (name, window, expectedHopMillis, needsBatch) =>
+      val testGroupBy = Builders.GroupBy(metaData = Builders.MetaData(name = s"gigatile-source-readiness-$name-test"),
+                                         aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(window))))
+      val function = new GigaTileProcessFunction(testGroupBy, inputSchema)
+      val testHarness = harness(function)
+
+      try {
+        testHarness.open()
+        testHarness.setProcessingTime(processingTs)
+        currentProcessor(function).minSmallWindowTileSize shouldEqual expectedHopMillis
+        if (needsBatch) {
+          testHarness.processElement2(batchRow(testGroupBy, 0L, -1000L, 3L), 0L)
+        }
+        advanceToLiveWatermark(testHarness, staleWatermark)
+        testHarness.processElement1(event(staleWatermark - 1000L, 5L), staleWatermark - 1000L)
+
+        withClue(s"$name aggregation hop: ") {
+          testHarness.extractOutputValues() shouldBe empty
+        }
+
+        testHarness.processWatermark1(new Watermark(liveWatermark))
+        testHarness.processElement1(event(liveWatermark, 7L), liveWatermark)
+
+        val outputs = testHarness.extractOutputValues()
+        withClue(s"$name aggregation hop: ") {
+          outputs should have size 1
+          decodeSum(outputs.get(0), testGroupBy) shouldEqual (if (needsBatch) 15L else 12L)
+        }
+      } finally testHarness.close()
+    }
+  }
+
+  it should "keep a sparse key fenced until the global watermark is live" in {
+    val testHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    val staleWatermark = processingTs - 10 * 60 * 1000L
+    val secondTimer = nextEvictionHop(nextEvictionHop(processingTs))
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      advanceToLiveWatermark(testHarness, staleWatermark)
+      testHarness.processElement1(event(staleWatermark - 1000L, 5L), staleWatermark - 1000L)
+      testHarness.setProcessingTime(secondTimer)
+      testHarness.extractOutputValues() shouldBe empty
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+
+      testHarness.processElement1(event(staleWatermark + 1000L, 7L), staleWatermark + 1000L)
+      testHarness.extractOutputValues() shouldBe empty
+
+      val liveTimer = nextEvictionHop(secondTimer)
+      testHarness.processWatermark1(new Watermark(healthyLiveWatermark(liveTimer)))
+      testHarness.setProcessingTime(liveTimer)
+      val outputs = testHarness.extractOutputValues()
+      outputs.size() shouldEqual 1
+      decodeSum(outputs.get(0)) shouldEqual 12L
+      outputs.get(0).latestTsMillis shouldEqual liveTimer
+    } finally testHarness.close()
+  }
+
+  it should "publish a lone event after its periodic watermark catches up" in {
+    val testHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    val eventTime = processingTs - 1000L
+    val retryTime = processingTs + 2L * FlinkJob.AutoWatermarkInterval
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      testHarness.processWatermarkStatus2(WatermarkStatus.IDLE)
+      testHarness.processElement1(event(eventTime, 5L), eventTime)
+
+      testHarness.extractOutputValues() shouldBe empty
+      testHarness.numProcessingTimeTimers() shouldEqual 2
+
+      testHarness.setProcessingTime(retryTime)
+      testHarness.extractOutputValues() shouldBe empty
+      testHarness.numEventTimeTimers() shouldEqual 1
+
+      val periodicWatermark = healthyLiveWatermark(processingTs)
+      testHarness.processWatermark1(new Watermark(periodicWatermark))
+
+      val outputs = testHarness.extractOutputValues()
+      outputs.size() shouldEqual 1
+      decodeSum(outputs.get(0)) shouldEqual 5L
+      outputs.get(0).latestTsMillis shouldEqual retryTime
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+    } finally testHarness.close()
+  }
+
+  it should "park a catch-up publication on one event-time activation without hot retries" in {
+    val testHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    val staleWatermark = processingTs - new Window(1, TimeUnit.HOURS).millis
+    val retryTime = processingTs + 2L * FlinkJob.AutoWatermarkInterval
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      advanceToLiveWatermark(testHarness, staleWatermark)
+      testHarness.processElement1(event(staleWatermark - 1000L, 5L), staleWatermark - 1000L)
+
+      testHarness.numProcessingTimeTimers() shouldEqual 2
+      testHarness.setProcessingTime(retryTime)
+
+      testHarness.extractOutputValues() shouldBe empty
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+      testHarness.numEventTimeTimers() shouldEqual 1
+      testHarness.processElement1(event(staleWatermark + 1000L, 7L), staleWatermark + 1000L)
+      testHarness.setProcessingTime(retryTime + 5L * FlinkJob.AutoWatermarkInterval)
+      testHarness.extractOutputValues() shouldBe empty
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+      testHarness.numEventTimeTimers() shouldEqual 1
+    } finally testHarness.close()
+  }
+
+  it should "publish a daily sparse key after watermark-only activation" in {
+    val dayMillis = new Window(1, TimeUnit.DAYS).millis
+    val dailyGroupBy = Builders.GroupBy(
+      metaData = Builders.MetaData(name = "gigatile-daily-sparse-activation-test"),
+      aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(30, TimeUnit.DAYS)))))
+    val function = new GigaTileProcessFunction(dailyGroupBy, inputSchema)
+    val testHarness = harness(function)
+    val staleWatermark = processingTs - new Window(1, TimeUnit.HOURS).millis
+    val retryDelay = 2L * FlinkJob.AutoWatermarkInterval
+    val retryTime = processingTs + retryDelay
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      testHarness.processElement2(batchRow(dailyGroupBy, 0L, -1000L, 3L), 0L)
+      advanceToLiveWatermark(testHarness, staleWatermark)
+      testHarness.processElement1(event(staleWatermark - 1000L, 5L), staleWatermark - 1000L)
+      currentProcessor(function).minEvictionInterval shouldEqual dayMillis
+
+      testHarness.setProcessingTime(retryTime)
+      testHarness.extractOutputValues() shouldBe empty
+      testHarness.numEventTimeTimers() shouldEqual 1
+
+      testHarness.processWatermark1(new Watermark(healthyLiveWatermark(retryTime)))
+
+      val outputs = testHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0), dailyGroupBy) shouldEqual 8L
+      outputs.get(0).latestTsMillis shouldEqual retryTime
+      retryTime should be < nextDay(processingTs)
+    } finally testHarness.close()
+  }
+
+  it should "advance a catch-up day before publishing a batch-ahead sparse key" in {
+    val dayMillis = new Window(1, TimeUnit.DAYS).millis
+    val dailyGroupBy = Builders.GroupBy(
+      metaData = Builders.MetaData(name = "gigatile-batch-ahead-activation-test"),
+      aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(30, TimeUnit.DAYS)))))
+    val function = new GigaTileProcessFunction(dailyGroupBy, inputSchema)
+    val testHarness = harness(function)
+    val currentProcessingTime = 10L * dayMillis + new Window(1, TimeUnit.HOURS).millis
+    val staleWatermark = 8L * dayMillis + new Window(1, TimeUnit.HOURS).millis
+    val batchEnd = 9L * dayMillis
+    val retryTime = currentProcessingTime + 2L * FlinkJob.AutoWatermarkInterval
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(currentProcessingTime)
+      advanceToLiveWatermark(testHarness, staleWatermark)
+      testHarness.processElement1(event(staleWatermark - 1000L, 5L), staleWatermark - 1000L)
+      testHarness.processElement2(batchRow(dailyGroupBy, batchEnd, batchEnd - 1000L, 3L), batchEnd)
+
+      currentDayStart(function) should be < batchEnd
+      testHarness.extractOutputValues() shouldBe empty
+      testHarness.setProcessingTime(retryTime)
+      testHarness.numEventTimeTimers() shouldEqual 1
+
+      testHarness.processWatermark1(new Watermark(liveActivationWatermark(retryTime)))
+
+      val outputs = testHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0), dailyGroupBy) shouldEqual 3L
+      currentDayStart(function) should be >= batchEnd
+    } finally testHarness.close()
+  }
+
+  it should "publish at the exact lower Live watermark boundary" in {
+    val testHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    val staleWatermark = processingTs - new Window(1, TimeUnit.HOURS).millis
+    val retryTime = processingTs + 2L * FlinkJob.AutoWatermarkInterval
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      advanceToLiveWatermark(testHarness, staleWatermark)
+      testHarness.processElement1(event(staleWatermark - 1000L, 5L), staleWatermark - 1000L)
+      testHarness.setProcessingTime(retryTime)
+
+      testHarness.processWatermark1(new Watermark(liveActivationWatermark(retryTime)))
+
+      val outputs = testHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldEqual 5L
+      outputs.get(0).latestTsMillis shouldEqual retryTime
+    } finally testHarness.close()
+  }
+
+  it should "move activation forward when processing time consumes the live slack" in {
+    val testHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    val staleWatermark = processingTs - new Window(1, TimeUnit.HOURS).millis
+    val retryDelay = 2L * FlinkJob.AutoWatermarkInterval
+    val retryTime = processingTs + retryDelay
+    val firstActivationWatermark = liveActivationWatermark(retryTime)
+    val delayedProcessingTime = retryTime + FlinkJob.CatchupWatermarkLagSlackMillis + 1L
+    val cooldownDelay = math.max(retryDelay, FlinkJob.CatchupWatermarkLagSlackMillis / 2L)
+    val cooldownTime = delayedProcessingTime + cooldownDelay
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      advanceToLiveWatermark(testHarness, staleWatermark)
+      testHarness.processElement1(event(staleWatermark - 1000L, 5L), staleWatermark - 1000L)
+      testHarness.setProcessingTime(retryTime)
+
+      testHarness.setProcessingTime(delayedProcessingTime)
+      testHarness.processWatermark1(new Watermark(firstActivationWatermark))
+      testHarness.extractOutputValues() shouldBe empty
+      testHarness.numEventTimeTimers() shouldEqual 0
+
+      testHarness.setProcessingTime(cooldownTime)
+      testHarness.extractOutputValues() shouldBe empty
+      testHarness.numEventTimeTimers() shouldEqual 1
+
+      testHarness.processWatermark1(new Watermark(healthyLiveWatermark(cooldownTime)))
+
+      val outputs = testHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldEqual 5L
+    } finally testHarness.close()
+  }
+
+  it should "preserve an eviction timer that shares a cleared publication-retry timestamp" in {
+    val testHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    val retryDelay = 2L * FlinkJob.AutoWatermarkInterval
+    val evictionTime = nextEvictionHop(processingTs)
+    val firstProcessingTime = evictionTime - retryDelay
+    val firstEventTime = firstProcessingTime - 1000L
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(firstProcessingTime)
+      testHarness.processWatermarkStatus2(WatermarkStatus.IDLE)
+      testHarness.processElement1(event(firstEventTime, 5L), firstEventTime)
+      // The retry and normal eviction markers share one physical Flink timer.
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+
+      testHarness.setProcessingTime(evictionTime)
+      testHarness.extractOutputValues() shouldBe empty
+      // Both roles fired: normal eviction remains scheduled and publication waits on watermark.
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+      testHarness.numEventTimeTimers() shouldEqual 1
+    } finally testHarness.close()
+  }
+
+  it should "preserve a pending publication retry while draining an earlier callback" in {
+    val eventTime = processingTs - 1000L
+    val injectedTimer = processingTs + 1L
+    val retryTime = processingTs + 2L * FlinkJob.AutoWatermarkInterval
+    injectedTimer should be < retryTime
+    val originalHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+
+    originalHarness.open()
+    originalHarness.setProcessingTime(processingTs)
+    originalHarness.processWatermarkStatus2(WatermarkStatus.IDLE)
+    originalHarness.processElement1(event(eventTime, 5L), eventTime)
+    val snapshot = originalHarness.snapshot(10L, processingTs)
+    originalHarness.close()
+
+    val injectorHarness = harness(new ProcessingTimerInjector(injectedTimer))
+    injectorHarness.setup()
+    injectorHarness.initializeState(snapshot)
+    injectorHarness.open()
+    injectorHarness.setProcessingTime(processingTs)
+    injectorHarness.processElement1(event(eventTime, 0L), eventTime)
+    val injectedSnapshot = injectorHarness.snapshot(11L, processingTs)
+    injectorHarness.close()
+
+    val restoredHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(injectedSnapshot)
+      restoredHarness.open()
+      restoredHarness.setProcessingTime(processingTs)
+      // The injected callback runs first while Flink already reports retryTime. It must not
+      // clear the still-queued publication retry marker.
+      restoredHarness.numProcessingTimeTimers() shouldEqual 3
+      advanceToHealthyLiveWatermark(restoredHarness, retryTime)
+      restoredHarness.setProcessingTime(retryTime)
+
+      val outputs = restoredHarness.extractOutputValues()
+      outputs.size() shouldEqual 1
+      decodeSum(outputs.get(0)) shouldEqual 5L
+      outputs.get(0).latestTsMillis shouldEqual retryTime
+      restoredHarness.numProcessingTimeTimers() shouldEqual 1
+    } finally restoredHarness.close()
+  }
+
+  it should "restore a watermark activation without another element" in {
+    val staleWatermark = processingTs - new Window(10, TimeUnit.MINUTES).millis
+    val retryTime = processingTs + 2L * FlinkJob.AutoWatermarkInterval
+    val originalHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+
+    originalHarness.open()
+    originalHarness.setProcessingTime(processingTs)
+    advanceToLiveWatermark(originalHarness, staleWatermark)
+    originalHarness.processElement1(event(staleWatermark - 1000L, 5L), staleWatermark - 1000L)
+    originalHarness.setProcessingTime(retryTime)
+    originalHarness.extractOutputValues() shouldBe empty
+    originalHarness.numProcessingTimeTimers() shouldEqual 1
+    originalHarness.numEventTimeTimers() shouldEqual 1
+    val snapshot = originalHarness.snapshot(11L, retryTime)
+    originalHarness.close()
+
+    val restoredHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(snapshot)
+      restoredHarness.open()
+      restoredHarness.setProcessingTime(retryTime)
+      advanceToHealthyLiveWatermark(restoredHarness, retryTime)
+      val outputs = restoredHarness.extractOutputValues()
+      outputs.size() shouldEqual 1
+      decodeSum(outputs.get(0)) shouldEqual 5L
+      outputs.get(0).latestTsMillis shouldEqual retryTime
+    } finally restoredHarness.close()
+  }
+
+  it should "restore a delayed activation cooldown without another element" in {
+    val staleWatermark = processingTs - new Window(10, TimeUnit.MINUTES).millis
+    val retryDelay = 2L * FlinkJob.AutoWatermarkInterval
+    val retryTime = processingTs + retryDelay
+    val firstActivationWatermark = liveActivationWatermark(retryTime)
+    val delayedProcessingTime = retryTime + FlinkJob.CatchupWatermarkLagSlackMillis + 1L
+    val cooldownDelay = math.max(retryDelay, FlinkJob.CatchupWatermarkLagSlackMillis / 2L)
+    val cooldownTime = delayedProcessingTime + cooldownDelay
+    val originalHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+
+    originalHarness.open()
+    originalHarness.setProcessingTime(processingTs)
+    advanceToLiveWatermark(originalHarness, staleWatermark)
+    originalHarness.processElement1(event(staleWatermark - 1000L, 5L), staleWatermark - 1000L)
+    originalHarness.setProcessingTime(retryTime)
+    originalHarness.setProcessingTime(delayedProcessingTime)
+    originalHarness.processWatermark1(new Watermark(firstActivationWatermark))
+    originalHarness.extractOutputValues() shouldBe empty
+    originalHarness.numEventTimeTimers() shouldEqual 0
+    val snapshot = originalHarness.snapshot(12L, delayedProcessingTime)
+    originalHarness.close()
+
+    val restoredHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(snapshot)
+      restoredHarness.open()
+      restoredHarness.setProcessingTime(delayedProcessingTime)
+      advanceToLiveWatermark(restoredHarness, firstActivationWatermark)
+      restoredHarness.setProcessingTime(cooldownTime)
+
+      restoredHarness.extractOutputValues() shouldBe empty
+      restoredHarness.numEventTimeTimers() shouldEqual 1
+      restoredHarness.processWatermark1(new Watermark(healthyLiveWatermark(cooldownTime)))
+
+      val outputs = restoredHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldEqual 5L
+      outputs.get(0).latestTsMillis shouldEqual cooldownTime
+    } finally restoredHarness.close()
+  }
+
+  it should "recover an expired retry marker on the next keyed callback" in {
+    val staleWatermark = processingTs - new Window(10, TimeUnit.MINUTES).millis
+    val retryDelay = 2L * FlinkJob.AutoWatermarkInterval
+    val retryTime = processingTs + retryDelay
+    val originalFunction = new GigaTileProcessFunction(groupBy, inputSchema)
+    val originalHarness = harness(originalFunction)
+
+    originalHarness.open()
+    originalHarness.setProcessingTime(processingTs)
+    advanceToLiveWatermark(originalHarness, staleWatermark)
+    originalHarness.processElement1(event(staleWatermark - 1000L, 5L), staleWatermark - 1000L)
+    originalHarness.setProcessingTime(retryTime)
+    originalHarness.extractOutputValues() shouldBe empty
+    setPublicationRetryTimestamp(originalFunction, retryTime)
+    clearPublicationActivationTimestamp(originalFunction)
+    val snapshot = originalHarness.snapshot(12L, retryTime)
+    originalHarness.close()
+
+    val restoredFunction = new GigaTileProcessFunction(groupBy, inputSchema)
+    val restoredHarness = harness(restoredFunction)
+    val restoredProcessingTime = retryTime + 1L
+    val restoredRetryTime = restoredProcessingTime + retryDelay
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(snapshot)
+      restoredHarness.open()
+      restoredHarness.setProcessingTime(restoredProcessingTime)
+      restoredHarness.processElement1(event(staleWatermark + 1000L, 7L), staleWatermark + 1000L)
+
+      publicationRetryTimestamp(restoredFunction) shouldEqual restoredRetryTime
+      advanceToHealthyLiveWatermark(restoredHarness, restoredRetryTime)
+      restoredHarness.setProcessingTime(restoredRetryTime)
+
+      val outputs = restoredHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldEqual 12L
+      outputs.get(0).latestTsMillis shouldEqual restoredRetryTime
+    } finally restoredHarness.close()
+  }
+
+  it should "coalesce event and batch publications from the same processing millisecond" in {
+    val dayMillis = new Window(1, TimeUnit.DAYS).millis
+    val batchGroupBy = Builders.GroupBy(
+      metaData = Builders.MetaData(name = "gigatile-process-function-collision-batch-test"),
+      aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(7, TimeUnit.DAYS)))))
+    val function = new GigaTileProcessFunction(batchGroupBy, inputSchema)
+    val testHarness = harness(function)
+    val callbackProcessingTime = 3 * dayMillis + new Window(1, TimeUnit.HOURS).millis
+    val initialBatchEnd = dayMillis
+    val replacementBatchEnd = 2 * dayMillis
+    val streamEventTime = replacementBatchEnd + new Window(1, TimeUnit.HOURS).millis
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(callbackProcessingTime - 1L)
+      advanceToHealthyLiveWatermark(testHarness, callbackProcessingTime - 1L)
+      testHarness.processElement2(
+        batchRow(batchGroupBy, initialBatchEnd, initialBatchEnd - 1000L, 1L),
+        initialBatchEnd)
+      decodeSum(testHarness.extractOutputValues().get(0), batchGroupBy) shouldEqual 1L
+
+      testHarness.setProcessingTime(callbackProcessingTime)
+      testHarness.processElement1(event(streamEventTime, 5L), streamEventTime)
+      testHarness.processElement2(
+        batchRow(batchGroupBy, replacementBatchEnd, replacementBatchEnd - 1000L, 7L),
+        replacementBatchEnd)
+
+      val initialOutputs = testHarness.extractOutputValues()
+      initialOutputs.size() shouldEqual 2
+      decodeSum(initialOutputs.get(1), batchGroupBy) shouldEqual 6L
+      setCurrentKey(testHarness, entityKey())
+      valueState[java.lang.Boolean](function, "pendingPublicationState").value() shouldEqual
+        java.lang.Boolean.TRUE
+
+      testHarness.setProcessingTime(callbackProcessingTime + 1L)
+      val outputs = testHarness.extractOutputValues()
+      outputs.size() shouldEqual 3
+      decodeSum(outputs.get(2), batchGroupBy) shouldEqual 12L
+      outputs.get(2).latestTsMillis shouldEqual callbackProcessingTime + 1L
+      setCurrentKey(testHarness, entityKey())
+      valueState[java.lang.Boolean](function, "pendingPublicationState").value() shouldBe null
+    } finally testHarness.close()
+  }
+
+  it should "keep a restored version collision fenced without a timer storm" in {
     val originalHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
     val firstEventTs = processingTs - 1000L
     originalHarness.open()
     originalHarness.setProcessingTime(processingTs)
+    advanceToHealthyLiveWatermark(originalHarness, processingTs)
     originalHarness.processElement1(event(firstEventTs, 5L), firstEventTs)
     originalHarness.processElement1(event(firstEventTs + 1L, 7L), firstEventTs + 1L)
     originalHarness.processElement1(event(firstEventTs + 2L, 3L), firstEventTs + 2L)
@@ -244,14 +895,19 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
       restoredHarness.setup()
       restoredHarness.initializeState(snapshot)
       restoredHarness.open()
-      // A delayed callback still uses the reserved strictly-newer version without moving
-      // aggregation time merely to flush the current snapshot.
       restoredHarness.setProcessingTime(processingTs + 100L)
+      restoredHarness.extractOutputValues() shouldBe empty
+      // The collision marker shares the next normal eviction timer while the connected
+      // watermark is uninitialized; it does not retry every millisecond.
+      restoredHarness.numProcessingTimeTimers() shouldEqual 1
 
+      val retryTimer = nextEvictionHop(processingTs + 100L)
+      advanceToHealthyLiveWatermark(restoredHarness, retryTimer)
+      restoredHarness.setProcessingTime(retryTimer)
       val outputs = restoredHarness.extractOutputValues()
       outputs.size() shouldEqual 1
       decodeSum(outputs.get(0)) shouldEqual 15L
-      outputs.get(0).latestTsMillis shouldEqual processingTs + 1L
+      outputs.get(0).latestTsMillis shouldEqual retryTimer
     } finally restoredHarness.close()
   }
 
@@ -262,6 +918,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     val originalHarness = harness(originalFunction)
     originalHarness.open()
     originalHarness.setProcessingTime(processingTs)
+    advanceToHealthyLiveWatermark(originalHarness, processingTs)
     originalHarness.processElement1(event(firstEventTs, 5L), firstEventTs)
     originalHarness.processElement1(event(firstEventTs + 1L, 7L), firstEventTs + 1L)
     val originalSnapshot = originalHarness.snapshot(31L, processingTs)
@@ -287,6 +944,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
       // With no keyed callback, there is no way for open() to enumerate and repair this key.
       restoredHarness.numProcessingTimeTimers() shouldEqual 0
 
+      advanceToHealthyLiveWatermark(restoredHarness, evictionTs)
       restoredHarness.processElement1(event(firstEventTs + 2L, 3L), firstEventTs + 2L)
       setCurrentKey(restoredHarness, entityKey())
       val repairedEviction = valueState[java.lang.Long](restoredFunction,
@@ -297,6 +955,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
       repairedCollision shouldEqual repairedEviction
       restoredHarness.numProcessingTimeTimers() shouldEqual 1
 
+      advanceToHealthyLiveWatermark(restoredHarness, repairedCollision)
       restoredHarness.setProcessingTime(repairedCollision)
 
       val outputs = restoredHarness.extractOutputValues()
@@ -318,6 +977,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     val originalHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
     originalHarness.open()
     originalHarness.setProcessingTime(justBeforeExpiry)
+    advanceToHealthyLiveWatermark(originalHarness, justBeforeExpiry)
     originalHarness.processElement1(event(eventTs, 5L), eventTs)
     val originalSnapshot = originalHarness.snapshot(33L, justBeforeExpiry)
     originalHarness.close()
@@ -338,6 +998,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
       restoredHarness.open()
       // Flink reports this jump target while it first drains injectedTimer. That earlier
       // callback must not steal ownership from the still-queued evictionTimer.
+      advanceToHealthyLiveWatermark(restoredHarness, evictionTimer)
       restoredHarness.setProcessingTime(evictionTimer)
 
       val outputs = restoredHarness.extractOutputValues()
@@ -358,6 +1019,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     val originalHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
     originalHarness.open()
     originalHarness.setProcessingTime(processingTs)
+    advanceToHealthyLiveWatermark(originalHarness, processingTs)
     originalHarness.processElement1(event(firstEventTs, 5L), firstEventTs)
     originalHarness.processElement1(event(firstEventTs + 1L, 7L), firstEventTs + 1L)
     val originalSnapshot = originalHarness.snapshot(35L, processingTs)
@@ -391,6 +1053,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
       restoredHarness.setProcessingTime(consumedCollisionTimer)
       // The injected callback runs first while Flink already reports evictionTimer as the
       // current processing time. The stale collision must join that still-queued eviction.
+      advanceToHealthyLiveWatermark(restoredHarness, evictionTimer)
       restoredHarness.setProcessingTime(evictionTimer)
 
       val outputs = restoredHarness.extractOutputValues()
@@ -411,6 +1074,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     try {
       testHarness.open()
       testHarness.setProcessingTime(processingTs)
+      advanceToHealthyLiveWatermark(testHarness, processingTs)
       failNextEncode(function)
       testHarness.processElement1(event(firstEventTs, 5L), firstEventTs)
 
@@ -428,32 +1092,31 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     } finally testHarness.close()
   }
 
-  it should "re-arm a version collision when snapshot construction fails" in {
+  it should "keep a failed collision on a queued eviction while draining delayed callbacks" in {
     val function = new GigaTileProcessFunction(groupBy, inputSchema)
     val testHarness = harness(function)
     val firstEventTs = processingTs - 1000L
+    val retryTimer = nextEvictionHop(processingTs)
 
     try {
       testHarness.open()
       testHarness.setProcessingTime(processingTs)
+      advanceToHealthyLiveWatermark(testHarness, processingTs)
       testHarness.processElement1(event(firstEventTs, 5L), firstEventTs)
       testHarness.processElement1(event(firstEventTs + 1L, 7L), firstEventTs + 1L)
 
       testHarness.extractOutputValues().size() shouldEqual 1
       failNextSnapshot(function)
 
-      testHarness.setProcessingTime(processingTs + 1L)
-
-      testHarness.extractOutputValues().size() shouldEqual 1
-      // The normal eviction timer and the re-armed collision timer must both remain live.
-      testHarness.numProcessingTimeTimers() shouldEqual 2
-
-      testHarness.setProcessingTime(processingTs + 2L)
+      // Flink drains the earlier collision callback while already reporting retryTimer as the
+      // wall clock. A transient failure must keep the collision on the queued eviction timer.
+      advanceToHealthyLiveWatermark(testHarness, retryTimer)
+      testHarness.setProcessingTime(retryTimer)
 
       val outputs = testHarness.extractOutputValues()
       outputs.size() shouldEqual 2
       decodeSum(outputs.get(1)) shouldEqual 12L
-      outputs.get(1).latestTsMillis shouldEqual processingTs + 2L
+      outputs.get(1).latestTsMillis shouldEqual retryTimer
       testHarness.numProcessingTimeTimers() shouldEqual 1
     } finally testHarness.close()
   }
@@ -468,6 +1131,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     try {
       testHarness.open()
       testHarness.setProcessingTime(collisionProcessingTs)
+      advanceToHealthyLiveWatermark(testHarness, collisionProcessingTs)
       testHarness.processElement1(event(expiringEventTs, 5L), expiringEventTs)
       testHarness.processElement1(event(expiringEventTs, 7L), expiringEventTs)
 
@@ -493,6 +1157,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     try {
       testHarness.open()
       testHarness.setProcessingTime(collisionProcessingTs)
+      advanceToHealthyLiveWatermark(testHarness, collisionProcessingTs)
       testHarness.processElement1(event(expiringEventTs, 5L), expiringEventTs)
       testHarness.processElement1(event(expiringEventTs, 7L), expiringEventTs)
       failNextEviction(function)
@@ -505,6 +1170,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
       testHarness.setProcessingTime(evictionTs + 1L)
       testHarness.extractOutputValues().size() shouldEqual 1
 
+      advanceToHealthyLiveWatermark(testHarness, retryTs)
       testHarness.setProcessingTime(retryTs)
 
       val outputs = testHarness.extractOutputValues()
@@ -522,6 +1188,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     try {
       testHarness.open()
       testHarness.setProcessingTime(processingTs)
+      advanceToHealthyLiveWatermark(testHarness, processingTs)
       testHarness.processElement1(keyedEvent("campaign-1", firstEventTs, 5L), firstEventTs)
       testHarness.processElement1(keyedEvent("campaign-1", firstEventTs + 1L, 7L), firstEventTs + 1L)
       testHarness.processElement1(keyedEvent("campaign-2", firstEventTs, 11L), firstEventTs)
@@ -546,6 +1213,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     try {
       testHarness.open()
       testHarness.setProcessingTime(exactHopTs)
+      advanceToHealthyLiveWatermark(testHarness, exactHopTs)
       testHarness.processElement1(event(exactHopTs, 5L), exactHopTs)
 
       val output = testHarness.extractOutputValues().get(0)
@@ -569,6 +1237,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
       restoredHarness.initializeState(snapshot)
       restoredHarness.open()
       restoredHarness.setProcessingTime(batchCallbackTs)
+      advanceToHealthyLiveWatermark(restoredHarness, batchCallbackTs)
       restoredHarness.processElement2(emptyBatchRow(groupBy, batchEndTs = 0L), 0L)
 
       val outputs = restoredHarness.extractOutputValues()
@@ -612,6 +1281,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
       restoredHarness.initializeState(snapshot)
       restoredHarness.open()
       restoredHarness.setProcessingTime(delayedCallbackTs)
+      advanceToHealthyLiveWatermark(restoredHarness, delayedCallbackTs)
       restoredHarness.processElement1(event(delayedCallbackTs - 1L, 7L), delayedCallbackTs - 1L)
 
       val outputs = restoredHarness.extractOutputValues()
@@ -649,6 +1319,72 @@ object GigaTileProcessFunctionTest {
 
   private def event(timestamp: Long, value: Long): ProjectedEvent =
     ProjectedEvent(Map(Constants.TimeColumn -> timestamp, "num" -> value), timestamp)
+
+  private def advanceToLiveWatermark(
+      testHarness: KeyedTwoInputStreamOperatorTestHarness[
+        util.List[Any],
+        ProjectedEvent,
+        BatchIrRow,
+        TimestampedTile],
+      watermark: Long
+  ): Unit = {
+    testHarness.processWatermarkStatus2(WatermarkStatus.IDLE)
+    testHarness.processWatermark1(new Watermark(watermark))
+  }
+
+  private def healthyLiveWatermark(processingTime: Long): Long =
+    processingTime - FlinkJob.AllowedOutOfOrderness.toMillis - 1L
+
+  private def liveActivationWatermark(processingTime: Long): Long =
+    processingTime - FlinkJob.LiveWatermarkLagToleranceMillis
+
+  private def advanceToHealthyLiveWatermark(
+      testHarness: KeyedTwoInputStreamOperatorTestHarness[
+        util.List[Any],
+        ProjectedEvent,
+        BatchIrRow,
+        TimestampedTile],
+      processingTime: Long
+  ): Unit =
+    advanceToLiveWatermark(testHarness, healthyLiveWatermark(processingTime))
+
+  private def nextDay(timestamp: Long): Long = {
+    val dayMillis = new Window(1, TimeUnit.DAYS).millis
+    TsUtils.round(timestamp, dayMillis) + dayMillis
+  }
+
+  private def currentProcessor(function: GigaTileProcessFunction): GigaTileStreamProcessor = {
+    val processorField = classOf[GigaTileProcessFunction].getDeclaredField("processor")
+    processorField.setAccessible(true)
+    processorField.get(function).asInstanceOf[GigaTileStreamProcessor]
+  }
+
+  private def publicationTimerState(
+      function: GigaTileProcessFunction,
+      fieldName: String
+  ): ValueState[java.lang.Long] = {
+    val stateField = classOf[GigaTileProcessFunction].getDeclaredField(fieldName)
+    stateField.setAccessible(true)
+    stateField.get(function).asInstanceOf[ValueState[java.lang.Long]]
+  }
+
+  private def publicationRetryTimestamp(function: GigaTileProcessFunction): Long =
+    publicationTimerState(function, "pendingPublicationRetryTimerState").value().longValue()
+
+  private def setPublicationRetryTimestamp(function: GigaTileProcessFunction, timestamp: Long): Unit =
+    publicationTimerState(function, "pendingPublicationRetryTimerState").update(timestamp)
+
+  private def clearPublicationActivationTimestamp(function: GigaTileProcessFunction): Unit =
+    publicationTimerState(function, "pendingPublicationActivationTimerState").clear()
+
+  private def currentFinalizedSum(function: GigaTileProcessFunction): AnyRef =
+    currentProcessor(function).currentSnapshot.finalizedVector(0).asInstanceOf[AnyRef]
+
+  private def currentDayStart(function: GigaTileProcessFunction): Long =
+    currentProcessor(function).store.getCurrentDayStart
+
+  private def dailyLargeSlotCount(function: GigaTileProcessFunction): Int =
+    currentProcessor(function).store.dailyLargeIrIterator.size
 
   private def keyedEvent(entity: String, timestamp: Long, value: Long): ProjectedEvent =
     ProjectedEvent(Map("entity" -> entity, Constants.TimeColumn -> timestamp, "num" -> value), timestamp)
@@ -763,6 +1499,21 @@ object GigaTileProcessFunctionTest {
       new SawtoothOnlineAggregator(batchEndTs, batchGroupBy.getAggregations.asScala.toSeq, inputSchema)
     val emptyBatchIr = batchAggregator.denormalizeBatchIr(batchAggregator.normalizeBatchIr(batchAggregator.init))
     new BatchIrRow(entityKey(), new GigaTileCodec(batchGroupBy, inputSchema).encodeBatchIr(emptyBatchIr), batchEndTs)
+  }
+
+  private def batchRow(
+      batchGroupBy: GroupBy,
+      batchEndTs: Long,
+      batchEventTs: Long,
+      value: Long
+  ): BatchIrRow = {
+    val batchAggregator =
+      new SawtoothOnlineAggregator(batchEndTs, batchGroupBy.getAggregations.asScala.toSeq, inputSchema)
+    val batchIr = batchAggregator.update(
+      batchAggregator.init,
+      new ArrayRow(Array[Any](batchEventTs, value), batchEventTs))
+    val finalBatchIr = batchAggregator.denormalizeBatchIr(batchAggregator.normalizeBatchIr(batchIr))
+    new BatchIrRow(entityKey(), new GigaTileCodec(batchGroupBy, inputSchema).encodeBatchIr(finalBatchIr), batchEndTs)
   }
 
   private class LegacyEventTimeTimerFunction(timerTimestamps: Seq[Long])

--- a/flink/src/test/scala/ai/chronon/flink/test/window/GigaTileProcessFunctionTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/window/GigaTileProcessFunctionTest.scala
@@ -1,0 +1,683 @@
+package ai.chronon.flink.test.window
+
+import ai.chronon.aggregator.windowing.{
+  GigaEmitResult,
+  GigaTileStreamProcessor,
+  SawtoothOnlineAggregator
+}
+import ai.chronon.api._
+import ai.chronon.api.Extensions.WindowOps
+import ai.chronon.flink.deser.ProjectedEvent
+import ai.chronon.flink.types.{BatchIrRow, TimestampedTile}
+import ai.chronon.flink.window.GigaTileProcessFunction
+import ai.chronon.online.GigaTileCodec
+import ai.chronon.online.serde.{ArrayRow, AvroCodec}
+import org.apache.flink.api.common.state.ValueState
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.functions.KeySelector
+import org.apache.flink.runtime.state.KeyedStateBackend
+import org.apache.flink.streaming.api.functions.co.KeyedCoProcessFunction
+import org.apache.flink.streaming.api.operators.co.KeyedCoProcessOperator
+import org.apache.flink.streaming.api.watermark.Watermark
+import org.apache.flink.streaming.util.KeyedTwoInputStreamOperatorTestHarness
+import org.apache.flink.util.Collector
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.util
+import scala.collection.JavaConverters._
+
+class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
+  import GigaTileProcessFunctionTest._
+
+  "GigaTileProcessFunction" should "use processing time for current-value versions and eviction timers" in {
+    val testHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    val retainedLateEventTs = processingTs - 30 * 60 * 1000L
+    val carriedProcessingTs = processingTs - 10 * 60 * 1000L
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      testHarness.processElement1(
+        ProjectedEvent(Map(Constants.TimeColumn -> retainedLateEventTs, "num" -> 5L), carriedProcessingTs),
+        retainedLateEventTs)
+
+      val output = testHarness.extractOutputValues().get(0)
+      decodeSum(output) shouldEqual 5L
+      output.latestTsMillis shouldEqual processingTs
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+      testHarness.numEventTimeTimers() shouldEqual 0
+    } finally testHarness.close()
+  }
+
+  it should "evict small-window state on processing time" in {
+    val testHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    val windowMillis = new Window(1, TimeUnit.HOURS).millis
+    val justBeforeExpiry = eventTs + windowMillis - 1L
+    val afterExpiry = TsUtils.round(justBeforeExpiry, new Window(5, TimeUnit.MINUTES).millis) +
+      new Window(5, TimeUnit.MINUTES).millis
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(justBeforeExpiry)
+      testHarness.processElement1(event(eventTs, 5L), eventTs)
+      testHarness.setProcessingTime(afterExpiry)
+
+      val outputs = testHarness.extractOutputValues()
+      val evictionOutput = outputs.get(outputs.size() - 1)
+      decodeSum(evictionOutput) shouldBe null
+      evictionOutput.latestTsMillis shouldEqual afterExpiry
+      testHarness.numProcessingTimeTimers() shouldEqual 0
+    } finally testHarness.close()
+  }
+
+  it should "roll the current day on processing time while retaining an eligible late event" in {
+    val testHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    val dayMillis = new Window(1, TimeUnit.DAYS).millis
+    val beforeMidnightProcessingTs = dayMillis - 60 * 1000L
+    val afterMidnightProcessingTs = dayMillis + 60 * 1000L
+    val initialEventTs = dayMillis - 30 * 60 * 1000L
+    val delayedEventTs = dayMillis - 10 * 60 * 1000L
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(beforeMidnightProcessingTs)
+      testHarness.processElement1(event(initialEventTs, 5L), initialEventTs)
+      testHarness.setProcessingTime(afterMidnightProcessingTs)
+      // Zipline suppresses redundant timer writes. Crossing midnight must still leave the
+      // retained pre-midnight value available to the next event.
+      testHarness.extractOutputValues().size() shouldEqual 1
+
+      testHarness.processElement1(event(delayedEventTs, 7L), delayedEventTs)
+      val outputs = testHarness.extractOutputValues()
+      val delayedEventOutput = outputs.get(outputs.size() - 1)
+      decodeSum(delayedEventOutput) shouldEqual 12L
+      delayedEventOutput.latestTsMillis shouldEqual afterMidnightProcessingTs
+    } finally testHarness.close()
+  }
+
+  it should "use processing time for batch refresh versions" in {
+    val batchGroupBy = Builders.GroupBy(
+      metaData = Builders.MetaData(name = "gigatile-process-function-batch-test"),
+      aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(7, TimeUnit.DAYS)))))
+    val testHarness = harness(new GigaTileProcessFunction(batchGroupBy, inputSchema))
+    val batchCodec = new GigaTileCodec(batchGroupBy, inputSchema)
+    val batchEndTs = TsUtils.round(eventTs, new Window(1, TimeUnit.DAYS).millis)
+    val batchEventTs = batchEndTs - 60 * 1000L
+    val batchAggregator =
+      new SawtoothOnlineAggregator(batchEndTs, batchGroupBy.getAggregations.asScala.toSeq, inputSchema)
+    val batchIr = batchAggregator.update(
+      batchAggregator.init,
+      new ArrayRow(Array[Any](batchEventTs, 7L), batchEventTs))
+    val finalBatchIr = batchAggregator.denormalizeBatchIr(batchAggregator.normalizeBatchIr(batchIr))
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      testHarness.processElement2(
+        new BatchIrRow(entityKey(), batchCodec.encodeBatchIr(finalBatchIr), batchEndTs),
+        batchEndTs)
+
+      val output = testHarness.extractOutputValues().get(0)
+      decodeSum(output, batchGroupBy) shouldEqual 7L
+      output.latestTsMillis shouldEqual processingTs
+    } finally testHarness.close()
+  }
+
+  it should "schedule decay when a batch refresh leaves the current value unchanged" in {
+    val batchGroupBy = Builders.GroupBy(
+      metaData = Builders.MetaData(name = "gigatile-process-function-empty-batch-test"),
+      aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(7, TimeUnit.DAYS)))))
+    val testHarness = harness(new GigaTileProcessFunction(batchGroupBy, inputSchema))
+    val batchCodec = new GigaTileCodec(batchGroupBy, inputSchema)
+    val batchEndTs = TsUtils.round(eventTs, new Window(1, TimeUnit.DAYS).millis)
+    val batchAggregator =
+      new SawtoothOnlineAggregator(batchEndTs, batchGroupBy.getAggregations.asScala.toSeq, inputSchema)
+    val emptyBatchIr = batchAggregator.denormalizeBatchIr(batchAggregator.normalizeBatchIr(batchAggregator.init))
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      testHarness.processElement2(
+        new BatchIrRow(entityKey(), batchCodec.encodeBatchIr(emptyBatchIr), batchEndTs),
+        batchEndTs)
+
+      testHarness.extractOutputValues().asScala shouldBe empty
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+    } finally testHarness.close()
+  }
+
+  it should "migrate restored legacy event-time timers without publishing twice" in {
+    val firstLegacyTimer = eventTs + 1000L
+    val secondLegacyTimer = firstLegacyTimer + 1000L
+    val originalHarness = harness(new LegacyEventTimeTimerFunction(Seq(firstLegacyTimer, secondLegacyTimer)))
+    originalHarness.open()
+    originalHarness.processElement1(event(eventTs, 1L), eventTs)
+    originalHarness.numEventTimeTimers() shouldEqual 2
+    val snapshot = originalHarness.snapshot(7L, processingTs)
+    originalHarness.close()
+
+    val restoredHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(snapshot)
+      restoredHarness.open()
+      restoredHarness.setProcessingTime(processingTs)
+      restoredHarness.processWatermark1(new Watermark(secondLegacyTimer))
+      restoredHarness.processWatermark2(new Watermark(secondLegacyTimer))
+
+      restoredHarness.extractOutputValues().asScala shouldBe empty
+      restoredHarness.numEventTimeTimers() shouldEqual 0
+      restoredHarness.numProcessingTimeTimers() shouldEqual 1
+    } finally restoredHarness.close()
+  }
+
+  it should "restore and flush same-millisecond updates with a strictly newer version" in {
+    val originalHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    val firstEventTs = processingTs - 1000L
+    originalHarness.open()
+    originalHarness.setProcessingTime(processingTs)
+    originalHarness.processElement1(event(firstEventTs, 5L), firstEventTs)
+    originalHarness.processElement1(event(firstEventTs + 1L, 7L), firstEventTs + 1L)
+    originalHarness.processElement1(event(firstEventTs + 2L, 3L), firstEventTs + 2L)
+
+    val initialOutputs = originalHarness.extractOutputValues()
+    initialOutputs.size() shouldEqual 1
+    decodeSum(initialOutputs.get(0)) shouldEqual 5L
+    initialOutputs.get(0).latestTsMillis shouldEqual processingTs
+    // One timer keeps normal eviction cadence; the other flushes the version collision.
+    originalHarness.numProcessingTimeTimers() shouldEqual 2
+    val snapshot = originalHarness.snapshot(8L, processingTs)
+    originalHarness.close()
+
+    val restoredHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(snapshot)
+      restoredHarness.open()
+      // A delayed callback still uses the reserved strictly-newer version without moving
+      // aggregation time merely to flush the current snapshot.
+      restoredHarness.setProcessingTime(processingTs + 100L)
+
+      val outputs = restoredHarness.extractOutputValues()
+      outputs.size() shouldEqual 1
+      decodeSum(outputs.get(0)) shouldEqual 15L
+      outputs.get(0).latestTsMillis shouldEqual processingTs + 1L
+    } finally restoredHarness.close()
+  }
+
+  it should "repair collision and eviction markers after a state-blind timer consumer" in {
+    val firstEventTs = processingTs - 1000L
+    val evictionTs = nextEvictionHop(processingTs)
+    val originalFunction = new GigaTileProcessFunction(groupBy, inputSchema)
+    val originalHarness = harness(originalFunction)
+    originalHarness.open()
+    originalHarness.setProcessingTime(processingTs)
+    originalHarness.processElement1(event(firstEventTs, 5L), firstEventTs)
+    originalHarness.processElement1(event(firstEventTs + 1L, 7L), firstEventTs + 1L)
+    val originalSnapshot = originalHarness.snapshot(31L, processingTs)
+    originalHarness.close()
+
+    val legacyHarness = harness(new StateBlindProcessingTimerConsumer)
+    legacyHarness.setup()
+    legacyHarness.initializeState(originalSnapshot)
+    legacyHarness.open()
+    legacyHarness.setProcessingTime(processingTs)
+    legacyHarness.setProcessingTime(evictionTs)
+    legacyHarness.numProcessingTimeTimers() shouldEqual 0
+    val legacySnapshot = legacyHarness.snapshot(32L, evictionTs)
+    legacyHarness.close()
+
+    val restoredFunction = new GigaTileProcessFunction(groupBy, inputSchema)
+    val restoredHarness = harness(restoredFunction)
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(legacySnapshot)
+      restoredHarness.open()
+      restoredHarness.setProcessingTime(evictionTs)
+      // With no keyed callback, there is no way for open() to enumerate and repair this key.
+      restoredHarness.numProcessingTimeTimers() shouldEqual 0
+
+      restoredHarness.processElement1(event(firstEventTs + 2L, 3L), firstEventTs + 2L)
+      setCurrentKey(restoredHarness, entityKey())
+      val repairedEviction = valueState[java.lang.Long](restoredFunction,
+                                                        "nextProcessingEvictionTimerState").value().longValue()
+      val repairedCollision = valueState[java.lang.Long](restoredFunction,
+                                                         "pendingVersionCollisionState").value().longValue()
+      repairedEviction should be > evictionTs
+      repairedCollision shouldEqual repairedEviction
+      restoredHarness.numProcessingTimeTimers() shouldEqual 1
+
+      restoredHarness.setProcessingTime(repairedCollision)
+
+      val outputs = restoredHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldEqual 15L
+      outputs.get(0).latestTsMillis shouldEqual repairedCollision
+      valueState[java.lang.Long](restoredFunction, "pendingVersionCollisionState").value() shouldBe null
+      restoredHarness.numProcessingTimeTimers() shouldEqual 1
+    } finally restoredHarness.close()
+  }
+
+  it should "keep a later owned timer while draining an earlier due callback" in {
+    val windowMillis = new Window(1, TimeUnit.HOURS).millis
+    val justBeforeExpiry = eventTs + windowMillis - 1L
+    val injectedTimer = justBeforeExpiry + 1L
+    val evictionTimer = nextEvictionHop(justBeforeExpiry)
+    injectedTimer should be < evictionTimer
+
+    val originalHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    originalHarness.open()
+    originalHarness.setProcessingTime(justBeforeExpiry)
+    originalHarness.processElement1(event(eventTs, 5L), eventTs)
+    val originalSnapshot = originalHarness.snapshot(33L, justBeforeExpiry)
+    originalHarness.close()
+
+    val injectorHarness = harness(new ProcessingTimerInjector(injectedTimer))
+    injectorHarness.setup()
+    injectorHarness.initializeState(originalSnapshot)
+    injectorHarness.open()
+    injectorHarness.setProcessingTime(justBeforeExpiry)
+    injectorHarness.processElement1(event(eventTs, 0L), eventTs)
+    val injectedSnapshot = injectorHarness.snapshot(34L, justBeforeExpiry)
+    injectorHarness.close()
+
+    val restoredHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(injectedSnapshot)
+      restoredHarness.open()
+      // Flink reports this jump target while it first drains injectedTimer. That earlier
+      // callback must not steal ownership from the still-queued evictionTimer.
+      restoredHarness.setProcessingTime(evictionTimer)
+
+      val outputs = restoredHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldBe null
+      outputs.get(0).latestTsMillis shouldEqual evictionTimer
+      restoredHarness.numProcessingTimeTimers() shouldEqual 0
+    } finally restoredHarness.close()
+  }
+
+  it should "share a queued eviction while draining an earlier collision repair callback" in {
+    val firstEventTs = processingTs - 1000L
+    val consumedCollisionTimer = processingTs + 1L
+    val injectedTimer = processingTs + 2L
+    val evictionTimer = nextEvictionHop(processingTs)
+    injectedTimer should be < evictionTimer
+
+    val originalHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    originalHarness.open()
+    originalHarness.setProcessingTime(processingTs)
+    originalHarness.processElement1(event(firstEventTs, 5L), firstEventTs)
+    originalHarness.processElement1(event(firstEventTs + 1L, 7L), firstEventTs + 1L)
+    val originalSnapshot = originalHarness.snapshot(35L, processingTs)
+    originalHarness.close()
+
+    val legacyHarness = harness(new StateBlindProcessingTimerConsumer)
+    legacyHarness.setup()
+    legacyHarness.initializeState(originalSnapshot)
+    legacyHarness.open()
+    legacyHarness.setProcessingTime(processingTs)
+    legacyHarness.setProcessingTime(consumedCollisionTimer)
+    legacyHarness.numProcessingTimeTimers() shouldEqual 1
+    val legacySnapshot = legacyHarness.snapshot(36L, consumedCollisionTimer)
+    legacyHarness.close()
+
+    val injectorHarness = harness(new ProcessingTimerInjector(injectedTimer))
+    injectorHarness.setup()
+    injectorHarness.initializeState(legacySnapshot)
+    injectorHarness.open()
+    injectorHarness.setProcessingTime(consumedCollisionTimer)
+    injectorHarness.processElement1(event(firstEventTs, 0L), firstEventTs)
+    val injectedSnapshot = injectorHarness.snapshot(37L, consumedCollisionTimer)
+    injectorHarness.close()
+
+    val restoredFunction = new GigaTileProcessFunction(groupBy, inputSchema)
+    val restoredHarness = harness(restoredFunction)
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(injectedSnapshot)
+      restoredHarness.open()
+      restoredHarness.setProcessingTime(consumedCollisionTimer)
+      // The injected callback runs first while Flink already reports evictionTimer as the
+      // current processing time. The stale collision must join that still-queued eviction.
+      restoredHarness.setProcessingTime(evictionTimer)
+
+      val outputs = restoredHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldEqual 12L
+      outputs.get(0).latestTsMillis shouldEqual evictionTimer
+      setCurrentKey(restoredHarness, entityKey())
+      valueState[java.lang.Long](restoredFunction, "pendingVersionCollisionState").value() shouldBe null
+      restoredHarness.numProcessingTimeTimers() shouldEqual 1
+    } finally restoredHarness.close()
+  }
+
+  it should "retry the current snapshot when the first publication fails" in {
+    val function = new GigaTileProcessFunction(groupBy, inputSchema)
+    val testHarness = harness(function)
+    val firstEventTs = processingTs - 1000L
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      failNextEncode(function)
+      testHarness.processElement1(event(firstEventTs, 5L), firstEventTs)
+
+      testHarness.extractOutputValues() shouldBe empty
+      // Normal eviction and the failed-snapshot retry both remain live.
+      testHarness.numProcessingTimeTimers() shouldEqual 2
+
+      testHarness.setProcessingTime(processingTs + 1L)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs.size() shouldEqual 1
+      decodeSum(outputs.get(0)) shouldEqual 5L
+      outputs.get(0).latestTsMillis shouldEqual processingTs + 1L
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+    } finally testHarness.close()
+  }
+
+  it should "re-arm a version collision when snapshot construction fails" in {
+    val function = new GigaTileProcessFunction(groupBy, inputSchema)
+    val testHarness = harness(function)
+    val firstEventTs = processingTs - 1000L
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      testHarness.processElement1(event(firstEventTs, 5L), firstEventTs)
+      testHarness.processElement1(event(firstEventTs + 1L, 7L), firstEventTs + 1L)
+
+      testHarness.extractOutputValues().size() shouldEqual 1
+      failNextSnapshot(function)
+
+      testHarness.setProcessingTime(processingTs + 1L)
+
+      testHarness.extractOutputValues().size() shouldEqual 1
+      // The normal eviction timer and the re-armed collision timer must both remain live.
+      testHarness.numProcessingTimeTimers() shouldEqual 2
+
+      testHarness.setProcessingTime(processingTs + 2L)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs.size() shouldEqual 2
+      decodeSum(outputs.get(1)) shouldEqual 12L
+      outputs.get(1).latestTsMillis shouldEqual processingTs + 2L
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+    } finally testHarness.close()
+  }
+
+  it should "evict before flushing when version and eviction timers coincide" in {
+    val testHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    val hopMillis = new Window(5, TimeUnit.MINUTES).millis
+    val evictionTs = TsUtils.round(processingTs, hopMillis) + hopMillis
+    val collisionProcessingTs = evictionTs - 1L
+    val expiringEventTs = evictionTs - new Window(1, TimeUnit.HOURS).millis - 1L
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(collisionProcessingTs)
+      testHarness.processElement1(event(expiringEventTs, 5L), expiringEventTs)
+      testHarness.processElement1(event(expiringEventTs, 7L), expiringEventTs)
+
+      testHarness.setProcessingTime(evictionTs)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs.size() shouldEqual 2
+      decodeSum(outputs.get(1)) shouldBe null
+      outputs.get(1).latestTsMillis shouldEqual evictionTs
+      testHarness.numProcessingTimeTimers() shouldEqual 0
+    } finally testHarness.close()
+  }
+
+  it should "delay a shared collision until a failed eviction is retried" in {
+    val function = new GigaTileProcessFunction(groupBy, inputSchema)
+    val testHarness = harness(function)
+    val hopMillis = new Window(5, TimeUnit.MINUTES).millis
+    val evictionTs = TsUtils.round(processingTs, hopMillis) + hopMillis
+    val retryTs = evictionTs + hopMillis
+    val collisionProcessingTs = evictionTs - 1L
+    val expiringEventTs = retryTs - new Window(1, TimeUnit.HOURS).millis - 1L
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(collisionProcessingTs)
+      testHarness.processElement1(event(expiringEventTs, 5L), expiringEventTs)
+      testHarness.processElement1(event(expiringEventTs, 7L), expiringEventTs)
+      failNextScheduledEviction(function)
+
+      testHarness.setProcessingTime(evictionTs)
+
+      testHarness.extractOutputValues().size() shouldEqual 1
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+
+      testHarness.setProcessingTime(evictionTs + 1L)
+      testHarness.extractOutputValues().size() shouldEqual 1
+
+      testHarness.setProcessingTime(retryTs)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs.size() shouldEqual 2
+      decodeSum(outputs.get(1)) shouldBe null
+      outputs.get(1).latestTsMillis shouldEqual retryTs
+      testHarness.numProcessingTimeTimers() shouldEqual 0
+    } finally testHarness.close()
+  }
+
+  it should "isolate same-millisecond publication collisions by key" in {
+    val testHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    val firstEventTs = processingTs - 1000L
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      testHarness.processElement1(keyedEvent("campaign-1", firstEventTs, 5L), firstEventTs)
+      testHarness.processElement1(keyedEvent("campaign-1", firstEventTs + 1L, 7L), firstEventTs + 1L)
+      testHarness.processElement1(keyedEvent("campaign-2", firstEventTs, 11L), firstEventTs)
+      testHarness.processElement1(keyedEvent("campaign-2", firstEventTs + 1L, 13L), firstEventTs + 1L)
+
+      testHarness.extractOutputValues().size() shouldEqual 2
+      testHarness.setProcessingTime(processingTs + 1L)
+
+      val flushedByKey = testHarness.extractOutputValues().asScala
+        .filter(_.latestTsMillis == processingTs + 1L)
+        .map(tile => tile.keys.get(0).toString -> decodeSum(tile))
+        .toMap
+      flushedByKey shouldEqual Map("campaign-1" -> 12L, "campaign-2" -> 24L)
+    } finally testHarness.close()
+  }
+}
+
+object GigaTileProcessFunctionTest {
+  private val eventTs = 1000000L
+  private val processingTs = eventTs + new Window(2, TimeUnit.HOURS).millis
+  private val inputSchema: Seq[(String, DataType)] =
+    Seq(Constants.TimeColumn -> LongType, "num" -> LongType)
+  private val groupBy = Builders.GroupBy(
+    metaData = Builders.MetaData(name = "gigatile-process-function-test"),
+    aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(1, TimeUnit.HOURS)))))
+
+  private def harness(
+      function: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]
+  ): KeyedTwoInputStreamOperatorTestHarness[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile] =
+    new KeyedTwoInputStreamOperatorTestHarness[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile](
+      new KeyedCoProcessOperator(function),
+      new KeySelector[ProjectedEvent, util.List[Any]] {
+        override def getKey(value: ProjectedEvent): util.List[Any] =
+          entityKey(value.fields.getOrElse("entity", "campaign-1").toString)
+      },
+      new KeySelector[BatchIrRow, util.List[Any]] {
+        override def getKey(value: BatchIrRow): util.List[Any] = value.entityKeys
+      },
+      TypeInformation
+        .of(classOf[util.List[_]])
+        .asInstanceOf[TypeInformation[util.List[Any]]])
+
+  private def event(timestamp: Long, value: Long): ProjectedEvent =
+    ProjectedEvent(Map(Constants.TimeColumn -> timestamp, "num" -> value), timestamp)
+
+  private def keyedEvent(entity: String, timestamp: Long, value: Long): ProjectedEvent =
+    ProjectedEvent(Map("entity" -> entity, Constants.TimeColumn -> timestamp, "num" -> value), timestamp)
+
+  private def entityKey(entity: String = "campaign-1"): util.List[Any] = {
+    val result = new util.ArrayList[Any](1)
+    result.add(entity)
+    result
+  }
+
+  private def nextEvictionHop(timestamp: Long): Long = {
+    val hopMillis = new Window(5, TimeUnit.MINUTES).millis
+    TsUtils.round(timestamp, hopMillis) + hopMillis
+  }
+
+  private def setCurrentKey(
+      testHarness: KeyedTwoInputStreamOperatorTestHarness[
+        util.List[Any],
+        ProjectedEvent,
+        BatchIrRow,
+        TimestampedTile],
+      key: util.List[Any]
+  ): Unit =
+    testHarness.getOperator.getKeyedStateBackend
+      .asInstanceOf[KeyedStateBackend[util.List[Any]]]
+      .setCurrentKey(key)
+
+  private def valueState[T](function: GigaTileProcessFunction, fieldName: String): ValueState[T] = {
+    val field = classOf[GigaTileProcessFunction].getDeclaredField(fieldName)
+    field.setAccessible(true)
+    field.get(function).asInstanceOf[ValueState[T]]
+  }
+
+  private def decodeSum(tile: TimestampedTile, decodeGroupBy: GroupBy = groupBy): AnyRef = {
+    val outputCodec = new GigaTileCodec(decodeGroupBy, inputSchema)
+    val fieldName = outputCodec.outputSchema.fields.head.name
+    AvroCodec
+      .of(ai.chronon.online.serde.AvroConversions.fromChrononSchema(outputCodec.outputSchema).toString)
+      .decodeMap(tile.tileBytes)(fieldName)
+  }
+
+  private def failNextSnapshot(function: GigaTileProcessFunction): Unit = {
+    val processorField = classOf[GigaTileProcessFunction].getDeclaredField("processor")
+    processorField.setAccessible(true)
+    val delegate = processorField.get(function).asInstanceOf[GigaTileStreamProcessor]
+    processorField.set(
+      function,
+      new GigaTileStreamProcessor(
+        delegate.megaTileAgg,
+        delegate.store,
+        delegate.irEqual,
+        delegate.maxBatchStalenessDays
+      ) {
+        private var shouldFail = true
+
+        override private[chronon] def currentSnapshot: GigaEmitResult = {
+          if (shouldFail) {
+            shouldFail = false
+            throw new RuntimeException("expected snapshot failure")
+          }
+          delegate.currentSnapshot
+        }
+      }
+    )
+  }
+
+  private def failNextEncode(function: GigaTileProcessFunction): Unit = {
+    val codecField = classOf[GigaTileProcessFunction].getDeclaredField("gigaTileCodec")
+    codecField.setAccessible(true)
+    codecField.set(
+      function,
+      new GigaTileCodec(groupBy, inputSchema) {
+        private var shouldFail = true
+
+        override def encodeOutput(finalizedVector: Array[Any]): Array[Byte] = {
+          if (shouldFail) {
+            shouldFail = false
+            throw new RuntimeException("expected publication encoding failure")
+          }
+          super.encodeOutput(finalizedVector)
+        }
+      })
+  }
+
+  private def failNextScheduledEviction(function: GigaTileProcessFunction): Unit = {
+    val processorField = classOf[GigaTileProcessFunction].getDeclaredField("processor")
+    processorField.setAccessible(true)
+    val delegate = processorField.get(function).asInstanceOf[GigaTileStreamProcessor]
+    processorField.set(
+      function,
+      new GigaTileStreamProcessor(
+        delegate.megaTileAgg,
+        delegate.store,
+        delegate.irEqual,
+        delegate.maxBatchStalenessDays
+      ) {
+        private var shouldFail = true
+
+        override def onScheduledEviction(timerTs: Long): GigaEmitResult = {
+          if (shouldFail) {
+            shouldFail = false
+            throw new RuntimeException("expected scheduled eviction failure")
+          }
+          delegate.onScheduledEviction(timerTs)
+        }
+      }
+    )
+  }
+
+  private class LegacyEventTimeTimerFunction(timerTimestamps: Seq[Long])
+      extends KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile] {
+    override def processElement1(
+        event: ProjectedEvent,
+        ctx: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#Context,
+        out: Collector[TimestampedTile]
+    ): Unit =
+      timerTimestamps.foreach(ctx.timerService().registerEventTimeTimer)
+
+    override def processElement2(
+        batchRow: BatchIrRow,
+        ctx: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#Context,
+        out: Collector[TimestampedTile]
+    ): Unit = ()
+  }
+
+  /** Models a rollback binary that consumes physical timers without binding the additive
+    * collision and eviction ownership descriptors.
+    */
+  private class StateBlindProcessingTimerConsumer
+      extends KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile] {
+    override def processElement1(
+        event: ProjectedEvent,
+        ctx: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#Context,
+        out: Collector[TimestampedTile]
+    ): Unit = ()
+
+    override def processElement2(
+        batchRow: BatchIrRow,
+        ctx: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#Context,
+        out: Collector[TimestampedTile]
+    ): Unit = ()
+
+    override def onTimer(
+        timestamp: Long,
+        ctx: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#OnTimerContext,
+        out: Collector[TimestampedTile]
+    ): Unit = ()
+  }
+
+  private class ProcessingTimerInjector(timerTimestamp: Long)
+      extends KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile] {
+    override def processElement1(
+        event: ProjectedEvent,
+        ctx: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#Context,
+        out: Collector[TimestampedTile]
+    ): Unit = ctx.timerService().registerProcessingTimeTimer(timerTimestamp)
+
+    override def processElement2(
+        batchRow: BatchIrRow,
+        ctx: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#Context,
+        out: Collector[TimestampedTile]
+    ): Unit = ()
+  }
+}

--- a/flink/src/test/scala/ai/chronon/flink/test/window/GigaTileProcessFunctionTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/window/GigaTileProcessFunctionTest.scala
@@ -1121,6 +1121,44 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     } finally testHarness.close()
   }
 
+  it should "re-arm shared eviction and collision roles when eviction fails" in {
+    val function = new GigaTileProcessFunction(groupBy, inputSchema)
+    val testHarness = harness(function)
+    val evictionTs = nextEvictionHop(processingTs)
+    val initialProcessingTs = evictionTs - 1L
+    val expiringEventTs = evictionTs - new Window(1, TimeUnit.HOURS).millis - 1L
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(initialProcessingTs)
+      advanceToHealthyLiveWatermark(testHarness, initialProcessingTs)
+      testHarness.processElement1(event(expiringEventTs, 5L), expiringEventTs)
+      testHarness.processElement1(event(expiringEventTs, 7L), expiringEventTs)
+
+      testHarness.extractOutputValues().size() shouldEqual 1
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+      failNextEviction(function)
+
+      testHarness.setProcessingTime(evictionTs)
+
+      testHarness.extractOutputValues().size() shouldEqual 1
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+      val retryTs = nextEvictionHop(evictionTs)
+      setCurrentKey(testHarness, entityKey())
+      valueState[java.lang.Long](function, "nextProcessingEvictionTimerState").value() shouldEqual retryTs
+      valueState[java.lang.Long](function, "pendingVersionCollisionState").value() shouldEqual retryTs
+
+      advanceToHealthyLiveWatermark(testHarness, retryTs)
+      testHarness.setProcessingTime(retryTs)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs.size() shouldEqual 2
+      decodeSum(outputs.get(1)) shouldBe null
+      outputs.get(1).latestTsMillis shouldEqual retryTs
+      testHarness.numProcessingTimeTimers() shouldEqual 0
+    } finally testHarness.close()
+  }
+
   it should "evict before flushing when version and eviction timers coincide" in {
     val testHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
     val hopMillis = new Window(5, TimeUnit.MINUTES).millis
@@ -1202,6 +1240,435 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
         .map(tile => tile.keys.get(0).toString -> decodeSum(tile))
         .toMap
       flushedByKey shouldEqual Map("campaign-1" -> 12L, "campaign-2" -> 24L)
+    } finally testHarness.close()
+  }
+
+  it should "coalesce live updates onto one wall-clock cadence" in {
+    val cadenceMillis = 1000L
+    val function = new GigaTileProcessFunction(groupBy, inputSchema, bufferingOutputTimeMillis = cadenceMillis)
+    val testHarness = harness(function)
+    val cadenceTs = nextBufferedWriteTick(groupBy, entityKey(), processingTs, cadenceMillis)
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      advanceToHealthyLiveWatermark(testHarness, processingTs)
+      testHarness.processElement1(event(processingTs - 2000L, 5L), processingTs - 2000L)
+      testHarness.processElement1(event(processingTs - 1999L, 7L), processingTs - 1999L)
+
+      testHarness.extractOutputValues() shouldBe empty
+      setCurrentKey(testHarness, entityKey())
+      valueState[java.lang.Boolean](function, "pendingPublicationState").value() shouldEqual java.lang.Boolean.TRUE
+      testHarness.setProcessingTime(cadenceTs)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldEqual 12L
+      outputs.get(0).latestTsMillis shouldEqual processingTs
+      setCurrentKey(testHarness, entityKey())
+      valueState[java.lang.Boolean](function, "pendingPublicationState").value() shouldBe null
+    } finally testHarness.close()
+  }
+
+  it should "hold a live batch refresh until the wall-clock cadence" in {
+    val cadenceMillis = 1000L
+    val batchGroupBy = Builders.GroupBy(
+      metaData = Builders.MetaData(name = "gigatile-buffered-batch-test"),
+      aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(7, TimeUnit.DAYS)))))
+    val testHarness = harness(
+      new GigaTileProcessFunction(batchGroupBy, inputSchema, bufferingOutputTimeMillis = cadenceMillis))
+    val cadenceTs = nextBufferedWriteTick(batchGroupBy, entityKey(), processingTs, cadenceMillis)
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      advanceToHealthyLiveWatermark(testHarness, processingTs)
+      testHarness.processElement2(batchRow(batchGroupBy, 0L, -1000L, 7L), 0L)
+
+      testHarness.extractOutputValues() shouldBe empty
+      testHarness.setProcessingTime(cadenceTs)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0), batchGroupBy) shouldEqual 7L
+      outputs.get(0).latestTsMillis shouldEqual processingTs
+    } finally testHarness.close()
+  }
+
+  it should "park a buffered write across Catchup cadence intervals and rebuild once Live" in {
+    val cadenceMillis = 1000L
+    val function = new GigaTileProcessFunction(groupBy, inputSchema, bufferingOutputTimeMillis = cadenceMillis)
+    val testHarness = harness(function)
+    val firstCadenceTs = nextBufferedWriteTick(groupBy, entityKey(), processingTs, cadenceMillis)
+    val catchupThreshold = new Window(5, TimeUnit.MINUTES).millis + FlinkJob.CatchupWatermarkLagSlackMillis
+    val watermark = processingTs - catchupThreshold + (firstCadenceTs - processingTs) / 2L
+    val evictionTs = nextEvictionHop(processingTs)
+    val afterSeveralCadences = firstCadenceTs + 10L * cadenceMillis
+    val liveCadenceTs = nextBufferedWriteTick(groupBy, entityKey(), afterSeveralCadences, cadenceMillis)
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      advanceToLiveWatermark(testHarness, watermark)
+      testHarness.processElement1(event(watermark - 1L, 5L), watermark - 1L)
+      setCurrentKey(testHarness, entityKey())
+      valueState[java.lang.Long](function, "pendingPublicationRetryTimerState").value() shouldBe null
+      valueState[java.lang.Long](function, "pendingPublicationActivationTimerState").value() shouldBe null
+
+      testHarness.setProcessingTime(firstCadenceTs)
+      testHarness.extractOutputValues() shouldBe empty
+      setCurrentKey(testHarness, entityKey())
+      valueState[java.lang.Long](function, "nextBufferedWriteTimerState").value() shouldBe null
+      valueState[java.lang.Long](function, "bufferedWriteLatestTsState").value() shouldEqual processingTs
+      valueState[java.lang.Boolean](function, "pendingPublicationState").value() shouldEqual java.lang.Boolean.TRUE
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+      testHarness.numEventTimeTimers() shouldEqual 1
+      valueState[java.lang.Long](function, "pendingPublicationRetryTimerState").value() shouldBe null
+      valueState[java.lang.Long](function, "pendingPublicationActivationTimerState").value() should not be null
+
+      afterSeveralCadences should be < evictionTs
+      testHarness.setProcessingTime(afterSeveralCadences)
+      testHarness.extractOutputValues() shouldBe empty
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+      testHarness.numEventTimeTimers() shouldEqual 1
+
+      advanceToHealthyLiveWatermark(testHarness, afterSeveralCadences)
+      testHarness.extractOutputValues() shouldBe empty
+      setCurrentKey(testHarness, entityKey())
+      valueState[java.lang.Long](function, "pendingPublicationActivationTimerState").value() shouldBe null
+      valueState[java.lang.Long](function, "nextBufferedWriteTimerState").value() shouldEqual liveCadenceTs
+      testHarness.setProcessingTime(liveCadenceTs)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldEqual 5L
+      outputs.get(0).latestTsMillis shouldEqual afterSeveralCadences
+    } finally testHarness.close()
+  }
+
+  it should "run eviction before a cadence timer at the same timestamp" in {
+    val cadenceMillis = 1L
+    val collisionTs = nextEvictionHop(processingTs)
+    val eventProcessingTs = collisionTs - 1L
+    val expiringEventTs = collisionTs - new Window(1, TimeUnit.HOURS).millis - 1L
+    val testHarness = harness(
+      new GigaTileProcessFunction(groupBy, inputSchema, bufferingOutputTimeMillis = cadenceMillis))
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(eventProcessingTs)
+      advanceToHealthyLiveWatermark(testHarness, eventProcessingTs)
+      testHarness.processElement1(event(expiringEventTs, 5L), expiringEventTs)
+
+      testHarness.extractOutputValues() shouldBe empty
+      testHarness.setProcessingTime(collisionTs)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldBe null
+      outputs.get(0).latestTsMillis shouldEqual collisionTs
+    } finally testHarness.close()
+  }
+
+  it should "emit once after eviction when all four timer roles share a callback" in {
+    val collisionTs = nextEvictionHop(processingTs)
+    val eventProcessingTs = collisionTs - 1L
+    val expiringEventTs = collisionTs - new Window(1, TimeUnit.HOURS).millis - 1L
+    val function = new GigaTileProcessFunction(groupBy, inputSchema, bufferingOutputTimeMillis = 1L)
+    val testHarness = harness(function)
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(eventProcessingTs)
+      advanceToHealthyLiveWatermark(testHarness, eventProcessingTs)
+      testHarness.processElement1(event(expiringEventTs, 5L), expiringEventTs)
+      setCurrentKey(testHarness, entityKey())
+      valueState[java.lang.Long](function, "pendingVersionCollisionState").update(collisionTs)
+      valueState[java.lang.Long](function, "pendingPublicationRetryTimerState").update(collisionTs)
+      valueState[java.lang.Boolean](function, "pendingPublicationState").update(java.lang.Boolean.TRUE)
+
+      testHarness.setProcessingTime(collisionTs)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldBe null
+      outputs.get(0).latestTsMillis shouldEqual collisionTs
+      valueState[java.lang.Long](function, "pendingVersionCollisionState").value() shouldBe null
+    } finally testHarness.close()
+  }
+
+  it should "clear a later cadence after a shared eviction and collision publishes" in {
+    val cadenceMillis = new Window(1, TimeUnit.HOURS).millis
+    val seedCadenceTs = nextBufferedWriteTick(groupBy, entityKey(), processingTs, cadenceMillis)
+    val eventProcessingTs = seedCadenceTs + 1L
+    val evictionTs = nextEvictionHop(eventProcessingTs)
+    val cadenceTs = nextBufferedWriteTick(groupBy, entityKey(), eventProcessingTs, cadenceMillis)
+    val expiringEventTs = evictionTs - new Window(1, TimeUnit.HOURS).millis - 1L
+    val function =
+      new GigaTileProcessFunction(groupBy, inputSchema, bufferingOutputTimeMillis = cadenceMillis)
+    val testHarness = harness(function)
+
+    cadenceTs should be > evictionTs
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(eventProcessingTs)
+      advanceToHealthyLiveWatermark(testHarness, eventProcessingTs)
+      testHarness.processElement1(event(expiringEventTs, 5L), expiringEventTs)
+      setCurrentKey(testHarness, entityKey())
+      valueState[java.lang.Long](function, "pendingVersionCollisionState").update(evictionTs)
+
+      advanceToHealthyLiveWatermark(testHarness, evictionTs)
+      testHarness.setProcessingTime(evictionTs)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldBe null
+      valueState[java.lang.Long](function, "bufferedWriteLatestTsState").value() shouldBe null
+      valueState[java.lang.Long](function, "nextBufferedWriteTimerState").value() shouldBe null
+
+      testHarness.setProcessingTime(cadenceTs + 1L)
+      testHarness.extractOutputValues() should have size 1
+      testHarness.numProcessingTimeTimers() shouldEqual 0
+    } finally testHarness.close()
+  }
+
+  it should "retry a failed cadence encoding on the next cadence tick" in {
+    val cadenceMillis = 1000L
+    val function = new GigaTileProcessFunction(groupBy, inputSchema, bufferingOutputTimeMillis = cadenceMillis)
+    val testHarness = harness(function)
+    val firstCadenceTs = nextBufferedWriteTick(groupBy, entityKey(), processingTs, cadenceMillis)
+    val secondCadenceTs = nextBufferedWriteTick(groupBy, entityKey(), firstCadenceTs, cadenceMillis)
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      advanceToHealthyLiveWatermark(testHarness, processingTs)
+      testHarness.processElement1(event(processingTs - 1000L, 5L), processingTs - 1000L)
+      failNextEncode(function)
+
+      testHarness.setProcessingTime(firstCadenceTs)
+      testHarness.extractOutputValues() shouldBe empty
+      testHarness.setProcessingTime(secondCadenceTs)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldEqual 5L
+    } finally testHarness.close()
+  }
+
+  it should "isolate buffered cadence state by key" in {
+    val cadenceMillis = 1000L
+    val testHarness = harness(
+      new GigaTileProcessFunction(groupBy, inputSchema, bufferingOutputTimeMillis = cadenceMillis))
+    val keys = Seq("campaign-1", "campaign-2")
+    val lastCadenceTs = keys.map(key => nextBufferedWriteTick(groupBy, entityKey(key), processingTs, cadenceMillis)).max
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      advanceToHealthyLiveWatermark(testHarness, processingTs)
+      testHarness.processElement1(keyedEvent(keys.head, processingTs - 1000L, 5L), processingTs - 1000L)
+      testHarness.processElement1(keyedEvent(keys.last, processingTs - 1000L, 11L), processingTs - 1000L)
+
+      testHarness.extractOutputValues() shouldBe empty
+      testHarness.setProcessingTime(lastCadenceTs)
+
+      val byKey = testHarness.extractOutputValues().asScala.map { tile =>
+        tile.keys.get(0).toString -> decodeSum(tile)
+      }.toMap
+      byKey shouldEqual Map("campaign-1" -> 5L, "campaign-2" -> 11L)
+    } finally testHarness.close()
+  }
+
+  it should "preserve a pending cadence while draining an earlier callback" in {
+    val cadenceMillis = 1000L
+    val firstCadenceTs = nextBufferedWriteTick(groupBy, entityKey(), processingTs, cadenceMillis)
+    val eventProcessingTime = if (firstCadenceTs - processingTs > 1L) processingTs else processingTs + 1L
+    val cadenceTs = nextBufferedWriteTick(groupBy, entityKey(), eventProcessingTime, cadenceMillis)
+    val injectedTimer = eventProcessingTime + 1L
+    injectedTimer should be < cadenceTs
+    val originalHarness = harness(
+      new GigaTileProcessFunction(groupBy, inputSchema, bufferingOutputTimeMillis = cadenceMillis))
+    originalHarness.open()
+    originalHarness.setProcessingTime(eventProcessingTime)
+    advanceToHealthyLiveWatermark(originalHarness, eventProcessingTime)
+    originalHarness.processElement1(event(eventProcessingTime - 1000L, 5L), eventProcessingTime - 1000L)
+    val snapshot = originalHarness.snapshot(20L, eventProcessingTime)
+    originalHarness.close()
+
+    val injectorHarness = harness(new ProcessingTimerInjector(injectedTimer))
+    injectorHarness.setup()
+    injectorHarness.initializeState(snapshot)
+    injectorHarness.open()
+    injectorHarness.setProcessingTime(eventProcessingTime)
+    injectorHarness.processElement1(event(eventProcessingTime - 1000L, 0L), eventProcessingTime - 1000L)
+    val injectedSnapshot = injectorHarness.snapshot(21L, eventProcessingTime)
+    injectorHarness.close()
+
+    val restoredHarness = harness(
+      new GigaTileProcessFunction(groupBy, inputSchema, bufferingOutputTimeMillis = cadenceMillis))
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(injectedSnapshot)
+      restoredHarness.open()
+      restoredHarness.setProcessingTime(eventProcessingTime)
+      // The injected callback runs first while Flink already reports cadenceTs. It must not
+      // move the still-queued cadence marker to the following interval.
+      restoredHarness.numProcessingTimeTimers() shouldEqual 3
+      advanceToHealthyLiveWatermark(restoredHarness, cadenceTs)
+      restoredHarness.setProcessingTime(cadenceTs)
+
+      val outputs = restoredHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldEqual 5L
+      outputs.get(0).latestTsMillis shouldEqual eventProcessingTime
+    } finally restoredHarness.close()
+  }
+
+  it should "flush a restored cadence after buffering is disabled" in {
+    val cadenceMillis = 1000L
+    val cadenceTs = nextBufferedWriteTick(groupBy, entityKey(), processingTs, cadenceMillis)
+    val originalHarness = harness(
+      new GigaTileProcessFunction(groupBy, inputSchema, bufferingOutputTimeMillis = cadenceMillis))
+    originalHarness.open()
+    originalHarness.setProcessingTime(processingTs)
+    advanceToHealthyLiveWatermark(originalHarness, processingTs)
+    originalHarness.processElement1(event(processingTs - 1000L, 5L), processingTs - 1000L)
+    val snapshot = originalHarness.snapshot(21L, processingTs)
+    originalHarness.close()
+
+    val restoredHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema, bufferingOutputTimeMillis = 0L))
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(snapshot)
+      restoredHarness.open()
+      restoredHarness.setProcessingTime(processingTs)
+      advanceToHealthyLiveWatermark(restoredHarness, processingTs)
+      restoredHarness.setProcessingTime(cadenceTs)
+
+      val outputs = restoredHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldEqual 5L
+      outputs.get(0).latestTsMillis shouldEqual processingTs
+    } finally restoredHarness.close()
+  }
+
+  it should "repair a cadence marker after a state-blind timer consumer" in {
+    val cadenceMillis = 1000L
+    val cadenceTs = nextBufferedWriteTick(groupBy, entityKey(), processingTs, cadenceMillis)
+    val evictionTs = nextEvictionHop(processingTs)
+    val originalFunction =
+      new GigaTileProcessFunction(groupBy, inputSchema, bufferingOutputTimeMillis = cadenceMillis)
+    val originalHarness = harness(originalFunction)
+    cadenceTs should be < evictionTs
+    originalHarness.open()
+    originalHarness.setProcessingTime(processingTs)
+    advanceToHealthyLiveWatermark(originalHarness, processingTs)
+    originalHarness.processElement1(event(processingTs - 1000L, 5L), processingTs - 1000L)
+    setCurrentKey(originalHarness, entityKey())
+    valueState[java.lang.Boolean](originalFunction, "pendingPublicationState").value() shouldEqual java.lang.Boolean.TRUE
+    valueState[java.lang.Long](originalFunction, "nextProcessingEvictionTimerState").value() should not be null
+    val snapshot = originalHarness.snapshot(23L, processingTs)
+    originalHarness.close()
+
+    // The older binary neither binds the cadence state nor recognizes its physical timer.
+    val legacyHarness = harness(new StateBlindProcessingTimerConsumer)
+    legacyHarness.setup()
+    legacyHarness.initializeState(snapshot)
+    legacyHarness.open()
+    legacyHarness.setProcessingTime(processingTs)
+    legacyHarness.setProcessingTime(cadenceTs)
+    legacyHarness.extractOutputValues() shouldBe empty
+    val legacySnapshot = legacyHarness.snapshot(24L, cadenceTs)
+    legacyHarness.close()
+
+    val restoredFunction =
+      new GigaTileProcessFunction(groupBy, inputSchema, bufferingOutputTimeMillis = cadenceMillis)
+    val restoredHarness = harness(restoredFunction)
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(legacySnapshot)
+      restoredHarness.open()
+      restoredHarness.setProcessingTime(cadenceTs)
+      advanceToHealthyLiveWatermark(restoredHarness, cadenceTs)
+      restoredHarness.processElement1(event(processingTs - 999L, 7L), processingTs - 999L)
+      setCurrentKey(restoredHarness, entityKey())
+      val repairedCadenceTs =
+        valueState[java.lang.Long](restoredFunction, "nextBufferedWriteTimerState").value().longValue()
+      repairedCadenceTs should be > cadenceTs
+      valueState[java.lang.Boolean](restoredFunction, "pendingPublicationState").value() shouldEqual
+        java.lang.Boolean.TRUE
+
+      restoredHarness.setProcessingTime(repairedCadenceTs)
+
+      val outputs = restoredHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldEqual 12L
+    } finally restoredHarness.close()
+  }
+
+  it should "flush a restored parked write through activation after buffering is disabled" in {
+    val cadenceMillis = 1000L
+    val function = new GigaTileProcessFunction(groupBy, inputSchema, bufferingOutputTimeMillis = cadenceMillis)
+    val cadenceTs = nextBufferedWriteTick(groupBy, entityKey(), processingTs, cadenceMillis)
+    val catchupThreshold = new Window(5, TimeUnit.MINUTES).millis + FlinkJob.CatchupWatermarkLagSlackMillis
+    val watermark = processingTs - catchupThreshold + (cadenceTs - processingTs) / 2L
+    val originalHarness = harness(function)
+    originalHarness.open()
+    originalHarness.setProcessingTime(processingTs)
+    advanceToLiveWatermark(originalHarness, watermark)
+    originalHarness.processElement1(event(watermark - 1L, 5L), watermark - 1L)
+    originalHarness.setProcessingTime(cadenceTs)
+    setCurrentKey(originalHarness, entityKey())
+    valueState[java.lang.Long](function, "nextBufferedWriteTimerState").value() shouldBe null
+    val snapshot = originalHarness.snapshot(22L, cadenceTs)
+    originalHarness.close()
+
+    val restoredFunction = new GigaTileProcessFunction(groupBy, inputSchema, bufferingOutputTimeMillis = 0L)
+    val restoredHarness = harness(restoredFunction)
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(snapshot)
+      restoredHarness.open()
+      restoredHarness.setProcessingTime(cadenceTs)
+      advanceToHealthyLiveWatermark(restoredHarness, cadenceTs)
+
+      val outputs = restoredHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldEqual 5L
+      outputs.get(0).latestTsMillis shouldEqual cadenceTs
+      setCurrentKey(restoredHarness, entityKey())
+      valueState[java.lang.Long](restoredFunction, "bufferedWriteLatestTsState").value() shouldBe null
+      valueState[java.lang.Long](restoredFunction, "nextBufferedWriteTimerState").value() shouldBe null
+    } finally restoredHarness.close()
+  }
+
+  it should "schedule a stale buffered version collision strictly after the cadence callback" in {
+    val cadenceMillis = 1000L
+    val function = new GigaTileProcessFunction(groupBy, inputSchema, bufferingOutputTimeMillis = cadenceMillis)
+    val testHarness = harness(function)
+    val cadenceTs = nextBufferedWriteTick(groupBy, entityKey(), processingTs, cadenceMillis)
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      advanceToHealthyLiveWatermark(testHarness, processingTs)
+      testHarness.processElement1(event(processingTs - 1000L, 5L), processingTs - 1000L)
+      setCurrentKey(testHarness, entityKey())
+      valueState[java.lang.Long](function, "lastEmittedVersionState").update(processingTs)
+
+      testHarness.setProcessingTime(cadenceTs)
+
+      testHarness.extractOutputValues() shouldBe empty
+      setCurrentKey(testHarness, entityKey())
+      val collisionTs = valueState[java.lang.Long](function, "pendingVersionCollisionState").value().longValue()
+      collisionTs should be > cadenceTs
+      valueState[java.lang.Boolean](function, "pendingPublicationState").value() shouldEqual
+        java.lang.Boolean.TRUE
+      testHarness.setProcessingTime(collisionTs)
+      decodeSum(testHarness.extractOutputValues().get(0)) shouldEqual 5L
+      setCurrentKey(testHarness, entityKey())
+      valueState[java.lang.Boolean](function, "pendingPublicationState").value() shouldBe null
     } finally testHarness.close()
   }
 
@@ -1351,6 +1818,19 @@ object GigaTileProcessFunctionTest {
   private def nextDay(timestamp: Long): Long = {
     val dayMillis = new Window(1, TimeUnit.DAYS).millis
     TsUtils.round(timestamp, dayMillis) + dayMillis
+  }
+
+  private def nextBufferedWriteTick(
+      phaseGroupBy: GroupBy,
+      key: util.List[Any],
+      currentProcessingTime: Long,
+      cadenceMillis: Long
+  ): Long = {
+    val phase =
+      Math.floorMod((phaseGroupBy.getMetaData.getName :: key.iterator().asScala.toList).hashCode().toLong, cadenceMillis)
+    val elapsedSincePhase = Math.floorMod(Math.floorMod(currentProcessingTime, cadenceMillis) - phase, cadenceMillis)
+    val delay = if (elapsedSincePhase == 0L) cadenceMillis else cadenceMillis - elapsedSincePhase
+    currentProcessingTime + delay
   }
 
   private def currentProcessor(function: GigaTileProcessFunction): GigaTileStreamProcessor = {

--- a/online/src/main/scala/ai/chronon/online/GigaTileCodec.scala
+++ b/online/src/main/scala/ai/chronon/online/GigaTileCodec.scala
@@ -1,0 +1,89 @@
+package ai.chronon.online
+
+import ai.chronon.aggregator.windowing.{FinalBatchIr, MegaTileAggregator}
+import ai.chronon.api.Extensions.MetadataOps
+import ai.chronon.api.{DataType, GroupBy, StructType}
+import ai.chronon.api.ScalaJavaConversions.IteratorOps
+import ai.chronon.online.serde.{AvroCodec, AvroConversions}
+import org.apache.avro.generic.GenericData
+
+import java.util
+
+/** Codec for the GigaTile pipeline. Three responsibilities:
+  *
+  * 1. Encode finalized feature vectors (output schema) — for KV writes.
+  * 2. Decode FinalBatchIr from upload table bytes — for Iceberg ingestion.
+  * 3. Encode windowed IR to bytes — for batch update mismatch detection.
+  */
+class GigaTileCodec(groupBy: GroupBy, inputSchema: Seq[(String, DataType)]) {
+
+  private val megaTileAgg = new MegaTileAggregator(groupBy.getAggregations.iterator().toScala.toSeq, inputSchema)
+  private val windowedAgg = megaTileAgg.windowedAggregator
+  private val baseAgg = megaTileAgg.baseAggregator
+
+  // --- Output encoding (finalized feature vector) ---
+
+  val outputSchema: StructType =
+    StructType.from(s"${groupBy.getMetaData.cleanName}_OUTPUT", windowedAgg.outputSchema)
+  private val outputEncodeFn: Any => Array[Byte] = AvroConversions.encodeBytes(outputSchema, null)
+
+  def encodeOutput(finalizedVector: Array[Any]): Array[Byte] = outputEncodeFn(finalizedVector)
+
+  // --- Windowed IR encoding (for mismatch comparison) ---
+
+  private val megaTileCodec = new MegaTileCodec(groupBy, inputSchema)
+
+  def encodeWindowedIr(ir: Array[Any]): Array[Byte] = megaTileCodec.encode(ir)
+
+  // --- Batch IR decoding (from upload table value_bytes) ---
+
+  private val irSchema: StructType =
+    StructType.from(s"${groupBy.getMetaData.cleanName}_IR", megaTileAgg.batchIrSchema)
+  private val irAvroSchema: String = AvroConversions.fromChrononSchema(irSchema).toString()
+
+  @transient private lazy val irCodec: AvroCodec = AvroCodec.of(irAvroSchema)
+  @transient private lazy val irRowConverter: Any => Array[Any] =
+    AvroConversions.genericRecordToChrononRowConverter(irSchema)
+
+  def decodeBatchIr(bytes: Array[Byte]): FinalBatchIr = {
+    if (bytes == null) return null
+    val record = irCodec.decode(bytes)
+    val batchRecord = irRowConverter(record)
+    val collapsed = windowedAgg.denormalize(batchRecord(0).asInstanceOf[Array[Any]])
+    val tailHops = batchRecord(1)
+      .asInstanceOf[util.ArrayList[Any]]
+      .iterator()
+      .toScala
+      .map(
+        _.asInstanceOf[util.ArrayList[Any]]
+          .iterator()
+          .toScala
+          .map(hop => baseAgg.denormalizeInPlace(hop.asInstanceOf[Array[Any]]))
+          .toArray)
+      .toArray
+    FinalBatchIr(collapsed, tailHops)
+  }
+
+  // --- Batch IR encoding (for Flink state persistence) ---
+
+  private val irEncodeFn: Any => Array[Byte] = AvroConversions.encodeBytes(irSchema, null)
+
+  def encodeBatchIr(batchIr: FinalBatchIr): Array[Byte] = {
+    if (batchIr == null) return null
+    val normalizedCollapsed = windowedAgg.normalize(batchIr.collapsed)
+    val normalizedHops: Any = if (batchIr.tailHops != null) {
+      val hopList = new util.ArrayList[Any](batchIr.tailHops.length)
+      for (hopArray <- batchIr.tailHops) {
+        val innerList = new util.ArrayList[Any](hopArray.length)
+        for (hop <- hopArray) {
+          innerList.add(baseAgg.normalizeInPlace(hop.clone().asInstanceOf[Array[Any]]))
+        }
+        hopList.add(innerList)
+      }
+      hopList
+    } else {
+      null
+    }
+    irEncodeFn(Array[Any](normalizedCollapsed, normalizedHops))
+  }
+}

--- a/online/src/main/scala/ai/chronon/online/GigaTileCodec.scala
+++ b/online/src/main/scala/ai/chronon/online/GigaTileCodec.scala
@@ -41,7 +41,9 @@ class GigaTileCodec(groupBy: GroupBy, inputSchema: Seq[(String, DataType)]) {
     StructType.from(s"${groupBy.getMetaData.cleanName}_IR", megaTileAgg.batchIrSchema)
   private val irAvroSchema: String = AvroConversions.fromChrononSchema(irSchema).toString()
 
-  @transient private lazy val irCodec: AvroCodec = AvroCodec.of(irAvroSchema)
+  // AvroCodec.of is backed by a per-thread cache; resolving per call defers to that cache so
+  // concurrent decodes (e.g. parallel batch ingestion) don't share one mutable decoder.
+  private def irCodec: AvroCodec = AvroCodec.of(irAvroSchema)
   @transient private lazy val irRowConverter: Any => Array[Any] =
     AvroConversions.genericRecordToChrononRowConverter(irSchema)
 

--- a/online/src/main/scala/ai/chronon/online/GroupByServingInfoParsed.scala
+++ b/online/src/main/scala/ai/chronon/online/GroupByServingInfoParsed.scala
@@ -108,6 +108,12 @@ class GroupByServingInfoParsed(val groupByServingInfo: GroupByServingInfo)
 
   // End mega tiling specific variables
 
+  // Start giga tiling specific variables
+
+  lazy val gigaTileCodec: GigaTileCodec = new GigaTileCodec(groupBy, valueInputSchema)
+
+  // End giga tiling specific variables
+
   def outputChrononSchema: StructType =
     if (groupByServingInfo.groupBy.aggregations == null) {
       selectedChrononSchema

--- a/online/src/main/scala/ai/chronon/online/fetcher/GroupByFetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/GroupByFetcher.scala
@@ -96,7 +96,7 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
 
       val (streamingRequestOpt, megaTileHistoricalRequestsOpt) =
         groupByServingInfo.groupByOps.inferredAccuracy match {
-          case Accuracy.TEMPORAL if groupByServingInfo.groupByOps.isGigaTilingEnabled =>
+          case Accuracy.TEMPORAL if groupByServingInfo.groupByOps.isPushEnabled =>
             // Giga tiling (push): single point get with plain entity key.
             // Flink writes finalized vectors — no merge needed.
             val dataset = groupByServingInfo.groupByOps.streamingDataset

--- a/online/src/main/scala/ai/chronon/online/fetcher/GroupByFetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/GroupByFetcher.scala
@@ -96,6 +96,12 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
 
       val (streamingRequestOpt, megaTileHistoricalRequestsOpt) =
         groupByServingInfo.groupByOps.inferredAccuracy match {
+          case Accuracy.TEMPORAL if groupByServingInfo.groupByOps.isGigaTilingEnabled =>
+            // Giga tiling (push): single point get with plain entity key.
+            // Flink writes finalized vectors — no merge needed.
+            val dataset = groupByServingInfo.groupByOps.streamingDataset
+            (Some(GetRequest(streamingKeyBytes, dataset)), None)
+
           case Accuracy.TEMPORAL if groupByServingInfo.groupByOps.isMegaTilingEnabled =>
             // Mega tiling: one daily point get per day from today back to batch day,
             // plus one extra fallback day for no-batch windows.

--- a/online/src/main/scala/ai/chronon/online/fetcher/GroupByFetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/GroupByFetcher.scala
@@ -97,9 +97,9 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
       val (streamingRequestOpt, megaTileHistoricalRequestsOpt) =
         groupByServingInfo.groupByOps.inferredAccuracy match {
           case Accuracy.TEMPORAL if groupByServingInfo.groupByOps.isPushEnabled =>
-            // Giga tiling (push): single point get with plain entity key.
+            // Push: single point get with plain entity key on the _PUSH dataset.
             // Flink writes finalized vectors — no merge needed.
-            val dataset = groupByServingInfo.groupByOps.streamingDataset
+            val dataset = groupByServingInfo.groupByOps.pushDataset
             (Some(GetRequest(streamingKeyBytes, dataset)), None)
 
           case Accuracy.TEMPORAL if groupByServingInfo.groupByOps.isMegaTilingEnabled =>

--- a/online/src/main/scala/ai/chronon/online/fetcher/GroupByResponseHandler.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/GroupByResponseHandler.scala
@@ -60,7 +60,27 @@ class GroupByResponseHandler(fetchContext: FetchContext, metadataStore: Metadata
                                                    System.currentTimeMillis() - batchResponseDecodeStartTime)
         response
 
-      } else { // temporal accurate
+      } else if (newServingInfo.groupByOps.isGigaTilingEnabled) { // push-based (giga tile)
+
+        // Flink writes finalized feature vectors. Single point get, decode, return.
+        val streamingResponses = streamingResponsesOpt.get
+        if (streamingResponses.nonEmpty) {
+          val latest = streamingResponses.maxBy(_.millis)
+          newServingInfo.outputCodec.decodeMap(latest.bytes)
+        } else {
+          // No streaming data yet. Fall back to batch-only if available.
+          val batchResponseDecodeStartTime = System.currentTimeMillis()
+          val response = getMapResponseFromBatchResponse(batchResponses,
+                                                          batchBytes,
+                                                          newServingInfo.outputCodec.decodeMap,
+                                                          newServingInfo,
+                                                          requestContext.keys)
+          requestContext.metricsContext.distribution("group_by.batchir_decode.latency.millis",
+                                                      System.currentTimeMillis() - batchResponseDecodeStartTime)
+          response
+        }
+
+      } else { // temporal accurate (mega tile or standard tiling)
 
         val updatedContext = requestContext.copy(servingInfo = newServingInfo)
         val streamingResponses = streamingResponsesOpt.get

--- a/online/src/main/scala/ai/chronon/online/fetcher/GroupByResponseHandler.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/GroupByResponseHandler.scala
@@ -68,16 +68,11 @@ class GroupByResponseHandler(fetchContext: FetchContext, metadataStore: Metadata
           val latest = streamingResponses.maxBy(_.millis)
           newServingInfo.outputCodec.decodeMap(latest.bytes)
         } else {
-          // No streaming data yet. Fall back to batch-only if available.
-          val batchResponseDecodeStartTime = System.currentTimeMillis()
-          val response = getMapResponseFromBatchResponse(batchResponses,
-                                                          batchBytes,
-                                                          newServingInfo.outputCodec.decodeMap,
-                                                          newServingInfo,
-                                                          requestContext.keys)
-          requestContext.metricsContext.distribution("group_by.batchir_decode.latency.millis",
-                                                      System.currentTimeMillis() - batchResponseDecodeStartTime)
-          response
+          // No streaming data yet (Flink hasn't emitted for this entity).
+          // Batch KV contains IR-schema bytes, not output-schema — can't decode here.
+          // Return nulls; Flink will emit a batch-only vector once Iceberg scan completes.
+          requestContext.metricsContext.increment("group_by.push.no_streaming_data")
+          newServingInfo.outputCodec.fieldNames.map(_ -> null).toMap
         }
 
       } else { // temporal accurate (mega tile or standard tiling)

--- a/online/src/main/scala/ai/chronon/online/fetcher/GroupByResponseHandler.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/GroupByResponseHandler.scala
@@ -60,7 +60,7 @@ class GroupByResponseHandler(fetchContext: FetchContext, metadataStore: Metadata
                                                    System.currentTimeMillis() - batchResponseDecodeStartTime)
         response
 
-      } else if (newServingInfo.groupByOps.isGigaTilingEnabled) { // push-based (giga tile)
+      } else if (newServingInfo.groupByOps.isPushEnabled) { // push-based (giga tile)
 
         // Flink writes finalized feature vectors. Single point get, decode, return.
         val streamingResponses = streamingResponsesOpt.get

--- a/online/src/test/scala/ai/chronon/online/test/GigaTileCodecRoundTripTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/GigaTileCodecRoundTripTest.scala
@@ -1,0 +1,283 @@
+package ai.chronon.online.test
+
+import ai.chronon.aggregator.row.RowAggregator
+import ai.chronon.aggregator.test.NaiveAggregator
+import ai.chronon.aggregator.windowing._
+import ai.chronon.api._
+import ai.chronon.api.Extensions.{AggregationOps, WindowOps}
+import ai.chronon.online.{GigaTileCodec, MegaTileCodec}
+import ai.chronon.online.serde.ArrayRow
+import com.google.gson.Gson
+import org.junit.Assert._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.slf4j.LoggerFactory
+
+import scala.collection.mutable
+import scala.util.Random
+
+/** Tests GigaTileStreamProcessor with serde round-trips on every state access,
+  * simulating what FlinkGigaTileStore does (encode on put, decode on get).
+  * Also tests GigaTileCodec.encodeBatchIr/decodeBatchIr round-trip.
+  */
+class GigaTileCodecRoundTripTest extends AnyFlatSpec {
+  @transient lazy val logger = LoggerFactory.getLogger(getClass)
+  val gson = new Gson
+
+  val AllWindows: Seq[Window] = Seq(
+    new Window(6, TimeUnit.HOURS),
+    new Window(1, TimeUnit.DAYS),
+    new Window(47, TimeUnit.HOURS),
+    new Window(2, TimeUnit.DAYS),
+    new Window(49, TimeUnit.HOURS),
+    new Window(3, TimeUnit.DAYS),
+    new Window(7, TimeUnit.DAYS)
+  )
+
+  val TailBufferMillis: Long = new Window(2, TimeUnit.DAYS).millis
+  val DayMillis: Long = new Window(1, TimeUnit.DAYS).millis
+  val Epsilon = 1e-6
+  val Schema: Seq[(String, DataType)] = Seq("ts" -> LongType, "num" -> LongType, "amount" -> DoubleType)
+
+  def approxEqual(a: Any, b: Any): Boolean = (a, b) match {
+    case (null, null)                         => true
+    case (null, _) | (_, null)                => false
+    case (x: Double, y: Double)               => Math.abs(x - y) <= Epsilon * Math.max(1.0, Math.max(Math.abs(x), Math.abs(y)))
+    case (x: java.util.List[_], y: java.util.List[_]) =>
+      x.size() == y.size() && (0 until x.size()).forall(i => approxEqual(x.get(i), y.get(i)))
+    case (x: java.util.Map[_, _], y: java.util.Map[_, _]) =>
+      x.size() == y.size() && x.keySet().toArray.forall(k => approxEqual(x.get(k), y.get(k)))
+    case (x: Array[_], y: Array[_]) =>
+      x.length == y.length && x.zip(y).forall { case (a, b) => approxEqual(a, b) }
+    case _ => a == b
+  }
+
+  def generateEvents(daySpan: Int, count: Int): Array[Row] = {
+    val rng = new Random(42)
+    val baseTs = 1774000000000L
+    val spanMillis = daySpan.toLong * DayMillis
+    (0 until count).map { _ =>
+      val ts = baseTs + (rng.nextDouble() * spanMillis).toLong
+      val num = rng.nextInt(1000).toLong
+      val amount = rng.nextDouble() * 500.0
+      new ArrayRow(Array(ts, num, amount), ts): Row
+    }.toArray
+  }
+
+  def naiveAggregate(allEvents: Array[Row], queryTimes: Array[Long],
+                     aggregations: Seq[Aggregation]): Array[Array[Any]] = {
+    val unpackedParts = aggregations.flatMap(_.unpack)
+    val unpacked = unpackedParts.map(_.window).toArray
+    val tailHops = unpacked.map(w => FiveMinuteResolution.calculateTailHop(w))
+    val rowAgg = new RowAggregator(Schema, unpackedParts)
+    val naiveAgg = new NaiveAggregator(rowAgg, unpacked, tailHops)
+    naiveAgg.aggregate(allEvents, queryTimes).map(ir => rowAgg.finalize(ir))
+  }
+
+  def buildGroupBy(aggregations: Seq[Aggregation]): GroupBy = {
+    import scala.collection.JavaConverters._
+    val gb = new GroupBy()
+    gb.setAggregations(aggregations.asJava)
+    val meta = new MetaData()
+    meta.setName("test_giga_tile_codec")
+    gb.setMetaData(meta)
+    gb
+  }
+
+  /** GigaTileStore that encodes/decodes on every access via GigaTileCodec + MegaTileCodec. */
+  class SerdeGigaTileStore(windowedAgg: RowAggregator, codec: MegaTileCodec, gigaCodec: GigaTileCodec)
+      extends GigaTileStore {
+    private val tileBytes = mutable.Map[(Long, Long), Array[Byte]]()
+    private var cachedSmallBytes: Array[Byte] = codec.encode(windowedAgg.init)
+    private var largeTodayBytes: Array[Byte] = codec.encode(windowedAgg.init)
+    private var largeYesterdayBytes: Array[Byte] = codec.encode(windowedAgg.init)
+    private var dayStart: Long = -1L
+    private var earliest: Long = Long.MaxValue
+    private var batchIrBytes: Array[Byte] = _
+    private var batchEnd: Long = -1L
+    private var runningLargeBytes: Array[Byte] = codec.encode(windowedAgg.init)
+
+    override def getTile(h: Long, t: Long): Array[Any] = tileBytes.get((h, t)).map(codec.decodeBaseIr).orNull
+    override def putTile(h: Long, t: Long, ir: Array[Any]): Unit = tileBytes((h, t)) = codec.encodeBaseIr(ir)
+    override def removeTile(h: Long, t: Long): Unit = tileBytes.remove((h, t))
+    override def tileIterator: Iterator[(Long, Long, Array[Any])] =
+      tileBytes.iterator.map { case ((h, t), b) => (h, t, codec.decodeBaseIr(b)) }
+
+    override def getCachedSmallWindowIr: Array[Any] = codec.decode(cachedSmallBytes)
+    override def putCachedSmallWindowIr(ir: Array[Any]): Unit = cachedSmallBytes = codec.encode(ir)
+    override def getLargeTodayIr: Array[Any] = codec.decode(largeTodayBytes)
+    override def putLargeTodayIr(ir: Array[Any]): Unit = largeTodayBytes = codec.encode(ir)
+    override def getLargeYesterdayIr: Array[Any] = codec.decode(largeYesterdayBytes)
+    override def putLargeYesterdayIr(ir: Array[Any]): Unit = largeYesterdayBytes = codec.encode(ir)
+    override def getCurrentDayStart: Long = dayStart
+    override def putCurrentDayStart(ts: Long): Unit = dayStart = ts
+    override def getEarliestTileStart: Long = earliest
+    override def putEarliestTileStart(ts: Long): Unit = earliest = ts
+
+    override def getBatchIr: FinalBatchIr =
+      if (batchIrBytes != null) gigaCodec.decodeBatchIr(batchIrBytes) else null
+    override def putBatchIr(ir: FinalBatchIr): Unit =
+      batchIrBytes = gigaCodec.encodeBatchIr(ir)
+    override def getBatchEndTs: Long = batchEnd
+    override def putBatchEndTs(ts: Long): Unit = batchEnd = ts
+    override def getRunningLargeIr: Array[Any] = codec.decode(runningLargeBytes)
+    override def putRunningLargeIr(ir: Array[Any]): Unit = runningLargeBytes = codec.encode(ir)
+  }
+
+  /** Full giga tile pipeline with serde round-trips at every state boundary. */
+  def gigaTileWithSerdeAggregate(allEvents: Array[Row],
+                                  queryTimes: Array[Long],
+                                  aggregations: Seq[Aggregation],
+                                  batchEnd: Long): Array[Array[Any]] = {
+
+    val megaTileAgg = new MegaTileAggregator(aggregations, Schema, tailBufferMillis = TailBufferMillis)
+    val gb = buildGroupBy(aggregations)
+    val codec = new MegaTileCodec(gb, Schema)
+    val gigaCodec = new GigaTileCodec(gb, Schema)
+    val store = new SerdeGigaTileStore(megaTileAgg.windowedAggregator, codec, gigaCodec)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, store)
+
+    // Build and load batch IR
+    val batchEvents = allEvents.filter(_.ts < batchEnd)
+    val onlineAgg = new SawtoothOnlineAggregator(batchEnd, aggregations, Schema, tailBufferMillis = TailBufferMillis)
+    var batchIr = onlineAgg.init
+    batchEvents.foreach(row => batchIr = onlineAgg.update(batchIr, row))
+    val normalizedBatchIr = onlineAgg.normalizeBatchIr(batchIr)
+    val denormalizedBatchIr = onlineAgg.denormalizeBatchIr(normalizedBatchIr)
+
+    val sortedEvents = allEvents.sortBy(_.ts)
+    val sortedQueries = queryTimes.sorted
+    val evictionInterval = processor.minEvictionInterval
+    var nextEvictionTs = Long.MaxValue
+    var lastEmitted: Array[Any] = null
+    var eventIdx = 0
+    val resultsByQueryTs = mutable.Map[Long, Array[Any]]()
+
+    // Load batch via onBatchUpdate (goes through serde)
+    val batchResult = processor.onBatchUpdate(denormalizedBatchIr, batchEnd, batchEnd)
+    if (batchResult.finalizedVector != null) lastEmitted = batchResult.finalizedVector
+    if (batchResult.needsEvictionTimer && nextEvictionTs == Long.MaxValue) {
+      nextEvictionTs = TsUtils.round(batchEnd, evictionInterval) + evictionInterval
+    }
+
+    def firePendingEvictions(upToTs: Long): Unit = {
+      while (nextEvictionTs <= upToTs) {
+        processor.advanceWatermark(nextEvictionTs)
+        val r = processor.onEviction(nextEvictionTs)
+        if (r.finalizedVector != null) lastEmitted = r.finalizedVector
+        nextEvictionTs += evictionInterval
+      }
+    }
+
+    for (queryTs <- sortedQueries) {
+      while (eventIdx < sortedEvents.length && sortedEvents(eventIdx).ts <= queryTs) {
+        val event = sortedEvents(eventIdx)
+        firePendingEvictions(event.ts)
+        processor.advanceWatermark(event.ts)
+        val result = processor.onEvent(event, event.ts)
+        if (result.finalizedVector != null) lastEmitted = result.finalizedVector
+        if (nextEvictionTs == Long.MaxValue) {
+          nextEvictionTs = TsUtils.round(event.ts, evictionInterval) + evictionInterval
+        }
+        eventIdx += 1
+      }
+
+      firePendingEvictions(queryTs)
+      processor.advanceWatermark(queryTs)
+      val evictResult = processor.onEviction(queryTs)
+      if (evictResult.finalizedVector != null) lastEmitted = evictResult.finalizedVector
+
+      resultsByQueryTs(queryTs) = lastEmitted
+    }
+
+    queryTimes.map(resultsByQueryTs)
+  }
+
+  it should "match naive with serde round-trips (batch fresh)" in {
+    val events = generateEvents(14, 20000)
+    val maxTs = events.map(_.ts).max
+    val batchEnd = TsUtils.round(maxTs - DayMillis, DayMillis)
+
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows),
+      Builders.Aggregation(Operation.AVERAGE, "amount", AllWindows)
+    )
+
+    val queryTimes = Array(batchEnd + 6 * 3600 * 1000L, batchEnd + 14 * 3600 * 1000L).filter(_ <= maxTs)
+    val results = gigaTileWithSerdeAggregate(events, queryTimes, aggregations, batchEnd)
+    val naive = naiveAggregate(events, queryTimes, aggregations)
+    assertEquals("result count", naive.length, results.length)
+    for (i <- queryTimes.indices) {
+      assertTrue(s"giga_serde_fresh: mismatch at query ${queryTimes(i)}\n  expected: ${gson.toJson(naive(i))}\n  got:      ${gson.toJson(results(i))}",
+                 approxEqual(results(i), naive(i)))
+    }
+  }
+
+  it should "match naive with serde round-trips (all agg types)" in {
+    val events = generateEvents(14, 20000)
+    val maxTs = events.map(_.ts).max
+    val batchEnd = TsUtils.round(maxTs - DayMillis, DayMillis)
+
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows),
+      Builders.Aggregation(Operation.AVERAGE, "amount", AllWindows),
+      Builders.Aggregation(Operation.MIN, "num", AllWindows),
+      Builders.Aggregation(Operation.MAX, "num", AllWindows),
+      Builders.Aggregation(Operation.LAST, "num", AllWindows),
+      Builders.Aggregation(Operation.FIRST, "num", AllWindows)
+    )
+
+    val queryTimes = Array(batchEnd + 14 * 3600 * 1000L).filter(_ <= maxTs)
+    val results = gigaTileWithSerdeAggregate(events, queryTimes, aggregations, batchEnd)
+    val naive = naiveAggregate(events, queryTimes, aggregations)
+    assertEquals("result count", naive.length, results.length)
+    for (i <- queryTimes.indices) {
+      assertTrue(s"giga_serde_all_agg: mismatch at query ${queryTimes(i)}\n  expected: ${gson.toJson(naive(i))}\n  got:      ${gson.toJson(results(i))}",
+                 approxEqual(results(i), naive(i)))
+    }
+  }
+
+  it should "round-trip batch IR through encode/decode" in {
+    val events = generateEvents(14, 10000)
+    val maxTs = events.map(_.ts).max
+    val batchEnd = TsUtils.round(maxTs - DayMillis, DayMillis)
+
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows),
+      Builders.Aggregation(Operation.AVERAGE, "amount", AllWindows)
+    )
+
+    val gb = buildGroupBy(aggregations)
+    val gigaCodec = new GigaTileCodec(gb, Schema)
+
+    // Build a real FinalBatchIr
+    val onlineAgg = new SawtoothOnlineAggregator(batchEnd, aggregations, Schema, tailBufferMillis = TailBufferMillis)
+    var batchIr = onlineAgg.init
+    events.filter(_.ts < batchEnd).foreach(row => batchIr = onlineAgg.update(batchIr, row))
+    val normalizedBatchIr = onlineAgg.normalizeBatchIr(batchIr)
+    val denormalized = onlineAgg.denormalizeBatchIr(normalizedBatchIr)
+
+    // Round-trip: encode → decode
+    val encoded = gigaCodec.encodeBatchIr(denormalized)
+    assertNotNull("encoded bytes should not be null", encoded)
+    assertTrue("encoded bytes should be non-empty", encoded.length > 0)
+
+    val decoded = gigaCodec.decodeBatchIr(encoded)
+    assertNotNull("decoded batch IR should not be null", decoded)
+
+    // Verify collapsed values match
+    assertEquals("collapsed length", denormalized.collapsed.length, decoded.collapsed.length)
+    for (i <- denormalized.collapsed.indices) {
+      assertTrue(s"collapsed[$i] mismatch: orig=${denormalized.collapsed(i)} decoded=${decoded.collapsed(i)}",
+                 approxEqual(denormalized.collapsed(i), decoded.collapsed(i)))
+    }
+
+    // Verify tail hops structure
+    assertEquals("tailHops length", denormalized.tailHops.length, decoded.tailHops.length)
+    for (i <- denormalized.tailHops.indices) {
+      assertEquals(s"tailHops[$i] length", denormalized.tailHops(i).length, decoded.tailHops(i).length)
+    }
+  }
+}

--- a/online/src/test/scala/ai/chronon/online/test/GigaTileCodecRoundTripTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/GigaTileCodecRoundTripTest.scala
@@ -287,4 +287,79 @@ class GigaTileCodecRoundTripTest extends AnyFlatSpec {
       assertEquals(s"tailHops[$i] length", denormalized.tailHops(i).length, decoded.tailHops(i).length)
     }
   }
+
+  // -----------------------------------------------------------------
+  // Gap H — GigaTileCodec.irCodec is `@transient private lazy val avroCodec = AvroCodec.of(...)`.
+  // AvroCodec.of is backed by a per-thread cache; caching the result in a lazy val means the
+  // first thread's codec is reused across all threads, leaking that thread's mutable decoder
+  // state. Mick's MegaTile fix `ced0185` switched to `private def avroCodec = ...` so each
+  // thread resolves its own codec. The same pattern in GigaTileCodec is currently safe only
+  // because Flink calls decodeBatchIr single-threaded per key — moving any decode onto a
+  // shared (e.g. fetcher / parallel-batch-ingest) path will hit this race.
+  //
+  // Reproduce by spinning N threads and decoding the same encoded batchIr concurrently. With
+  // a thread-safe codec the decoded results are all equal and no decode throws. With the
+  // lazy-val pattern, repeated runs surface either an exception or inconsistent decodes.
+  // -----------------------------------------------------------------
+  it should "FAIL: GigaTileCodec.decodeBatchIr must be thread-safe" in {
+    val batchEnd = TsUtils.round(1700000000000L, DayMillis)
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows),
+      Builders.Aggregation(Operation.AVERAGE, "amount", AllWindows)
+    )
+    val gb = buildGroupBy(aggregations)
+    val gigaCodec = new GigaTileCodec(gb, Schema)
+
+    val events = generateEvents(14, 5000).filter(_.ts < batchEnd)
+    val onlineAgg = new SawtoothOnlineAggregator(batchEnd, aggregations, Schema, tailBufferMillis = TailBufferMillis)
+    var batchIr = onlineAgg.init
+    events.foreach(row => batchIr = onlineAgg.update(batchIr, row))
+    val denormalized = onlineAgg.denormalizeBatchIr(onlineAgg.normalizeBatchIr(batchIr))
+    val encoded = gigaCodec.encodeBatchIr(denormalized)
+
+    val nThreads = 16
+    val iterations = 200
+    val pool = java.util.concurrent.Executors.newFixedThreadPool(nThreads)
+    val errors = java.util.concurrent.ConcurrentHashMap.newKeySet[String]()
+    val collapsedHashes = java.util.concurrent.ConcurrentHashMap.newKeySet[String]()
+    val barrier = new java.util.concurrent.CyclicBarrier(nThreads)
+    val futures = (0 until nThreads).map { _ =>
+      pool.submit(new Runnable {
+        override def run(): Unit = {
+          barrier.await()
+          var i = 0
+          while (i < iterations) {
+            try {
+              val decoded = gigaCodec.decodeBatchIr(encoded)
+              val collapsedFingerprint = decoded.collapsed.map(v => if (v == null) "null" else v.toString).mkString(",")
+              collapsedHashes.add(collapsedFingerprint)
+            } catch {
+              case t: Throwable => errors.add(s"${t.getClass.getSimpleName}: ${t.getMessage}")
+            }
+            i += 1
+          }
+        }
+      })
+    }
+    futures.foreach(_.get(60, java.util.concurrent.TimeUnit.SECONDS))
+    pool.shutdown()
+
+    assertTrue(s"concurrent decodes must not throw — observed: ${errors.toArray.mkString("; ")}", errors.isEmpty)
+    assertEquals(
+      s"all concurrent decodes must return the same collapsed fingerprint — observed ${collapsedHashes.size} distinct values",
+      1,
+      collapsedHashes.size
+    )
+
+    // Defense-in-depth assertion: prefer that irCodec resolves per call (def, not lazy val),
+    // matching Mick's MegaTileCodec fix. The runtime test above can flake; this static check
+    // pins the fix shape.
+    val irCodecField = classOf[GigaTileCodec].getDeclaredFields.find(_.getName == "irCodec")
+    assertTrue(
+      "GigaTileCodec.irCodec must be resolved per-call (def) so AvroCodec.of's per-thread cache " +
+        "isn't bypassed — it is currently a `lazy val`",
+      irCodecField.isEmpty
+    )
+  }
 }

--- a/online/src/test/scala/ai/chronon/online/test/GigaTileCodecRoundTripTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/GigaTileCodecRoundTripTest.scala
@@ -88,8 +88,7 @@ class GigaTileCodecRoundTripTest extends AnyFlatSpec {
       extends GigaTileStore {
     private val tileBytes = mutable.Map[(Long, Long), Array[Byte]]()
     private var cachedSmallBytes: Array[Byte] = codec.encode(windowedAgg.init)
-    private var largeTodayBytes: Array[Byte] = codec.encode(windowedAgg.init)
-    private var largeYesterdayBytes: Array[Byte] = codec.encode(windowedAgg.init)
+    private val dailyLargeBytes = mutable.Map[Long, Array[Byte]]()
     private var dayStart: Long = -1L
     private var earliest: Long = Long.MaxValue
     private var batchIrBytes: Array[Byte] = _
@@ -104,10 +103,12 @@ class GigaTileCodecRoundTripTest extends AnyFlatSpec {
 
     override def getCachedSmallWindowIr: Array[Any] = codec.decode(cachedSmallBytes)
     override def putCachedSmallWindowIr(ir: Array[Any]): Unit = cachedSmallBytes = codec.encode(ir)
-    override def getLargeTodayIr: Array[Any] = codec.decode(largeTodayBytes)
-    override def putLargeTodayIr(ir: Array[Any]): Unit = largeTodayBytes = codec.encode(ir)
-    override def getLargeYesterdayIr: Array[Any] = codec.decode(largeYesterdayBytes)
-    override def putLargeYesterdayIr(ir: Array[Any]): Unit = largeYesterdayBytes = codec.encode(ir)
+    // Today/yesterday are required by the parent TileStore trait but unused by GigaTile —
+    // routing happens through the per-day map below.
+    override def getLargeTodayIr: Array[Any] = windowedAgg.init
+    override def putLargeTodayIr(ir: Array[Any]): Unit = ()
+    override def getLargeYesterdayIr: Array[Any] = windowedAgg.init
+    override def putLargeYesterdayIr(ir: Array[Any]): Unit = ()
     override def getCurrentDayStart: Long = dayStart
     override def putCurrentDayStart(ts: Long): Unit = dayStart = ts
     override def getEarliestTileStart: Long = earliest
@@ -121,6 +122,12 @@ class GigaTileCodecRoundTripTest extends AnyFlatSpec {
     override def putBatchEndTs(ts: Long): Unit = batchEnd = ts
     override def getRunningLargeIr: Array[Any] = codec.decode(runningLargeBytes)
     override def putRunningLargeIr(ir: Array[Any]): Unit = runningLargeBytes = codec.encode(ir)
+
+    override def getDailyLargeIr(ds: Long): Array[Any] = dailyLargeBytes.get(ds).map(codec.decode).orNull
+    override def putDailyLargeIr(ds: Long, ir: Array[Any]): Unit = dailyLargeBytes(ds) = codec.encode(ir)
+    override def removeDailyLargeIr(ds: Long): Unit = dailyLargeBytes.remove(ds)
+    override def dailyLargeIrIterator: Iterator[(Long, Array[Any])] =
+      dailyLargeBytes.iterator.map { case (ds, b) => (ds, codec.decode(b)) }
   }
 
   /** Full giga tile pipeline with serde round-trips at every state boundary. */

--- a/online/src/test/scala/ai/chronon/online/test/GigaTileCodecRoundTripTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/GigaTileCodecRoundTripTest.scala
@@ -94,6 +94,8 @@ class GigaTileCodecRoundTripTest extends AnyFlatSpec {
     private var batchIrBytes: Array[Byte] = _
     private var batchEnd: Long = -1L
     private var runningLargeBytes: Array[Byte] = codec.encode(windowedAgg.init)
+    private var cachedSmallWindowAsOfTs: Long = -1L
+    private var lastLargeRecomputeAsOfTs: Long = Long.MinValue
 
     override def getTile(h: Long, t: Long): Array[Any] = tileBytes.get((h, t)).map(codec.decodeBaseIr).orNull
     override def putTile(h: Long, t: Long, ir: Array[Any]): Unit = tileBytes((h, t)) = codec.encodeBaseIr(ir)
@@ -122,6 +124,10 @@ class GigaTileCodecRoundTripTest extends AnyFlatSpec {
     override def putBatchEndTs(ts: Long): Unit = batchEnd = ts
     override def getRunningLargeIr: Array[Any] = codec.decode(runningLargeBytes)
     override def putRunningLargeIr(ir: Array[Any]): Unit = runningLargeBytes = codec.encode(ir)
+    override def getCachedSmallWindowAsOfTs: Long = cachedSmallWindowAsOfTs
+    override def putCachedSmallWindowAsOfTs(ts: Long): Unit = cachedSmallWindowAsOfTs = ts
+    override def getLastLargeRecomputeAsOfTs: Long = lastLargeRecomputeAsOfTs
+    override def putLastLargeRecomputeAsOfTs(ts: Long): Unit = lastLargeRecomputeAsOfTs = ts
 
     // Daily slot IRs are base-aggregator-shaped (one column per (op, input)) — fanned out
     // to per-window columns at recompute time via baseIrIndices.

--- a/online/src/test/scala/ai/chronon/online/test/GigaTileCodecRoundTripTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/GigaTileCodecRoundTripTest.scala
@@ -123,11 +123,13 @@ class GigaTileCodecRoundTripTest extends AnyFlatSpec {
     override def getRunningLargeIr: Array[Any] = codec.decode(runningLargeBytes)
     override def putRunningLargeIr(ir: Array[Any]): Unit = runningLargeBytes = codec.encode(ir)
 
-    override def getDailyLargeIr(ds: Long): Array[Any] = dailyLargeBytes.get(ds).map(codec.decode).orNull
-    override def putDailyLargeIr(ds: Long, ir: Array[Any]): Unit = dailyLargeBytes(ds) = codec.encode(ir)
+    // Daily slot IRs are base-aggregator-shaped (one column per (op, input)) — fanned out
+    // to per-window columns at recompute time via baseIrIndices.
+    override def getDailyLargeIr(ds: Long): Array[Any] = dailyLargeBytes.get(ds).map(codec.decodeBaseIr).orNull
+    override def putDailyLargeIr(ds: Long, ir: Array[Any]): Unit = dailyLargeBytes(ds) = codec.encodeBaseIr(ir)
     override def removeDailyLargeIr(ds: Long): Unit = dailyLargeBytes.remove(ds)
     override def dailyLargeIrIterator: Iterator[(Long, Array[Any])] =
-      dailyLargeBytes.iterator.map { case (ds, b) => (ds, codec.decode(b)) }
+      dailyLargeBytes.iterator.map { case (ds, b) => (ds, codec.decodeBaseIr(b)) }
   }
 
   /** Full giga tile pipeline with serde round-trips at every state boundary. */

--- a/spark/src/main/scala/ai/chronon/spark/GroupByUpload.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupByUpload.scala
@@ -532,7 +532,7 @@ object GroupByUpload {
     // The KVUploadNodeRunner (bulkPut) is being disabled for PUSH — Flink reads entity
     // batch IRs from Iceberg, not KV. But the serving info metadata must still reach KV
     // so the Flink job and fetcher can discover schemas and batchEndDate.
-    if (new GroupByOps(groupByConf).isGigaTilingEnabled) {
+    if (new GroupByOps(groupByConf).isPushEnabled) {
       apiOpt match {
         case Some(onlineApi) =>
           val kvStore = onlineApi.genKvStore

--- a/spark/src/main/scala/ai/chronon/spark/GroupByUpload.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupByUpload.scala
@@ -22,7 +22,7 @@ import ai.chronon.api.Extensions.{GroupByOps, MetadataOps, SourceOps}
 import ai.chronon.api.ScalaJavaConversions._
 import ai.chronon.api._
 import ai.chronon.online.Extensions.ChrononStructTypeOps
-import ai.chronon.online.GroupByServingInfoParsed
+import ai.chronon.online.{GroupByServingInfoParsed, KVStore}
 import ai.chronon.online.metrics.Metrics
 import ai.chronon.online.serde.{AvroConversions, SparkConversions}
 import ai.chronon.spark.Extensions._
@@ -37,6 +37,7 @@ import org.slf4j.{Logger, LoggerFactory}
 
 import scala.annotation.tailrec
 import scala.collection.mutable
+import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration.DurationInt
 import scala.util.Try
 
@@ -447,7 +448,8 @@ object GroupByUpload {
           endDs: String,
           tableUtilsOpt: Option[TableUtils] = None,
           showDf: Boolean = false,
-          jsonPercent: Int = 1): Unit = {
+          jsonPercent: Int = 1,
+          apiOpt: Option[ai.chronon.online.Api] = None): Unit = {
     import ai.chronon.spark.submission.SparkSessionBuilder
     val tableUtils: TableUtils =
       tableUtilsOpt.getOrElse(
@@ -523,6 +525,28 @@ object GroupByUpload {
         context.gauge(Metrics.Name.RowCount, metricRow(0).getLong(2))
       } else {
         throw new RuntimeException("GroupBy upload resulted in zero rows.")
+      }
+    }
+
+    // For PUSH GroupBys, write GroupByServingInfo directly to KV.
+    // The KVUploadNodeRunner (bulkPut) is being disabled for PUSH — Flink reads entity
+    // batch IRs from Iceberg, not KV. But the serving info metadata must still reach KV
+    // so the Flink job and fetcher can discover schemas and batchEndDate.
+    if (new GroupByOps(groupByConf).isGigaTilingEnabled) {
+      apiOpt match {
+        case Some(onlineApi) =>
+          val kvStore = onlineApi.genKvStore
+          val dataset = groupByConf.batchDataset
+          kvStore.create(dataset)
+          val servingInfoKey = Constants.GroupByServingInfoKey.getBytes(Constants.UTF8)
+          val servingInfoValue = ThriftJsonCodec.toJsonStr(groupByServingInfo).getBytes(Constants.UTF8)
+          val putRequest = KVStore.PutRequest(servingInfoKey, servingInfoValue, dataset)
+          implicit val ec: ExecutionContext = ExecutionContext.global
+          Await.result(kvStore.put(putRequest), 1.hour)
+          logger.info(s"PUSH GroupBy: wrote GroupByServingInfo directly to KV dataset=$dataset")
+        case None =>
+          logger.warn("PUSH GroupBy but no API provided — serving info not written to KV. " +
+            "Pass apiOpt to GroupByUpload.run() or ensure KVUploadNodeRunner runs separately.")
       }
     }
 

--- a/spark/src/main/scala/ai/chronon/spark/batch/BatchNodeRunner.scala
+++ b/spark/src/main/scala/ai/chronon/spark/batch/BatchNodeRunner.scala
@@ -224,7 +224,7 @@ class BatchNodeRunner(node: Node, tableUtils: TableUtils, api: Api) extends Node
     val groupBy = groupByUpload.groupBy
     logger.info(s"Running groupBy upload for '${metadata.name}' for day: ${range.end}")
 
-    GroupByUpload.run(groupBy, range.end, Option(tableUtils))
+    GroupByUpload.run(groupBy, range.end, Option(tableUtils), apiOpt = Option(api))
     logger.info(s"Successfully completed groupBy upload for '${metadata.name}' for day: ${range.end}")
   }
 

--- a/spark/src/main/scala/ai/chronon/spark/kv_store/KVUploadNodeRunner.scala
+++ b/spark/src/main/scala/ai/chronon/spark/kv_store/KVUploadNodeRunner.scala
@@ -89,10 +89,15 @@ class KVUploadNodeRunner(api: Api) extends NodeRunner {
     }
 
     val startTime = System.currentTimeMillis()
+
     logger.info(s"Starting KV upload for GroupBy: $groupByName, partition: $partitionString, table: $offlineTable")
 
     try {
       val kvStore = api.genKvStore
+      // For PUSH GroupBys, entity rows are redundant (Flink reads from Iceberg),
+      // but bulkPut also transfers the GroupByServingInfo metadata row which is
+      // needed by the Flink job and fetcher. Skipping entity rows requires
+      // row-level filtering in bulkPut — deferred to a follow-up.
       kvStore.bulkPut(offlineTable, groupByName, partitionString)
 
       val duration = (System.currentTimeMillis() - startTime) / 1000

--- a/spark/src/main/scala/ai/chronon/spark/kv_store/KVUploadNodeRunner.scala
+++ b/spark/src/main/scala/ai/chronon/spark/kv_store/KVUploadNodeRunner.scala
@@ -94,10 +94,6 @@ class KVUploadNodeRunner(api: Api) extends NodeRunner {
 
     try {
       val kvStore = api.genKvStore
-      // For PUSH GroupBys, entity rows are redundant (Flink reads from Iceberg),
-      // but bulkPut also transfers the GroupByServingInfo metadata row which is
-      // needed by the Flink job and fetcher. Skipping entity rows requires
-      // row-level filtering in bulkPut — deferred to a follow-up.
       kvStore.bulkPut(offlineTable, groupByName, partitionString)
 
       val duration = (System.currentTimeMillis() - startTime) / 1000

--- a/spark/src/test/scala/ai/chronon/spark/groupby/GigaTileUploadIntegrationTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/groupby/GigaTileUploadIntegrationTest.scala
@@ -1,0 +1,271 @@
+package ai.chronon.spark.groupby
+
+import ai.chronon.aggregator.row.RowAggregator
+import ai.chronon.aggregator.test.{Column, NaiveAggregator}
+import ai.chronon.aggregator.windowing._
+import ai.chronon.api.Extensions._
+import ai.chronon.api.ScalaJavaConversions._
+import ai.chronon.api._
+import ai.chronon.online.{GigaTileCodec, InMemoryKvStore}
+import ai.chronon.online.serde.{AvroCodec, AvroConversions, ArrayRow}
+import ai.chronon.spark.Extensions.DataframeOps
+import ai.chronon.spark.GroupByUpload
+import ai.chronon.spark.catalog.TableUtils
+import ai.chronon.spark.utils.{DataFrameGen, MockApi, OnlineUtils, SparkTestBase}
+import com.google.gson.Gson
+import org.junit.Assert._
+import org.scalatest.matchers.should.Matchers
+import org.slf4j.LoggerFactory
+
+/** End-to-end test: Spark GroupByUpload → upload table → read back value_bytes →
+  * GigaTileCodec.decodeBatchIr → GigaTileStreamProcessor → finalized vectors.
+  *
+  * Validates the Spark→Flink handoff: that Avro bytes written by GroupByUpload are
+  * correctly decoded by the Flink-side GigaTileCodec, and that the serving info
+  * reaches KV for PUSH GroupBys.
+  */
+class GigaTileUploadIntegrationTest extends SparkTestBase with Matchers {
+  @transient lazy val logger = LoggerFactory.getLogger(getClass)
+  val gson = new Gson
+
+  private val tableUtils = TableUtils(spark)
+  private val createdDatabases = scala.collection.mutable.Set[String]()
+
+  private def testNamespace(suffix: String): String = {
+    val uuid = java.util.UUID.randomUUID().toString.replace("-", "").take(8)
+    val ns = s"giga_upload_test_${suffix}_${uuid}"
+    createdDatabases.add(ns)
+    ns
+  }
+
+  override def afterAll(): Unit = {
+    createdDatabases.foreach { db =>
+      try { spark.sql(s"DROP DATABASE IF EXISTS $db CASCADE") }
+      catch { case e: Exception => logger.warn(s"Failed to drop database $db", e) }
+    }
+    super.afterAll()
+  }
+
+  val TailBufferMillis: Long = new Window(2, TimeUnit.DAYS).millis
+  val Epsilon = 1e-6
+
+  def approxEqual(a: Any, b: Any): Boolean = (a, b) match {
+    case (null, null)            => true
+    case (null, _) | (_, null)   => false
+    case (x: Double, y: Double)  => Math.abs(x - y) <= Epsilon * Math.max(1.0, Math.max(Math.abs(x), Math.abs(y)))
+    case (x: Array[_], y: Array[_]) =>
+      x.length == y.length && x.zip(y).forall { case (a, b) => approxEqual(a, b) }
+    case _ => a == b
+  }
+
+  it should "decode GroupByUpload value_bytes through GigaTileCodec and match naive" in {
+    val namespace = testNamespace("decode_upload")
+    val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
+    val yesterday = tableUtils.partitionSpec.before(today)
+    spark.sql(s"CREATE DATABASE IF NOT EXISTS $namespace")
+    tableUtils.sql(s"USE $namespace")
+
+    // Generate events
+    val eventsTable = "events_giga_upload"
+    val eventSchema = List(
+      Column("user", StringType, 10),
+      Column("amount", DoubleType, 500),
+      Column("count_val", LongType, 100)
+    )
+    val eventDf = DataFrameGen.events(spark, eventSchema, count = 5000, partitions = 14)
+    eventDf.save(s"$namespace.$eventsTable")
+
+    // GroupBy with mixed small + large windows
+    val windows = Seq(
+      new Window(6, TimeUnit.HOURS),
+      new Window(1, TimeUnit.DAYS),
+      new Window(2, TimeUnit.DAYS),
+      new Window(3, TimeUnit.DAYS),
+      new Window(7, TimeUnit.DAYS)
+    )
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM, "amount", windows),
+      Builders.Aggregation(Operation.COUNT, "count_val", windows)
+    )
+    val groupByConf = Builders.GroupBy(
+      sources = Seq(Builders.Source.events(Builders.Query(), table = eventsTable)),
+      keyColumns = Seq("user"),
+      aggregations = aggregations,
+      metaData = Builders.MetaData(namespace = namespace, name = "giga_upload_e2e"),
+      accuracy = Accuracy.TEMPORAL
+    )
+    // Set PUSH strategy
+    groupByConf.setOnlineStrategy(OnlineStrategy.PUSH)
+
+    // Use a batchEnd 2 days before today so there are streaming events post-batchEnd.
+    // GroupByUpload uses endDs as the partition, batchEnd = endDs + 1 day.
+    val twoDaysAgo = tableUtils.partitionSpec.before(yesterday)
+
+    // Step 1: Run GroupByUpload — writes to upload table
+    GroupByUpload.run(groupByConf, endDs = twoDaysAgo, tableUtilsOpt = Some(tableUtils))
+
+    // Step 2: Read value_bytes and key_bytes from upload table (simulating Iceberg source)
+    val uploadTable = groupByConf.metaData.uploadTable
+    logger.info(s"Reading upload table: $uploadTable")
+    val fullDf = tableUtils.loadTable(uploadTable)
+    logger.info(s"Upload table total rows: ${fullDf.count()}, columns: ${fullDf.columns.mkString(", ")}")
+    logger.info(s"key_json distinct values: ${fullDf.select("key_json").distinct().collect().map(_.getString(0)).mkString("|")}")
+    fullDf.show(5, truncate = false)
+    val uploadDf = fullDf.where(s"key_json IS NULL OR key_json != '${Constants.GroupByServingInfoKey}'")
+      .select("key_bytes", "value_bytes")
+    val uploadRows = uploadDf.collect()
+    logger.info(s"Entity rows (excluding serving info): ${uploadRows.length}")
+    assertTrue(s"Upload table should have entity rows, got ${uploadRows.length}", uploadRows.length > 0)
+    logger.info(s"Upload table has ${uploadRows.length} entity rows")
+
+    // Step 3: Decode value_bytes through GigaTileCodec (same path as BatchIrRowDecoder)
+    val inputSchema: Seq[(String, DataType)] = Seq("amount" -> DoubleType, "count_val" -> LongType)
+    val gigaCodec = new GigaTileCodec(groupByConf, inputSchema)
+
+    // Pick a few entities to test
+    val testEntities = uploadRows.take(5)
+    for (row <- testEntities) {
+      val valueBytes = row.getAs[Array[Byte]]("value_bytes")
+      assertNotNull("value_bytes should not be null", valueBytes)
+      assertTrue("value_bytes should be non-empty", valueBytes.length > 0)
+
+      // Decode — this is the critical path: Spark-written Avro → Flink-side decode
+      val batchIr = gigaCodec.decodeBatchIr(valueBytes)
+      assertNotNull("decoded FinalBatchIr should not be null", batchIr)
+      assertNotNull("collapsed should not be null", batchIr.collapsed)
+      assertNotNull("tailHops should not be null", batchIr.tailHops)
+
+      // Round-trip: encode → decode should preserve structure
+      val reEncoded = gigaCodec.encodeBatchIr(batchIr)
+      val reDecoded = gigaCodec.decodeBatchIr(reEncoded)
+      assertEquals("collapsed length", batchIr.collapsed.length, reDecoded.collapsed.length)
+      assertEquals("tailHops length", batchIr.tailHops.length, reDecoded.tailHops.length)
+    }
+
+    // Step 4: Pick one entity, feed through GigaTileStreamProcessor, verify against naive
+    val megaTileAgg = new MegaTileAggregator(aggregations, inputSchema, tailBufferMillis = TailBufferMillis)
+    val store = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, store)
+
+    // Decode one entity's batch IR
+    val entityRow = testEntities(0)
+    val entityBatchIr = gigaCodec.decodeBatchIr(entityRow.getAs[Array[Byte]]("value_bytes"))
+
+    // Decode entity key to identify which events belong to this entity
+    val keyBytes = entityRow.getAs[Array[Byte]]("key_bytes")
+    val keyCodec = AvroCodec.of(
+      AvroConversions.fromChrononSchema(
+        ai.chronon.api.StructType.from("Key", Array(("user", StringType)))).toString())
+    val keyRecord = keyCodec.decode(keyBytes)
+    val keyConverter = AvroConversions.genericRecordToChrononRowConverter(
+      ai.chronon.api.StructType.from("Key", Array(("user", StringType))))
+    val entityKey = keyConverter(keyRecord)(0).toString
+
+    // batchEnd = endDs + 1 day (after(endDs) convention)
+    val batchEnd = {
+      val fmt = new java.text.SimpleDateFormat("yyyy-MM-dd")
+      fmt.setTimeZone(java.util.TimeZone.getTimeZone("UTC"))
+      fmt.parse(twoDaysAgo).getTime + 24 * 3600 * 1000L
+    }
+
+    // Load batch IR into processor
+    processor.onBatchUpdate(entityBatchIr, batchEnd, batchEnd)
+
+    // Read all events for this entity from the source table
+    val entityEventsDf = tableUtils.sql(
+      s"SELECT ts, amount, count_val FROM $namespace.$eventsTable WHERE user = '$entityKey'")
+    val entityEvents = entityEventsDf.collect()
+      .map { r =>
+        val ts = r.getAs[Long]("ts")
+        val amount = r.getAs[Any]("amount") match {
+          case d: Double => d
+          case l: Long   => l.toDouble
+          case null      => null
+        }
+        val countVal = r.getAs[Any]("count_val") match {
+          case l: Long => l
+          case i: Int  => i.toLong
+          case null    => null
+        }
+        new ArrayRow(Array(amount, countVal), ts): ai.chronon.api.Row
+      }
+      .sortBy(_.ts)
+
+    // Flink processes ALL events from Kafka (including pre-batchEnd).
+    // Small windows are fully covered by tiles — batchEnd only matters for large windows.
+    val streamingEvents = entityEvents
+    for (event <- streamingEvents) {
+      processor.advanceWatermark(event.ts)
+      processor.onEvent(event, event.ts)
+    }
+
+    // Query at a point after all events
+    val queryTs = if (streamingEvents.nonEmpty) streamingEvents.map(_.ts).max + 1000L
+                  else batchEnd + 3600 * 1000L
+    // Run eviction at queryTs — always emits because irEqual default is always-mismatch
+    processor.advanceWatermark(queryTs)
+    val evictResult = processor.onEviction(queryTs)
+    assertNotNull("eviction should produce a finalized vector", evictResult.finalizedVector)
+    val gigaResult = evictResult.finalizedVector
+
+    // Compute naive expected result
+    val unpackedParts = aggregations.flatMap(_.unpack)
+    val unpacked = unpackedParts.map(_.window).toArray
+    val tailHops = unpacked.map(w => FiveMinuteResolution.calculateTailHop(w))
+    val rowAgg = new RowAggregator(inputSchema, unpackedParts)
+    val naiveAgg = new NaiveAggregator(rowAgg, unpacked, tailHops)
+    val naiveResult = naiveAgg.aggregate(entityEvents, Seq(queryTs)).map(ir => rowAgg.finalize(ir))
+
+    // Compare
+    assertNotNull("giga result should not be null", gigaResult)
+    logger.info(s"Entity=$entityKey events=${entityEvents.length} streaming=${streamingEvents.length}")
+    logger.info(s"Giga:  ${gson.toJson(gigaResult)}")
+    logger.info(s"Naive: ${gson.toJson(naiveResult(0))}")
+    assertTrue(s"Giga tile result should match naive for entity=$entityKey",
+               approxEqual(gigaResult, naiveResult(0)))
+  }
+
+  it should "write serving info to KV for PUSH GroupBys via GroupByUpload" in {
+    val namespace = testNamespace("serving_info_kv")
+    val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
+    val yesterday = tableUtils.partitionSpec.before(today)
+    spark.sql(s"CREATE DATABASE IF NOT EXISTS $namespace")
+    tableUtils.sql(s"USE $namespace")
+
+    val eventsTable = "events_serving_info"
+    val eventSchema = List(Column("user", StringType, 5), Column("amount", DoubleType, 100))
+    val eventDf = DataFrameGen.events(spark, eventSchema, count = 500, partitions = 7)
+    eventDf.save(s"$namespace.$eventsTable")
+
+    val groupByConf = Builders.GroupBy(
+      sources = Seq(Builders.Source.events(Builders.Query(), table = eventsTable)),
+      keyColumns = Seq("user"),
+      aggregations = Seq(Builders.Aggregation(Operation.SUM, "amount", Seq(new Window(1, TimeUnit.DAYS)))),
+      metaData = Builders.MetaData(namespace = namespace, name = "giga_serving_info_e2e"),
+      accuracy = Accuracy.TEMPORAL
+    )
+    groupByConf.setOnlineStrategy(OnlineStrategy.PUSH)
+
+    // Build an API with InMemoryKvStore
+    val inMemoryKvStore = OnlineUtils.buildInMemoryKVStore(s"giga_serving_info_test")
+    val mockApi = new MockApi(() => inMemoryKvStore, namespace)
+
+    // Run upload with API — should write serving info directly to KV for PUSH
+    GroupByUpload.run(groupByConf, endDs = yesterday, tableUtilsOpt = Some(tableUtils),
+                      apiOpt = Some(mockApi))
+
+    // Verify serving info is in KV
+    val dataset = groupByConf.batchDataset
+    val servingInfoKey = Constants.GroupByServingInfoKey.getBytes(Constants.UTF8)
+    val getRequest = ai.chronon.online.KVStore.GetRequest(servingInfoKey, dataset)
+    val response = scala.concurrent.Await.result(inMemoryKvStore.get(getRequest), scala.concurrent.duration.Duration(10, "s"))
+    assertTrue("serving info should be in KV", response.values.isSuccess)
+    assertTrue("serving info should have bytes", response.values.get.nonEmpty)
+
+    val servingInfoBytes = response.latest.get.bytes
+    val servingInfoJson = new String(servingInfoBytes, Constants.UTF8)
+    assertTrue("serving info should contain groupBy name",
+               servingInfoJson.contains("giga_serving_info_e2e"))
+    logger.info(s"Serving info written to KV: ${servingInfoJson.take(200)}...")
+  }
+}

--- a/thrift/api.thrift
+++ b/thrift/api.thrift
@@ -279,7 +279,8 @@ enum Accuracy {
 
 enum OnlineStrategy {
     DEFAULT = 0,
-    STREAMING_MEGATILES = 1
+    STREAMING_MEGATILES = 1,
+    PUSH = 2
 }
 
 enum EngineType {


### PR DESCRIPTION
## Summary

Push-based architecture: Flink produces finalized feature vectors per entity. Fetcher does a single point get with zero compute.

### Design doc (gigatile.md)
- Full architecture: batch IR from Iceberg connected stream, `runningLargeIr` (batch + streaming merged), finalized vector emit
- Scenario tables, entity matrix, startup/bootstrap analysis, cost model

### Step 1: Core processor (aggregator module)
- **GigaTileStore / InMemoryGigaTileStore**: extended TileStore trait with batch IR state
- **GigaTileStreamProcessor**: `onEvent`, `onEviction`, `onBatchUpdate`, `advanceWatermark` with `runningLargeIr` management
- **stripSmallWindowHops**: prunes unused 5-min tail hops from FinalBatchIr (~36 KB/entity savings)
- **8 tests** vs NaiveAggregator: batch fresh/delayed/refresh, idle, new entity, all agg types, day transitions, multi-day gap

### Step 2: Flink wiring (thrift, api, online, flink modules)
- **OnlineStrategy.PUSH** thrift enum + `isGigaTilingEnabled`
- **GigaTileCodec**: encode finalized vectors (output schema), encode/decode FinalBatchIr (Flink state), encode windowed IR (mismatch check)
- **GigaTileProcessFunction**: `KeyedCoProcessFunction` — stream 1 = Kafka events, stream 2 = batch IR from Iceberg
- **FlinkGigaTileStore**: Flink-backed `GigaTileStore` with decode memoization for all state
- **GigaTileAvroCodecFn**: plain entity key bytes (no TileKey wrapper)
- Pipeline wiring: `buildGigaTiledTail` connects event + batch streams

### Step 3: Iceberg connected stream
- **iceberg-flink-runtime-1.17:1.6.1** + **flink-table-common** dependencies
- **BatchIrSourceBuilder**: Iceberg source in streaming monitor mode with `withIdleness()` watermark. Graceful fallback to idle stream when Iceberg is not configured.
- **BatchIrRowDecoder**: RowData → BatchIrRow (decode key_bytes → entity key)

### Step 4: Fetcher simplification
- **GroupByFetcher**: PUSH → single `GetRequest(entityKeyBytes, dataset)`, no batch KV read
- **GroupByResponseHandler**: PUSH → `outputCodec.decodeMap(latest.bytes)`, no merge logic

Stacked on megatile PR.

## Test plan

- [x] `./mill aggregator.test.testOnly "ai.chronon.aggregator.test.GigaTileStreamProcessorTest"` — 8/8 pass
- [x] `./mill aggregator.test.testOnly "ai.chronon.aggregator.test.MegaTileStreamProcessorTest"` — 7/7 pass
- [x] `./mill aggregator.test.testOnly "ai.chronon.aggregator.test.MegaTileAggregatorTest"` — 6/6 pass
- [x] `./mill flink.compile` — clean
- [x] `./mill online.compile` — clean
- [x] `./mill api.compile` — clean