### PR TITLE
ci: Add canary compile check before integration tests

### DIFF
--- a/.github/workflows/push_to_canary.yaml
+++ b/.github/workflows/push_to_canary.yaml
@@ -20,8 +20,32 @@ jobs:
     uses: ./.github/workflows/reusable_build_and_push.yaml
     secrets: inherit
 
-  run_aws_integration_tests:
+  canary_compile_check:
     needs: build_and_push
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository }}-ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    defaults:
+      run:
+        working-directory: ${{ github.workspace }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Compile canary configs
+        shell: bash
+        run: |
+          export PATH="$HOME/.cargo/bin:$PATH"
+          # Generate thrift sources and set up PYTHONPATH so zipline compile runs from source
+          ./mill python.generatedSources
+          export PYTHONHASHSEED=0
+          export PYTHONPATH="$(pwd)/python/src:$(pwd)/out/python/generatedSources.dest:$(pwd)/python/test/canary"
+          cd python/test/canary
+          python -m ai.chronon.repo.zipline compile
+
+  run_aws_integration_tests:
+    needs: [build_and_push, canary_compile_check]
     runs-on: ubuntu-latest
     environment: aws
 
@@ -125,7 +149,7 @@ jobs:
           curl -X POST -H 'Content-type: application/json' --data @/tmp/slack_payload.json "$SLACK_WEBHOOK_URL"
 
   run_gcp_integration_tests:
-    needs: build_and_push
+    needs: [build_and_push, canary_compile_check]
     runs-on: ubuntu-latest
     environment: gcp
 
@@ -230,7 +254,7 @@ jobs:
           curl -X POST -H 'Content-type: application/json' --data @/tmp/slack_payload.json "$SLACK_WEBHOOK_URL"
 
   run_fetcher_integration_tests:
-    needs: build_and_push
+    needs: [build_and_push, canary_compile_check]
     runs-on: ubuntu-latest
 
     permissions:
@@ -777,7 +801,7 @@ jobs:
 
 
   on_fail_notify_slack:
-    needs: [run_aws_integration_tests, run_gcp_integration_tests, run_fetcher_integration_tests, merge_to_main-passing-tests]
+    needs: [canary_compile_check, run_aws_integration_tests, run_gcp_integration_tests, run_fetcher_integration_tests, merge_to_main-passing-tests]
     if: failure()
     runs-on: ubuntu-latest
 
@@ -818,6 +842,7 @@ jobs:
 
       - name: Build notification payload
         env:
+          COMPILE_CHECK_RESULT: ${{ needs.canary_compile_check.result }}
           AWS_TESTS_RESULT: ${{ needs.run_aws_integration_tests.result }}
           GCP_TESTS_RESULT: ${{ needs.run_gcp_integration_tests.result }}
           FETCHER_TESTS_RESULT: ${{ needs.run_fetcher_integration_tests.result }}
@@ -855,6 +880,7 @@ jobs:
               pass
 
           jobs = [
+              ('COMPILE_CHECK_RESULT', 'Canary Compile Check'),
               ('AWS_TESTS_RESULT', 'AWS Integration Tests'),
               ('GCP_TESTS_RESULT', 'GCP Integration Tests'),
               ('FETCHER_TESTS_RESULT', 'Fetcher Integration Tests'),


### PR DESCRIPTION
## Summary
  - Add `canary_compile_check` job to the Push To Canary workflow that runs `zipline compile` on canary
  configs before integration tests
  - All integration test jobs (`run_aws_integration_tests`, `run_gcp_integration_tests`,
  `run_fetcher_integration_tests`) now depend on this check passing
  - If compilation fails, integration tests are skipped and `merge_to_main-passing-tests` is blocked

  ## Motivation
  A recent change (#1693) altered compiled output hashes without being caught by CI, causing `zipline compile`
   failures for customers ("online config cannot be changed in-place"). The existing test suite only checks
  internal consistency (compiler output matches checked-in files), not whether the compiler itself produces
  valid output against the canary configs.

  ## What this does NOT do
  - Does not block merging PRs to `main` — the `ci-gate` job is unchanged
  - Does not add any new dependencies to the PR CI workflow (`ci.yaml`)

  ## Test plan
  - [ ] Push To Canary workflow runs `canary_compile_check` before integration tests
  - [ ] Integration tests are skipped if compile check fails
  - [ ] `merge_to_main-passing-tests` is blocked transitively when compile fails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a canary compilation/validation step to CI that runs before integration tests, so integration jobs now wait for this validation to complete—helping catch issues earlier and reduce flaky test runs.
  * Updated failure notifications to include the canary compilation result in alerts for clearer, more actionable CI failure reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->