### PR TITLE
test: Add cloud-specific table validation helpers

### DIFF
--- a/python/test/integration/helpers/validation.py
+++ b/python/test/integration/helpers/validation.py
@@ -1,0 +1,182 @@
+"""Cloud-specific output table validation for integration tests.
+
+After a backfill completes, these helpers verify that output tables
+exist and contain non-null data for the expected partitions.
+"""
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+try:
+    from google.cloud import bigquery as _bigquery
+except ImportError:
+    _bigquery = None  # type: ignore[assignment]
+
+try:
+    import boto3
+except ImportError:
+    boto3 = None  # type: ignore[assignment]
+
+try:
+    import pyarrow.parquet as pq
+except ImportError:
+    pq = None  # type: ignore[assignment]
+
+
+def validate_table_has_data(
+    cloud: str,
+    table_name: str,
+    partition_col: str,
+    partition_value: str,
+) -> bool:
+    """Return True if the table partition has at least one row."""
+    if cloud == "gcp":
+        return _gcp_table_has_data(table_name, partition_col, partition_value)
+    elif cloud == "aws":
+        return _aws_table_has_data(table_name, partition_col, partition_value)
+    elif cloud == "azure":
+        return _azure_table_has_data(table_name, partition_col, partition_value)
+    else:
+        raise ValueError(f"Unsupported cloud: {cloud}")
+
+
+def validate_columns_non_null(
+    cloud: str,
+    table_name: str,
+    columns: list[str],
+    partition_col: str,
+    partition_value: str,
+) -> bool:
+    """Return True if every column in *columns* has at least one non-null value in the partition."""
+    if cloud == "gcp":
+        return _gcp_columns_non_null(table_name, columns, partition_col, partition_value)
+    elif cloud == "aws":
+        return _aws_columns_non_null(table_name, columns, partition_col, partition_value)
+    elif cloud == "azure":
+        return _azure_columns_non_null(table_name, columns, partition_col, partition_value)
+    else:
+        raise ValueError(f"Unsupported cloud: {cloud}")
+
+
+# ---------------------------------------------------------------------------
+# GCP (BigQuery)
+# ---------------------------------------------------------------------------
+
+
+def _gcp_table_has_data(table_name: str, partition_col: str, partition_value: str) -> bool:
+    project = os.environ.get("GCP_BQ_PROJECT", "canary-443022")
+    client = _bigquery.Client(project=project)
+
+    query = (
+        f"SELECT COUNT(*) as cnt FROM `{table_name}` "
+        f"WHERE {partition_col} = '{partition_value}'"
+    )
+    logger.info("GCP validation query: %s", query)
+    result = client.query(query).result()
+    row = next(iter(result))
+    cnt = row.cnt
+    logger.info("GCP row count for %s partition %s=%s: %d", table_name, partition_col, partition_value, cnt)
+    return cnt > 0
+
+
+def _gcp_columns_non_null(
+    table_name: str, columns: list[str], partition_col: str, partition_value: str
+) -> bool:
+    project = os.environ.get("GCP_BQ_PROJECT", "canary-443022")
+    client = _bigquery.Client(project=project)
+
+    non_null_exprs = ", ".join(f"COUNTIF({c} IS NOT NULL) as {c}_nonnull" for c in columns)
+    query = (
+        f"SELECT COUNT(*) as total, {non_null_exprs} "
+        f"FROM `{table_name}` WHERE {partition_col} = '{partition_value}'"
+    )
+    logger.info("GCP non-null validation query: %s", query)
+    result = client.query(query).result()
+    row = next(iter(result))
+
+    for c in columns:
+        nonnull_count = getattr(row, f"{c}_nonnull")
+        logger.info("  %s: %d non-null values", c, nonnull_count)
+        if nonnull_count == 0:
+            logger.warning("Column %s has zero non-null values in %s", c, table_name)
+            return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# AWS (S3 / Parquet)
+# ---------------------------------------------------------------------------
+
+_S3_BUCKET = "zipline-warehouse-canary"
+_S3_TABLE_PREFIX = "data/tables"
+
+
+def _aws_table_has_data(table_name: str, partition_col: str, partition_value: str) -> bool:
+    region = os.environ.get("AWS_REGION", "us-west-2")
+    s3 = boto3.client("s3", region_name=region)
+
+    prefix = f"{_S3_TABLE_PREFIX}/{table_name}/data/{partition_col}={partition_value}/"
+    logger.info("AWS validation: listing s3://%s/%s", _S3_BUCKET, prefix)
+
+    resp = s3.list_objects_v2(Bucket=_S3_BUCKET, Prefix=prefix, MaxKeys=10)
+    parquet_files = [
+        obj["Key"] for obj in resp.get("Contents", []) if obj["Key"].endswith(".parquet")
+    ]
+    logger.info("AWS found %d parquet files for %s", len(parquet_files), table_name)
+    return len(parquet_files) > 0
+
+
+def _aws_columns_non_null(
+    table_name: str, columns: list[str], partition_col: str, partition_value: str
+) -> bool:
+    region = os.environ.get("AWS_REGION", "us-west-2")
+    s3 = boto3.client("s3", region_name=region)
+
+    prefix = f"{_S3_TABLE_PREFIX}/{table_name}/data/{partition_col}={partition_value}/"
+    resp = s3.list_objects_v2(Bucket=_S3_BUCKET, Prefix=prefix, MaxKeys=10)
+    parquet_files = [
+        obj["Key"] for obj in resp.get("Contents", []) if obj["Key"].endswith(".parquet")
+    ]
+
+    if not parquet_files:
+        logger.warning("No parquet files found for %s at %s", table_name, prefix)
+        return False
+
+    # Read the first parquet file and check columns
+    key = parquet_files[0]
+    logger.info("AWS reading s3://%s/%s for non-null check", _S3_BUCKET, key)
+    obj = s3.get_object(Bucket=_S3_BUCKET, Key=key)
+    table = pq.read_table(obj["Body"])
+
+    for c in columns:
+        if c not in table.column_names:
+            logger.warning("Column %s not found in parquet file for %s", c, table_name)
+            return False
+        col = table.column(c)
+        non_null = col.null_count < len(col)
+        logger.info("  %s: %d/%d non-null", c, len(col) - col.null_count, len(col))
+        if not non_null:
+            logger.warning("Column %s is entirely null in %s", c, table_name)
+            return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Azure (stub)
+# ---------------------------------------------------------------------------
+
+
+def _azure_table_has_data(table_name: str, partition_col: str, partition_value: str) -> bool:
+    # TODO: implement Snowflake/Iceberg REST validation for Azure canary tables
+    logger.warning("Azure table validation not yet implemented for %s", table_name)
+    return True
+
+
+def _azure_columns_non_null(
+    table_name: str, columns: list[str], partition_col: str, partition_value: str
+) -> bool:
+    # TODO: implement Snowflake/Iceberg REST validation for Azure canary tables
+    logger.warning("Azure column validation not yet implemented for %s", table_name)
+    return True

