### PR TITLE
test: Replace hub backfill tests with chaining DAG + sparse config

### DIFF
--- a/python/test/canary/group_bys/aws/sparse_activities.py
+++ b/python/test/canary/group_bys/aws/sparse_activities.py
@@ -1,0 +1,38 @@
+from ai.chronon.types import Aggregation, EventSource, GroupBy, Operation, Query, TimeUnit, Window, selects
+
+"""
+GroupBy over demo.sparse_activities, an AWS Glue/Iceberg table with data
+every other day.  Used by integration tests to exercise backfill behaviour
+when source partitions are missing for some days in the requested range.
+"""
+
+source = EventSource(
+    table="demo.sparse_activities",
+    query=Query(
+        selects=selects(
+            user_id="user_id",
+            duration_seconds="duration_seconds",
+        ),
+        time_column="ts",
+    ),
+)
+
+v1 = GroupBy(
+    sources=[source],
+    keys=["user_id"],
+    online=False,
+    version=0,
+    aggregations=[
+        Aggregation(
+            input_column="duration_seconds",
+            operation=Operation.SUM,
+            windows=[Window(length=7, time_unit=TimeUnit.DAYS)],
+        ),
+        Aggregation(
+            input_column="duration_seconds",
+            operation=Operation.COUNT,
+            windows=[Window(length=7, time_unit=TimeUnit.DAYS)],
+        ),
+    ],
+    output_namespace="data",
+)

--- a/python/test/integration/test_hub_backfill.py
+++ b/python/test/integration/test_hub_backfill.py
@@ -1,7 +1,7 @@
 """Cloud-agnostic hub backfill integration tests.
 
 Exercises: compile -> upload diffs -> backfill -> poll workflow to success.
-Replaces the former test_gcp_hub_quickstart.py and test_aws_hub_quickstart.py.
+Tests cover the full chaining DAG, derivations, sparse data, and no-data scenarios.
 """
 
 import pytest
@@ -10,12 +10,71 @@ from click.testing import CliRunner
 from .helpers.cli import compile_configs, submit_backfill
 from .helpers.workflow import poll_workflow
 
