### PR TITLE
feat: add modular_execution flag to Join

### DIFF
--- a/api/src/main/scala/ai/chronon/api/planner/LocalRunner.scala
+++ b/api/src/main/scala/ai/chronon/api/planner/LocalRunner.scala
@@ -27,12 +27,23 @@ object LocalRunner {
     .filterNot(isIgnorableFile)
     .map(ThriftJsonCodec.fromJsonFile(_, check = true))
 
+  private def isModularMode(join: Join): Boolean =
+    Option(join.metaData)
+      .flatMap(md => Option(md.executionInfo))
+      .flatMap(ei => Option(ei.conf))
+      .flatMap(c => Option(c.common))
+      .exists(_.get("modular_execution") == "true")
+
+  private def selectJoinPlanner(join: Join)(implicit partitionSpec: PartitionSpec): ConfPlanner[Join] =
+    if (isModularMode(join)) new JoinPlanner(join)
+    else MonolithJoinPlanner(join)
+
   def processConfigurations(confSubfolder: String, confType: String)(implicit
       partitionSpec: PartitionSpec): Seq[ConfPlan] = {
     confType match {
       case Constants.JoinFolder => {
         val confs = parseConfs[Join](confSubfolder)
-        confs.map((c) => MonolithJoinPlanner(c)).map(_.buildPlan)
+        confs.map(c => selectJoinPlanner(c).buildPlan)
       }
       case Constants.StagingQueryFolder => {
         val confs = parseConfs[StagingQuery](confSubfolder)

--- a/python/src/ai/chronon/join.py
+++ b/python/src/ai/chronon/join.py
@@ -322,6 +322,7 @@ def Join(
     cluster_conf: common.ClusterConfigProperties = None,
     step_days: int = None,
     enable_stats_compute: bool = None,
+    modular_execution: bool = False,
 ) -> api.Join:
     """
     Construct a join object. A join can pull together data from various GroupBy's both offline and online. This is also
@@ -424,6 +425,10 @@ def Join(
         Whether to enable enhanced statistics computation and upload for this join.
         When True, stats compute and upload nodes will be added to the workflow.
     :type enable_stats_compute: bool
+    :param modular_execution:
+        When True, uses modular join planning (JoinPlanner) instead of the default
+        monolith planner (MonolithJoinPlanner).
+    :type modular_execution: bool
     """
     # Normalize row_ids
     if isinstance(row_ids, str):
@@ -479,6 +484,15 @@ def Join(
     # Set default online_schedule if online is True and online_schedule is not specified
     if online and online_schedule is None:
         online_schedule = "@daily"
+
+    if modular_execution:
+        if conf is None:
+            conf = common.ConfigProperties(common={"modular_execution": "true"})
+        else:
+            if conf.common is None:
+                conf.common = {"modular_execution": "true"}
+            else:
+                conf.common["modular_execution"] = "true"
 
     exec_info = common.ExecutionInfo(
         offlineSchedule=offline_schedule,


### PR DESCRIPTION
Adds a boolean modular_execution parameter to Join() (default false). When true, stores "modular_execution=true" in conf.common, which causes LocalRunner (and platform UploadHandler) to route to JoinPlanner instead of MonolithJoinPlanner.

## Summary

## Checklist
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `modular_execution` option to Join operations and updated the Join API to accept it; when enabled, joins use a modular planner for optimized execution.
  * Runtime now detects `modular_execution` from join metadata and routes planning to a modular planner where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->