### PR TITLE
CTRL-97 - Default offline_schedule to None for Join

### DIFF
--- a/python/src/ai/chronon/join.py
+++ b/python/src/ai/chronon/join.py
@@ -314,7 +314,7 @@ def Join(
     consistency_sample_percent: float = 5.0,
     use_long_names: bool = False,
     # execution params
-    offline_schedule: str = "@daily",
+    offline_schedule: str = None,
     online_schedule: str = None,
     historical_backfill: bool = None,
     conf: common.ConfigProperties = None,

--- a/python/test/canary/compiled/group_bys/aws/user_activities_chained.chained_user_gb__0
+++ b/python/test/canary/compiled/group_bys/aws/user_activities_chained.chained_user_gb__0
@@ -109,11 +109,10 @@
           }
         }
       },
-      "historicalBackfill": 0,
-      "onlineSchedule": "@daily"
+      "historicalBackfill": 0
     },
     "name": "aws.user_activities_chained.chained_user_gb__0",
-    "online": 1,
+    "online": 0,
     "outputNamespace": "data",
     "sourceFile": "group_bys/aws/user_activities_chained.py",
     "team": "aws",
@@ -188,7 +187,6 @@
           },
           "metaData": {
             "executionInfo": {
-              "offlineSchedule": "@daily",
               "onlineSchedule": "@daily"
             },
             "name": "aws.demo_parent.parent_join__0",

--- a/python/test/canary/compiled/joins/aws/demo.derivations_v1__2
+++ b/python/test/canary/compiled/joins/aws/demo.derivations_v1__2
@@ -873,7 +873,6 @@
           }
         }
       },
-      "offlineSchedule": "@daily",
       "onlineSchedule": "@daily",
       "stepDays": 30
     },

--- a/python/test/canary/compiled/joins/aws/demo.v1__1
+++ b/python/test/canary/compiled/joins/aws/demo.v1__1
@@ -973,7 +973,6 @@
           }
         }
       },
-      "offlineSchedule": "@daily",
       "onlineSchedule": "@daily",
       "stepDays": 30
     },

--- a/python/test/canary/compiled/joins/aws/demo_chaining.downstream_join__0
+++ b/python/test/canary/compiled/joins/aws/demo_chaining.downstream_join__0
@@ -111,11 +111,10 @@
                 }
               }
             },
-            "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "historicalBackfill": 0
           },
           "name": "aws.user_activities_chained.chained_user_gb__0",
-          "online": 1,
+          "online": 0,
           "outputNamespace": "data",
           "team": "aws",
           "version": "0"
@@ -189,7 +188,6 @@
                 },
                 "metaData": {
                   "executionInfo": {
-                    "offlineSchedule": "@daily",
                     "onlineSchedule": "@daily"
                   },
                   "name": "aws.demo_parent.parent_join__0",
@@ -329,12 +327,10 @@
             "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
           }
         }
-      },
-      "offlineSchedule": "@daily",
-      "onlineSchedule": "@daily"
+      }
     },
     "name": "aws.demo_chaining.downstream_join__0",
-    "online": 1,
+    "online": 0,
     "outputNamespace": "data",
     "production": 0,
     "samplePercent": 100.0,

--- a/python/test/canary/compiled/joins/aws/demo_parent.parent_join__0
+++ b/python/test/canary/compiled/joins/aws/demo_parent.parent_join__0
@@ -277,7 +277,6 @@
           }
         }
       },
-      "offlineSchedule": "@daily",
       "onlineSchedule": "@daily"
     },
     "name": "aws.demo_parent.parent_join__0",

--- a/python/test/canary/compiled/joins/aws/item_event_join.canary_batch_v1__0
+++ b/python/test/canary/compiled/joins/aws/item_event_join.canary_batch_v1__0
@@ -315,7 +315,6 @@
           }
         }
       },
-      "offlineSchedule": "@daily",
       "onlineSchedule": "@daily"
     },
     "name": "aws.item_event_join.canary_batch_v1__0",

--- a/python/test/canary/compiled/joins/aws/item_event_join.canary_combined_v1__0
+++ b/python/test/canary/compiled/joins/aws/item_event_join.canary_combined_v1__0
@@ -497,7 +497,6 @@
           }
         }
       },
