### PR TITLE
Include chronon-fetcher image in zipline install command

### DIFF
--- a/python/src/ai/chronon/repo/admin.py
+++ b/python/src/ai/chronon/repo/admin.py
@@ -60,6 +60,7 @@ def _app_images(cloud):
         ("hub", f"ziplineai/hub-{cloud}"),
         ("eval", f"ziplineai/eval-{cloud}"),
         ("frontend", "ziplineai/web-ui"),
+        ("fetcher", "ziplineai/chronon-fetcher"),
     ]
 
 
@@ -835,14 +836,14 @@ def _print_summary(results, release, cloud, registry):
         console.print("\n[bold green]All artifacts loaded successfully.[/bold green]")
         if is_local:
             console.print("\nImages available in local Docker daemon:")
-            console.print(f"  ziplineai/hub-{cloud}:{release}")
-            console.print(f"  ziplineai/eval-{cloud}:{release}")
-            console.print(f"  ziplineai/web-ui:{release}")
+            for _image_type, repo in _app_images(cloud):
+                console.print(f"  {repo}:{release}")
         else:
             console.print("\nFor terraform.tfvars:")
             console.print(f'  hub_image      = "{registry}/ziplineai/hub-{cloud}:{release}"')
             console.print(f'  eval_image     = "{registry}/ziplineai/eval-{cloud}:{release}"')
             console.print(f'  frontend_image = "{registry}/ziplineai/web-ui:{release}"')
+            console.print(f'  fetcher_image  = "{registry}/ziplineai/chronon-fetcher:{release}"')
             console.print(f'  engine_image   = "{registry}/ziplineai/engine-{cloud}:{release}"')
     else:
         console.print("\n[bold red]Some artifacts failed to load. See errors above.[/bold red]")


### PR DESCRIPTION
## Summary

When `zipline install` runs it should include the image necessary for the fetcher `chronon-fetcher`. No existing covering tests on which images run (its just a list) so skipped.

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added fetcher application support to deployments.

* **Chores**
  * Updated deployment summary output to dynamically list all application images.
  * Updated registry configuration to include fetcher image reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->