### PR TITLE
Update GroupBy aggregation methods for types and docstrings

### DIFF
--- a/python/src/ai/chronon/group_by.py
+++ b/python/src/ai/chronon/group_by.py
@@ -16,7 +16,7 @@ import inspect
 import json
 import logging
 from copy import deepcopy
-from typing import Callable, Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import ai.chronon.utils as utils
 import ai.chronon.windows as window_utils
@@ -24,6 +24,7 @@ import gen_thrift.api.ttypes as ttypes
 import gen_thrift.common.ttypes as common
 
 OperationType = int  # type(zthrift.Operation.FIRST)
+OperationWithArgs = Tuple[ttypes.Operation, Dict[str, str]]
 
 
 def _get_output_table_name(obj, full_name: bool = False):
@@ -48,19 +49,9 @@ LOGGER = logging.getLogger()
 
 def collector(
     op: ttypes.Operation,
-) -> Callable[[int], Tuple[ttypes.Operation, Dict[str, str]]]:
-    return lambda k: (op, {"k": str(k)})
-
-
-def generic_collector(op: ttypes.Operation, required, **kwargs):
-    def _collector(*args, **other_args):
-        arguments = kwargs.copy() if kwargs else {}
-        for idx, arg in enumerate(required):
-            arguments[arg] = args[idx]
-        arguments.update(other_args)
-        return (op, {k: str(v) for k, v in arguments.items()})
-
-    return _collector
+    k: int,
+) -> OperationWithArgs:
+    return (op, {"k": str(k)})
 
 
 # To simplify imports
@@ -84,11 +75,17 @@ class Operation:
     APPROX_UNIQUE_COUNT = ttypes.Operation.APPROX_UNIQUE_COUNT
     """Approximate count of unique values using CPC (Compressed Probability Counting) sketch"""
 
-    APPROX_UNIQUE_COUNT_LGK = collector(ttypes.Operation.APPROX_UNIQUE_COUNT)
-    """Configurable approximate unique count with lgK parameter for sketch size tuning.
-    Default lgK is 8. See CpcSketch.java for accuracy vs size tradeoffs:
-    https://github.com/apache/incubator-datasketches-java/blob/master/src/main/java/org/apache/datasketches/cpc/CpcSketch.java#L180
-    """
+    @staticmethod
+    def APPROX_UNIQUE_COUNT_LGK(k: int) -> OperationWithArgs:
+        """
+        Configurable approximate unique count with lgK parameter for sketch size tuning.
+
+        :param k: lgK sketch parameter. Larger values use more memory and improve approximation accuracy.
+
+        Default lgK is 8. See CpcSketch.java for accuracy vs size tradeoffs:
+        https://github.com/apache/incubator-datasketches-java/blob/master/src/main/java/org/apache/datasketches/cpc/CpcSketch.java#L180
+        """
+        return collector(ttypes.Operation.APPROX_UNIQUE_COUNT, k)
 
     UNIQUE_COUNT = ttypes.Operation.UNIQUE_COUNT
     """
@@ -117,44 +114,105 @@ class Operation:
     HISTOGRAM = ttypes.Operation.HISTOGRAM
     """Full frequency distribution of values"""
 
-    FREQUENT_K = collector(ttypes.Operation.HISTOGRAM)
-    """
-    !! Could be expensive if the cardinality of the column is high !!
-    Computes columns values that are frequent in the input column exactly.
-    Produces a map of items as keys and counts as values.
-    """
+    @staticmethod
+    def FREQUENT_K(k: int) -> OperationWithArgs:
+        """
+        Computes column values that are frequent in the input column exactly.
 
-    APPROX_FREQUENT_K = collector(ttypes.Operation.APPROX_FREQUENT_K)
-    """
-    Computes columns values that are frequent in the input column approximately.
-    Produces a map of items as keys and counts as values approximately.
-    """
+        :param k: Maximum number of frequent values to retain in the output map.
 
-    APPROX_HEAVY_HITTERS_K = collector(ttypes.Operation.APPROX_HEAVY_HITTERS_K)
-    """
-    Computes column values that are skewed in the input column.
-    Produces a map of items as keys and counts as values approximately.
-    Different from APPROX_FREQUENT_K in that it only retains if a value is abnormally
-    more frequent.
-    """
+        Warning: Could be expensive if the cardinality of the column is high.
+        Produces a map of items as keys and counts as values.
+        """
+        return collector(ttypes.Operation.HISTOGRAM, k)
 
-    FIRST_K = collector(ttypes.Operation.FIRST_K)
-    """Returns first k input column values by time column"""
+    @staticmethod
+    def APPROX_FREQUENT_K(k: int) -> OperationWithArgs:
+        """
+        Computes column values that are frequent in the input column approximately.
 