-      "offlineSchedule": "@daily",
       "onlineSchedule": "@daily"
     },
     "name": "aws.item_event_join.canary_combined_v1__0",

--- a/python/test/canary/compiled/joins/aws/item_event_join.canary_streaming_v1__0
+++ b/python/test/canary/compiled/joins/aws/item_event_join.canary_streaming_v1__0
@@ -289,7 +289,6 @@
           }
         }
       },
-      "offlineSchedule": "@daily",
       "onlineSchedule": "@daily"
     },
     "name": "aws.item_event_join.canary_streaming_v1__0",

--- a/python/test/canary/compiled/joins/aws/training_set.v1_dev__0
+++ b/python/test/canary/compiled/joins/aws/training_set.v1_dev__0
@@ -312,8 +312,7 @@
             "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
           }
         }
-      },
-      "offlineSchedule": "@daily"
+      }
     },
     "name": "aws.training_set.v1_dev__0",
     "online": 0,

--- a/python/test/canary/compiled/joins/aws/training_set.v1_hub__0
+++ b/python/test/canary/compiled/joins/aws/training_set.v1_hub__0
@@ -312,8 +312,7 @@
             "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
           }
         }
-      },
-      "offlineSchedule": "@daily"
+      }
     },
     "name": "aws.training_set.v1_hub__0",
     "online": 0,

--- a/python/test/canary/compiled/joins/aws/training_set.v1_test__0
+++ b/python/test/canary/compiled/joins/aws/training_set.v1_test__0
@@ -312,8 +312,7 @@
             "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
           }
         }
-      },
-      "offlineSchedule": "@daily"
+      }
     },
     "name": "aws.training_set.v1_test__0",
     "online": 0,

--- a/python/test/canary/compiled/joins/azure/demo.derivations_v3
+++ b/python/test/canary/compiled/joins/azure/demo.derivations_v3
@@ -206,7 +206,6 @@
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
         }
       },
-      "offlineSchedule": "@daily",
       "onlineSchedule": "@daily",
       "stepDays": 30
     },

--- a/python/test/canary/compiled/joins/azure/demo.v2
+++ b/python/test/canary/compiled/joins/azure/demo.v2
@@ -258,7 +258,6 @@
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
         }
       },
-      "offlineSchedule": "@daily",
       "onlineSchedule": "@daily",
       "stepDays": 30
     },

--- a/python/test/canary/compiled/joins/azure/demo_chaining.downstream_join__0
+++ b/python/test/canary/compiled/joins/azure/demo_chaining.downstream_join__0
@@ -234,7 +234,6 @@
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
         }
       },
-      "offlineSchedule": "@daily",
       "onlineSchedule": "@daily"
     },
     "name": "azure.demo_chaining.downstream_join__0",

--- a/python/test/canary/compiled/joins/azure/item_event_join.canary_batch_v1__0
+++ b/python/test/canary/compiled/joins/azure/item_event_join.canary_batch_v1__0
@@ -221,7 +221,6 @@
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
         }
       },
-      "offlineSchedule": "@daily",
       "onlineSchedule": "@daily"
     },
     "name": "azure.item_event_join.canary_batch_v1__0",

--- a/python/test/canary/compiled/joins/azure/item_event_join.canary_combined_v1__0
+++ b/python/test/canary/compiled/joins/azure/item_event_join.canary_combined_v1__0
@@ -356,7 +356,6 @@
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
         }
       },
-      "offlineSchedule": "@daily",
       "onlineSchedule": "@daily"
     },
     "name": "azure.item_event_join.canary_combined_v1__0",

--- a/python/test/canary/compiled/joins/azure/item_event_join.canary_streaming_v1__0
+++ b/python/test/canary/compiled/joins/azure/item_event_join.canary_streaming_v1__0
@@ -195,7 +195,6 @@
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
         }
       },
-      "offlineSchedule": "@daily",
       "onlineSchedule": "@daily"
     },
     "name": "azure.item_event_join.canary_streaming_v1__0",

--- a/python/test/canary/compiled/joins/azure/training_set.v1_dev__0
+++ b/python/test/canary/compiled/joins/azure/training_set.v1_dev__0
@@ -218,8 +218,7 @@
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
         }
