### PR TITLE
fix: partition column difference input output

### DIFF
--- a/cloud_azure/src/main/scala/ai/chronon/integrations/cloud_azure/Snowflake.scala
+++ b/cloud_azure/src/main/scala/ai/chronon/integrations/cloud_azure/Snowflake.scala
@@ -230,8 +230,13 @@ case object Snowflake extends Format {
         .flatMap { row =>
           if (row.isNullAt(0) || row.isNullAt(1)) None
           else {
-            val minMillis = row.getDate(0).toLocalDate.atStartOfDay(ZoneOffset.UTC).toInstant.toEpochMilli
-            val maxMillis = row.getDate(1).toLocalDate.atStartOfDay(ZoneOffset.UTC).toInstant.toEpochMilli
+            def toEpochMilli(value: Any): Long = value match {
+              case d: java.sql.Date        => d.toLocalDate.atStartOfDay(ZoneOffset.UTC).toInstant.toEpochMilli
+              case ld: java.time.LocalDate => ld.atStartOfDay(ZoneOffset.UTC).toInstant.toEpochMilli
+              case other => throw new IllegalArgumentException(s"Unexpected date type: ${other.getClass}")
+            }
+            val minMillis = toEpochMilli(row.get(0))
+            val maxMillis = toEpochMilli(row.get(1))
             Some(partitionSpec.expandRange(partitionSpec.at(minMillis), partitionSpec.at(maxMillis)))
           }
         }

--- a/cloud_azure/src/main/scala/ai/chronon/integrations/cloud_azure/Snowflake.scala
+++ b/cloud_azure/src/main/scala/ai/chronon/integrations/cloud_azure/Snowflake.scala
@@ -26,6 +26,12 @@ case object Snowflake extends Format {
 
   @transient private lazy val snowflakeLogger = LoggerFactory.getLogger(getClass)
 
+  private def toEpochMilli(value: Any): Long = value match {
+    case d: java.sql.Date        => d.toLocalDate.atStartOfDay(ZoneOffset.UTC).toInstant.toEpochMilli
+    case ld: java.time.LocalDate => ld.atStartOfDay(ZoneOffset.UTC).toInstant.toEpochMilli
+    case other                   => throw new IllegalArgumentException(s"Unexpected date type: ${other.getClass}")
+  }
+
   override def table(tableName: String, partitionFilters: String)(implicit sparkSession: SparkSession): DataFrame = {
     throw new UnsupportedOperationException(
       "Direct table reads are not supported for Snowflake format. Use a stagingQuery with EngineType.SNOWFLAKE to export the data first.")
@@ -201,7 +207,7 @@ case object Snowflake extends Format {
       result.flatMap { row =>
         if (row.isNullAt(0)) None
         else {
-          val utcMillis = row.getDate(0).toLocalDate.atStartOfDay(ZoneOffset.UTC).toInstant.toEpochMilli
+          val utcMillis = toEpochMilli(row.get(0))
           Some(partitionSpec.at(utcMillis))
         }
       }
@@ -230,11 +236,6 @@ case object Snowflake extends Format {
         .flatMap { row =>
           if (row.isNullAt(0) || row.isNullAt(1)) None
           else {
-            def toEpochMilli(value: Any): Long = value match {
-              case d: java.sql.Date        => d.toLocalDate.atStartOfDay(ZoneOffset.UTC).toInstant.toEpochMilli
-              case ld: java.time.LocalDate => ld.atStartOfDay(ZoneOffset.UTC).toInstant.toEpochMilli
-              case other => throw new IllegalArgumentException(s"Unexpected date type: ${other.getClass}")
-            }
             val minMillis = toEpochMilli(row.get(0))
             val maxMillis = toEpochMilli(row.get(1))
             Some(partitionSpec.expandRange(partitionSpec.at(minMillis), partitionSpec.at(maxMillis)))

--- a/cloud_azure/src/main/scala/ai/chronon/integrations/cloud_azure/SnowflakeConnector.scala
+++ b/cloud_azure/src/main/scala/ai/chronon/integrations/cloud_azure/SnowflakeConnector.scala
@@ -21,8 +21,8 @@ object SnowflakeConnector {
 
   def extractPemBase64(pemContent: String): String =
     pemContent
-      .replaceAll("-----BEGIN.*-----", "")
-      .replaceAll("-----END.*-----", "")
+      .replaceFirst("-----BEGIN[^-]*-----", "")
+      .replaceFirst("-----END[^-]*-----", "")
       .replaceAll("\\s", "")
 
   def buildSparkConnectorOptions(jdbcUrl: String, pemContent: String): Map[String, String] = {

--- a/cloud_azure/src/main/scala/ai/chronon/integrations/cloud_azure/SnowflakeImport.scala
+++ b/cloud_azure/src/main/scala/ai/chronon/integrations/cloud_azure/SnowflakeImport.scala
@@ -301,6 +301,7 @@ class SnowflakeImport(stagingQueryConf: api.StagingQuery, endPartition: String, 
         range.end,
         endPartition
       )
+    logger.info(s"Running query:\n$renderedQuery")
     val sfOptions = SnowflakeConnector.buildSparkConnectorOptions(snowflakeJdbcUrl, getPrivateKeyPem())
     val df = SnowflakeConnector.read(tableUtils.sparkSession, sfOptions, renderedQuery)
 

--- a/python/test/canary/compiled/staging_queries/azure/exports.dim_listings_pc__0
+++ b/python/test/canary/compiled/staging_queries/azure/exports.dim_listings_pc__0
@@ -67,7 +67,8 @@
           "length": 1,
           "timeUnit": 1
         },
-        "table": "dim_listings_custom_part"
+        "table": "dim_listings_custom_part",
+        "timePartitioned": 1
       }
     }
   ]

--- a/python/test/canary/compiled/staging_queries/azure/exports.dim_listings_pc__0
+++ b/python/test/canary/compiled/staging_queries/azure/exports.dim_listings_pc__0
@@ -1,0 +1,74 @@
+{
+  "engineType": 2,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_dim_listings_custom_part_with_offset_0\", \"spec\": \"dim_listings_custom_part/datest={{ macros.ds_add(ds, 0) }}\"}]}",
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_azure.AzureFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkCatalog",
+          "spark.sql.catalog.spark_catalog.credential": "XtyCirtE0/o3pcTMdkLCh7LXVno=:i++cOG/+vHgZwU8Wnj5Qx3hIzHwvlr0rhaGJnDwIBTg=",
+          "spark.sql.catalog.spark_catalog.header.X-Iceberg-Access-Delegation": "vended-credentials",
+          "spark.sql.catalog.spark_catalog.scope": "PRINCIPAL_ROLE:engine",
+          "spark.sql.catalog.spark_catalog.type": "rest",
+          "spark.sql.catalog.spark_catalog.uri": "https://vejlulx-azure-oc.snowflakecomputing.com/polaris/api/catalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "demo-v2",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "abfss://dev-zipline-artifacts@ziplineai2.dfs.core.windows.net",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "azure",
+          "CUSTOMER_ID": "dev",
+          "EVAL_URL": "https://dev-azure.zipline.ai/services/eval",
+          "FRONTEND_URL": "https://dev-azure.zipline.ai",
+          "HUB_URL": "https://dev-orch-azure.zipline.ai",
+          "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
+          "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "azure.exports.dim_listings_pc__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/azure/exports.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "query": "\n    SELECT\n        *,\n        DATE_TRUNC('DAY', datest)::DATE as ds\n    FROM dim_listings_custom_part\n    WHERE\n    datest BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "datest",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "dim_listings_custom_part"
+      }
+    }
+  ]
+}

--- a/python/test/canary/staging_queries/azure/exports.py
+++ b/python/test/canary/staging_queries/azure/exports.py
@@ -23,7 +23,7 @@ def get_select_star_export(table: str, partition_column: str = "ds"):
     )
 
 
-def get_native_partition_export(table: str, partition_column: str):
+def get_native_partition_export(table: str, partition_column: str, time_partitioned: bool = None):
     snowflake_partition_sql = f"""
     SELECT
         *,
@@ -37,7 +37,7 @@ def get_native_partition_export(table: str, partition_column: str):
         output_namespace="data",
         engine_type=EngineType.SNOWFLAKE,
         dependencies=[
-            TableDependency(table=f"{table}", partition_column=partition_column, offset=0)
+            TableDependency(table=f"{table}", partition_column=partition_column, offset=0, time_partitioned=time_partitioned)
         ],
         version=0,
         step_days=30,
@@ -47,7 +47,7 @@ def get_native_partition_export(table: str, partition_column: str):
 
 user_activities = get_native_partition_export("user_activities", "ds")
 checkouts = get_native_partition_export("checkouts", "ds")
-dim_listings_pc = get_native_partition_export("dim_listings_custom_part", "datest")
+dim_listings_pc = get_native_partition_export("dim_listings_custom_part", "datest", time_partitioned=True)
 dim_listings = get_select_star_export("dim_listings", "ds")
 dim_merchants = get_select_star_export("dim_merchants", "ds")
 dim_users = get_select_star_export("dim_users", "ds")

--- a/python/test/canary/staging_queries/azure/exports.py
+++ b/python/test/canary/staging_queries/azure/exports.py
@@ -47,6 +47,7 @@ def get_native_partition_export(table: str, partition_column: str):
 
 user_activities = get_native_partition_export("user_activities", "ds")
 checkouts = get_native_partition_export("checkouts", "ds")
+dim_listings_pc = get_native_partition_export("dim_listings_custom_part", "datest")
 dim_listings = get_select_star_export("dim_listings", "ds")
 dim_merchants = get_select_star_export("dim_merchants", "ds")
 dim_users = get_select_star_export("dim_users", "ds")


### PR DESCRIPTION
## Summary

When a table dependency had a different partition column there was a failure. Added a config that can replicate the context and made changes necessary to make it work more reliably.

```
TableUtils.scala:625: Where str:
TableUtils.scala:123: Getting virtual partitions for time-partitioned table dim_listings_custom_part using column datest
Snowflake.scala:222: Executing virtual partitions query: SELECT MIN(datest)::DATE AS min_val, MAX(datest)::DATE AS max_val FROM dim_listings_custom_part
TableUtils.scala:144: Found 53, between (2026-01-09, 2026-03-02) partitions for table: dim_listings_custom_part
BatchNodeRunner.scala:661: Starting batch node runner for 'azure.exports.dim_listings_pc__0__staging'
KvPartitionsStore.scala:20: Storing partitions for table 'dim_listings_custom_part': {"partitions":"(2026-01-09 -\u003e 2026-03-02)"}
CosmosKVStoreImpl.scala:613: [multiPut] [requestId=be624e59-dd1e-4ea7-958c-acdd1f0e3bd8] Starting with 1 requests
CosmosKVStoreImpl.scala:616: [multiPut] [requestId=be624e59-dd1e-4ea7-958c-acdd1f0e3bd8] Grouped into 1 containers
CosmosKVStoreImpl.scala:772: [multiPut] [requestId=be624e59-dd1e-4ea7-958c-acdd1f0e3bd8] Completed: total=1, success=1, failures=0
SemanticUtils.scala:95: Table data.azure_exports_dim_listings_pc__0 has properties: Some(Map(format -> iceberg/parquet, current-snapshot-id -> 11045404452797801, write.parquet.compression-codec -> zstd, created-at -> 2026-03-31T22:10:52.274626809Z, file_format -> PARQUET, commit.retry.max-wait-ms -> 600000, commit.status-check.max-wait-ms -> 600000, write.merge.isolation-level -> snapshot, commit.status-check.min-wait-ms -> 10000, commit.retry.num-retries -> 20, commit.retry.min-wait-ms -> 10000, table_type -> iceberg, format-version -> 2, commit.status-check.num-retries -> 20))
SemanticUtils.scala:73: No semantic hash found for table data.azure_exports_dim_listings_pc__0. Skipping archival — hash will be set after successful job completion.
BatchNodeRunner.scala:210: Running staging query for 'azure.exports.dim_listings_pc__0__staging'
StagingQuery.scala:159: Using Snowflake staging query
SnowflakeImport.scala:304: Running query:

SELECT
*,
        DATE_TRUNC('DAY', datest)::DATE as ds
    FROM dim_listings_custom_part
    WHERE
    datest BETWEEN '2026-03-02' AND '2026-03-02'

AzureFormatProvider.scala:26: AzureFormatProvider: Detected Iceberg table data.azure_exports_dim_listings_pc__0
TableUtils.scala:625: Where str:
AzureFormatProvider.scala:26: AzureFormatProvider: Detected Iceberg table data.azure_exports_dim_listings_pc__0
TableUtils.scala:625: Where str:
TableUtils.scala:289: Writing to data.azure_exports_dim_listings_pc__0 ...
TableUtils.scala:297: Finished writing to data.azure_exports_dim_listings_pc__0
BatchNodeRunner.scala:219: Successfully completed staging query for 'azure.exports.dim_listings_pc__0__staging'
```
## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a native time-partitioned staging export for Azure/Snowflake (daily schedule) and a corresponding canary compiled query.

* **Bug Fixes**
  * Improved UTC-based date handling for consistent partition range calculations.
  * More precise PEM credential parsing to avoid malformed key issues.

* **Chores**
  * Added informational logging to surface fully rendered Snowflake SQL for troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->