### PR TITLE
feat: support sparse input tables via Query.sparse flag

### DIFF
--- a/api/src/main/scala/ai/chronon/api/planner/TableDependencies.scala
+++ b/api/src/main/scala/ai/chronon/api/planner/TableDependencies.scala
@@ -101,6 +101,7 @@ object TableDependencies {
       .setEndOffset(endOffset)
       .setStartCutOff(startCutOff)
       .setEndCutOff(endCutOff)
+    if (Option(source.query).exists(q => q.isSetSparse && q.sparse)) tableDep.setSparse(true)
 
     Some(tableDep)
   }
@@ -135,13 +136,15 @@ object TableDependencies {
       .setPartitionInterval(query.getPartitionInterval)
     if (isTimePartitioned) tableInfo.setTimePartitioned(true)
 
-    new TableDependency()
+    val tableDep = new TableDependency()
       .setTableInfo(tableInfo)
       .setStartOffset(offset)
       .setEndOffset(offset)
       .setStartCutOff(query.startPartition)
       .setEndCutOff(query.endPartition)
+    if (query.isSetSparse && query.sparse) tableDep.setSparse(true)
 
+    tableDep
   }
 
   def fromJoinSources(sources: java.util.List[api.Source]): Seq[TableDependency] = {

--- a/api/src/test/scala/ai/chronon/api/test/planner/TableDependenciesTest.scala
+++ b/api/src/test/scala/ai/chronon/api/test/planner/TableDependenciesTest.scala
@@ -220,6 +220,69 @@ class TableDependenciesTest extends AnyFlatSpec with Matchers {
     result.getEndCutOff should be(null)
   }
 
+  it should "propagate sparse flag from query" in {
+    val table = "test.sparse_table"
+    val query = Builders.Query(partitionColumn = "ds")
+    query.setSparse(true)
+
+    val result = TableDependencies.fromTable(table, query)
+
+    result should not be null
+    result.isSetSparse should be(true)
+    result.sparse should be(true)
+  }
+
+  it should "not set sparse when query does not have it" in {
+    val table = "test.dense_table"
+    val query = Builders.Query(partitionColumn = "ds")
+
+    val result = TableDependencies.fromTable(table, query)
+
+    result should not be null
+    result.isSetSparse should be(false)
+  }
+
+  "TableDependencies.fromSource" should "propagate sparse flag from source query" in {
+    val query = Builders.Query(
+      partitionColumn = "ds",
+      timeColumn = "UNIX_TIMESTAMP(ts) * 1000"
+    )
+    query.setSparse(true)
+
+    val source = Builders.Source.events(query, table = "test_db.sparse_events")
+    val result = TableDependencies.fromSource(source)
+
+    result should be(defined)
+    result.get.isSetSparse should be(true)
+    result.get.sparse should be(true)
+  }
+
+  "TableDependencies.fromGroupBy" should "propagate sparse flag through sources" in {
+    val query = Builders.Query(
+      partitionColumn = "ds",
+      timeColumn = "UNIX_TIMESTAMP(ts) * 1000"
+    )
+    query.setSparse(true)
+
+    val source = Builders.Source.events(query, table = "test_db.sparse_events")
+    val groupBy = Builders.GroupBy(
+      sources = Seq(source),
+      keyColumns = Seq("user_id"),
+      aggregations = Seq(
+        Builders.Aggregation(
+          inputColumn = "value",
+          operation = Operation.SUM,
+          windows = Seq(new Window(7, TimeUnit.DAYS))
+        )
+      )
+    )
+
+    val deps = TableDependencies.fromGroupBy(groupBy)
+    deps should not be empty
+    deps.head.isSetSparse should be(true)
+    deps.head.sparse should be(true)
+  }
+
   "TableDependencies.fromJoinSources" should "create dependencies for JoinSources" in {
     import ai.chronon.api.Builders._
 

--- a/python/src/ai/chronon/query.py
+++ b/python/src/ai/chronon/query.py
@@ -31,6 +31,7 @@ def Query(
     partition_format: str = None,
     sub_partitions_to_wait_for: List[str] = None,
     time_partitioned: bool = None,
+    sparse: bool = None,
 ) -> api.Query:
     """
     Create a query object that is used to scan data from various data sources.
@@ -106,6 +107,7 @@ def Query(
         subPartitionsToWaitFor=sub_partitions_to_wait_for,
         partitionFormat=partition_format,
         timePartitioned=time_partitioned,
+        sparse=sparse,
     )
 
 

--- a/python/src/ai/chronon/staging_query.py
+++ b/python/src/ai/chronon/staging_query.py
@@ -31,6 +31,7 @@ class TableDependency:
     additional_partitions: Optional[List[str]] = None
     offset: Optional[int] = None
     time_partitioned: Optional[bool] = None
+    sparse: Optional[bool] = None
 
     def to_thrift(self):
         if self.partition_column is not None and self.offset is None:
@@ -48,6 +49,7 @@ class TableDependency:
             endOffset=offset_window,
             startCutOff=None,
             endCutOff=None,
+            sparse=self.sparse,
         )
 
 

--- a/python/test/canary/compiled/group_bys/aws/user_activities_sparse.v1__1
+++ b/python/test/canary/compiled/group_bys/aws/user_activities_sparse.v1__1
@@ -1,0 +1,162 @@
+{
+  "aggregations": [
+    {
+      "argMap": {},
+      "inputColumn": "view_event",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "click_event",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_event",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    }
+  ],
+  "keyColumns": [
+    "user_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "click_event_sum_7d": "6258e2cfd920a7d8cdc1002adc5d5d68",
+      "purchase_event_sum_7d": "020a61b92308ff3f58f5e8953fb32e25",
+      "user_id": "c4f09c0393da34d98eca1432766ae7d6",
+      "view_event_sum_7d": "2f135a2b16514dffe823c09d4db484d6"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo_user_activities_raw_sparse_with_offset_0\", \"spec\": \"demo.user_activities_raw_sparse/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 300}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "historicalBackfill": 0,
+      "stepDays": 30
+    },
+    "name": "aws.user_activities_sparse.v1__1",
+    "online": 0,
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/aws/user_activities_sparse.py",
+    "team": "aws",
+    "version": "1"
+  },
+  "sources": [
+    {
+      "events": {
+        "query": {
+          "selects": {
+            "click_event": "IF(event_type = 'click', 1, 0)",
+            "listing_id": "listing_id",
+            "purchase_event": "IF(event_type = 'purchase', 1, 0)",
+            "user_id": "user_id",
+            "view_event": "IF(event_type = 'view', 1, 0)"
+          },
+          "sparse": 1,
+          "timeColumn": "unix_millis(TIMESTAMP(event_time_ms))"
+        },
+        "table": "demo.user_activities_raw_sparse"
+      }
+    }
+  ]
+}

--- a/python/test/canary/compiled/joins/aws/sparse_test.v1__1
+++ b/python/test/canary/compiled/joins/aws/sparse_test.v1__1
@@ -1,0 +1,462 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "view_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "click_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          }
+        ],
+        "keyColumns": [
+          "user_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "click_event_sum_7d": "6258e2cfd920a7d8cdc1002adc5d5d68",
+            "purchase_event_sum_7d": "020a61b92308ff3f58f5e8953fb32e25",
+            "user_id": "c4f09c0393da34d98eca1432766ae7d6",
+            "view_event_sum_7d": "2f135a2b16514dffe823c09d4db484d6"
+          },
+          "executionInfo": {
+            "clusterConf": {
+              "common": {
+                "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 300}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+              }
+            },
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.table_write.upload.format": "ion",
+                "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.memory": "1g",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "1g",
+                "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                "spark.sql.shuffle.partitions": "10",
+                "taskmanager.memory.process.size": "4G"
+              },
+              "modeConfigs": {
+                "backfill": {
+                  "spark.chronon.coalesce.factor": "10",
+                  "spark.chronon.partition.column": "ds",
+                  "spark.chronon.partition.format": "yyyy-MM-dd",
+                  "spark.chronon.table_write.format": "iceberg",
+                  "spark.chronon.table_write.upload.format": "ion",
+                  "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                  "spark.default.parallelism": "10",
+                  "spark.driver.cores": "1",
+                  "spark.driver.memory": "1g",
+                  "spark.executor.cores": "1",
+                  "spark.executor.memory": "1g",
+                  "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                  "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                  "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                  "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                  "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                  "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                  "spark.sql.shuffle.partitions": "10",
+                  "taskmanager.memory.process.size": "4G"
+                }
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                "AWS_REGION": "us-west-2",
+                "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                "CLOUD_PROVIDER": "aws",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_KINESIS": "true",
+                "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+              },
+              "modeEnvironments": {
+                "upload": {
+                  "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                  "AWS_REGION": "us-west-2",
+                  "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                  "CLOUD_PROVIDER": "aws",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_KINESIS": "true",
+                  "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                  "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                  "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                  "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                }
+              }
+            },
+            "historicalBackfill": 0,
+            "stepDays": 30
+          },
+          "name": "aws.user_activities_sparse.v1__1",
+          "online": 0,
+          "outputNamespace": "data",
+          "team": "aws",
+          "version": "1"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "selects": {
+                  "click_event": "IF(event_type = 'click', 1, 0)",
+                  "listing_id": "listing_id",
+                  "purchase_event": "IF(event_type = 'purchase', 1, 0)",
+                  "user_id": "user_id",
+                  "view_event": "IF(event_type = 'view', 1, 0)"
+                },
+                "sparse": 1,
+                "timeColumn": "unix_millis(TIMESTAMP(event_time_ms))"
+              },
+              "table": "demo.user_activities_raw_sparse"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    },
+    {
+      "groupBy": {
+        "keyColumns": [
+          "listing_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "brief_description": "c02f5fdfa63b63dc6a593a20cbab7d66",
+            "currency": "27d3da8403941e88f04007211468833e",
+            "headline": "961d1b3f1536af92638c63b2085fa728",
+            "inventory_count": "f3f379de8d3f9e74b60600f0356327d4",
+            "is_active": "b73c53f1089d15c7549d1be9e45bc05a",
+            "is_expensive": "dfe960db190729abde16b0eba360dfc4",
+            "is_in_stock": "6f24425755fd59b8a5a93de6912b111c",
+            "listing_id": "76323e9628393438a3d9bd1e0a0dcf40",
+            "long_description": "0588c5abbb679b56d18028e929d62124",
+            "main_image_path": "e670b87ebe0042f36d6dcb0379ce12da",
+            "merchant_id": "14059af75922b7fe7d8993867667f4af",
+            "price_cents": "33f80b9b819b9b68c65fc31652d4cc26",
+            "primary_category": "76c07f8cf4d4c3465843d890b89f8bb0",
+            "secondary_image_paths": "2d21e3616fce29041df8387677ef5193",
+            "tags": "b02298b5dc181fd94c357eef9f0623ca",
+            "weight_grams": "8b5ac3514f1c8f0db67748e07de128f4"
+          },
+          "executionInfo": {
+            "clusterConf": {
+              "common": {
+                "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 300}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+              }
+            },
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.table_write.upload.format": "ion",
+                "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.memory": "1g",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "1g",
+                "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                "spark.sql.shuffle.partitions": "10",
+                "taskmanager.memory.process.size": "4G"
+              },
+              "modeConfigs": {
+                "backfill": {
+                  "spark.chronon.coalesce.factor": "10",
+                  "spark.chronon.partition.column": "ds",
+                  "spark.chronon.partition.format": "yyyy-MM-dd",
+                  "spark.chronon.table_write.format": "iceberg",
+                  "spark.chronon.table_write.upload.format": "ion",
+                  "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                  "spark.default.parallelism": "10",
+                  "spark.driver.cores": "1",
+                  "spark.driver.memory": "1g",
+                  "spark.executor.cores": "1",
+                  "spark.executor.memory": "1g",
+                  "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                  "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                  "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                  "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                  "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                  "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                  "spark.sql.shuffle.partitions": "10",
+                  "taskmanager.memory.process.size": "4G"
+                }
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                "AWS_REGION": "us-west-2",
+                "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                "CLOUD_PROVIDER": "aws",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_KINESIS": "true",
+                "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+              },
+              "modeEnvironments": {
+                "upload": {
+                  "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                  "AWS_REGION": "us-west-2",
+                  "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                  "CLOUD_PROVIDER": "aws",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_KINESIS": "true",
+                  "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                  "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                  "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                  "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                }
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily",
+            "stepDays": 30
+          },
+          "name": "aws.dim_listings.v1__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "aws",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "entities": {
+              "query": {
+                "selects": {
+                  "brief_description": "brief_description",
+                  "currency": "currency",
+                  "headline": "headline",
+                  "inventory_count": "inventory_count",
+                  "is_active": "is_active",
+                  "is_expensive": "IF(price_cents > 10000, 1, 0)",
+                  "is_in_stock": "IF(inventory_count > 0, 1, 0)",
+                  "listing_id": "listing_id",
+                  "long_description": "long_description",
+                  "main_image_path": "main_image_path",
+                  "merchant_id": "merchant_id",
+                  "price_cents": "price_cents",
+                  "primary_category": "primary_category",
+                  "secondary_image_paths": "secondary_image_paths",
+                  "tags": "tags",
+                  "weight_grams": "weight_grams"
+                },
+                "startPartition": "2025-01-01"
+              },
+              "snapshotTable": "data.aws_exports_dim_listings__0"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "listing_id": "listing_id",
+          "row_id": "event_id",
+          "ts": "event_time_ms",
+          "user_id": "user_id"
+        },
+        "sparse": 1,
+        "timeColumn": "event_time_ms"
+      },
+      "table": "data.aws_exports_user_activities_sparse__1"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "listing_id": "1be221f799e4905624ec293419412f7c",
+      "listing_id_brief_description": "a3b2d3bf75ff5f108987c066d5e7b439",
+      "listing_id_currency": "ed8fd92e6348e010038c4cbbfd9b0301",
+      "listing_id_headline": "f87fb305c916328e6680fbf4fc63c7f2",
+      "listing_id_inventory_count": "b01cb4b88b9ce88db437ac1b554c1cf6",
+      "listing_id_is_active": "ecc8852ae3dbc22748515a1dd6ce0217",
+      "listing_id_is_expensive": "57112eaf2abdcb47208732cd0a35a7e4",
+      "listing_id_is_in_stock": "8c60978dc7308e4301a38e80d4e90700",
+      "listing_id_listing_id": "9413c4976b8f87030e7bbcba4fdf2e3b",
+      "listing_id_long_description": "6d8b278b0e0b8283a90a37db0d84e768",
+      "listing_id_main_image_path": "3a785ea45c55254df5a88d4349fe64a8",
+      "listing_id_merchant_id": "7bfbea165fa78608f1f415569c70d4d3",
+      "listing_id_price_cents": "b3eb7cf564311431caa4674697a0ea28",
+      "listing_id_primary_category": "e627e918a2a9dfbcff5a4548c3fc2c67",
+      "listing_id_secondary_image_paths": "25bd918d1b96afad0c564c0884a8f4a5",
+      "listing_id_tags": "5e3ab0b515a18d52975774c73ef44c07",
+      "listing_id_weight_grams": "d18649b9392bc0cc1526a118a04e9a5a",
+      "row_id": "c9b9c26cedcaf0d6fd9964149de78c87",
+      "ts": "9332c9031b7680c5ad8b872e7e12880c",
+      "user_id": "7a55033467a030631befeb9f908c80aa",
+      "user_id_click_event_sum_7d": "5fa5ece1edfbc3746b421f44dfa6e1c5",
+      "user_id_purchase_event_sum_7d": "6d5d758bb4b13b6d90ec5a859d791d5e",
+      "user_id_view_event_sum_7d": "185ebdaf989ad2293098132443e35d66"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_exports_user_activities_sparse__1_with_offset_0\", \"spec\": \"data.aws_exports_user_activities_sparse__1/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_demo_user_activities_raw_sparse_with_offset_0\", \"spec\": \"demo.user_activities_raw_sparse/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_aws_exports_dim_listings__0_with_offset_0\", \"spec\": \"data.aws_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 300}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "aws.sparse_test.v1__1",
+    "online": 0,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/aws/sparse_test.py",
+    "team": "aws",
+    "version": "1"
+  },
+  "rowIds": [
+    "event_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/compiled/staging_queries/aws/exports.user_activities_sparse__1
+++ b/python/test/canary/compiled/staging_queries/aws/exports.user_activities_sparse__1
@@ -1,0 +1,122 @@
+{
+  "engineType": 0,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo_user_activities_raw_sparse_with_offset_0\", \"spec\": \"demo.user_activities_raw_sparse/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 300}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "aws.exports.user_activities_sparse__1",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/aws/exports.py",
+    "team": "aws",
+    "version": "1"
+  },
+  "query": "\n    SELECT\n        *\n    FROM demo.user_activities_raw_sparse\n    WHERE\n    ds BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "sparse": 1,
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "demo.user_activities_raw_sparse"
+      }
+    }
+  ]
+}

--- a/python/test/canary/group_bys/aws/user_activities_sparse.py
+++ b/python/test/canary/group_bys/aws/user_activities_sparse.py
@@ -1,0 +1,34 @@
+from gen_thrift.api.ttypes import EventSource, Source
+
+from ai.chronon.group_by import Aggregation, GroupBy, Operation, TimeUnit, Window
+from ai.chronon.query import Query, selects
+
+source = Source(
+    events=EventSource(
+        table="demo.user_activities_raw_sparse",
+        query=Query(
+            selects=selects(
+                user_id="user_id",
+                listing_id="listing_id",
+                view_event="IF(event_type = 'view', 1, 0)",
+                click_event="IF(event_type = 'click', 1, 0)",
+                purchase_event="IF(event_type = 'purchase', 1, 0)",
+            ),
+            time_column="unix_millis(TIMESTAMP(event_time_ms))",
+            sparse=True,
+        ),
+    )
+)
+
+v1 = GroupBy(
+    sources=[source],
+    keys=["user_id"],
+    online=False,
+    version=1,
+    aggregations=[
+        Aggregation(input_column="view_event", operation=Operation.SUM, windows=[Window(length=7, time_unit=TimeUnit.DAYS)]),
+        Aggregation(input_column="click_event", operation=Operation.SUM, windows=[Window(length=7, time_unit=TimeUnit.DAYS)]),
+        Aggregation(input_column="purchase_event", operation=Operation.SUM, windows=[Window(length=7, time_unit=TimeUnit.DAYS)]),
+    ],
+    step_days=30,
+)

--- a/python/test/canary/joins/aws/sparse_test.py
+++ b/python/test/canary/joins/aws/sparse_test.py
@@ -1,0 +1,33 @@
+from group_bys.aws import dim_listings, user_activities_sparse
+from staging_queries.aws import exports
+
+from ai.chronon.join import Join, JoinPart
+from ai.chronon.query import Query, selects
+from ai.chronon.source import EventSource
+
+# Left side: sparse user activity events (only 5 partitions out of 20)
+source = EventSource(
+    table=exports.user_activities_sparse.table,
+    query=Query(
+        selects=selects(
+            user_id="user_id",
+            listing_id="listing_id",
+            row_id="event_id",
+        ),
+        time_column="event_time_ms",
+        sparse=True,
+    ),
+)
+
+v1 = Join(
+    left=source,
+    row_ids=["event_id"],
+    right_parts=[
+        JoinPart(group_by=user_activities_sparse.v1),
+        JoinPart(group_by=dim_listings.v1),
+    ],
+    version=1,
+    online=False,
+    output_namespace="data",
+    step_days=30,
+)

--- a/python/test/canary/staging_queries/aws/exports.py
+++ b/python/test/canary/staging_queries/aws/exports.py
@@ -48,3 +48,22 @@ checkouts = get_native_partition_export("checkouts", "ts")
 dim_listings = get_select_star_export("dim_listings", "ds")
 dim_merchants = get_select_star_export("dim_merchants", "ds")
 dim_users = get_select_star_export("dim_users", "ds")
+
+# Sparse input table — only has partitions on 01-01, 01-05, 01-10, 01-15, 01-20
+# Used to test backfill with missing input partitions
+user_activities_sparse = StagingQuery(
+    query="""
+    SELECT
+        *
+    FROM demo.user_activities_raw_sparse
+    WHERE
+    ds BETWEEN {{ start_date }} AND {{ end_date }}
+    """,
+    output_namespace="data",
+    engine_type=EngineType.SPARK,
+    dependencies=[
+        TableDependency(table="demo.user_activities_raw_sparse", partition_column="ds", offset=0, sparse=True)
+    ],
+    version=1,
+    step_days=30,
+)

--- a/spark/src/main/scala/ai/chronon/spark/batch/BatchNodeRunner.scala
+++ b/spark/src/main/scala/ai/chronon/spark/batch/BatchNodeRunner.scala
@@ -190,15 +190,15 @@ class BatchNodeRunner(node: Node, tableUtils: TableUtils, api: Api) extends Node
           logger.info(s"Input table ${tableName} has the requested range present: ${range}.")
           Success(())
         case Success(missingPartitions) if attempt < retryCount =>
-          logger.warn(
-            s"Attempt ${attempt + 1} failed: Input table ${tableName} is missing partitions: ${missingPartitions
-                .mkString(", ")}. Retrying in ${retryIntervalMin} minutes")
+          logger.warn(s"Attempt ${attempt + 1} failed: Input table ${tableName} is missing partitions: " +
+            s"${PartitionRange.collapsedPrint(missingPartitions)(tableUtils.partitionSpec)}. Retrying in ${retryIntervalMin} minutes")
           Thread.sleep(retryIntervalMin * 60 * 1000)
           retry(attempt + 1)
         case Success(missingPartitions) =>
-          Failure(new RuntimeException(
-            s"Sensor timed out after ${retryIntervalMin * attempt} minutes. Input table ${tableName} is missing partitions: ${missingPartitions
-                .mkString(", ")}"))
+          Failure(
+            new RuntimeException(
+              s"Sensor timed out after ${retryIntervalMin * attempt} minutes. Input table ${tableName} is missing partitions: " +
+                s"${PartitionRange.collapsedPrint(missingPartitions)(tableUtils.partitionSpec)}"))
         case Failure(e) => Failure(e)
       }
     }
@@ -538,8 +538,9 @@ class BatchNodeRunner(node: Node, tableUtils: TableUtils, api: Api) extends Node
     if (!translatedRange.partitions.forall(p => allOutputTablePartitions.contains(p))) {
       val missingPartitions = translatedRange.partitions.filterNot(p => allOutputTablePartitions.contains(p))
       logger.error(
-        s"After job completion, output table ${metadata.executionInfo.outputTableInfo.table} is missing partitions: ${missingPartitions
-            .mkString(", ")} from the requested range: $translatedRange. All output partitions: ${allOutputTablePartitions}"
+        s"After job completion, output table ${metadata.executionInfo.outputTableInfo.table} is missing partitions: " +
+          s"${PartitionRange.collapsedPrint(missingPartitions)(tableUtils.partitionSpec)} from the requested range: " +
+          s"$translatedRange. All output partitions: ${PartitionRange.collapsedPrint(allOutputTablePartitions)(tableUtils.partitionSpec)}"
       )
     }
 
@@ -597,6 +598,7 @@ class BatchNodeRunner(node: Node, tableUtils: TableUtils, api: Api) extends Node
 
     inputTableDependencies
       .filterNot(_._2.forall(td => td.isSetIsSoftNodeDependency && td.isSoftNodeDependency))
+      .filterNot(_._2.forall(td => td.isSetSparse && td.sparse))
       .map { case (table, deps) =>
         val inputPartitionSpec = deps.head.tableInfo.partitionSpec(tableUtils.partitionSpec)
         val isTimePartitioned = deps.head.tableInfo.isSetTimePartitioned && deps.head.tableInfo.timePartitioned
@@ -692,7 +694,7 @@ class BatchNodeRunner(node: Node, tableUtils: TableUtils, api: Api) extends Node
           "The following input tables are missing partitions for the requested range:\n" +
             inputTableToMissingPartitions
               .map { case (tableName, missing) =>
-                s"Table: $tableName, Missing Partitions: ${missing.mkString(", ")}"
+                s"Table: $tableName, Missing Partitions: ${PartitionRange.collapsedPrint(missing)(tableUtils.partitionSpec)}"
               }
               .mkString("\n")
         )

--- a/spark/src/test/scala/ai/chronon/spark/batch/BatchNodeRunnerTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/batch/BatchNodeRunnerTest.scala
@@ -109,10 +109,12 @@ class BatchNodeRunnerTest extends SparkTestBase with Matchers with BeforeAndAfte
                          partitionColumn: String = "ds",
                          partitionFormat: String = "yyyy-MM-dd",
                          semanticHash: Option[String] = None,
-                         isSoftDependency: Boolean = false): MetaData = {
+                         isSoftDependency: Boolean = false,
+                         sparse: Boolean = false): MetaData = {
     implicit val partitionSpec: PartitionSpec = tableUtils.partitionSpec
 
     val query = new Query().setPartitionColumn(partitionColumn).setPartitionFormat(partitionFormat)
+    if (sparse) query.setSparse(true)
     val tableDependency = TableDependencies.fromTable(inputTable, query)
 
     semanticHash.foreach(tableDependency.setSemanticHash)
@@ -702,6 +704,21 @@ class BatchNodeRunnerTest extends SparkTestBase with Matchers with BeforeAndAfte
 
     val inputTableStatus = statuses.find(_.name == "test_db.input_table")
     assertTrue("Should not have status for soft dependency", inputTableStatus.isEmpty)
+  }
+
+  it should "filter out sparse dependencies" in {
+    val metadata = createTestMetadata("test_db.input_table", "test_db.output_table", sparse = true)
+    val nodeContent = createTestNodeContent()
+    val node = new Node()
+    node.setMetaData(metadata)
+    node.setContent(nodeContent)
+    val runner = new BatchNodeRunner(node, tableUtils, mockApi)
+    val range = PartitionRange(twoDaysAgo, yesterday)(tableUtils.partitionSpec)
+
+    val statuses = runner.computeInputTablePartitionStatuses(metadata, range, tableUtils).toSeq
+
+    val inputTableStatus = statuses.find(_.name == "test_db.input_table")
+    assertTrue("Should not have status for sparse dependency", inputTableStatus.isEmpty)
   }
 
   it should "capture semantic hash when set on table dependency" in {

--- a/thrift/api.thrift
+++ b/thrift/api.thrift
@@ -58,6 +58,9 @@ struct Query {
     **/
     25: optional bool timePartitioned
 
+    // Source table may not have data for every partition in the requested range.
+    26: optional bool sparse
+
 }
  
 /**

--- a/thrift/common.thrift
+++ b/thrift/common.thrift
@@ -122,6 +122,10 @@ struct TableDependency {
 
     7: optional string semanticHash
 
+    // When true, the source table may not have data for every partition in the requested range.
+    // The engine skips missing input partition checks and the orchestrator ignores KvPartition data.
+    8: optional bool sparse
+
     /**
     * JoinParts could use data from batch backfill-s or upload tables when available
     * When not available they shouldn't force computation of the backfills and upload tables.


### PR DESCRIPTION
## Summary

Add sparse flag to Query (api.thrift) and TableDependency (common.thrift) for sources that may not have data for every partition in the requested range.

- Planner propagates sparse from Query to TableDependency in both fromSource() and fromTable() paths
- BatchNodeRunner skips missing partition check for sparse dependencies and uses collapsedPrint for partition logging
- Python API exposes sparse on Query() and StagingQuery.TableDependency
- Tests for sparse propagation in TableDependencies and BatchNodeRunner
- Canary test configs for sparse GroupBy, Join, and StagingQuery

## Checklist
- [x] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sparse flag to queries and table dependencies
  * Engine can skip partition existence checks for sparse-marked sources

* **Behavior**
  * Partition validation now excludes sparse dependencies to avoid false failures
  * New example configurations for sparse event aggregations, joins, and exports

* **Tests**
  * Added tests to verify sparse flag propagation and batch behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->