-      },
-      "offlineSchedule": "@daily"
+      }
     },
     "name": "azure.training_set.v1_dev__0",
     "online": 0,

--- a/python/test/canary/compiled/joins/azure/training_set.v1_dev_notds__0
+++ b/python/test/canary/compiled/joins/azure/training_set.v1_dev_notds__0
@@ -220,8 +220,7 @@
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
         }
-      },
-      "offlineSchedule": "@daily"
+      }
     },
     "name": "azure.training_set.v1_dev_notds__0",
     "online": 0,

--- a/python/test/canary/compiled/joins/azure/training_set.v1_hub__0
+++ b/python/test/canary/compiled/joins/azure/training_set.v1_hub__0
@@ -218,8 +218,7 @@
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
         }
-      },
-      "offlineSchedule": "@daily"
+      }
     },
     "name": "azure.training_set.v1_hub__0",
     "online": 0,

--- a/python/test/canary/compiled/joins/azure/training_set.v1_test__0
+++ b/python/test/canary/compiled/joins/azure/training_set.v1_test__0
@@ -218,8 +218,7 @@
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
         }
-      },
-      "offlineSchedule": "@daily"
+      }
     },
     "name": "azure.training_set.v1_test__0",
     "online": 0,

--- a/python/test/canary/compiled/joins/azure/training_set.v1_test_notds__0
+++ b/python/test/canary/compiled/joins/azure/training_set.v1_test_notds__0
@@ -220,8 +220,7 @@
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
         }
-      },
-      "offlineSchedule": "@daily"
+      }
     },
     "name": "azure.training_set.v1_test_notds__0",
     "online": 0,

--- a/python/test/canary/compiled/joins/gcp/demo.v1__1
+++ b/python/test/canary/compiled/joins/gcp/demo.v1__1
@@ -891,7 +891,6 @@
           }
         }
       },
-      "offlineSchedule": "@daily",
       "onlineSchedule": "@daily",
       "stepDays": 30
     },

--- a/python/test/canary/compiled/joins/gcp/demo_chaining.downstream_join__0
+++ b/python/test/canary/compiled/joins/gcp/demo_chaining.downstream_join__0
@@ -289,7 +289,6 @@
           }
         }
       },
-      "offlineSchedule": "@daily",
       "onlineSchedule": "@daily"
     },
     "name": "gcp.demo_chaining.downstream_join__0",

--- a/python/test/canary/compiled/joins/gcp/item_event_join.canary_batch_v1__0
+++ b/python/test/canary/compiled/joins/gcp/item_event_join.canary_batch_v1__0
@@ -275,7 +275,6 @@
           }
         }
       },
-      "offlineSchedule": "@daily",
       "onlineSchedule": "@daily"
     },
     "name": "gcp.item_event_join.canary_batch_v1__0",

--- a/python/test/canary/compiled/joins/gcp/item_event_join.canary_combined_v1__0
+++ b/python/test/canary/compiled/joins/gcp/item_event_join.canary_combined_v1__0
@@ -437,7 +437,6 @@
           }
         }
       },
-      "offlineSchedule": "@daily",
       "onlineSchedule": "@daily"
     },
     "name": "gcp.item_event_join.canary_combined_v1__0",

--- a/python/test/canary/compiled/joins/gcp/item_event_join.canary_streaming_v1__0
+++ b/python/test/canary/compiled/joins/gcp/item_event_join.canary_streaming_v1__0
@@ -249,7 +249,6 @@
           }
         }
       },
-      "offlineSchedule": "@daily",
       "onlineSchedule": "@daily"
     },
     "name": "gcp.item_event_join.canary_streaming_v1__0",

--- a/python/test/canary/compiled/joins/gcp/training_set.v1_dev__0
+++ b/python/test/canary/compiled/joins/gcp/training_set.v1_dev__0
@@ -272,8 +272,7 @@
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
           }
         }
-      },
-      "offlineSchedule": "@daily"
+      }
     },
     "name": "gcp.training_set.v1_dev__0",
     "online": 0,

--- a/python/test/canary/compiled/joins/gcp/training_set.v1_dev_notds__0
+++ b/python/test/canary/compiled/joins/gcp/training_set.v1_dev_notds__0
@@ -274,8 +274,7 @@
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
           }
         }