--- a/python/test/test_validation_helper.py
+++ b/python/test/test_validation_helper.py
@@ -1,0 +1,119 @@
+"""Unit tests for integration validation helpers with mocked cloud clients."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from integration.helpers.validation import (
+    validate_columns_non_null,
+    validate_table_has_data,
+)
+
+
+# ---------------------------------------------------------------------------
+# GCP tests
+# ---------------------------------------------------------------------------
+
+
+@patch("integration.helpers.validation._bigquery")
+def test_gcp_validate_returns_true_when_data_exists(mock_bq):
+    mock_client = MagicMock()
+    mock_bq.Client.return_value = mock_client
+
+    row = MagicMock()
+    row.cnt = 5
+    mock_client.query.return_value.result.return_value = iter([row])
+
+    assert validate_table_has_data("gcp", "project.dataset.table", "ds", "2024-01-01") is True
+
+
+@patch("integration.helpers.validation._bigquery")
+def test_gcp_validate_returns_false_when_no_data(mock_bq):
+    mock_client = MagicMock()
+    mock_bq.Client.return_value = mock_client
+
+    row = MagicMock()
+    row.cnt = 0
+    mock_client.query.return_value.result.return_value = iter([row])
+
+    assert validate_table_has_data("gcp", "project.dataset.table", "ds", "2024-01-01") is False
+
+
+@patch("integration.helpers.validation._bigquery")
+def test_gcp_columns_non_null_returns_true(mock_bq):
+    mock_client = MagicMock()
+    mock_bq.Client.return_value = mock_client
+
+    row = MagicMock()
+    row.total = 10
+    row.col_a_nonnull = 8
+    row.col_b_nonnull = 3
+    mock_client.query.return_value.result.return_value = iter([row])
+
+    assert (
+        validate_columns_non_null(
+            "gcp", "project.dataset.table", ["col_a", "col_b"], "ds", "2024-01-01"
+        )
+        is True
+    )
+
+
+@patch("integration.helpers.validation._bigquery")
+def test_gcp_columns_non_null_returns_false_when_all_null(mock_bq):
+    mock_client = MagicMock()
+    mock_bq.Client.return_value = mock_client
+
+    row = MagicMock()
+    row.total = 10
+    row.col_a_nonnull = 0
+    row.col_b_nonnull = 5
+    mock_client.query.return_value.result.return_value = iter([row])
+
+    assert (
+        validate_columns_non_null(
+            "gcp", "project.dataset.table", ["col_a", "col_b"], "ds", "2024-01-01"
+        )
+        is False
+    )
+
+
+# ---------------------------------------------------------------------------
+# AWS tests
+# ---------------------------------------------------------------------------
+
+
+@patch("integration.helpers.validation.boto3")
+def test_aws_validate_returns_true_when_parquet_exists(mock_boto3):
+    mock_s3 = MagicMock()
+    mock_boto3.client.return_value = mock_s3
+
+    mock_s3.list_objects_v2.return_value = {
+        "Contents": [
+            {"Key": "data/tables/my_table/data/ds=2024-01-01/part-00000.parquet"},
+        ]
+    }
+
+    assert validate_table_has_data("aws", "my_table", "ds", "2024-01-01") is True
+
+
+@patch("integration.helpers.validation.boto3")
+def test_aws_validate_returns_false_when_no_parquet(mock_boto3):
+    mock_s3 = MagicMock()
+    mock_boto3.client.return_value = mock_s3
+
+    mock_s3.list_objects_v2.return_value = {"Contents": []}
+
+    assert validate_table_has_data("aws", "my_table", "ds", "2024-01-01") is False
+
+
+# ---------------------------------------------------------------------------
+# Azure tests
+# ---------------------------------------------------------------------------
+
+
+def test_azure_validate_returns_true_stub():
+    assert validate_table_has_data("azure", "some_table", "ds", "2024-01-01") is True
+
+
+def test_azure_columns_non_null_returns_true_stub():
+    assert validate_columns_non_null("azure", "some_table", ["col_a"], "ds", "2024-01-01") is True

--- a/python/test/test_validation_helper.py
+++ b/python/test/test_validation_helper.py
@@ -1,10 +1,15 @@
 """Unit tests for integration validation helpers with mocked cloud clients."""
 
+import os
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from integration.helpers.validation import (
+# Add the integration directory to the path so we can import the helpers
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "integration"))
+
+from helpers.validation import (  # noqa: E402
     validate_columns_non_null,
     validate_table_has_data,
 )
@@ -15,7 +20,7 @@ from integration.helpers.validation import (
 # ---------------------------------------------------------------------------
 
 
-@patch("integration.helpers.validation._bigquery")
+@patch("helpers.validation._bigquery")
 def test_gcp_validate_returns_true_when_data_exists(mock_bq):
     mock_client = MagicMock()
     mock_bq.Client.return_value = mock_client
@@ -27,7 +32,7 @@ def test_gcp_validate_returns_true_when_data_exists(mock_bq):
     assert validate_table_has_data("gcp", "project.dataset.table", "ds", "2024-01-01") is True
 
 
-@patch("integration.helpers.validation._bigquery")
+@patch("helpers.validation._bigquery")
 def test_gcp_validate_returns_false_when_no_data(mock_bq):
     mock_client = MagicMock()
     mock_bq.Client.return_value = mock_client
@@ -39,7 +44,7 @@ def test_gcp_validate_returns_false_when_no_data(mock_bq):
     assert validate_table_has_data("gcp", "project.dataset.table", "ds", "2024-01-01") is False
 
 
-@patch("integration.helpers.validation._bigquery")
+@patch("helpers.validation._bigquery")
 def test_gcp_columns_non_null_returns_true(mock_bq):
     mock_client = MagicMock()
     mock_bq.Client.return_value = mock_client
@@ -58,7 +63,7 @@ def test_gcp_columns_non_null_returns_true(mock_bq):
     )
 
 
-@patch("integration.helpers.validation._bigquery")
+@patch("helpers.validation._bigquery")
 def test_gcp_columns_non_null_returns_false_when_all_null(mock_bq):
     mock_client = MagicMock()
     mock_bq.Client.return_value = mock_client
@@ -82,7 +87,7 @@ def test_gcp_columns_non_null_returns_false_when_all_null(mock_bq):
 # ---------------------------------------------------------------------------
 
 
-@patch("integration.helpers.validation.boto3")
+@patch("helpers.validation.boto3")
 def test_aws_validate_returns_true_when_parquet_exists(mock_boto3):
     mock_s3 = MagicMock()
     mock_boto3.client.return_value = mock_s3
@@ -96,7 +101,7 @@ def test_aws_validate_returns_true_when_parquet_exists(mock_boto3):
     assert validate_table_has_data("aws", "my_table", "ds", "2024-01-01") is True
 
 
-@patch("integration.helpers.validation.boto3")
+@patch("helpers.validation.boto3")
 def test_aws_validate_returns_false_when_no_parquet(mock_boto3):
     mock_s3 = MagicMock()
     mock_boto3.client.return_value = mock_s3


### PR DESCRIPTION
## Summary
Part of the comprehensive test infrastructure push.

Shared infrastructure for verifying output tables after hub backfills.

## Files
### helpers/validation.py
- `validate_table_has_data(cloud, table_name, partition_col, partition_value)` — GCP (BigQuery), AWS (S3/parquet), Azure (stub)
- `validate_columns_non_null(cloud, table_name, columns, partition_col, partition_value)` — verify non-null values

### test_validation_helper.py (8 tests)
- GCP: data exists/empty, columns non-null/all-null (mocked BigQuery)
- AWS: parquet exists/empty (mocked boto3)
- Azure: stub always returns True

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added cloud-aware integration-test validation helpers to verify table data presence and non-null columns across GCP, AWS, and Azure.

* **Tests**
  * Added unit tests that mock cloud clients to exercise the new validation helpers for GCP, AWS, and Azure behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->