-# Demo join conf paths differ across clouds (variable names / versions vary).
-DEMO_DERIVATIONS = {
+STANDARD_RANGE = ("2026-01-10", "2026-01-14")  # 5 days, all clouds
+SPARSE_RANGE = ("2026-03-15", "2026-03-25")    # 11 days, AWS only (every-other-day data)
+
+CHAINING_CONF = {
+    "gcp": "compiled/joins/gcp/demo_chaining.downstream_join__0",
+    "aws": "compiled/joins/aws/demo_chaining.downstream_join__0",
+}
+
+DERIVATIONS_CONF = {
     "gcp": "compiled/joins/gcp/demo.derivations_v1__2",
     "aws": "compiled/joins/aws/demo.derivations_v1__2",
     "azure": "compiled/joins/azure/demo.derivations_v3",
 }
+
+SPARSE_CONF = {
+    "aws": "compiled/group_bys/aws/sparse_activities.v1__0",
+}
+
+
+@pytest.mark.integration
+def test_chaining_backfill(confs, chronon_root, hub_url, cloud):
+    """Full DAG backfill: sensors -> staging queries -> GroupBys -> parent join -> chained GB -> downstream join."""
+    if cloud == "azure":
+        pytest.skip("USER_ACTIVITIES not seeded in Snowflake")
+
+    runner = CliRunner()
+    compile_configs(runner, chronon_root)
+
+    start_ds, end_ds = STANDARD_RANGE
+    workflow_id = submit_backfill(
+        runner, chronon_root, hub_url,
+        confs[CHAINING_CONF[cloud]], start_ds, end_ds,
+    )
+    poll_workflow(hub_url, workflow_id, timeout=2400, interval=45)
+
+
+@pytest.mark.integration
+def test_derivations_backfill(confs, chronon_root, hub_url, cloud):
+    """Derivations backfill reuses upstream staging query data across all clouds."""
+    runner = CliRunner()
+    compile_configs(runner, chronon_root)
+
+    start_ds, end_ds = STANDARD_RANGE
+    workflow_id = submit_backfill(
+        runner, chronon_root, hub_url,
+        confs[DERIVATIONS_CONF[cloud]], start_ds, end_ds,
+    )
+    poll_workflow(hub_url, workflow_id, timeout=2400, interval=45)
+
+
+@pytest.mark.integration
+def test_sparse_backfill(confs, chronon_root, hub_url, cloud):
+    """Sparse data backfill exercises handling of missing partitions in source data."""
+    if cloud != "aws":
+        pytest.skip("sparse_activities table only exists in AWS")
+
+    runner = CliRunner()
+    compile_configs(runner, chronon_root)
+
+    start_ds, end_ds = SPARSE_RANGE
+    workflow_id = submit_backfill(
+        runner, chronon_root, hub_url,
+        confs[SPARSE_CONF[cloud]], start_ds, end_ds,
+    )
+    poll_workflow(hub_url, workflow_id, timeout=2400, interval=45)
 
 
 @pytest.mark.integration
@@ -26,31 +85,7 @@ def test_backfill_no_data(confs, chronon_root, hub_url, cloud):
 
     workflow_id = submit_backfill(
         runner, chronon_root, hub_url,
-        confs(DEMO_DERIVATIONS[cloud]), "1969-01-01", "1969-01-01",
+        confs[DERIVATIONS_CONF[cloud]], "1969-01-01", "1969-01-01",
     )
     with pytest.raises(RuntimeError, match="ended with status FAILED"):
         poll_workflow(hub_url, workflow_id, timeout=1800, interval=45)
-
-
-# Conf for multi-day backfill that expects success.
-# GCP/AWS: join derivation (exercises full multi-step DAG).
-# Azure: staging query (user_activities/checkouts not yet seeded in Snowflake canary).
-MULTIDAY_BACKFILL = {
-    "gcp": "compiled/joins/gcp/demo.derivations_v1__2",
-    "aws": "compiled/joins/aws/demo.derivations_v1__2",
-    "azure": "compiled/staging_queries/azure/exports.dim_listings__0",
-}
-
-
-@pytest.mark.integration
-def test_backfill_multiday(confs, chronon_root, hub_url, cloud):
-    """Multi-day backfill exercises multi-step allocation."""
-    runner = CliRunner()
-    compile_configs(runner, chronon_root)
-
-    workflow_id = submit_backfill(
-        runner, chronon_root, hub_url,
-        confs(MULTIDAY_BACKFILL[cloud]),
-        "2026-03-01", "2026-03-03",
-    )
-    poll_workflow(hub_url, workflow_id, timeout=1800, interval=45)


### PR DESCRIPTION
## Summary
Part of the comprehensive test infrastructure push.

- Replace flat join configs (demo.v1, demo.derivations) with chaining configs that exercise the full DAG in a single backfill: sensors → staging queries → GroupBys → parent join → chained GroupBy → downstream join
- Add `sparse_activities.py` canary config for AWS (reads from `demo.sparse_activities` — data every other day)
- Extend `templates.py` with chaining + dim + sparse ConfigTemplates for GCP and AWS
- Azure: skip with TODO placeholders (USER_ACTIVITIES not seeded in Snowflake)

## Tests
- `test_chaining_backfill` (GCP+AWS) — full DAG backfill, 5 days
- `test_derivations_backfill` (all clouds) — derivations, reuses upstream data
- `test_sparse_backfill` (AWS only) — sparse partition handling, 11 days
- `test_backfill_no_data` (all clouds) — failure path

## Coverage Added
| Scenario | Status |
|---|---|
| Sensors (partition check) | **NEW** |
| Staging queries via hub DAG | **NEW** |
| JoinSource (chaining) | **NEW** |
| Parent join → child GroupBy | **NEW** |
| Sparse partition handling | **NEW** |
| EventSource, EntitySource | Already covered |
| Join derivations | Already covered |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  - Expanded backfill integration test coverage across cloud providers with multiple data scenarios and improved timeout configurations
  
* **Chores**
  - Added canary test configuration for sparse activity validation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->