-      },
-      "offlineSchedule": "@daily"
+      }
     },
     "name": "gcp.training_set.v1_dev_notds__0",
     "online": 0,

--- a/python/test/canary/compiled/joins/gcp/training_set.v1_hub__0
+++ b/python/test/canary/compiled/joins/gcp/training_set.v1_hub__0
@@ -272,8 +272,7 @@
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
           }
         }
-      },
-      "offlineSchedule": "@daily"
+      }
     },
     "name": "gcp.training_set.v1_hub__0",
     "online": 0,

--- a/python/test/canary/compiled/joins/gcp/training_set.v1_test__0
+++ b/python/test/canary/compiled/joins/gcp/training_set.v1_test__0
@@ -272,8 +272,7 @@
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
           }
         }
-      },
-      "offlineSchedule": "@daily"
+      }
     },
     "name": "gcp.training_set.v1_test__0",
     "online": 0,

--- a/python/test/canary/compiled/joins/gcp/training_set.v1_test_notds__0
+++ b/python/test/canary/compiled/joins/gcp/training_set.v1_test_notds__0
@@ -274,8 +274,7 @@
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
           }
         }
-      },
-      "offlineSchedule": "@daily"
+      }
     },
     "name": "gcp.training_set.v1_test_notds__0",
     "online": 0,

--- a/python/test/canary/compiled/joins/quickstart/demo.v1__1
+++ b/python/test/canary/compiled/joins/quickstart/demo.v1__1
@@ -1021,7 +1021,6 @@
           }
         }
       },
-      "offlineSchedule": "@daily",
       "onlineSchedule": "@daily",
       "stepDays": 5
     },

--- a/python/test/canary/compiled/model_transforms/aws/ctr.v1__1
+++ b/python/test/canary/compiled/model_transforms/aws/ctr.v1__1
@@ -770,7 +770,6 @@
           "metaData": {
             "executionInfo": {
               "enableStatsCompute": 1,
-              "offlineSchedule": "@daily",
               "onlineSchedule": "@daily",
               "stepDays": 30
             },

--- a/python/test/canary/compiled/model_transforms/aws/listing.v1__2
+++ b/python/test/canary/compiled/model_transforms/aws/listing.v1__2
@@ -751,7 +751,6 @@
           "metaData": {
             "executionInfo": {
               "enableStatsCompute": 1,
-              "offlineSchedule": "@daily",
               "onlineSchedule": "@daily",
               "stepDays": 30
             },

--- a/python/test/canary/compiled/model_transforms/gcp/listing.v1__2
+++ b/python/test/canary/compiled/model_transforms/gcp/listing.v1__2
@@ -709,7 +709,6 @@
           "metaData": {
             "executionInfo": {
               "enableStatsCompute": 1,
-              "offlineSchedule": "@daily",
               "onlineSchedule": "@daily",
               "stepDays": 30
             },

--- a/python/test/canary/group_bys/aws/user_activities_chained.py
+++ b/python/test/canary/group_bys/aws/user_activities_chained.py
@@ -11,7 +11,7 @@ include listing price information.
 chained_user_gb = GroupBy(
     sources=[demo_parent.upstream_join_source],
     keys=["user_id"],
-    online=True,
+    online=False,
     version=0,
     aggregations=[
         Aggregation(

--- a/python/test/canary/joins/aws/demo_chaining.py
+++ b/python/test/canary/joins/aws/demo_chaining.py
@@ -19,6 +19,6 @@ downstream_join = Join(
         ),
     ],
     version=0,
-    online=True,
+    online=False,
     output_namespace="data",
 )

--- a/python/test/canary/joins/gcp/demo.py
+++ b/python/test/canary/joins/gcp/demo.py
@@ -55,6 +55,7 @@ v1 = Join(
     output_namespace="data",
     step_days=30,
     enable_stats_compute=True,
+    offline_schedule="@daily"
 )
 
 # Example join with some derivations


### PR DESCRIPTION
## Summary
To support a `schedule-all` concept for the Zipline hub, we need to default Join offline schedules to None. Or else, `schedule-all` will likely schedule a lot of unexpected Joins for frontfills


## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * Modified default offline job scheduling behavior to require explicit configuration instead of defaulting to daily execution, providing greater flexibility in schedule management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->