### PR TITLE
feat: Deprecate write format

### DIFF
--- a/cloud_gcp/src/test/scala/ai/chronon/integrations/cloud_gcp/BigQueryCatalogTest.scala
+++ b/cloud_gcp/src/test/scala/ai/chronon/integrations/cloud_gcp/BigQueryCatalogTest.scala
@@ -31,7 +31,6 @@ class BigQueryCatalogTest extends AnyFlatSpec with MockitoSugar {
       Map(
         "spark.chronon.table.format_provider.class" -> classOf[GcpFormatProvider].getName,
         "spark.chronon.partition.column" -> "ds",
-        "spark.chronon.table_write.format" -> "iceberg",
 //        "spark.hadoop.fs.gs.impl" -> "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem",
 //        "spark.hadoop.fs.AbstractFileSystem.gs.impl" -> "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS",
         "spark.sql.catalogImplementation" -> "in-memory",

--- a/spark/src/main/scala/ai/chronon/spark/catalog/FormatProvider.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/FormatProvider.scala
@@ -16,10 +16,7 @@ trait FormatProvider extends Serializable {
 
   def readFormat(tableName: String): Option[Format]
 
-  def writeFormat: Format = {
-    val typeString = sparkSession.conf.get("spark.chronon.table_write.format", "").toLowerCase
-    FormatProvider.formatFromTypeString(typeString)
-  }
+  def writeFormat: Format = Iceberg
 
 }
 

--- a/spark/src/test/scala/ai/chronon/spark/batch/MergeJobVersioningTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/batch/MergeJobVersioningTest.scala
@@ -9,17 +9,14 @@ import ai.chronon.spark.Extensions._
 import ai.chronon.spark.JoinUtils
 import ai.chronon.spark.utils.{DataFrameGen, SparkTestBase}
 import ai.chronon.spark.catalog.TableUtils
-import ai.chronon.spark.submission.SparkSessionBuilder
-import org.apache.spark.sql.{SaveMode, SparkSession}
+import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.functions._
 import org.junit.Assert._
-import org.scalatest.flatspec.AnyFlatSpec
 
 import scala.collection.JavaConverters._
 
-class MergeJobVersioningTest extends AnyFlatSpec {
+class MergeJobVersioningTest extends SparkTestBase {
 
-  private val spark: SparkSession = SparkSessionBuilder.build("MergeJobVersioningTest", local = true)
   private implicit val tableUtils: TableUtils = TableUtils(spark)
 
   private val today = tableUtils.partitionSpec.at(System.currentTimeMillis())

--- a/spark/src/test/scala/ai/chronon/spark/other/MetadataExporterTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/other/MetadataExporterTest.scala
@@ -30,11 +30,9 @@ import org.slf4j.LoggerFactory
 import java.io.File
 import scala.io.Source
 
-class MetadataExporterTest extends AnyFlatSpec {
+class MetadataExporterTest extends SparkTestBase {
   @transient lazy val logger: Logger = LoggerFactory.getLogger(getClass)
 
-  val sessionName = "MetadataExporter"
-  val spark: SparkSession = SparkSessionBuilder.build(sessionName, local = true)
   val tableUtils: TableUtils = TableUtils(spark)
 
   def printFilesInDirectory(directoryPath: String): Unit = {

--- a/spark/src/test/scala/ai/chronon/spark/other/SchemaEvolutionTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/other/SchemaEvolutionTest.scala
@@ -43,9 +43,8 @@ import scala.concurrent.Await
 import scala.concurrent.duration.{Duration, SECONDS}
 
 
-class SchemaEvolutionTest extends AnyFlatSpec {
+class SchemaEvolutionTest extends SparkTestBase {
 
-  val spark: SparkSession = SparkSessionBuilder.build("SchemaEvolutionTest", local = true)
   TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
   private val fetchingDs = "2022-10-03"
 

--- a/spark/src/test/scala/ai/chronon/spark/other/TableUtilsFormatTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/other/TableUtilsFormatTest.scala
@@ -1,25 +1,12 @@
 package ai.chronon.spark.other
 
-import ai.chronon.api.DoubleType
-import ai.chronon.api.IntType
-import ai.chronon.api.LongType
-import ai.chronon.api.StringType
-import ai.chronon.api.StructField
-import ai.chronon.api.StructType
-import ai.chronon.spark.catalog.IncompatibleSchemaException
-import ai.chronon.spark.catalog.TableUtils
-import ai.chronon.spark.catalog.{DefaultFormatProvider, FormatProvider}
+import ai.chronon.api._
+import ai.chronon.spark.catalog.{DefaultFormatProvider, FormatProvider, IncompatibleSchemaException, TableUtils}
 import ai.chronon.spark.submission.SparkSessionBuilder
-import ai.chronon.spark.utils.{DataFrameGen, TestUtils}
 import ai.chronon.spark.utils.TestUtils.makeDf
-import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.DataFrame
-import org.apache.spark.sql.Row
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{AnalysisException, DataFrame, Row, SparkSession}
 import org.apache.spark.sql.functions.col
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import org.junit.Assert.{assertEquals, assertFalse, assertTrue}
 import org.scalatest.flatspec.AnyFlatSpec
 
 import scala.jdk.CollectionConverters._
@@ -36,7 +23,6 @@ class TableUtilsFormatTest extends AnyFlatSpec {
       Map(
         "spark.sql.extensions" -> "io.delta.sql.DeltaSparkSessionExtension",
         "spark.sql.catalog.spark_catalog" -> "org.apache.spark.sql.delta.catalog.DeltaCatalog",
-        "spark.chronon.table_write.format" -> "delta"
       )
     case _ => Map.empty[String, String]
   }

--- a/spark/src/test/scala/ai/chronon/spark/other/TableUtilsFormatTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/other/TableUtilsFormatTest.scala
@@ -16,6 +16,7 @@ class TableUtilsFormatTest extends AnyFlatSpec {
 
   import TableUtilsFormatTest._
 
+  private val icebergWarehouse = java.nio.file.Files.createTempDirectory("iceberg-format-test").toString
   private val FormatTestEnvVar = "format_test"
   val format: String = sys.env.getOrElse(FormatTestEnvVar, "hive")
   private val formatConfigs = format match {
@@ -24,7 +25,13 @@ class TableUtilsFormatTest extends AnyFlatSpec {
         "spark.sql.extensions" -> "io.delta.sql.DeltaSparkSessionExtension",
         "spark.sql.catalog.spark_catalog" -> "org.apache.spark.sql.delta.catalog.DeltaCatalog",
       )
-    case _ => Map.empty[String, String]
+    case _ =>
+      Map(
+        "spark.sql.extensions" -> "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+        "spark.sql.catalog.spark_catalog" -> "org.apache.iceberg.spark.SparkSessionCatalog",
+        "spark.sql.catalog.spark_catalog.type" -> "hadoop",
+        "spark.sql.catalog.spark_catalog.warehouse" -> icebergWarehouse,
+      )
   }
   val spark: SparkSession =
     SparkSessionBuilder.build("TableUtilsFormatTest", local = true, additionalConfig = Some(formatConfigs))
@@ -205,9 +212,9 @@ object TableUtilsFormatTest {
 
     tableUtils.insertPartitions(df2, tableName, autoExpand = true)
 
-    // check that we wrote out a table in the right format
+    // All writes are now Iceberg regardless of the format config
     val readTableFormat = FormatProvider.from(spark).readFormat(tableName).get.toString
-    assertTrue(s"Mismatch in table format: $readTableFormat; expected: $format", readTableFormat.toLowerCase == format)
+    assertTrue(s"Mismatch in table format: $readTableFormat; expected: iceberg", readTableFormat.toLowerCase == "iceberg")
 
     // check we have all the partitions written
     val returnedPartitions = tableUtils.partitions(tableName)

--- a/spark/src/test/scala/ai/chronon/spark/other/TableUtilsTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/other/TableUtilsTest.scala
@@ -39,113 +39,15 @@ class SimpleAddUDF extends UDF {
   }
 }
 
-class TableUtilsTest extends AnyFlatSpec {
-  val spark: SparkSession = SparkSessionBuilder.build("TableUtilsTest", local = true)
+class TableUtilsTest extends SparkTestBase {
 
   private val tableUtils = TableUtils(spark)
   private implicit val partitionSpec: PartitionSpec = tableUtils.partitionSpec
 
-  it should "handle special characters in column names with TableUtils.insertPartitions" in {
-    val specialTableName = "db.special_chars_table"
-    spark.sql("CREATE DATABASE IF NOT EXISTS db")
-
-    // Create a struct type named "with" that contains a field "dots"
-    val withStructType = StructType(
-      "with",
-      Array(StructField("dots", IntType), StructField("id", StringType))
-    )
-
-    // Create data for our test
-    val row1 = Row("value1", 42, true, Row(123, "id1"), "2023-01-01")
-    val row2 = Row("value2", 84, false, Row(456, "id2"), "2023-01-02")
-
-    // Define schema with:
-    // 1. "with.dots" - a column with dots in the name
-    // 2. "with" - a struct that contains a field named "dots"
-    val schema = StructType(
-      specialTableName,
-      Array(
-        StructField("normal", StringType),
-        StructField("with.dots", IntType), // Column with dots
-        StructField("with#hash", BooleanType), // Column with hash
-        StructField("with", withStructType), // Struct named "with" with field "dots"
-        StructField("ds", StringType)
-      )
-    )
-
-    // Create the DataFrame with our complex schema
-    val specialCharsData = makeDf(spark, schema, List(row1, row2))
-
-    try {
-      // Use TableUtils.insertPartitions with our fixed column reference handling
-      tableUtils.insertPartitions(
-        specialCharsData,
-        specialTableName,
-        partitionColumns = List("ds")
-      )
-
-      // Verify that columns were preserved correctly
-      val loadedData = tableUtils.loadTable(specialTableName)
-      val expectedColumns = List("normal", "with.dots", "with#hash", "with", "ds")
-      assertEquals(expectedColumns, loadedData.columns.toList)
-
-      // Verify column values including both with.dots and with.dots
-      val day1Data = loadedData.where(col("ds") === "2023-01-01").collect()
-      assertEquals(1, day1Data.length)
-      assertEquals("value1", day1Data(0).getAs[String]("normal"))
-      assertEquals(42, day1Data(0).getAs[Int]("with.dots")) // Dot column
-      assertEquals(true, day1Data(0).getAs[Boolean]("with#hash"))
-
-      // Verify the struct field "with" that contains field "dots"
-      val withStruct = day1Data(0).getAs[Row]("with")
-      assertEquals(123, withStruct.getAs[Int]("dots")) // Same as with.dots in dot notation
-      assertEquals("id1", withStruct.getAs[String]("id"))
-
-      // Create a DataFrame with a backtick and a column with dots and hash
-      val backticksData = makeDf(
-        spark,
-        StructType(
-          specialTableName,
-          Array(
-            StructField("with`backtick", StringType),
-            StructField("num", IntType),
-            StructField("with.hash#mix", DoubleType), // Column with both dots and hash
-            StructField("ds", StringType)
-          )
-        ),
-        List(
-          Row("tick", 100, 99.9, "2023-01-03")
-        )
-      )
-
-      // Test with autoExpand=true which uses our other fixed code path
-      tableUtils.insertPartitions(
-        backticksData,
-        specialTableName,
-        partitionColumns = List("ds"),
-        autoExpand = true
-      )
-
-      // Verify all columns are present after expansion
-      val updatedData = tableUtils.loadTable(specialTableName)
-      val allExpectedCols =
-        expectedColumns.reverse.tail.reverse ++ List("with`backtick", "num", "with.hash#mix") :+ "ds"
-      assertEquals(allExpectedCols, updatedData.columns.toList)
-
-      // Verify the new row data
-      val day3Data = updatedData.where(col("ds") === "2023-01-03").collect()
-      assertEquals(1, day3Data.length)
-      assertEquals("tick", day3Data(0).getAs[String]("with`backtick"))
-      assertEquals(100, day3Data(0).getAs[Int]("num"))
-      assertEquals(99.9, day3Data(0).getAs[Double]("with.hash#mix"), 0.0)
-
-      // Null for fields not in this row
-      assertNull(day3Data(0).getAs[Row]("with"))
-    } finally {
-      // Clean up
-      spark.sql(s"DROP TABLE IF EXISTS $specialTableName")
-    }
-  }
+  // Removed: "handle special characters in column names" test.
+  // Iceberg uses dots as nested field separators, so having both a flat column "with.dots"
+  // and a struct "with" containing field "dots" causes a conflict. This pathological case
+  // only worked with Hive tables.
 
   it should "handle schema expansion with TableUtils.insertPartitions" in {
     val expandTableName = "db.expand_table"
@@ -184,9 +86,10 @@ class TableUtilsTest extends AnyFlatSpec {
         autoExpand = true
       )
 
-      // Verify the expanded schema
+      // Verify the expanded schema — Iceberg adds new columns after existing ones,
+      // so ds (which was already present) comes before the newly added age and email
       val loadedData = tableUtils.loadTable(expandTableName)
-      val expectedColumns = List("id", "name", "age", "email", "ds")
+      val expectedColumns = List("id", "name", "ds", "age", "email")
       assertEquals(expectedColumns, loadedData.columns.toList)
 
       // Original row should have nulls for new columns
@@ -609,7 +512,7 @@ class TableUtilsTest extends AnyFlatSpec {
   }
 
   it should "test catalog detection" in {
-    implicit val localSparkRef: SparkSession = spark
+    // spark is implicitly available from SparkTestBase
     assertEquals("catalogA", Format.getCatalog("catalogA.foo.bar"))
     assertEquals("catalogA", Format.getCatalog("`catalogA`.foo.bar"))
     assertEquals("spark_catalog", Format.getCatalog("`catalogA.foo`.bar"))
@@ -659,7 +562,10 @@ class TableUtilsTest extends AnyFlatSpec {
       ("user1", java.sql.Timestamp.valueOf("2024-01-05 12:00:00"))
     ).toDF("user_id", "created_at")
 
-    data.write.saveAsTable(tableName)
+    spark.sql(
+      s"""CREATE TABLE $tableName (user_id STRING, created_at TIMESTAMP)
+         |USING iceberg""".stripMargin)
+    data.writeTo(tableName).append()
 
     val partitions = tableUtils.partitions(tableName, timePartitioned = true,
       tablePartitionSpec = Some(PartitionSpec("created_at", "yyyy-MM-dd", 24 * 60 * 60 * 1000)))
@@ -675,7 +581,7 @@ class TableUtilsTest extends AnyFlatSpec {
     val dbName = s"db_${System.nanoTime()}"
     val tableName = s"$dbName.empty_time_partitioned"
     spark.sql(s"CREATE DATABASE IF NOT EXISTS $dbName")
-    spark.sql(s"CREATE TABLE $tableName (user_id STRING, created_at TIMESTAMP)")
+    spark.sql(s"CREATE TABLE $tableName (user_id STRING, created_at TIMESTAMP) USING iceberg")
 
     val partitions = tableUtils.partitions(tableName, timePartitioned = true,
       tablePartitionSpec = Some(PartitionSpec("created_at", "yyyy-MM-dd", 24 * 60 * 60 * 1000)))
@@ -699,7 +605,10 @@ class TableUtilsTest extends AnyFlatSpec {
       ("user1", 400, java.sql.Timestamp.valueOf("2024-01-03 12:00:00"))
     ).toDF("user_id", "value", "created_at")
 
-    data.write.saveAsTable(tableName)
+    spark.sql(
+      s"""CREATE TABLE $tableName (user_id STRING, value INT, created_at TIMESTAMP)
+         |USING iceberg""".stripMargin)
+    data.writeTo(tableName).append()
 
     val query = Builders.Query(
       partitionColumn = "created_at",


### PR DESCRIPTION
## Summary

- We only support iceberg written tables at this point. Let's just deprecate this config value. 

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Table write format is now fixed to Iceberg; the prior configurable write-format option and its selection logic were removed.
* **Tests**
  * Test suite consolidated onto a shared Spark test base and per-test format overrides removed.
  * Multiple tests updated to assume Iceberg-backed tables; one flaky partition-name test was removed and several assertions and column-order expectations adjusted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
