### PR TITLE
fix source types for list invariance

### DIFF
--- a/python/src/ai/chronon/group_by.py
+++ b/python/src/ai/chronon/group_by.py
@@ -15,6 +15,7 @@
 import inspect
 import json
 import logging
+from collections.abc import Sequence
 from copy import deepcopy
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
@@ -412,7 +413,7 @@ def get_output_col_names(aggregation):
 
 
 def GroupBy(
-    sources: Union[List[utils.ANY_SOURCE_TYPE], utils.ANY_SOURCE_TYPE],
+    sources: Union[Sequence[utils.ANY_SOURCE_TYPE], utils.ANY_SOURCE_TYPE],
     keys: List[str],
     aggregations: Optional[List[ttypes.Aggregation]],
     version: Optional[int] = None,
@@ -460,7 +461,7 @@ def GroupBy(
 
         Multiple sources can be supplied to backfill the historical values with their respective start and end
         partitions. However, only one source is allowed to be a streaming one.
-    :type sources: List[gen_thrift.api.ttypes.Events|gen_thrift.api.ttypes.Entities]
+    :type sources: List of sources or a single source
     :param keys:
         List of primary keys that defines the data that needs to be collected in the result table. Similar to the
         GroupBy in the SQL context.
@@ -607,11 +608,9 @@ def GroupBy(
             )
         return source
 
-    if not isinstance(sources, list):
-        sources = [sources]
-
     sources = [
-        _sanitize_columns(utils.normalize_source(source, output_namespace)) for source in sources
+        _sanitize_columns(source)
+        for source in utils.normalize_sources(sources, output_namespace)
     ]
 
     # get caller's filename to assign team

--- a/python/src/ai/chronon/model.py
+++ b/python/src/ai/chronon/model.py
@@ -1,4 +1,5 @@
 import inspect
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Union
 
@@ -7,7 +8,7 @@ import gen_thrift.common.ttypes as common
 from ai.chronon import utils
 from ai.chronon import windows as window_utils
 from ai.chronon.data_types import DataType, FieldsType
-from ai.chronon.utils import ANY_SOURCE_TYPE, normalize_source
+from ai.chronon.utils import ANY_SOURCE_TYPE, normalize_source, normalize_sources
 
 
 class ModelBackend:
@@ -301,7 +302,7 @@ def _get_model_transforms_output_table_name(
 
 
 def ModelTransforms(
-    sources: List[ANY_SOURCE_TYPE],
+    sources: Sequence[ANY_SOURCE_TYPE],
     models: List[ttypes.Model],
     version: int,
     passthrough_fields: Optional[List[str]] = None,
@@ -338,7 +339,7 @@ def ModelTransforms(
                 utils.__set_name(model, ttypes.Model, "models")
 
     # Normalize all sources to ensure they are properly wrapped
-    normalized_sources = [normalize_source(source) for source in sources]
+    normalized_sources = normalize_sources(sources)
 
     # Create metadata
     meta_data = ttypes.MetaData(

--- a/python/src/ai/chronon/utils.py
+++ b/python/src/ai/chronon/utils.py
@@ -69,12 +69,18 @@ def normalize_sources(
     sources: Union[Sequence[ANY_SOURCE_TYPE], ANY_SOURCE_TYPE], output_namespace: str = None
 ) -> List[api.Source]:
     """Convert a source or source sequence into wrapped api.Source objects."""
-    if isinstance(sources, get_args(ANY_SOURCE_TYPE)):
+    source_types = get_args(ANY_SOURCE_TYPE)
+
+    if isinstance(sources, source_types):
         sources = [sources]
-    elif isinstance(sources, Sequence):
-        sources = list(sources)
-    else:
+    elif not isinstance(sources, Sequence):
         raise TypeError("sources must be a source or a sequence of sources")
+
+    for index, source in enumerate(sources):
+        if not isinstance(source, source_types):
+            raise TypeError(
+                f"sources[{index}] must be a supported source type, got {type(source).__name__}"
+            )
 
     return [normalize_source(source, output_namespace) for source in sources]
 

--- a/python/src/ai/chronon/utils.py
+++ b/python/src/ai/chronon/utils.py
@@ -20,8 +20,8 @@ import re
 import shutil
 import subprocess
 import tempfile
-from collections.abc import Iterable
-from typing import List, Optional, Union, cast
+from collections.abc import Iterable, Sequence
+from typing import List, Optional, Union, cast, get_args
 
 import ai.chronon.repo.extract_objects as eo
 import gen_thrift.api.ttypes as api
@@ -63,6 +63,20 @@ def normalize_source(source: ANY_SOURCE_TYPE, output_namespace: str = None) -> a
             return source
     else:
         print("unrecognized " + str(source))
+
+
+def normalize_sources(
+    sources: Union[Sequence[ANY_SOURCE_TYPE], ANY_SOURCE_TYPE], output_namespace: str = None
+) -> List[api.Source]:
+    """Convert a source or source sequence into wrapped api.Source objects."""
+    if isinstance(sources, get_args(ANY_SOURCE_TYPE)):
+        sources = [sources]
+    elif isinstance(sources, Sequence):
+        sources = list(sources)
+    else:
+        raise TypeError("sources must be a source or a sequence of sources")
+
+    return [normalize_source(source, output_namespace) for source in sources]
 
 
 def edit_distance(str1, str2):

--- a/python/test/test_group_by.py
+++ b/python/test/test_group_by.py
@@ -217,6 +217,23 @@ def test_select_sanitization():
     )
 
 
+def test_tuple_sources_are_normalized():
+    gb = group_by.GroupBy(
+        sources=(event_source("event_table1"), event_source("event_table2")),
+        keys=["subject"],
+        aggregations=group_by.Aggregations(
+            event_id=ttypes.Aggregation(operation=ttypes.Operation.LAST),
+            cnt=ttypes.Aggregation(operation=ttypes.Operation.COUNT),
+        ),
+        version=0,
+    )
+
+    assert [source.events.table for source in gb.sources] == [
+        "event_table1",
+        "event_table2",
+    ]
+
+
 def test_snapshot_with_hour_aggregation():
     with pytest.raises(AssertionError):
         group_by.GroupBy(

--- a/python/test/test_utils.py
+++ b/python/test/test_utils.py
@@ -113,6 +113,11 @@ def test_dedupe_in_order():
     assert utils.dedupe_in_order([2, 1, 3, 1, 3, 2]) == [2, 1, 3]
 
 
+def test_normalize_sources_rejects_invalid_element():
+    with pytest.raises(TypeError, match=r"sources\[1\] must be a supported source type, got int"):
+        utils.normalize_sources([api.EventSource(), 123])
+
+
 def test_get_applicable_mode_for_group_bys(
     group_by_requiring_backfill, online_group_by_requiring_streaming
 ):


### PR DESCRIPTION
## Summary

Python lists are invariant, so if we have a case of `List[EventSource]` that does not  meet the requirement for `list[EventSource | EntitySource | etc]`. `Sequence` is covariant so it would match. 

Swapping from `List` to `Sequence` and then normalizing down to the `List[api.Source]` type post-call. Added a check against the expanded `Tuple` case as well. 

## Checklist
- [x] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Source parameters now accept any sequence type (e.g., tuples) in addition to lists.

* **Bug Fixes**
  * Centralized source normalization preserves iteration order and handles single vs. multiple sources consistently.
  * Validation now reports indexed errors for invalid sequence elements.

* **Tests**
  * Added tests verifying sequence normalization, ordering, and invalid-element error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->