-    LAST_K = collector(ttypes.Operation.LAST_K)
-    """Returns last k input column values by time column"""
+        :param k: Maximum number of frequent values to retain in the output map.
 
-    TOP_K = collector(ttypes.Operation.TOP_K)
-    """Returns k largest values of the input column. Input needs to be sortable."""
+        Produces a map of items as keys and counts as values approximately.
+        """
+        return collector(ttypes.Operation.APPROX_FREQUENT_K, k)
 
-    BOTTOM_K = collector(ttypes.Operation.BOTTOM_K)
-    """Returns k smallest values of the input column"""
+    @staticmethod
+    def APPROX_HEAVY_HITTERS_K(k: int) -> OperationWithArgs:
+        """
+        Computes column values that are skewed in the input column.
 
-    UNIQUE_TOP_K = collector(ttypes.Operation.UNIQUE_TOP_K)
-    """Returns top k unique elements ranked by their values. Automatically deduplicates inputs. For structs, requires sort_key (String) and unique_id (Long) fields."""
+        :param k: Maximum number of heavy hitters to retain in the output map.
 
-    APPROX_PERCENTILE = generic_collector(ttypes.Operation.APPROX_PERCENTILE, ["percentiles"], k=20)
-    """Approximate percentile calculation with configurable accuracy parameter k=20"""
+        Produces a map of items as keys and counts as values approximately.
+        Different from APPROX_FREQUENT_K in that it only retains if a value is abnormally
+        more frequent.
+        """
+        return collector(ttypes.Operation.APPROX_HEAVY_HITTERS_K, k)
+
+    @staticmethod
+    def FIRST_K(k: int) -> OperationWithArgs:
+        """
+        Returns first k input column values by time column.
+
+        :param k: Number of earliest values to return.
+        """
+        return collector(ttypes.Operation.FIRST_K, k)
+
+    @staticmethod
+    def LAST_K(k: int) -> OperationWithArgs:
+        """
+        Returns last k input column values by time column.
+
+        :param k: Number of latest values to return.
+        """
+        return collector(ttypes.Operation.LAST_K, k)
+
+    @staticmethod
+    def TOP_K(k: int) -> OperationWithArgs:
+        """
+        Returns k largest values of the input column.
+
+        :param k: Number of largest values to return.
+        """
+        return collector(ttypes.Operation.TOP_K, k)
+
+    @staticmethod
+    def BOTTOM_K(k: int) -> OperationWithArgs:
+        """
+        Returns k smallest values of the input column.
+
+        :param k: Number of smallest values to return.
+        """
+        return collector(ttypes.Operation.BOTTOM_K, k)
+
+    @staticmethod
+    def UNIQUE_TOP_K(k: int) -> OperationWithArgs:
+        """
+        Returns top k unique elements ranked by their values.
+
+        :param k: Number of unique top-ranked values to return.
+
+        Automatically deduplicates inputs. For structs, requires sort_key (String)
+        and unique_id (Long) fields.
+        """
+        return collector(ttypes.Operation.UNIQUE_TOP_K, k)
+
+    @staticmethod
+    def APPROX_PERCENTILE(
+        percentiles: Union[List[float], str],
+        k: int = 20,
+    ) -> OperationWithArgs:
+        """
+        Approximate percentile calculation over the input column.
+
+        :param percentiles: Quantiles to compute as values between 0 and 1.
+        :param k: KLL sketch parameter. Larger values use more memory and improve approximation accuracy.
+        """
+        return (
+            ttypes.Operation.APPROX_PERCENTILE,
+            {"k": str(k), "percentiles": str(percentiles)},
+        )
 
 
 def Aggregations(**agg_dict):
@@ -201,7 +259,7 @@ def op_to_str(operation: OperationType):
 # See docs/Aggregations.md
 def Aggregation(
     input_column: str = None,
-    operation: Union[ttypes.Operation, Tuple[ttypes.Operation, Dict[str, str]]] = None,
+    operation: Union[ttypes.Operation, OperationWithArgs] = None,
     windows: Union[List[common.Window], List[str]] = None,
     buckets: List[str] = None,
     tags: Dict[str, str] = None,


### PR DESCRIPTION
## Summary

Currently the Operation types are invalid or return `Any` in editors as reassignment back to a constant is a little unclear. This change:

- Uses static methods where factory methods were getting assigned to constructors. This allows for complete docstrings over the param set, and a little bit more comprehensive typing. 
- Drops `generic_collector`, it was only being used for the `APPROX_PERCENTILE` case but that case is best handled as a one-off as then we can type the input args. 

## Checklist
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Operation configuration API simplified to use explicit static-style constructors for configurable operations, improving discoverability.
  * Aggregation parameter types clarified to accept a consistent operation-plus-arguments pair, reducing ambiguity.
  * Internal operation-building logic streamlined for more predictable behavior and easier maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->