### PR TITLE
Extend JobSubmitter and sub-classes to expose flink job id + chkpoint path details

### DIFF
--- a/cloud_aws/src/main/scala/ai/chronon/integrations/aws/EmrServerlessSubmitter.scala
+++ b/cloud_aws/src/main/scala/ai/chronon/integrations/aws/EmrServerlessSubmitter.scala
@@ -8,6 +8,7 @@ import software.amazon.awssdk.services.emr.EmrClient
 import software.amazon.awssdk.services.emr.model.ListStudiosRequest
 import software.amazon.awssdk.services.emrserverless.EmrServerlessClient
 import software.amazon.awssdk.services.emrserverless.model._
+import software.amazon.awssdk.services.s3.S3Client
 
 import java.util.concurrent.ConcurrentHashMap
 import scala.concurrent.ExecutionContext
@@ -28,6 +29,8 @@ class EmrServerlessSubmitter(
     ingressBaseUrl: Option[String] = None,
     emrStudioId: Option[String] = None,
     flinkHealthCheckFn: Option[String] => Boolean = _ => true,
+    flinkInternalJobIdFetchFn: Option[String] => Option[String] = _ => None,
+    s3Client: Option[S3Client] = None,
     cloudWatchLogGroupName: Option[String] = None,
     applicationName: String = EmrServerlessSubmitter.DefaultApplicationName
 ) extends JobSubmitter {
@@ -369,6 +372,22 @@ class EmrServerlessSubmitter(
     ingressBaseUrl.map(base => s"${base.stripSuffix("/")}/flink/$deploymentName/")
   }
 
+  override def getFlinkInternalJobId(jobId: String): Option[String] =
+    flinkInternalJobIdFetchFn(getFlinkUrl(jobId))
+
+  override def getLatestCheckpointPath(flinkInternalJobId: String, flinkStateUri: String): Option[String] = {
+    val s3 = s3Client.getOrElse {
+      logger.warn(s"S3 client not available, cannot resolve checkpoint path for Flink job $flinkInternalJobId")
+      return None
+    }
+    val result = S3StorageClient.resolveLatestCheckpointPath(s3, flinkInternalJobId, flinkStateUri)
+    result match {
+      case Some(path) => logger.info(s"Resolved latest checkpoint for Flink job $flinkInternalJobId: $path")
+      case None       => logger.warn(s"No checkpoints found for Flink job $flinkInternalJobId at $flinkStateUri/checkpoints/$flinkInternalJobId")
+    }
+    result
+  }
+
   override def buildFlinkSubmissionProps(env: Map[String, String],
                                          version: String,
                                          artifactPrefix: String): Map[String, String] = {
@@ -480,6 +499,8 @@ object EmrServerlessSubmitter {
       cloudWatchLogGroupName: Option[String] = None,
       k8sConfig: Option[io.fabric8.kubernetes.client.Config] = None,
       flinkHealthCheckFn: Option[String] => Boolean = _ => true,
+      flinkInternalJobIdFetchFn: Option[String] => Option[String] = _ => None,
+      s3Client: Option[S3Client] = None,
       applicationName: String = DefaultApplicationName,
       kvStoreApiProperties: Map[String, String] = Map.empty
   ): EmrServerlessSubmitter = {
@@ -502,6 +523,8 @@ object EmrServerlessSubmitter {
       ingressBaseUrl = ingressBaseUrl,
       emrStudioId = emrStudioId,
       flinkHealthCheckFn = flinkHealthCheckFn,
+      flinkInternalJobIdFetchFn = flinkInternalJobIdFetchFn,
+      s3Client = s3Client,
       cloudWatchLogGroupName = cloudWatchLogGroupName,
       applicationName = applicationName,
       kvStoreApiProperties = kvStoreApiProperties

--- a/cloud_aws/src/main/scala/ai/chronon/integrations/aws/EmrServerlessSubmitter.scala
+++ b/cloud_aws/src/main/scala/ai/chronon/integrations/aws/EmrServerlessSubmitter.scala
@@ -383,7 +383,9 @@ class EmrServerlessSubmitter(
     val result = S3StorageClient.resolveLatestCheckpointPath(s3, flinkInternalJobId, flinkStateUri)
     result match {
       case Some(path) => logger.info(s"Resolved latest checkpoint for Flink job $flinkInternalJobId: $path")
-      case None       => logger.warn(s"No checkpoints found for Flink job $flinkInternalJobId at $flinkStateUri/checkpoints/$flinkInternalJobId")
+      case None =>
+        logger.warn(
+          s"No checkpoints found for Flink job $flinkInternalJobId at $flinkStateUri/checkpoints/$flinkInternalJobId")
     }
     result
   }

--- a/cloud_aws/src/main/scala/ai/chronon/integrations/aws/EmrSubmitter.scala
+++ b/cloud_aws/src/main/scala/ai/chronon/integrations/aws/EmrSubmitter.scala
@@ -689,7 +689,9 @@ class EmrSubmitter(customerId: String,
     val result = S3StorageClient.resolveLatestCheckpointPath(s3, flinkInternalJobId, flinkStateUri)
     result match {
       case Some(path) => logger.info(s"Resolved latest checkpoint for Flink job $flinkInternalJobId: $path")
-      case None       => logger.warn(s"No checkpoints found for Flink job $flinkInternalJobId at $flinkStateUri/checkpoints/$flinkInternalJobId")
+      case None =>
+        logger.warn(
+          s"No checkpoints found for Flink job $flinkInternalJobId at $flinkStateUri/checkpoints/$flinkInternalJobId")
     }
     result
   }

--- a/cloud_aws/src/main/scala/ai/chronon/integrations/aws/EmrSubmitter.scala
+++ b/cloud_aws/src/main/scala/ai/chronon/integrations/aws/EmrSubmitter.scala
@@ -36,7 +36,8 @@ class EmrSubmitter(customerId: String,
                    flinkEksNamespace: Option[String] = None,
                    eksClusterName: Option[String] = None,
                    ingressBaseUrl: Option[String] = None,
-                   flinkHealthCheckFn: Option[String] => Boolean = _ => true)
+                   flinkHealthCheckFn: Option[String] => Boolean = _ => true,
+                   flinkInternalJobIdFetchFn: Option[String] => Option[String] = _ => None)
     extends JobSubmitter {
 
   private val ClusterApplications = List(
@@ -675,6 +676,22 @@ class EmrSubmitter(customerId: String,
     if (parts.length != 3) return None
     val deploymentName = parts(2)
     ingressBaseUrl.map(base => s"${base.stripSuffix("/")}/flink/$deploymentName/")
+  }
+
+  override def getFlinkInternalJobId(jobId: String): Option[String] =
+    flinkInternalJobIdFetchFn(getFlinkUrl(jobId))
+
+  override def getLatestCheckpointPath(flinkInternalJobId: String, flinkStateUri: String): Option[String] = {
+    val s3 = s3Client.getOrElse {
+      logger.warn(s"S3 client not available, cannot resolve checkpoint path for Flink job $flinkInternalJobId")
+      return None
+    }
+    val result = S3StorageClient.resolveLatestCheckpointPath(s3, flinkInternalJobId, flinkStateUri)
+    result match {
+      case Some(path) => logger.info(s"Resolved latest checkpoint for Flink job $flinkInternalJobId: $path")
+      case None       => logger.warn(s"No checkpoints found for Flink job $flinkInternalJobId at $flinkStateUri/checkpoints/$flinkInternalJobId")
+    }
+    result
   }
 
   override def deprecatedClusterNameEnvVars: Seq[String] = Seq(EmrClusterNameEnvVar)

--- a/cloud_aws/src/main/scala/ai/chronon/integrations/aws/S3StorageClient.scala
+++ b/cloud_aws/src/main/scala/ai/chronon/integrations/aws/S3StorageClient.scala
@@ -68,3 +68,29 @@ class S3StorageClient(s3Client: S3Client) extends StorageClient {
     else (stripped.substring(0, slashIdx), stripped.substring(slashIdx + 1))
   }
 }
+
+private[aws] object S3StorageClient {
+
+  /** Lists checkpoints under `{flinkStateUri}/checkpoints/{flinkInternalJobId}/chk-*` and
+    * returns the path to the highest-numbered checkpoint, or None if none exist.
+    */
+  def resolveLatestCheckpointPath(s3Client: S3Client,
+                                   flinkInternalJobId: String,
+                                   flinkStateUri: String): Option[String] =
+    resolveLatestCheckpointPath(new S3StorageClient(s3Client), flinkInternalJobId, flinkStateUri)
+
+  def resolveLatestCheckpointPath(storageClient: StorageClient,
+                                   flinkInternalJobId: String,
+                                   flinkStateUri: String): Option[String] = {
+    val jobCheckpointPath = s"$flinkStateUri/checkpoints/$flinkInternalJobId"
+    val latestCheckpoint = storageClient
+      .listFiles(jobCheckpointPath)
+      .filter(_.split("/").exists(_.startsWith("chk-")))
+      .map(_.split("/").find(_.startsWith("chk-")).get)
+      .toList
+      .distinct
+      .sortBy(_.substring(4).toInt)(Ordering.Int.reverse)
+      .headOption
+    latestCheckpoint.map(chk => s"$jobCheckpointPath/$chk")
+  }
+}

--- a/cloud_aws/src/main/scala/ai/chronon/integrations/aws/S3StorageClient.scala
+++ b/cloud_aws/src/main/scala/ai/chronon/integrations/aws/S3StorageClient.scala
@@ -75,13 +75,13 @@ private[aws] object S3StorageClient {
     * returns the path to the highest-numbered checkpoint, or None if none exist.
     */
   def resolveLatestCheckpointPath(s3Client: S3Client,
-                                   flinkInternalJobId: String,
-                                   flinkStateUri: String): Option[String] =
+                                  flinkInternalJobId: String,
+                                  flinkStateUri: String): Option[String] =
     resolveLatestCheckpointPath(new S3StorageClient(s3Client), flinkInternalJobId, flinkStateUri)
 
   def resolveLatestCheckpointPath(storageClient: StorageClient,
-                                   flinkInternalJobId: String,
-                                   flinkStateUri: String): Option[String] = {
+                                  flinkInternalJobId: String,
+                                  flinkStateUri: String): Option[String] = {
     val jobCheckpointPath = s"$flinkStateUri/checkpoints/$flinkInternalJobId"
     val latestCheckpoint = storageClient
       .listFiles(jobCheckpointPath)

--- a/cloud_aws/src/test/scala/ai/chronon/integrations/aws/EmrServerlessSubmitterTest.scala
+++ b/cloud_aws/src/test/scala/ai/chronon/integrations/aws/EmrServerlessSubmitterTest.scala
@@ -3,7 +3,7 @@ package ai.chronon.integrations.aws
 import ai.chronon.api.JobStatusType
 import ai.chronon.spark.submission
 import ai.chronon.spark.submission.JobSubmitterConstants._
-import ai.chronon.spark.submission.FlinkJob
+import ai.chronon.spark.submission.{FlinkJob, StorageClient}
 import org.junit.Assert.assertEquals
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers._
@@ -60,7 +60,8 @@ class EmrServerlessSubmitterTest extends AnyFlatSpec with Matchers with MockitoS
       kvStoreApiProperties: Map[String, String] = Map(
         "AWS_DYNAMODB_TABLE_NAME" -> "test-table",
         "AWS_DEFAULT_REGION" -> "us-east-1"
-      )
+      ),
+      s3Client: Option[software.amazon.awssdk.services.s3.S3Client] = None
   ): EmrServerlessSubmitter = {
     new EmrServerlessSubmitter(
       mockClient,
@@ -72,7 +73,8 @@ class EmrServerlessSubmitterTest extends AnyFlatSpec with Matchers with MockitoS
       ingressBaseUrl = ingressBaseUrl,
       emrStudioId = emrStudioId,
       applicationName = applicationName,
-      kvStoreApiProperties = kvStoreApiProperties
+      kvStoreApiProperties = kvStoreApiProperties,
+      s3Client = s3Client
     )
   }
 
@@ -1157,6 +1159,67 @@ class EmrServerlessSubmitterTest extends AnyFlatSpec with Matchers with MockitoS
 
     val props = requestCaptor.getValue.configurationOverrides().applicationConfiguration().get(0).properties()
     props.get("spark.some.token") shouldBe "{CHRONON_NONEXISTENT_VAR_XYZ}"
+  }
+
+  "getLatestCheckpointPath" should "return the highest-numbered checkpoint" in {
+    val mockStorageClient = mock[StorageClient]
+    val flinkJobId = "abc123"
+    val flinkStateUri = "s3://my-bucket/flink-state"
+    val checkpointBase = s"$flinkStateUri/checkpoints/$flinkJobId"
+
+    when(mockStorageClient.listFiles(checkpointBase)).thenReturn(
+      Iterator(
+        s"$checkpointBase/chk-3/_metadata",
+        s"$checkpointBase/chk-7/_metadata",
+        s"$checkpointBase/chk-1/_metadata"
+      )
+    )
+
+    val result = S3StorageClient.resolveLatestCheckpointPath(mockStorageClient, flinkJobId, flinkStateUri)
+    assertEquals(Some(s"$checkpointBase/chk-7"), result)
+  }
+
+  it should "return None when no checkpoints exist" in {
+    val mockStorageClient = mock[StorageClient]
+    when(mockStorageClient.listFiles(any[String])).thenReturn(Iterator.empty)
+
+    val result = S3StorageClient.resolveLatestCheckpointPath(mockStorageClient, "abc123", "s3://my-bucket/flink-state")
+    assertEquals(None, result)
+  }
+
+  it should "return None when s3Client is not set" in {
+    val submitter = createSubmitter(mock[EmrServerlessClient], s3Client = None)
+    val result = submitter.getLatestCheckpointPath("abc123", "s3://my-bucket/flink-state")
+    assertEquals(None, result)
+  }
+
+  "getFlinkInternalJobId" should "delegate to flinkInternalJobIdFetchFn" in {
+    val mockClient = mock[EmrServerlessClient]
+    mockListApplications(mockClient, "app-123")
+    val flinkJobId = "flink-internal-uuid-456"
+    val submitter = new EmrServerlessSubmitter(
+      mockClient,
+      executionRoleArn = "arn:aws:iam::123456789012:role/EMRServerlessRole",
+      s3LogUri = "s3://my-bucket/logs/",
+      applicationName = "test-app",
+      flinkInternalJobIdFetchFn = _ => Some(flinkJobId)
+    )
+    val result = submitter.getFlinkInternalJobId("flink:app-123:my-deployment")
+    assertEquals(Some(flinkJobId), result)
+  }
+
+  it should "return None when fetch fn returns None" in {
+    val mockClient = mock[EmrServerlessClient]
+    mockListApplications(mockClient, "app-123")
+    val submitter = new EmrServerlessSubmitter(
+      mockClient,
+      executionRoleArn = "arn:aws:iam::123456789012:role/EMRServerlessRole",
+      s3LogUri = "s3://my-bucket/logs/",
+      applicationName = "test-app",
+      flinkInternalJobIdFetchFn = _ => None
+    )
+    val result = submitter.getFlinkInternalJobId("flink:app-123:my-deployment")
+    assertEquals(None, result)
   }
 
   /**

--- a/cloud_aws/src/test/scala/ai/chronon/integrations/aws/EmrSubmitterTest.scala
+++ b/cloud_aws/src/test/scala/ai/chronon/integrations/aws/EmrSubmitterTest.scala
@@ -3,9 +3,10 @@ package ai.chronon.integrations.aws
 import ai.chronon.api.JobStatusType
 import ai.chronon.api.ScalaJavaConversions.ListOps
 import ai.chronon.spark.submission.JobSubmitterConstants._
-import ai.chronon.spark.submission.{FlinkJob, SparkJob}
+import ai.chronon.spark.submission.{FlinkJob, SparkJob, StorageClient}
 import io.fabric8.kubernetes.client.Config
 import org.junit.Assert.assertEquals
+import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito.{verify, when}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -472,6 +473,54 @@ class EmrSubmitterTest extends AnyFlatSpec with Matchers with MockitoSugar {
     println(s"   View logs: kubectl logs -n zipline-flink -l app=$deploymentName")
 
     assert(deploymentName.nonEmpty, "Deployment name should not be empty")
+  }
+
+  it should "getLatestCheckpointPath returns the highest-numbered checkpoint" in {
+    val mockStorageClient = mock[StorageClient]
+    val flinkJobId = "abc123"
+    val flinkStateUri = "s3://my-bucket/flink-state"
+    val checkpointBase = s"$flinkStateUri/checkpoints/$flinkJobId"
+
+    when(mockStorageClient.listFiles(checkpointBase)).thenReturn(
+      Iterator(
+        s"$checkpointBase/chk-5/_metadata",
+        s"$checkpointBase/chk-1/_metadata",
+        s"$checkpointBase/chk-12/_metadata"
+      )
+    )
+
+    val result = S3StorageClient.resolveLatestCheckpointPath(mockStorageClient, flinkJobId, flinkStateUri)
+    assertEquals(Some(s"$checkpointBase/chk-12"), result)
+  }
+
+  it should "getLatestCheckpointPath returns None when no checkpoints exist" in {
+    val mockStorageClient = mock[StorageClient]
+    val flinkJobId = "abc123"
+    val flinkStateUri = "s3://my-bucket/flink-state"
+
+    when(mockStorageClient.listFiles(anyString())).thenReturn(Iterator.empty)
+
+    val result = S3StorageClient.resolveLatestCheckpointPath(mockStorageClient, flinkJobId, flinkStateUri)
+    assertEquals(None, result)
+  }
+
+  it should "getLatestCheckpointPath returns None when s3Client is not set" in {
+    val submitter = new EmrSubmitter("canary", mock[EmrClient], mock[Ec2Client], None, s3Client = None)
+    val result = submitter.getLatestCheckpointPath("abc123", "s3://my-bucket/flink-state")
+    assertEquals(None, result)
+  }
+
+  it should "getFlinkInternalJobId delegates to flinkInternalJobIdFetchFn" in {
+    val flinkJobId = "flink-internal-uuid-123"
+    val submitter = new EmrSubmitter(
+      "canary",
+      mock[EmrClient],
+      mock[Ec2Client],
+      None,
+      flinkInternalJobIdFetchFn = _ => Some(flinkJobId)
+    )
+    val result = submitter.getFlinkInternalJobId("emr:cluster:flink:my-deployment")
+    assertEquals(Some(flinkJobId), result)
   }
 
   it should "Used to iterate locally. Do not enable this in CI/CD!" ignore {

--- a/cloud_gcp/src/main/scala/ai/chronon/integrations/cloud_gcp/DataprocSubmitter.scala
+++ b/cloud_gcp/src/main/scala/ai/chronon/integrations/cloud_gcp/DataprocSubmitter.scala
@@ -25,7 +25,8 @@ class DataprocSubmitter(jobControllerClient: JobControllerClient,
                         bigtableInstanceId: String = "",
                         override val tablePartitionsDataset: String = "",
                         override val dqMetricsDataset: String = "",
-                        flinkHealthCheckFn: Option[String] => Boolean = _ => true)
+                        flinkHealthCheckFn: Option[String] => Boolean = _ => true,
+                        flinkInternalJobIdFetchFn: Option[String] => Option[String] = _ => None)
     extends JobSubmitter {
 
   def listRunningGroupByFlinkJobs(groupByName: String): List[String] = {
@@ -55,6 +56,18 @@ class DataprocSubmitter(jobControllerClient: JobControllerClient,
     labels.get(DataprocUtils.formatDataprocLabel(ZiplineVersion))
   }
 
+  private def resolveLatestCheckpointPath(flinkJobId: String, checkpointBasePath: String): Option[String] = {
+    val jobCheckpointPath = s"$checkpointBasePath/$flinkJobId"
+    val matchedFiles = gcsClient.listFiles(jobCheckpointPath).toList
+    val latestCheckpoint = matchedFiles
+      .filter(_.split("/").exists(_.startsWith("chk-")))
+      .map(_.split("/").find(_.startsWith("chk-")).get)
+      .distinct
+      .sortBy(_.substring(4).toInt)(Ordering.Int.reverse)
+      .headOption
+    latestCheckpoint.map(chk => s"$jobCheckpointPath/$chk")
+  }
+
   def getLatestFlinkCheckpoint(groupByName: String,
                                manifestBucketPath: String,
                                flinkCheckpointUri: String): Option[String] = {
@@ -76,27 +89,8 @@ class DataprocSubmitter(jobControllerClient: JobControllerClient,
       .map(_.split("=")(1))
       .getOrElse(throw new RuntimeException("Flink job id not found in manifest file."))
 
-    val flinkJobIdCheckpointPath = s"$flinkCheckpointUri/$flinkJobId"
-    val matchedFiles = gcsClient.listFiles(flinkJobIdCheckpointPath).toList
-    val allCheckpoints = matchedFiles
-      .filter(_.split("/").exists(_.startsWith("chk-")))
-      .map(_.split("/").find(_.startsWith("chk-")).get)
-      .distinct
-      .sortBy(chk => chk.substring(4).toInt)(Ordering.Int.reverse)
-    logger.info(s"Flink checkpoints for $groupByName: $allCheckpoints")
-
-    val latestCheckpoint = allCheckpoints.headOption
-    val latestCheckpointUri = latestCheckpoint
-      .map(chk => {
-        s"$flinkJobIdCheckpointPath/$chk"
-      })
-
-    if (latestCheckpointUri.isEmpty) {
-      logger.info(s"No checkpoints found for $groupByName.")
-    } else {
-      logger.info(s"Latest checkpoint for $groupByName: ${latestCheckpointUri.get}")
-    }
-
+    val latestCheckpointUri = resolveLatestCheckpointPath(flinkJobId, flinkCheckpointUri)
+    logger.info(s"Latest checkpoint for $groupByName: $latestCheckpointUri")
     latestCheckpointUri
   }
 
@@ -604,6 +598,18 @@ class DataprocSubmitter(jobControllerClient: JobControllerClient,
         s"$baseUrl/gateway/default/yarn/proxy/$appId/"
       }
     }
+  }
+
+  override def getFlinkInternalJobId(jobId: String): Option[String] =
+    flinkInternalJobIdFetchFn(getFlinkUrl(jobId))
+
+  override def getLatestCheckpointPath(flinkInternalJobId: String, flinkStateUri: String): Option[String] = {
+    val result = resolveLatestCheckpointPath(flinkInternalJobId, s"$flinkStateUri/checkpoints")
+    result match {
+      case Some(path) => logger.info(s"Resolved latest checkpoint for Flink job $flinkInternalJobId: $path")
+      case None       => logger.warn(s"No checkpoints found for Flink job $flinkInternalJobId at $flinkStateUri/checkpoints/$flinkInternalJobId")
+    }
+    result
   }
 
   override def deprecatedClusterNameEnvVars: Seq[String] = Seq(GcpDataprocClusterNameEnvVar)

--- a/cloud_gcp/src/main/scala/ai/chronon/integrations/cloud_gcp/DataprocSubmitter.scala
+++ b/cloud_gcp/src/main/scala/ai/chronon/integrations/cloud_gcp/DataprocSubmitter.scala
@@ -607,7 +607,9 @@ class DataprocSubmitter(jobControllerClient: JobControllerClient,
     val result = resolveLatestCheckpointPath(flinkInternalJobId, s"$flinkStateUri/checkpoints")
     result match {
       case Some(path) => logger.info(s"Resolved latest checkpoint for Flink job $flinkInternalJobId: $path")
-      case None       => logger.warn(s"No checkpoints found for Flink job $flinkInternalJobId at $flinkStateUri/checkpoints/$flinkInternalJobId")
+      case None =>
+        logger.warn(
+          s"No checkpoints found for Flink job $flinkInternalJobId at $flinkStateUri/checkpoints/$flinkInternalJobId")
     }
     result
   }

--- a/cloud_gcp/src/test/scala/ai/chronon/integrations/cloud_gcp/DataprocSubmitterTest.scala
+++ b/cloud_gcp/src/test/scala/ai/chronon/integrations/cloud_gcp/DataprocSubmitterTest.scala
@@ -1382,4 +1382,75 @@ class DataprocSubmitterTest extends AnyFlatSpec with MockitoSugar {
       submitter.buildFlinkSubmissionProps(Map.empty, testVersion, testArtifactPrefix)
     }
   }
+
+  it should "getLatestCheckpointPath returns the highest-numbered checkpoint" in {
+    val mockGcsClient = mock[GCSClient]
+    val flinkJobId = "abc123"
+    val flinkStateUri = "gs://my-bucket/flink-state"
+    val checkpointBase = s"$flinkStateUri/checkpoints/$flinkJobId"
+
+    when(mockGcsClient.listFiles(checkpointBase)).thenReturn(
+      Iterator(
+        s"$checkpointBase/chk-3/_metadata",
+        s"$checkpointBase/chk-1/_metadata",
+        s"$checkpointBase/chk-10/_metadata",
+        s"$checkpointBase/chk-2/_metadata"
+      )
+    )
+
+    val submitter = new DataprocSubmitter(jobControllerClient = mock[JobControllerClient],
+                                          gcsClient = mockGcsClient,
+                                          region = "test-region",
+                                          projectId = "test-project")
+
+    val result = submitter.getLatestCheckpointPath(flinkJobId, flinkStateUri)
+    assertEquals(Some(s"$checkpointBase/chk-10"), result)
+  }
+
+  it should "getLatestCheckpointPath returns None when no checkpoints exist" in {
+    val mockGcsClient = mock[GCSClient]
+    val flinkJobId = "abc123"
+    val flinkStateUri = "gs://my-bucket/flink-state"
+    val checkpointBase = s"$flinkStateUri/checkpoints/$flinkJobId"
+
+    when(mockGcsClient.listFiles(checkpointBase)).thenReturn(Iterator.empty)
+
+    val submitter = new DataprocSubmitter(jobControllerClient = mock[JobControllerClient],
+                                          gcsClient = mockGcsClient,
+                                          region = "test-region",
+                                          projectId = "test-project")
+
+    val result = submitter.getLatestCheckpointPath(flinkJobId, flinkStateUri)
+    assertEquals(None, result)
+  }
+
+  it should "getFlinkInternalJobId delegates to flinkInternalJobIdFetchFn" in {
+    val mockJobControllerClient = mock[JobControllerClient]
+    val flinkJobId = "flink-internal-uuid-123"
+    val dataprocJobId = "dataproc-job-456"
+
+    val submitter = new DataprocSubmitter(
+      jobControllerClient = mockJobControllerClient,
+      gcsClient = mock[GCSClient],
+      region = "test-region",
+      projectId = "test-project",
+      flinkInternalJobIdFetchFn = _ => Some(flinkJobId)
+    )
+
+    val result = submitter.getFlinkInternalJobId(dataprocJobId)
+    assertEquals(Some(flinkJobId), result)
+  }
+
+  it should "getFlinkInternalJobId returns None when fetch fn returns None" in {
+    val submitter = new DataprocSubmitter(
+      jobControllerClient = mock[JobControllerClient],
+      gcsClient = mock[GCSClient],
+      region = "test-region",
+      projectId = "test-project",
+      flinkInternalJobIdFetchFn = _ => None
+    )
+
+    val result = submitter.getFlinkInternalJobId("any-job-id")
+    assertEquals(None, result)
+  }
 }

--- a/spark/src/main/scala/ai/chronon/spark/submission/JobSubmitter.scala
+++ b/spark/src/main/scala/ai/chronon/spark/submission/JobSubmitter.scala
@@ -38,6 +38,10 @@ trait JobSubmitter {
 
   def getFlinkUrl(jobId: String): Option[String] = None
 
+  def getFlinkInternalJobId(jobId: String): Option[String] = None
+
+  def getLatestCheckpointPath(flinkInternalJobId: String, flinkStateUri: String): Option[String] = None
+
   // --- Lifecycle methods ---
 
   def close(): Unit = {}


### PR DESCRIPTION
## Summary
To help downstream clients with being able to resume Flink jobs in case of failures from checkpoints / savepoints, this PR adds a couple of methods to the JobSubmitter and the concrete impls (Dataproc & Emr) to retrieve the Flink job id (differs from the Dataproc / Eks job id) and looking up the latest checkpoint path for that job id. 
Callers can:
* Submit job via Dataproc / Eks 
* Look up Flink job id (persist if needed)
* When the job fails - look up the latest checkpoint based on the previous job id
* Resubmit using savepoint

We already have rails to submit jobs with a savepoint / checkpoint path, we were missing exposing the Flink job id + helper to look up latest checkpoint.

## Testing
Tested the cold deploy + flow where we deploy, crash the job and resubmit (both aws, gcp) and confirm the resubmit is done with the checkpoint path.

## Checklist
- [X] Added Unit Tests
- [X] Covered by existing CI
- [X] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Flink checkpoint resolution support for AWS EMR and GCP Dataproc job submissions.
  * Implemented Flink internal job ID resolution for enhanced job tracking across cloud platforms.
  * Enhanced job submission with automatic checkpoint path discovery.

* **Tests**
  * Added comprehensive test coverage for checkpoint discovery and resolution workflows.
  * Added tests for Flink job ID resolution handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->