### PR TITLE
test: Add unit tests for column hashing and config construction

### DIFF
--- a/python/test/test_column_hashing.py
+++ b/python/test/test_column_hashing.py
@@ -1,0 +1,290 @@
+"""Tests for semantic hash computation in column_hashing.py."""
+
+import pytest
+
+import gen_thrift.api.ttypes as api
+import gen_thrift.common.ttypes as common
+from ai.chronon.cli.compile.column_hashing import (
+    compute_group_by_columns_hashes,
+    compute_join_column_hashes,
+)
+
+
+def _make_event_source(table, selects, time_column="ts_col"):
+    """Helper to build a Source wrapping an EventSource with the given table and selects."""
+    return api.Source(
+        events=api.EventSource(
+            table=table,
+            query=api.Query(selects=selects, timeColumn=time_column),
+        )
+    )
+
+
+def _make_group_by(
+    name,
+    table,
+    keys,
+    selects,
+    aggregations=None,
+    team="test_team",
+    version=0,
+    derivations=None,
+    description=None,
+):
+    """Build a minimal GroupBy thrift object suitable for hashing."""
+    source = _make_event_source(table, selects)
+    meta = api.MetaData(name=name, team=team, version=version)
+    if description:
+        meta.description = description
+    return api.GroupBy(
+        sources=[source],
+        keyColumns=keys,
+        aggregations=aggregations,
+        metaData=meta,
+        derivations=derivations,
+    )
+
+
+def _simple_aggregation(input_column, operation=api.Operation.SUM, windows=None):
+    return api.Aggregation(
+        inputColumn=input_column,
+        operation=operation,
+        argMap={},
+        windows=windows,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_groupby_hash_deterministic():
+    """Computing the hash twice for the same GroupBy yields identical results."""
+    gb = _make_group_by(
+        name="test_team.my_group_by__0",
+        table="db.events",
+        keys=["user_id"],
+        selects={"user_id": "user_id", "amount": "amount"},
+        aggregations=[_simple_aggregation("amount")],
+    )
+    hash1 = compute_group_by_columns_hashes(gb)
+    hash2 = compute_group_by_columns_hashes(gb)
+    assert hash1 == hash2
+
+
+# ---------------------------------------------------------------------------
+# Sensitivity to semantic changes
+# ---------------------------------------------------------------------------
+
+
+def test_groupby_hash_changes_on_aggregation_add():
+    """Adding an aggregation changes the set of output column hashes."""
+    gb1 = _make_group_by(
+        name="test_team.gb__0",
+        table="db.events",
+        keys=["user_id"],
+        selects={"user_id": "user_id", "amount": "amount", "count_col": "count_col"},
+        aggregations=[_simple_aggregation("amount")],
+    )
+    gb2 = _make_group_by(
+        name="test_team.gb__0",
+        table="db.events",
+        keys=["user_id"],
+        selects={"user_id": "user_id", "amount": "amount", "count_col": "count_col"},
+        aggregations=[
+            _simple_aggregation("amount"),
+            _simple_aggregation("count_col", operation=api.Operation.COUNT),
+        ],
+    )
+    h1 = compute_group_by_columns_hashes(gb1)
+    h2 = compute_group_by_columns_hashes(gb2)
+    # gb2 should have an extra column hash that gb1 does not
+    assert set(h1.keys()) != set(h2.keys())
+
+
+def test_groupby_hash_changes_on_source_table():
+    """Changing the source table name produces different hashes."""
+    common_kwargs = dict(
+        name="test_team.gb__0",
+        keys=["user_id"],
+        selects={"user_id": "user_id", "amount": "amount"},
+        aggregations=[_simple_aggregation("amount")],
+    )
+    gb_a = _make_group_by(table="db.events_v1", **common_kwargs)
+    gb_b = _make_group_by(table="db.events_v2", **common_kwargs)
+
+    ha = compute_group_by_columns_hashes(gb_a)
+    hb = compute_group_by_columns_hashes(gb_b)
+    # The hash for the same output column should differ
+    assert ha["amount_sum"] != hb["amount_sum"]
+
+
+def test_groupby_hash_stable_on_metadata_change():
+    """Changing metadata like team or description does not change hashes (metadata is not semantic)."""
+    gb1 = _make_group_by(
+        name="test_team.gb__0",
+        table="db.events",
+        keys=["user_id"],
+        selects={"user_id": "user_id", "val": "val"},
+        aggregations=[_simple_aggregation("val")],
+        team="alpha_team",
+        description="original description",
+    )
+    gb2 = _make_group_by(
+        name="test_team.gb__0",
+        table="db.events",
+        keys=["user_id"],
+        selects={"user_id": "user_id", "val": "val"},
+        aggregations=[_simple_aggregation("val")],
+        team="beta_team",
+        description="completely different description",
+    )
+    assert compute_group_by_columns_hashes(gb1) == compute_group_by_columns_hashes(gb2)
+
+
+# ---------------------------------------------------------------------------
+# Join hashing
+# ---------------------------------------------------------------------------
+
+
+def _make_join(
+    name,
+    left_table,
+    left_selects,
+    join_parts,
+    derivations=None,
+    use_long_names=False,
+):
+    left = _make_event_source(left_table, left_selects)
+    meta = api.MetaData(name=name, version=0)
+    return api.Join(
+        left=left,
+        joinParts=join_parts,
+        metaData=meta,
+        derivations=derivations,
+        useLongNames=use_long_names,
+    )
+
+
+def test_join_hash_includes_all_parts():
+    """Join hash output includes columns from all JoinParts."""
+    gb1 = _make_group_by(
+        name="test_team.gb1__0",
+        table="db.events",
+        keys=["user_id"],
+        selects={"user_id": "user_id", "a": "a"},
+        aggregations=[_simple_aggregation("a")],
+    )
+    gb2 = _make_group_by(
+        name="test_team.gb2__0",
+        table="db.events2",
+        keys=["user_id"],
+        selects={"user_id": "user_id", "b": "b"},
+        aggregations=[_simple_aggregation("b", operation=api.Operation.MAX)],
+    )
+    jp1 = api.JoinPart(groupBy=gb1)
+    jp2 = api.JoinPart(groupBy=gb2)
+    join = _make_join(
+        name="test_team.my_join__0",
+        left_table="db.left_table",
+        left_selects={"user_id": "user_id"},
+        join_parts=[jp1, jp2],
+    )
+    hashes = compute_join_column_hashes(join)
+    # Should contain columns from both group bys
+    col_names = list(hashes.keys())
+    has_gb1_col = any("a_sum" in c for c in col_names)
+    has_gb2_col = any("b_max" in c for c in col_names)
+    assert has_gb1_col, f"Expected column from gb1 in {col_names}"
+    assert has_gb2_col, f"Expected column from gb2 in {col_names}"
+
+
+def test_join_hash_with_prefix():
+    """Adding a prefix to a JoinPart changes the output column names (and therefore the hash keys)."""
+    gb = _make_group_by(
+        name="test_team.gb__0",
+        table="db.events",
+        keys=["user_id"],
+        selects={"user_id": "user_id", "val": "val"},
+        aggregations=[_simple_aggregation("val")],
+    )
+    jp_no_prefix = api.JoinPart(groupBy=gb)
+    jp_with_prefix = api.JoinPart(groupBy=gb, prefix="seller")
+
+    join_no = _make_join(
+        name="test_team.j__0",
+        left_table="db.left",
+        left_selects={"user_id": "user_id"},
+        join_parts=[jp_no_prefix],
+    )
+    join_yes = _make_join(
+        name="test_team.j__0",
+        left_table="db.left",
+        left_selects={"user_id": "user_id"},
+        join_parts=[jp_with_prefix],
+    )
+    h_no = compute_join_column_hashes(join_no)
+    h_yes = compute_join_column_hashes(join_yes)
+    assert set(h_no.keys()) != set(h_yes.keys()), "Prefix should change output column names"
+
+
+def test_join_hash_with_derivations():
+    """Adding a derivation to a Join changes the hash output."""
+    gb = _make_group_by(
+        name="test_team.gb__0",
+        table="db.events",
+        keys=["user_id"],
+        selects={"user_id": "user_id", "val": "val"},
+        aggregations=[_simple_aggregation("val")],
+    )
+    jp = api.JoinPart(groupBy=gb)
+
+    join_base = _make_join(
+        name="test_team.j__0",
+        left_table="db.left",
+        left_selects={"user_id": "user_id"},
+        join_parts=[jp],
+    )
+    join_derived = _make_join(
+        name="test_team.j__0",
+        left_table="db.left",
+        left_selects={"user_id": "user_id"},
+        join_parts=[jp],
+        derivations=[api.Derivation(name="double_val", expression="user_id_val_sum * 2")],
+    )
+    h_base = compute_join_column_hashes(join_base)
+    h_derived = compute_join_column_hashes(join_derived)
+    assert h_base != h_derived
+
+
+def test_useLongNames_affects_feature_names():
+    """useLongNames=True produces different column names than False."""
+    gb = _make_group_by(
+        name="test_team.gb__0",
+        table="db.events",
+        keys=["user_id"],
+        selects={"user_id": "user_id", "val": "val"},
+        aggregations=[_simple_aggregation("val")],
+    )
+    jp = api.JoinPart(groupBy=gb)
+
+    join_short = _make_join(
+        name="test_team.j__0",
+        left_table="db.left",
+        left_selects={"user_id": "user_id"},
+        join_parts=[jp],
+        use_long_names=False,
+    )
+    join_long = _make_join(
+        name="test_team.j__0",
+        left_table="db.left",
+        left_selects={"user_id": "user_id"},
+        join_parts=[jp],
+        use_long_names=True,
+    )
+    h_short = compute_join_column_hashes(join_short)
+    h_long = compute_join_column_hashes(join_long)
+    assert set(h_short.keys()) != set(h_long.keys()), (
+        f"useLongNames should change column names: short={set(h_short.keys())}, long={set(h_long.keys())}"
+    )

--- a/python/test/test_config_construction.py
+++ b/python/test/test_config_construction.py
@@ -1,0 +1,326 @@
+"""Tests for config construction: GroupBy, Join, StagingQuery, Source."""
+
+from unittest.mock import patch
+
+import pytest
+
+import gen_thrift.api.ttypes as api
+import gen_thrift.common.ttypes as common
+from ai.chronon.group_by import (
+    Aggregation,
+    DefaultAggregation,
+    Derivation,
+    GroupBy,
+    Operation,
+    TimeUnit,
+    Window,
+)
+from ai.chronon.join import Join, JoinPart
+from ai.chronon.query import Query, selects
+from ai.chronon.source import EntitySource, EventSource, JoinSource
+from ai.chronon.staging_query import EngineType, StagingQuery, TableDependency
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _event_source(table="db.events", select_map=None, time_column="event_ts"):
+    if select_map is None:
+        select_map = selects("user_id", "amount")
+    return EventSource(table=table, query=Query(selects=select_map, time_column=time_column))
+
+
+def _entity_source(snapshot_table="db.snapshots", select_map=None):
+    if select_map is None:
+        select_map = selects("user_id", "status")
+    return EntitySource(snapshot_table=snapshot_table, query=Query(selects=select_map))
+
+
+# ---------------------------------------------------------------------------
+# GroupBy construction
+# ---------------------------------------------------------------------------
+
+
+class TestGroupByConstruction:
+    def test_groupby_basic_construction(self):
+        """Simple GroupBy with EventSource, keys, aggregations creates without error."""
+        gb = GroupBy(
+            sources=[_event_source()],
+            keys=["user_id"],
+            aggregations=[Aggregation(input_column="amount", operation=Operation.SUM)],
+        )
+        assert isinstance(gb, api.GroupBy)
+        assert gb.keyColumns == ["user_id"]
+        assert len(gb.aggregations) == 1
+
+    def test_aggregation_with_windows(self):
+        """Aggregation with multiple window sizes is accepted."""
+        agg = Aggregation(
+            input_column="amount",
+            operation=Operation.SUM,
+            windows=[Window(7, TimeUnit.DAYS), Window(30, TimeUnit.DAYS)],
+        )
+        gb = GroupBy(
+            sources=[_event_source()],
+            keys=["user_id"],
+            aggregations=[agg],
+        )
+        assert len(gb.aggregations[0].windows) == 2
+
+    def test_aggregation_with_string_windows(self):
+        """String-format windows like '7d' are normalized."""
+        agg = Aggregation(input_column="amount", operation=Operation.SUM, windows=["7d", "30d"])
+        gb = GroupBy(
+            sources=[_event_source()],
+            keys=["user_id"],
+            aggregations=[agg],
+        )
+        assert len(gb.aggregations[0].windows) == 2
+
+    def test_default_aggregation_excludes_keys(self):
+        """DefaultAggregation on a source skips key columns and reserved columns."""
+        src = _event_source(select_map=selects("user_id", "amount", "score"))
+        aggs = DefaultAggregation(
+            keys=["user_id"],
+            sources=[src],
+            operation=Operation.LAST,
+        )
+        input_cols = [a.inputColumn for a in aggs]
+        assert "user_id" not in input_cols
+        assert "amount" in input_cols
+        assert "score" in input_cols
+
+    def test_groupby_with_derivations(self):
+        """GroupBy with Derivation objects creates without error."""
+        gb = GroupBy(
+            sources=[_event_source()],
+            keys=["user_id"],
+            aggregations=[Aggregation(input_column="amount", operation=Operation.SUM)],
+            derivations=[
+                Derivation(name="*", expression="*"),
+                Derivation(name="double_amount", expression="amount_sum * 2"),
+            ],
+        )
+        assert gb.derivations is not None
+        assert len(gb.derivations) == 2
+
+    def test_groupby_no_aggregations_entity_source(self):
+        """GroupBy with aggregations=None is valid for EntitySource without mutations."""
+        gb = GroupBy(
+            sources=[_entity_source()],
+            keys=["user_id"],
+            aggregations=None,
+        )
+        assert gb.aggregations is None
+
+
+# ---------------------------------------------------------------------------
+# JoinPart construction
+# ---------------------------------------------------------------------------
+
+
+class TestJoinPartConstruction:
+    def _make_gb(self, keys=None):
+        """Create a GroupBy with a pre-set metaData.name to avoid GC module resolution."""
+        if keys is None:
+            keys = ["user_id"]
+        select_map = {k: k for k in keys}
+        select_map["amount"] = "amount"
+        gb = GroupBy(
+            sources=[_event_source(select_map=select_map, time_column="event_ts")],
+            keys=keys,
+            aggregations=[Aggregation(input_column="amount", operation=Operation.SUM)],
+        )
+        # Ensure metaData.name is set so JoinPart doesn't need GC module resolution
+        gb.metaData.name = "test_team.test_gb__0"
+        return gb
+
+    def test_join_part_basic(self):
+        """JoinPart with valid GroupBy creates without error."""
+        gb = self._make_gb()
+        jp = JoinPart(group_by=gb)
+        assert isinstance(jp, api.JoinPart)
+        assert jp.groupBy is gb
+
+    def test_join_part_key_mapping_valid(self):
+        """key_mapping with values matching GroupBy keys is accepted."""
+        gb = self._make_gb(keys=["user_id"])
+        jp = JoinPart(group_by=gb, key_mapping={"buyer_id": "user_id"})
+        assert jp.keyMapping == {"buyer_id": "user_id"}
+
+    def test_join_part_key_mapping_invalid(self):
+        """key_mapping with values not in GroupBy keys raises ValueError."""
+        gb = self._make_gb(keys=["user_id"])
+        with pytest.raises(ValueError, match="Invalid key_mapping"):
+            JoinPart(group_by=gb, key_mapping={"buyer_id": "nonexistent_key"})
+
+    def test_join_part_with_prefix(self):
+        """JoinPart with prefix set."""
+        gb = self._make_gb()
+        jp = JoinPart(group_by=gb, prefix="seller")
+        assert jp.prefix == "seller"
+
+
+# ---------------------------------------------------------------------------
+# Join construction
+# ---------------------------------------------------------------------------
+
+
+class TestJoinConstruction:
+    def _make_join_parts(self):
+        gb = GroupBy(
+            sources=[_event_source()],
+            keys=["user_id"],
+            aggregations=[Aggregation(input_column="amount", operation=Operation.SUM)],
+        )
+        gb.metaData.name = "test_team.test_gb__0"
+        return [JoinPart(group_by=gb)]
+
+    def test_join_basic(self):
+        """Basic Join construction with left source and right parts."""
+        join = Join(
+            left=_event_source(),
+            right_parts=self._make_join_parts(),
+            row_ids=["user_id"],
+        )
+        assert isinstance(join, api.Join)
+        assert len(join.joinParts) == 1
+
+    def test_join_with_derivations(self):
+        """Join with derivations creates without error."""
+        from ai.chronon.join import Derivation as JoinDerivation
+
+        join = Join(
+            left=_event_source(),
+            right_parts=self._make_join_parts(),
+            row_ids=["user_id"],
+            derivations=[JoinDerivation(name="derived_col", expression="user_id_amount_sum * 2")],
+        )
+        assert join.derivations is not None
+        assert len(join.derivations) == 1
+
+    def test_join_row_ids_string_normalized(self):
+        """A single string row_id is normalized to a list."""
+        join = Join(
+            left=_event_source(),
+            right_parts=self._make_join_parts(),
+            row_ids="user_id",
+        )
+        assert join.rowIds == ["user_id"]
+
+
+# ---------------------------------------------------------------------------
+# StagingQuery construction
+# ---------------------------------------------------------------------------
+
+
+class TestStagingQueryConstruction:
+    def test_staging_query_basic(self):
+        """Simple StagingQuery with query and dependencies."""
+        sq = StagingQuery(
+            query="SELECT * FROM db.my_table WHERE ds = '{{ end_date }}'",
+            dependencies=[TableDependency(table="db.my_table", partition_column="ds", offset=0)],
+        )
+        assert isinstance(sq, api.StagingQuery)
+        assert "my_table" in sq.query
+
+    def test_staging_query_template_variables(self):
+        """Query with {{ start_date }} and {{ end_date }} is accepted."""
+        query_str = (
+            "SELECT * FROM db.events "
+            "WHERE ds BETWEEN '{{ start_date }}' AND '{{ end_date }}'"
+        )
+        sq = StagingQuery(
+            query=query_str,
+            dependencies=[TableDependency(table="db.events", partition_column="ds", offset=0)],
+        )
+        assert "{{ start_date }}" in sq.query
+        assert "{{ end_date }}" in sq.query
+
+    def test_staging_query_unparseable_sql(self):
+        """Malformed SQL is handled gracefully (no crash) when no tables are detected."""
+        # _tables_in_query catches parse errors and returns [], so no dependency check triggers
+        sq = StagingQuery(
+            query="THIS IS NOT VALID SQL !!@#$%",
+        )
+        assert isinstance(sq, api.StagingQuery)
+
+    def test_staging_query_engine_types(self):
+        """SPARK, BIGQUERY, SNOWFLAKE engine types are all accepted."""
+        for engine in [EngineType.SPARK, EngineType.BIGQUERY, EngineType.SNOWFLAKE]:
+            sq = StagingQuery(
+                query="SELECT 1",
+                engine_type=engine,
+            )
+            assert sq.engineType == engine
+
+    def test_staging_query_with_table_dependency(self):
+        """TableDependency objects are converted to thrift properly."""
+        dep = TableDependency(table="db.events", partition_column="ds", offset=1)
+        sq = StagingQuery(
+            query="SELECT * FROM db.events WHERE ds = '{{ end_date }}'",
+            dependencies=[dep],
+        )
+        assert len(sq.tableDependencies) == 1
+        assert sq.tableDependencies[0].tableInfo.table == "db.events"
+
+
+# ---------------------------------------------------------------------------
+# Source construction
+# ---------------------------------------------------------------------------
+
+
+class TestSourceConstruction:
+    def test_event_source_basic(self):
+        """EventSource with table and query returns a Source with events set."""
+        src = EventSource(table="db.events", query=Query(selects=selects("user_id", "amount")))
+        assert isinstance(src, api.Source)
+        assert src.events is not None
+        assert src.events.table == "db.events"
+
+    def test_entity_source_basic(self):
+        """EntitySource with snapshot_table returns a Source with entities set."""
+        src = EntitySource(
+            snapshot_table="db.users",
+            query=Query(selects=selects("user_id", "status")),
+        )
+        assert isinstance(src, api.Source)
+        assert src.entities is not None
+        assert src.entities.snapshotTable == "db.users"
+
+    def test_entity_source_with_mutation(self):
+        """EntitySource with mutation_table sets the field correctly."""
+        src = EntitySource(
+            snapshot_table="db.users",
+            query=Query(selects=selects("user_id", "status")),
+            mutation_table="db.users_mutations",
+        )
+        assert src.entities.mutationTable == "db.users_mutations"
+
+    def test_join_source_construction(self):
+        """JoinSource wrapping a Join returns a Source with joinSource set."""
+        # Build a minimal Join thrift object directly to avoid side effects
+        left = _event_source()
+        gb = GroupBy(
+            sources=[_event_source()],
+            keys=["user_id"],
+            aggregations=[Aggregation(input_column="amount", operation=Operation.SUM)],
+        )
+        gb.metaData.name = "test_team.inner_gb__0"
+        jp = JoinPart(group_by=gb)
+        inner_join = Join(
+            left=left,
+            right_parts=[jp],
+            row_ids=["user_id"],
+        )
+        inner_join.metaData.name = "test_team.inner_join__0"
+
+        src = JoinSource(
+            join=inner_join,
+            query=Query(selects=selects("user_id", "amount_sum")),
+        )
+        assert isinstance(src, api.Source)
+        assert src.joinSource is not None
+        assert src.joinSource.join is inner_join


### PR DESCRIPTION
## Summary
Part of the comprehensive test infrastructure push.

Unit tests for semantic hash computation and config object construction.

## Tests
### test_column_hashing.py (8 tests)
- Hash determinism, aggregation/source change detection
- Metadata stability (changes don't affect hash)
- Prefix, derivation, useLongNames effects on hashes

### test_config_construction.py (22 tests)
- **GroupBy**: basic, windowed, string windows, DefaultAggregation, derivations, entity passthrough
- **JoinPart**: basic, valid/invalid key_mapping, prefix
- **Join**: basic, derivations, row_ids normalization
- **StagingQuery**: basic, templates, unparseable SQL, engine types, TableDependency
- **Source**: EventSource, EntitySource, EntitySource with mutations, JoinSource

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests verifying deterministic and semantically sensitive hashing for group-by and join outputs (including invariance to non-semantic metadata, sensitivity to added aggregations, prefixes, derivations, and name-format options).
  * Added tests validating construction and serialization of configuration objects (sources, joins/join parts, staging queries, aggregations/windows), input normalization, key-mapping validation, error handling for unparseable SQL, and engine/type propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->