### PR TITLE
feat: add support for spark on kubernetes

### DIFF
--- a/.github/workflows/grype_scan_reusable.yaml
+++ b/.github/workflows/grype_scan_reusable.yaml
@@ -42,6 +42,9 @@ jobs:
       - name: Build Cloud AWS JAR
         run: ./mill cloud_aws\[${{ env.SCALA_VERSION }}\].assembly
 
+      - name: Build Cloud K8s JAR
+        run: ./mill cloud_k8s\[${{ env.SCALA_VERSION }}\].assembly
+
       - name: Build Cloud Azure JAR
         run: ./mill cloud_azure\[${{ env.SCALA_VERSION }}\].assembly
 
@@ -61,6 +64,7 @@ jobs:
           cp out/service/${{ env.SCALA_VERSION }}/assembly.dest/out.jar build_output/service_assembly_deploy.jar
           cp out/cloud_gcp/${{ env.SCALA_VERSION }}/assembly.dest/out.jar build_output/cloud_gcp_lib_deploy.jar
           cp out/cloud_aws/${{ env.SCALA_VERSION }}/assembly.dest/out.jar build_output/cloud_aws_lib_deploy.jar
+          cp out/cloud_k8s/${{ env.SCALA_VERSION }}/assembly.dest/out.jar build_output/cloud_k8s_lib_deploy.jar
           cp out/cloud_azure/${{ env.SCALA_VERSION }}/assembly.dest/out.jar build_output/cloud_azure_lib_deploy.jar
 
       - name: Set up Docker Buildx
@@ -93,6 +97,12 @@ jobs:
         with:
           name: grype-cloud-aws-jar
           path: out/cloud_aws/${{ env.SCALA_VERSION }}/assembly.dest/out.jar
+
+      - name: Upload Cloud K8s Jar
+        uses: actions/upload-artifact@v4
+        with:
+          name: grype-cloud-k8s-jar
+          path: out/cloud_k8s/${{ env.SCALA_VERSION }}/assembly.dest/out.jar
 
       - name: Upload Cloud Azure Jar
         uses: actions/upload-artifact@v4
@@ -141,6 +151,10 @@ jobs:
             fail_on: low
           - artifact: cloud-aws
             artifact_name: grype-cloud-aws-jar
+            scan_type: jar
+            fail_on: low
+          - artifact: cloud-k8s
+            artifact_name: grype-cloud-k8s-jar
             scan_type: jar
             fail_on: low
           - artifact: cloud-azure

--- a/.github/workflows/push_to_canary.yaml
+++ b/.github/workflows/push_to_canary.yaml
@@ -421,6 +421,12 @@ jobs:
           name: cloud-azure-jar
           path: cloud-azure-jar
 
+      - name: Download Cloud K8s Jar
+        uses: actions/download-artifact@v4
+        with:
+          name: cloud-k8s-jar
+          path: cloud-k8s-jar
+
       - name: Download Service Assembly Jar
         uses: actions/download-artifact@v4
         with:
@@ -433,6 +439,7 @@ jobs:
           cp cloud-aws-jar/out.jar build_output/cloud_aws_lib_deploy.jar
           cp cloud-gcp-jar/out.jar build_output/cloud_gcp_lib_deploy.jar
           cp cloud-azure-jar/out.jar build_output/cloud_azure_lib_deploy.jar
+          cp cloud-k8s-jar/out.jar build_output/cloud_k8s_lib_deploy.jar
           cp service-assembly-jar/out.jar build_output/service_assembly_deploy.jar
 
       - name: Set up Docker Buildx
@@ -768,6 +775,7 @@ jobs:
             flink-assembly-jar
             cloud-aws-jar
             cloud-gcp-jar
+            cloud-k8s-jar
             service-assembly-jar
             pubsub-jar
             kinesis-jar

--- a/.github/workflows/reusable_build_and_push.yaml
+++ b/.github/workflows/reusable_build_and_push.yaml
@@ -103,6 +103,12 @@ jobs:
           name: cloud-gcp-jar
           path: out/cloud_gcp/${{ env.SCALA_VERSION }}/assembly.dest/out.jar
 
+      - name: Upload Cloud K8s Jar
+        uses: actions/upload-artifact@v4
+        with:
+          name: cloud-k8s-jar
+          path: out/cloud_k8s/${{ env.SCALA_VERSION }}/assembly.dest/out.jar
+
 
       - name: Upload Cloud Azure Jar
         uses: actions/upload-artifact@v4
@@ -170,6 +176,12 @@ jobs:
           name: service-assembly-jar
           path: service-assembly-jar
 
+      - name: Download Cloud K8s Jar
+        uses: actions/download-artifact@v4
+        with:
+          name: cloud-k8s-jar
+          path: cloud-k8s-jar
+
       - name: Download Kinesis Jar
         uses: actions/download-artifact@v4
         with:
@@ -180,6 +192,7 @@ jobs:
         run: |
           mv flink-assembly-jar/out.jar flink_assembly_deploy.jar
           mv cloud-aws-jar/out.jar cloud_aws_lib_deploy.jar
+          mv cloud-k8s-jar/out.jar cloud_k8s_lib_deploy.jar
           mv service-assembly-jar/out.jar service_assembly_deploy.jar
           mv kinesis-jar/out.jar connectors_kinesis_deploy.jar
 
@@ -196,6 +209,7 @@ jobs:
           aws s3 cp ${{ needs.build_artifacts.outputs.wheel_name }} s3://zipline-artifacts-canary/release/${{ needs.build_artifacts.outputs.version }}/wheels/ --metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
           aws s3 cp flink_assembly_deploy.jar s3://zipline-artifacts-canary/release/${{ needs.build_artifacts.outputs.version }}/jars/flink_assembly_deploy.jar --metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
           aws s3 cp cloud_aws_lib_deploy.jar s3://zipline-artifacts-canary/release/${{ needs.build_artifacts.outputs.version }}/jars/cloud_aws_lib_deploy.jar --metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
+          aws s3 cp cloud_k8s_lib_deploy.jar s3://zipline-artifacts-canary/release/${{ needs.build_artifacts.outputs.version }}/jars/cloud_k8s_lib_deploy.jar --metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
           aws s3 cp service_assembly_deploy.jar s3://zipline-artifacts-canary/release/${{ needs.build_artifacts.outputs.version }}/jars/service_assembly_deploy.jar --metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
           aws s3 cp connectors_kinesis_deploy.jar s3://zipline-artifacts-canary/release/${{ needs.build_artifacts.outputs.version }}/jars/connectors_kinesis_deploy.jar --metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
 
@@ -233,6 +247,12 @@ jobs:
           name: service-assembly-jar
           path: service-assembly-jar
 
+      - name: Download Cloud K8s Jar
+        uses: actions/download-artifact@v4
+        with:
+          name: cloud-k8s-jar
+          path: cloud-k8s-jar
+
       - name: Download PubSub Jar
         uses: actions/download-artifact@v4
         with:
@@ -243,6 +263,7 @@ jobs:
         run: |
           mv flink-assembly-jar/out.jar flink_assembly_deploy.jar
           mv cloud-gcp-jar/out.jar cloud_gcp_lib_deploy.jar
+          mv cloud-k8s-jar/out.jar cloud_k8s_lib_deploy.jar
           mv service-assembly-jar/out.jar service_assembly_deploy.jar
           mv pubsub-jar/out.jar connectors_pubsub_deploy.jar
 
@@ -268,6 +289,9 @@ jobs:
 
           gcloud storage cp cloud_gcp_lib_deploy.jar gs://zipline-artifacts-canary/release/${{ needs.build_artifacts.outputs.version }}/jars/cloud_gcp_lib_deploy.jar
           gcloud storage objects update gs://zipline-artifacts-canary/release/${{ needs.build_artifacts.outputs.version }}/jars/cloud_gcp_lib_deploy.jar --custom-metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
+
+          gcloud storage cp cloud_k8s_lib_deploy.jar gs://zipline-artifacts-canary/release/${{ needs.build_artifacts.outputs.version }}/jars/cloud_k8s_lib_deploy.jar
+          gcloud storage objects update gs://zipline-artifacts-canary/release/${{ needs.build_artifacts.outputs.version }}/jars/cloud_k8s_lib_deploy.jar --custom-metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
 
           gcloud storage cp service_assembly_deploy.jar gs://zipline-artifacts-canary/release/${{ needs.build_artifacts.outputs.version }}/jars/service_assembly_deploy.jar
           gcloud storage objects update gs://zipline-artifacts-canary/release/${{ needs.build_artifacts.outputs.version }}/jars/service_assembly_deploy.jar --custom-metadata="updated_date=$(date),commit=$(git rev-parse HEAD),branch=$(git rev-parse --abbrev-ref HEAD)"
@@ -317,9 +341,16 @@ jobs:
           name: cloud-azure-jar
           path: cloud-azure-jar
 
+      - name: Download Cloud K8s Jar
+        uses: actions/download-artifact@v4
+        with:
+          name: cloud-k8s-jar
+          path: cloud-k8s-jar
+
       - name: Rename JAR files to expected names
         run: |
           mv cloud-azure-jar/out.jar cloud_azure_lib_deploy.jar
+          mv cloud-k8s-jar/out.jar cloud_k8s_lib_deploy.jar
           mv flink-assembly-jar/out.jar flink_assembly_deploy.jar
           mv service-assembly-jar/out.jar service_assembly_deploy.jar
 
@@ -337,6 +368,14 @@ jobs:
             --container-name $CONTAINER \
             --file cloud_azure_lib_deploy.jar \
             --name release/${VERSION}/jars/cloud_azure_lib_deploy.jar \
+            --overwrite
+
+          az storage blob upload \
+            --account-name $ACCOUNT \
+            --auth-mode login \
+            --container-name $CONTAINER \
+            --file cloud_k8s_lib_deploy.jar \
+            --name release/${VERSION}/jars/cloud_k8s_lib_deploy.jar \
             --overwrite
 
           az storage blob upload \

--- a/build.mill
+++ b/build.mill
@@ -119,7 +119,14 @@ object Constants {
   val avroVersion = "1.12.1"
   val protobufVersion = "3.25.5"
   val jettyVersion = "12.0.33"
-  
+  // Vert.x is a runtime dep of fabric8 kubernetes-client used by K8sSubmitter; pinned here so
+  // cloud_k8s and any future K8s-targeted module share a single coordinated version.
+  val vertxVersion = "4.5.27"
+  // Netty is pulled in transitively by Vert.x and fabric8 kubernetes-client at mismatched
+  // 4.1.x patch levels; pinned here so every K8s/Flink-flavored assembly shares a single
+  // CVE-clear version. Bump when grype flags new GHSAs against 4.1.x codec/handler modules.
+  val nettyVersion = "4.1.133.Final"
+
   // Common JVM arguments for all test modules
   def commonTestForkArgs = Seq(
     "--add-opens=java.base/java.lang=ALL-UNNAMED",
@@ -408,6 +415,7 @@ trait ArtifactsModule extends Cross.Module[String] {
       flink(scalaVersion).assembly(),
       cloud_gcp(scalaVersion).assembly(),
       cloud_aws(scalaVersion).assembly(),
+      cloud_k8s(scalaVersion).assembly(),
       cloud_azure(scalaVersion).assembly(),
       service(scalaVersion).assembly(),
       flink_connectors.pubsub(scalaVersion).assembly(),

--- a/cloud_k8s/package.mill
+++ b/cloud_k8s/package.mill
@@ -19,14 +19,31 @@ trait CloudK8sModule extends Cross.Module[String] with build.BaseModule {
       .exclude("com.fasterxml.jackson.core" -> "jackson-annotations")
       .exclude("com.fasterxml.jackson.dataformat" -> "jackson-dataformat-yaml")
       .exclude("com.fasterxml.jackson.datatype" -> "jackson-datatype-jsr310"),
-    mvn"io.vertx:vertx-core:4.5.27",
-    mvn"io.vertx:vertx-web-client:4.5.27",
-  )
+    // Required at runtime by KubeConfigUtils.parseConfig when K8sSubmitter builds a fabric8
+    // client via Config.autoConfigure; pinned to keep YAML parsing aligned with the explicitly
+    // forced jackson-core/databind/annotations versions above.
+    mvn"com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${build.Constants.jacksonVersion}".forceVersion(),
+    mvn"io.vertx:vertx-core:${build.Constants.vertxVersion}",
+    mvn"io.vertx:vertx-web-client:${build.Constants.vertxVersion}",
+  ) ++ Seq(
+    mvn"io.netty:netty-codec:${build.Constants.nettyVersion}",
+    mvn"io.netty:netty-codec-http:${build.Constants.nettyVersion}",
+    mvn"io.netty:netty-codec-http2:${build.Constants.nettyVersion}",
+    mvn"io.netty:netty-codec-dns:${build.Constants.nettyVersion}",
+    mvn"io.netty:netty-codec-mqtt:${build.Constants.nettyVersion}",
+    mvn"io.netty:netty-codec-redis:${build.Constants.nettyVersion}",
+    mvn"io.netty:netty-handler-proxy:${build.Constants.nettyVersion}",
+  ).map(_.forceVersion())
 
   object test extends build.BaseTestModule {
     def scalaVersion = crossValue
     def moduleDeps = Seq(build.cloud_k8s(crossValue))
-    def mvnDeps = super.mvnDeps() ++ build.Constants.testDeps
+    def mvnDeps = super.mvnDeps() ++ build.Constants.testDeps ++ Seq(
+      mvn"io.fabric8:kubernetes-server-mock:7.5.2"
+        .exclude("com.fasterxml.jackson.core" -> "jackson-core")
+        .exclude("com.fasterxml.jackson.core" -> "jackson-databind")
+        .exclude("com.fasterxml.jackson.core" -> "jackson-annotations"),
+    )
     override def testFramework = "org.scalatest.tools.Framework"
     def forkArgs = build.Constants.commonTestForkArgs
   }

--- a/cloud_k8s/src/main/scala/ai/chronon/integrations/cloud_k8s/K8sSubmitter.scala
+++ b/cloud_k8s/src/main/scala/ai/chronon/integrations/cloud_k8s/K8sSubmitter.scala
@@ -1,0 +1,725 @@
+package ai.chronon.integrations.cloud_k8s
+
+import ai.chronon.api.Builders.MetaData
+import ai.chronon.api.JobStatusType
+import ai.chronon.spark.submission.JobSubmitterConstants._
+import ai.chronon.spark.submission.{FlinkJob, JobSubmitter, JobType, SparkJob}
+import io.fabric8.kubernetes.api.model.{ContainerStatus, Pod}
+import io.fabric8.kubernetes.client.{Config, KubernetesClient, KubernetesClientBuilder}
+
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+import scala.collection.mutable
+import scala.jdk.CollectionConverters._
+import scala.util.control.NonFatal
+
+/** Kubernetes job submitter for Chronon (Spark today; Flink-on-K8s planned).
+  * Named generically (`K8sSubmitter`, not `K8sSparkSubmitter`) to leave room
+  * for Flink without a rename.
+  *
+  * Submission mode is resolved from job/mode-config, submission properties, and
+  * `CHRONON_K8S_SUBMISSION_MODE` (see [[SubmissionMode]]). `SparkSubmit` shells out
+  * to `spark-submit`; `SparkOperator` dispatches to companion CRD ingress stubs until
+  * SparkApplication apply is implemented.
+  */
+class K8sSubmitter(
+    val sparkSubmitPath: String,
+    val k8sMaster: String,
+    val namespace: String,
+    val serviceAccount: String,
+    val image: String,
+    val fileUploadPath: String,
+    val extraSparkConf: Map[String, String],
+    val configResolver: () => Config = () => Config.autoConfigure(null)
+) extends JobSubmitter {
+
+  override def isClusterCreateNeeded(isLongRunning: Boolean): Boolean = false
+
+  override def submit(
+      jobType: JobType,
+      submissionProperties: Map[String, String],
+      jobProperties: Map[String, String],
+      files: List[String],
+      labels: Map[String, String],
+      envVars: Map[String, String],
+      args: String*
+  ): String = {
+    require(jobType == SparkJob, "K8sSubmitter only supports Spark batch jobs")
+    if (labels.nonEmpty) {
+      logger.warn(
+        "K8sSubmitter.submit ignores `labels` (not mapped to spark.kubernetes.*.label.*); use SPARK_K8S_CONF or job properties if you need driver/executor labels."
+      )
+    }
+    val rawArgs = args.toArray
+    val appName = K8sSubmitter.resolveSparkAppName(submissionProperties, rawArgs)
+    val jobIdUuid = submissionProperties.getOrElse(
+      JobId,
+      throw new IllegalArgumentException(s"Missing required submission property: $JobId")
+    )
+    val chrononJobId = K8sSubmitter.formatChrononJobId(jobType, namespace, appName, jobIdUuid)
+    val effectiveJobProperties = jobProperties ++ envVarsToSparkProperties(envVars)
+    SubmissionMode.resolve(submissionProperties, effectiveJobProperties) match {
+      case SubmissionMode.SparkOperator =>
+        K8sSubmitter.submitViaSparkApplicationCrd(
+          submitter = this,
+          jobType = jobType,
+          submissionProperties = submissionProperties,
+          jobProperties = effectiveJobProperties,
+          files = files,
+          labels = labels,
+          envVars = envVars,
+          rawArgs = rawArgs,
+          appName = appName,
+          chrononJobId = chrononJobId
+        )
+      case SubmissionMode.SparkSubmit =>
+        val argv = K8sSubmitter.buildSparkSubmitArgv(
+          submitter = this,
+          submissionProperties = submissionProperties,
+          jobProperties = effectiveJobProperties,
+          files = files,
+          rawArgs = rawArgs,
+          jobType = jobType,
+          sparkAppName = appName,
+          chrononJobId = chrononJobId,
+          waitForAppCompletion = false
+        )
+        val proc = K8sSubmitter.runSparkSubmitProcess(argv, inheritIo = true)
+        val exit = K8sSubmitter.waitForSparkSubmitExitCode(proc)
+        if (exit != 0) throw new RuntimeException(s"spark-submit failed with exit code $exit")
+        chrononJobId
+    }
+  }
+
+  override def status(jobId: String): JobStatusType = {
+    var client: KubernetesClient = null
+    try {
+      client = new KubernetesClientBuilder().withConfig(configResolver()).build()
+      K8sSubmitter.findDriverPod(client, namespace, jobId, attempts = 1, sleepMs = 0L) match {
+        case None =>
+          logger.warn(
+            s"No driver pod found for ${K8sSubmitter.ChrononJobIdLabel}=$jobId," +
+              s"${K8sSubmitter.SparkRoleLabel}=${K8sSubmitter.SparkRoleDriver} in namespace $namespace"
+          )
+          JobStatusType.UNKNOWN
+        case Some(pod) =>
+          K8sSubmitter.mapPodPhaseToStatus(pod)
+      }
+    } catch {
+      case e: io.fabric8.kubernetes.client.KubernetesClientException if e.getCode == 403 =>
+        logger.error(
+          "K8s API returned 403 querying driver pod. Ensure the submitter's service account has get/list on pods."
+        )
+        throw e
+      case NonFatal(e) =>
+        logger.error(
+          s"K8s driver status query failed (${e.getClass.getSimpleName}): ${Option(e.getMessage).getOrElse("")}",
+          e
+        )
+        throw e
+    } finally {
+      if (client != null) client.close()
+    }
+  }
+
+  override def kill(jobId: String): Unit = {
+    var client: KubernetesClient = null
+    try {
+      client = new KubernetesClientBuilder().withConfig(configResolver()).build()
+      client
+        .pods()
+        .inNamespace(namespace)
+        .withLabel(K8sSubmitter.ChrononJobIdLabel, jobId)
+        .delete()
+    } finally {
+      if (client != null) client.close()
+    }
+  }
+}
+
+object K8sSubmitter {
+
+  // Spark stamps `spark-app-name` (from `spark.app.name`) and `spark-role=driver` on every driver
+  // pod. We treat `spark-app-name` as a human-readable display label only -- it is NOT unique per
+  // submission (same conf with different modes/runs/retries produces the same value), so basing
+  // pod lookup on it can pick a stale `Succeeded` sibling and report false success. Authoritative
+  // pod identification uses our own `chronon-job-id` label which carries the typed job id
+  // produced by `formatChrononJobId` (always unique per submission).
+  private[cloud_k8s] val SparkAppNameLabel = "spark-app-name"
+  private[cloud_k8s] val SparkRoleLabel = "spark-role"
+  private[cloud_k8s] val SparkRoleDriver = "driver"
+  private[cloud_k8s] val ChrononJobIdLabel = "chronon-job-id"
+
+  /** When set, this env var overrides every other source of `spark.app.name`.
+    *
+    * Provided for orchestrators (e.g. Airflow) that want to inject a human-readable display name
+    * (typically the task id) without having to touch the CLI args of every wrapped runner.
+    * Lookup correctness no longer depends on the value being unique because pod lookup uses the
+    * separate `chronon-job-id` label.
+    */
+  private[cloud_k8s] val SparkAppNameEnvVar = "CHRONON_SPARK_APP_NAME"
+
+  /** Env var -> K8s label key mapping for execution-context labels.
+    *
+    * Each entry expands to `spark.kubernetes.{driver,executor}.label.<labelKey> = <env value>`
+    * when the env var is set and non-empty. Stamping is skipped silently when the env var is
+    * missing so non-orchestrated callers degrade gracefully.
+    *
+    * Label keys are `chronon-` prefixed so they remain unambiguous when the namespace is shared
+    * with other workloads that may stamp their own `task` / `workflow` / etc. labels.
+    */
+  private[cloud_k8s] val ContextLabelEnvVars: Seq[(String, String)] = Seq(
+    "CHRONON_DAG_ID" -> "chronon-dag-id",
+    "CHRONON_TASK_ID" -> "chronon-task-id",
+    "CHRONON_MODE" -> "chronon-mode",
+    "CHRONON_DS" -> "chronon-ds",
+    "CHRONON_TRY_NUMBER" -> "chronon-try-number",
+    "CHRONON_RUN_ID" -> "chronon-run-id"
+  )
+
+  private val SparkSubmitMaxWaitDays: Long = 7L
+
+  // Bounded retry while the API server catches up with the driver pod that spark-submit just landed.
+  private[cloud_k8s] val VerifyDriverPodAttempts: Int = 5
+  private[cloud_k8s] val VerifyDriverPodSleepMs: Long = 2000L
+
+  private[cloud_k8s] def waitForSparkSubmitExitCode(proc: java.lang.Process): Int = {
+    val completed = proc.waitFor(SparkSubmitMaxWaitDays, TimeUnit.DAYS)
+    if (!completed) {
+      proc.destroyForcibly()
+      throw new RuntimeException("spark-submit did not complete within the wait window")
+    }
+    proc.exitValue()
+  }
+
+  def parseSemicolonSparkConf(raw: String): Map[String, String] = {
+    if (raw == null || raw.trim.isEmpty) return Map.empty
+    val out = mutable.Map.empty[String, String]
+    raw.split(';').foreach { token =>
+      val t = token.trim
+      if (t.nonEmpty) {
+        val idx = t.indexOf('=')
+        if (idx <= 0) {
+          throw new IllegalArgumentException(s"Malformed token in SPARK_K8S_CONF: '$t' (expected key=value)")
+        }
+        val k = t.substring(0, idx).trim
+        if (k.isEmpty) throw new IllegalArgumentException(s"Empty key in SPARK_K8S_CONF token: '$t'")
+        val v = t.substring(idx + 1).trim
+        out += k -> v
+      }
+    }
+    out.toMap
+  }
+
+  def getFilesArgs(args: Array[String]): List[String] = {
+    val filesArgs = args.filter(_.startsWith(FilesArgKeyword))
+    if (filesArgs.length > 1) {
+      JobSubmitter.logger.warn(
+        s"Multiple ${FilesArgKeyword} arguments (${filesArgs.length}); only the first is used for staged config paths"
+      )
+    }
+    if (filesArgs.isEmpty) Nil
+    else {
+      val head = filesArgs.head
+      val eqIdx = head.indexOf('=')
+      if (eqIdx < 0 || eqIdx >= head.length - 1) Nil
+      else
+        head.substring(eqIdx + 1).split(",").map(_.trim).filter(_.nonEmpty).toList
+    }
+  }
+
+  def createSubmissionPropsMap(args: Array[String]): Map[String, String] = {
+    val jarUri = JobSubmitter
+      .getArgValue(args, JarUriArgKeyword)
+      .getOrElse(throw new IllegalArgumentException("Missing required argument: " + JarUriArgKeyword))
+    val mainClass = JobSubmitter
+      .getArgValue(args, MainClassKeyword)
+      .getOrElse(throw new IllegalArgumentException("Missing required argument: " + MainClassKeyword))
+    val jobId = JobSubmitter
+      .getArgValue(args, JobIdArgKeyword)
+      .getOrElse(throw new IllegalArgumentException("Missing required argument: " + JobIdArgKeyword))
+    val metadataName = Option(JobSubmitter.getMetadata(args).getOrElse(MetaData()).getName).getOrElse("")
+    val ziplineVersion = JobSubmitter
+      .getArgValue(args, ZiplineVersionArgKeyword)
+      .getOrElse(throw new IllegalArgumentException("Missing required argument: " + ZiplineVersionArgKeyword))
+    val additional = JobSubmitter.getArgValue(args, AdditionalJarsUriArgKeyword).map(AdditionalJars -> _).toMap
+    Map(
+      MainClass -> mainClass,
+      JarURI -> jarUri,
+      MetadataName -> metadataName,
+      JobId -> jobId,
+      ZiplineVersion -> ziplineVersion
+    ) ++ additional
+  }
+
+  def sanitizeSparkAppName(raw: String): String = {
+    val slug = raw.toLowerCase.replaceAll("[^a-z0-9\\-]+", "-").replaceAll("-+", "-")
+    val trimmed = slug.stripPrefix("-").stripSuffix("-")
+    val base = if (trimmed.isEmpty) "chronon-app" else trimmed
+    val maxLen = 63
+    if (base.length <= maxLen) base else base.take(maxLen).stripSuffix("-")
+  }
+
+  /** Render `raw` into a K8s label-value-safe string per the spec
+    * `[A-Za-z0-9]([A-Za-z0-9_.-]{0,61}[A-Za-z0-9])?`: keep only `[A-Za-z0-9._-]`, collapse runs
+    * of `-`, trim non-alphanumerics from both ends, cap at 63 chars (re-trimming after).
+    *
+    * Returns the empty string when no alphanumeric content survives; callers must skip empty
+    * results (a label value of `""` is rejected by K8s).
+    */
+  private[cloud_k8s] def sanitizeLabelValue(raw: String): String = {
+    if (raw == null) return ""
+    val slug = raw.replaceAll("[^A-Za-z0-9._-]", "-").replaceAll("-+", "-")
+    val trimmed = slug.dropWhile(c => !c.isLetterOrDigit).reverse.dropWhile(c => !c.isLetterOrDigit).reverse
+    if (trimmed.length <= 63) trimmed
+    else trimmed.take(63).reverse.dropWhile(c => !c.isLetterOrDigit).reverse
+  }
+
+  /** Build a typed, K8s-label-safe job id of the form
+    * `spark.<namespace>.<sanitized-app-name>.<uuid12>`.
+    *
+    * Mirrors `EmrServerlessSubmitter`'s `<jobType>:...` shape *structurally* but uses dots rather
+    * than colons because K8s label values reject `:` (regex above). The 12-hex-char UUID prefix
+    * gives 2^48 collision-free ids per (namespace, app-name) tuple, which is far more than any
+    * realistic single-tenant pod fleet.
+    *
+    * Total length is bounded at K8s' 63-char label-value limit; namespace and app-name are
+    * truncated proportionally if needed (the UUID slot is preserved verbatim because it carries
+    * the uniqueness guarantee).
+    */
+  private[cloud_k8s] def formatChrononJobId(
+      jobType: JobType,
+      namespace: String,
+      sparkAppName: String,
+      jobIdUuid: String
+  ): String = {
+    // Only Spark today. Structure parametrized so the future Flink-on-K8s submitter can reuse
+    // this with `prefix = "flink"` (matching EmrServerlessSubmitter's per-jobType prefix).
+    val prefix = jobType match {
+      case SparkJob => "spark"
+      case FlinkJob => "flink"
+    }
+    val nsSlug = sanitizeLabelValue(namespace)
+    val appSlug = sanitizeLabelValue(sparkAppName)
+    val shortUuid = jobIdUuid.replace("-", "").toLowerCase.take(12)
+    // K8s label values: <= 63 chars. Reserve fixed pieces (prefix + 3 dots + uuid12) and split
+    // the remaining budget between namespace (capped at 20) and app name.
+    val MaxLen = 63
+    val fixedLen = prefix.length + 3 + shortUuid.length
+    val varBudget = math.max(0, MaxLen - fixedLen)
+    val nsMax = math.min(nsSlug.length, math.min(20, varBudget))
+    val ns = nsSlug.take(nsMax)
+    val appBudget = math.max(0, varBudget - ns.length)
+    val app = appSlug.take(appBudget)
+    sanitizeLabelValue(s"$prefix.$ns.$app.$shortUuid")
+  }
+
+  def resolveSparkAppName(
+      submissionProperties: Map[String, String],
+      args: Array[String],
+      envLookup: String => Option[String] = sys.env.get
+  ): String = {
+    val fromEnv = envLookup(SparkAppNameEnvVar).map(_.trim).filter(_.nonEmpty)
+    val fromProps = submissionProperties.get(MetadataName).map(_.trim).filter(_.nonEmpty)
+    val fromMeta = JobSubmitter.getMetadata(args).flatMap(m => Option(m.getName).map(_.trim).filter(_.nonEmpty))
+    val fromJobId = submissionProperties.get(JobId).map(_.trim).filter(_.nonEmpty)
+    sanitizeSparkAppName(
+      fromEnv.orElse(fromProps).orElse(fromMeta).orElse(fromJobId).getOrElse("chronon-app")
+    )
+  }
+
+  def fromEnv(configResolver: () => Config = () => Config.autoConfigure(null)): K8sSubmitter = {
+    val master = sys.env.getOrElse(
+      "SPARK_K8S_MASTER",
+      throw new IllegalStateException("Required environment variable SPARK_K8S_MASTER is not set")
+    )
+    val image = sys.env.getOrElse(
+      "SPARK_K8S_IMAGE",
+      throw new IllegalStateException("Required environment variable SPARK_K8S_IMAGE is not set")
+    )
+    val uploadPath = sys.env.getOrElse(
+      "SPARK_K8S_FILE_UPLOAD_PATH",
+      throw new IllegalStateException("Required environment variable SPARK_K8S_FILE_UPLOAD_PATH is not set")
+    )
+    new K8sSubmitter(
+      sparkSubmitPath = sys.env.getOrElse("SPARK_SUBMIT_PATH", "spark-submit"),
+      k8sMaster = master,
+      namespace = sys.env.getOrElse("SPARK_K8S_NAMESPACE", "default"),
+      serviceAccount = sys.env.getOrElse("SPARK_K8S_SERVICE_ACCOUNT", "default"),
+      image = image,
+      fileUploadPath = uploadPath,
+      extraSparkConf = parseSemicolonSparkConf(sys.env.getOrElse("SPARK_K8S_CONF", "")),
+      configResolver = configResolver
+    )
+  }
+
+  def buildSparkSubmitArgv(
+      submitter: K8sSubmitter,
+      submissionProperties: Map[String, String],
+      jobProperties: Map[String, String],
+      files: List[String],
+      rawArgs: Array[String],
+      jobType: JobType,
+      sparkAppName: String,
+      chrononJobId: String,
+      waitForAppCompletion: Boolean,
+      contextLabelEnv: String => Option[String] = sys.env.get
+  ): Seq[String] = {
+    val mainClass =
+      submissionProperties.getOrElse(MainClass, throw new IllegalArgumentException("Main class not found"))
+    val jarUri = submissionProperties.getOrElse(JarURI, throw new IllegalArgumentException("Jar URI not found"))
+    val appArgs = JobSubmitter.getApplicationArgs(jobType, rawArgs)
+
+    val confPairs = mutable.ArrayBuffer[(String, String)](
+      "spark.kubernetes.namespace" -> submitter.namespace,
+      "spark.kubernetes.authenticate.driver.serviceAccountName" -> submitter.serviceAccount,
+      "spark.kubernetes.container.image" -> submitter.image,
+      "spark.kubernetes.file.upload.path" -> submitter.fileUploadPath
+    )
+    submitter.extraSparkConf.foreach { case (k, v) => confPairs += k -> v }
+    // Chronon-only keys (e.g. submission-mode) must not become spark-submit --conf entries.
+    jobProperties.foreach {
+      case (k, v) if k != SubmissionMode.PropertyKey => confPairs += k -> v
+      case _                                         =>
+    }
+    // Spark uses last --conf value per key; append so submitter-controlled settings cannot be
+    // overridden by SPARK_K8S_CONF or mode job properties (wait/delete/app name/labels).
+    confPairs += "spark.app.name" -> sparkAppName
+    confPairs += "spark.kubernetes.submission.waitAppCompletion" -> waitForAppCompletion.toString
+    confPairs += "spark.kubernetes.driver.deleteOnTermination" -> "false"
+    val sanitizedJobId = sanitizeLabelValue(chrononJobId)
+    if (sanitizedJobId.nonEmpty) {
+      confPairs += s"spark.kubernetes.driver.label.$ChrononJobIdLabel" -> sanitizedJobId
+    }
+    // Mirror the env-driven context labels onto both driver and executor pods so ops queries
+    // like `kubectl get pods -l chronon-mode=metadata-upload,chronon-ds=2026-04-29` return
+    // executors alongside the driver. Skip silently when the corresponding env var is unset.
+    ContextLabelEnvVars.foreach { case (envName, labelKey) =>
+      contextLabelEnv(envName).map(_.trim).filter(_.nonEmpty).foreach { raw =>
+        val value = sanitizeLabelValue(raw)
+        if (value.nonEmpty) {
+          confPairs += s"spark.kubernetes.driver.label.$labelKey" -> value
+          confPairs += s"spark.kubernetes.executor.label.$labelKey" -> value
+        }
+      }
+    }
+
+    val argv = mutable.ArrayBuffer[String](
+      submitter.sparkSubmitPath,
+      "--master",
+      submitter.k8sMaster,
+      "--deploy-mode",
+      "cluster",
+      "--class",
+      mainClass
+    )
+    confPairs.foreach { case (k, v) =>
+      argv += "--conf"
+      argv += s"$k=$v"
+    }
+    if (files.nonEmpty) {
+      argv += "--files"
+      argv += files.mkString(",")
+    }
+    submissionProperties.get(AdditionalJars).foreach { jars =>
+      argv += "--jars"
+      argv += jars
+    }
+    argv += jarUri
+    appArgs.foreach(argv += _)
+    argv.toSeq
+  }
+
+  def runSparkSubmitProcess(argv: Seq[String], inheritIo: Boolean): java.lang.Process = {
+    val pb = new ProcessBuilder(argv: _*)
+    if (inheritIo) pb.inheritIO()
+    pb.start()
+  }
+
+  def mapPodPhaseToStatus(pod: Pod): JobStatusType = {
+    val phase = Option(pod.getStatus).flatMap(s => Option(s.getPhase)).map(_.trim.toUpperCase).getOrElse("")
+    phase match {
+      case "PENDING"   => JobStatusType.PENDING
+      case "RUNNING"   => JobStatusType.RUNNING
+      case "SUCCEEDED" => JobStatusType.SUCCEEDED
+      case "FAILED"    => JobStatusType.FAILED
+      case _           => JobStatusType.UNKNOWN
+    }
+  }
+
+  private def pickDriverContainer(statuses: Seq[ContainerStatus]): Option[ContainerStatus] = {
+    val nonInit = statuses.filterNot(s => Option(s.getName).exists(_.startsWith("spark-init")))
+    nonInit.find(s => Option(s.getName).exists(_.contains("driver"))).orElse(nonInit.headOption)
+  }
+
+  def readDriverTermination(pod: Pod): Option[(Int, Option[String])] = {
+    val statuses = Option(pod.getStatus)
+      .flatMap(s => Option(s.getContainerStatuses))
+      .map(_.asScala.toSeq)
+      .getOrElse(Nil)
+    pickDriverContainer(statuses).flatMap { cs =>
+      Option(cs.getState).flatMap(s => Option(s.getTerminated)).map { terminated =>
+        val reason = Option(terminated.getReason).map(_.trim).filter(_.nonEmpty)
+        (terminated.getExitCode, reason)
+      }
+    }
+  }
+
+  /** Retry while the API server catches up. Throws on multiple matches rather than `items.head`
+    * (see block comment above on stale-pod false success).
+    */
+  private[cloud_k8s] def findDriverPod(
+      client: KubernetesClient,
+      namespace: String,
+      chrononJobId: String,
+      attempts: Int = VerifyDriverPodAttempts,
+      sleepMs: Long = VerifyDriverPodSleepMs
+  ): Option[Pod] = {
+    val tries = math.max(1, attempts)
+    var i = 0
+    while (i < tries) {
+      val pods = client
+        .pods()
+        .inNamespace(namespace)
+        .withLabel(ChrononJobIdLabel, chrononJobId)
+        .withLabel(SparkRoleLabel, SparkRoleDriver)
+        .list()
+      val items = Option(pods.getItems).map(_.asScala.toList).getOrElse(Nil)
+      if (items.nonEmpty) {
+        if (items.size > 1) {
+          throw new IllegalStateException(
+            s"Multiple driver pods (${items.size}) matched $ChrononJobIdLabel=$chrononJobId in " +
+              s"$namespace; chronon-job-id is supposed to be unique per submission, this indicates " +
+              "a bug in formatChrononJobId or in label stamping. Refusing to silently pick one."
+          )
+        }
+        return Some(items.head)
+      }
+      i += 1
+      if (i < tries && sleepMs > 0L) {
+        try Thread.sleep(sleepMs)
+        catch { case _: InterruptedException => Thread.currentThread().interrupt() }
+      }
+    }
+    None
+  }
+
+  /** Derive a definitive exit code from a driver pod's observed state.
+    *
+    * Pod phase is authoritative when terminal, because `spark-submit` is known to occasionally
+    * report 0 for a driver pod whose watcher actually observed `Failed`. Returns `None` for
+    * non-terminal phases so the caller can fall back to the spark-submit exit code.
+    */
+  private[cloud_k8s] def driverExitCodeFromPod(pod: Pod): Option[Int] = {
+    val phase = Option(pod.getStatus).flatMap(s => Option(s.getPhase)).map(_.trim).getOrElse("")
+    val terminated = readDriverTermination(pod)
+    phase.toUpperCase match {
+      case "SUCCEEDED" => Some(0)
+      case "FAILED" =>
+        terminated match {
+          case Some((code, _)) if code != 0 => Some(code)
+          case _                            => Some(1)
+        }
+      case "RUNNING" | "PENDING" | "UNKNOWN" | "" =>
+        // Pod still settling; defer to caller (which will fall back to spark-submit exit code).
+        terminated.collect { case (code, _) if code != 0 => code }
+      case _ =>
+        terminated.map(_._1)
+    }
+  }
+
+  /** Implementation of [[verifyDriverAndCleanup]] that operates on an externally-managed client,
+    * for tests. Production callers should use [[verifyDriverAndCleanup]] which owns the
+    * [[KubernetesClient]] lifecycle.
+    */
+  private[cloud_k8s] def verifyDriverAndCleanupWith(
+      client: KubernetesClient,
+      namespace: String,
+      chrononJobId: String,
+      sparkSubmitExitCode: Int,
+      attempts: Int = VerifyDriverPodAttempts,
+      sleepMs: Long = VerifyDriverPodSleepMs
+  ): Int = {
+    findDriverPod(client, namespace, chrononJobId, attempts = attempts, sleepMs = sleepMs) match {
+      case None =>
+        // Pod never landed (or was already deleted); fall back to the spark-submit exit code and
+        // log loudly so a false success (spark-submit 0 for an actually-failed driver) is debuggable.
+        JobSubmitter.logger.error(
+          s"Driver pod not found for $ChrononJobIdLabel=$chrononJobId,$SparkRoleLabel=$SparkRoleDriver in $namespace " +
+            s"after $attempts attempts; falling back to spark-submit exit code $sparkSubmitExitCode"
+        )
+        sparkSubmitExitCode
+
+      case Some(pod) =>
+        val podName = Option(pod.getMetadata).flatMap(m => Option(m.getName)).getOrElse(chrononJobId)
+        val phase = Option(pod.getStatus).flatMap(s => Option(s.getPhase)).getOrElse("Unknown")
+        val termination = readDriverTermination(pod)
+
+        val code = driverExitCodeFromPod(pod) match {
+          case Some(c) =>
+            if (c != 0) {
+              val reason = termination.flatMap(_._2).getOrElse("")
+              JobSubmitter.logger.error(
+                s"Driver pod $podName terminated unsuccessfully (phase=$phase, exitCode=$c" +
+                  (if (reason.nonEmpty) s", reason=$reason)" else ")")
+              )
+            }
+            c
+          case None =>
+            JobSubmitter.logger.warn(
+              s"Driver pod $podName phase=$phase has no terminated container state; " +
+                s"falling back to spark-submit exit code $sparkSubmitExitCode"
+            )
+            sparkSubmitExitCode
+        }
+
+        try client.pods().inNamespace(namespace).withName(podName).delete()
+        catch { case NonFatal(_) => () }
+        code
+    }
+  }
+
+  def verifyDriverAndCleanup(
+      namespace: String,
+      chrononJobId: String,
+      sparkSubmitExitCode: Int,
+      configResolver: () => Config = () => Config.autoConfigure(null)
+  ): Int = {
+    var client: KubernetesClient = null
+    try {
+      client = new KubernetesClientBuilder().withConfig(configResolver()).build()
+      verifyDriverAndCleanupWith(client, namespace, chrononJobId, sparkSubmitExitCode)
+    } catch {
+      case NonFatal(e) =>
+        JobSubmitter.logger.warn(
+          s"K8s verify/cleanup failed (${e.getClass.getSimpleName}): ${Option(e.getMessage).getOrElse("")}; " +
+            s"falling back to spark-submit exit code $sparkSubmitExitCode"
+        )
+        sparkSubmitExitCode
+    } finally {
+      if (client != null) client.close()
+    }
+  }
+
+  def runBlockingFromArgs(args: Array[String], configResolver: () => Config = () => Config.autoConfigure(null)): Int = {
+    val jobTypeStr = JobSubmitter
+      .getArgValue(args, JobTypeArgKeyword)
+      .getOrElse(throw new IllegalArgumentException("Missing required argument: " + JobTypeArgKeyword))
+    if (!jobTypeStr.equalsIgnoreCase(SparkJobType)) {
+      throw new IllegalArgumentException(s"K8sSubmitter only supports --job-type=$SparkJobType, got $jobTypeStr")
+    }
+    val submitter = fromEnv(configResolver)
+    val submissionProps = createSubmissionPropsMap(args)
+    val jobProps = JobSubmitter.getModeConfigProperties(args).getOrElse(Map.empty)
+    val files = getFilesArgs(args)
+    val appName = resolveSparkAppName(submissionProps, args)
+    val jobIdUuid = submissionProps.getOrElse(
+      JobId,
+      throw new IllegalArgumentException(s"Missing required argument: $JobIdArgKeyword")
+    )
+    val chrononJobId = formatChrononJobId(SparkJob, submitter.namespace, appName, jobIdUuid)
+    SubmissionMode.resolve(submissionProps, jobProps) match {
+      case SubmissionMode.SparkOperator =>
+        runBlockingViaSparkApplicationCrd(
+          submitter = submitter,
+          submissionProps = submissionProps,
+          jobProps = jobProps,
+          files = files,
+          args = args,
+          appName = appName,
+          chrononJobId = chrononJobId,
+          configResolver = configResolver
+        )
+      case SubmissionMode.SparkSubmit =>
+        val argv = buildSparkSubmitArgv(
+          submitter = submitter,
+          submissionProperties = submissionProps,
+          jobProperties = jobProps,
+          files = files,
+          rawArgs = args,
+          jobType = SparkJob,
+          sparkAppName = appName,
+          chrononJobId = chrononJobId,
+          waitForAppCompletion = true
+        )
+
+        JobSubmitter.logger.info(s"Job submitted with ID: $chrononJobId")
+        val proc =
+          try runSparkSubmitProcess(argv, inheritIo = true)
+          catch {
+            case e: IOException if e.getMessage != null && e.getMessage.contains("error=2") =>
+              JobSubmitter.logger.error(
+                s"spark-submit not found at ${submitter.sparkSubmitPath}. Set SPARK_SUBMIT_PATH if not on PATH."
+              )
+              throw e
+          }
+
+        val sparkExit = waitForSparkSubmitExitCode(proc)
+
+        val finalExit = verifyDriverAndCleanup(
+          namespace = submitter.namespace,
+          chrononJobId = chrononJobId,
+          sparkSubmitExitCode = sparkExit,
+          configResolver = configResolver
+        )
+        if (finalExit == 0) JobSubmitter.logger.info("Job completed with status: SUCCESS")
+        else JobSubmitter.logger.info("Job completed with status: FAILED")
+        finalExit
+    }
+  }
+
+  /** CRD ingress for async [[K8sSubmitter.submit]]; production impl must apply `chronon-job-id` on the driver. */
+  private[cloud_k8s] def submitViaSparkApplicationCrd(
+      submitter: K8sSubmitter,
+      jobType: JobType,
+      submissionProperties: Map[String, String],
+      jobProperties: Map[String, String],
+      files: List[String],
+      labels: Map[String, String],
+      envVars: Map[String, String],
+      rawArgs: Array[String],
+      appName: String,
+      chrononJobId: String
+  ): String = {
+    throw new UnsupportedOperationException(
+      s"submission-mode=${SubmissionMode.SparkOperator.name} (SparkApplication CRD) is not implemented yet; " +
+        s"use ${SubmissionMode.SparkSubmit.name} or unset ${SubmissionMode.EnvVar} / ${SubmissionMode.PropertyKey}."
+    )
+  }
+
+  /** CRD ingress for [[runBlockingFromArgs]]; production impl must apply `chronon-job-id` on the driver. */
+  private[cloud_k8s] def runBlockingViaSparkApplicationCrd(
+      submitter: K8sSubmitter,
+      submissionProps: Map[String, String],
+      jobProps: Map[String, String],
+      files: List[String],
+      args: Array[String],
+      appName: String,
+      chrononJobId: String,
+      configResolver: () => Config
+  ): Int = {
+    throw new UnsupportedOperationException(
+      s"submission-mode=${SubmissionMode.SparkOperator.name} (SparkApplication CRD) is not implemented yet; " +
+        s"use ${SubmissionMode.SparkSubmit.name} or unset ${SubmissionMode.EnvVar} / ${SubmissionMode.PropertyKey}."
+    )
+  }
+
+  def main(args: Array[String]): Unit = {
+    try {
+      System.exit(runBlockingFromArgs(args))
+    } catch {
+      case e: IllegalStateException if e.getMessage != null && e.getMessage.contains("SPARK_K8S") =>
+        JobSubmitter.logger.warn(e.getMessage)
+        System.exit(1)
+      case e: IllegalArgumentException =>
+        JobSubmitter.logger.warn("Invalid K8sSubmitter arguments", e)
+        System.exit(1)
+      case e: IOException =>
+        JobSubmitter.logger.error("K8sSubmitter I/O failure (e.g. spark-submit missing)", e)
+        System.exit(1)
+      case NonFatal(e) =>
+        JobSubmitter.logger.error("K8sSubmitter.main failed", e)
+        System.exit(1)
+    }
+  }
+}

--- a/cloud_k8s/src/main/scala/ai/chronon/integrations/cloud_k8s/SubmissionMode.scala
+++ b/cloud_k8s/src/main/scala/ai/chronon/integrations/cloud_k8s/SubmissionMode.scala
@@ -1,0 +1,37 @@
+package ai.chronon.integrations.cloud_k8s
+
+/** K8s Spark dispatch: native spark-submit vs SparkApplication CRD (stub). */
+sealed trait SubmissionMode { def name: String }
+
+object SubmissionMode {
+
+  case object SparkSubmit extends SubmissionMode { val name: String = "spark-submit" }
+
+  case object SparkOperator extends SubmissionMode { val name: String = "spark-operator" }
+
+  val Default: SubmissionMode = SparkSubmit
+
+  val EnvVar: String = "CHRONON_K8S_SUBMISSION_MODE"
+
+  val PropertyKey: String = "submission-mode"
+
+  def parse(raw: String): SubmissionMode = Option(raw).map(_.trim.toLowerCase).getOrElse("") match {
+    case "" | "spark-submit" => SparkSubmit
+    case "spark-operator"    => SparkOperator
+    case other =>
+      throw new IllegalArgumentException(
+        s"Unknown $EnvVar value '$other'; expected one of: ${SparkSubmit.name}, ${SparkOperator.name}"
+      )
+  }
+
+  def resolve(submissionProperties: Map[String, String], jobProperties: Map[String, String]): SubmissionMode =
+    submissionProperties
+      .get(PropertyKey)
+      .orElse(jobProperties.get(PropertyKey))
+      .orElse(sys.env.get(EnvVar))
+      .map(parse)
+      .getOrElse(Default)
+
+  def resolve(submissionProperties: Map[String, String]): SubmissionMode =
+    resolve(submissionProperties, Map.empty)
+}

--- a/cloud_k8s/src/test/scala/ai/chronon/integrations/cloud_k8s/K8sSubmitterTest.scala
+++ b/cloud_k8s/src/test/scala/ai/chronon/integrations/cloud_k8s/K8sSubmitterTest.scala
@@ -1,0 +1,729 @@
+package ai.chronon.integrations.cloud_k8s
+
+import ai.chronon.api.JobStatusType
+import ai.chronon.spark.submission.JobSubmitterConstants._
+import ai.chronon.spark.submission.{FlinkJob, SparkJob}
+import io.fabric8.kubernetes.api.model.{
+  ContainerStateBuilder,
+  ContainerStatusBuilder,
+  Pod,
+  PodBuilder,
+  PodListBuilder,
+  PodStatusBuilder
+}
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer
+import org.junit.Assert.{assertEquals, assertTrue}
+import org.scalatest.flatspec.AnyFlatSpec
+
+import scala.jdk.CollectionConverters._
+
+class K8sSubmitterTest extends AnyFlatSpec {
+
+  private def submitter =
+    new K8sSubmitter(
+      sparkSubmitPath = "spark-submit",
+      k8sMaster = "k8s://https://cluster.example:6443",
+      namespace = "spark-jobs",
+      serviceAccount = "spark-sa",
+      image = "registry/spark:latest",
+      fileUploadPath = "s3://warehouse/spark-staging",
+      extraSparkConf = Map("spark.executor.memory" -> "4g")
+    )
+
+  "parseSemicolonSparkConf" should "parse semicolon-delimited conf and preserve commas in values" in {
+    val parsed = K8sSubmitter.parseSemicolonSparkConf(
+      "spark.executor.memory=4g;spark.jars=a.jar,b.jar;spark.driver.extraJavaOptions=-Dfoo=1,-Dbar=2"
+    )
+    assertEquals("4g", parsed("spark.executor.memory"))
+    assertEquals("a.jar,b.jar", parsed("spark.jars"))
+    assertEquals("-Dfoo=1,-Dbar=2", parsed("spark.driver.extraJavaOptions"))
+  }
+
+  it should "throw for malformed entries" in {
+    val ex = intercept[IllegalArgumentException] {
+      K8sSubmitter.parseSemicolonSparkConf("spark.executor.memory=4g;badtoken")
+    }
+    assertTrue(ex.getMessage.contains("Malformed token"))
+  }
+
+  "sanitizeSparkAppName" should "create a label-safe app id" in {
+    val value = K8sSubmitter.sanitizeSparkAppName("Team/My GroupBy.v1")
+    assertEquals("team-my-groupby-v1", value)
+  }
+
+  "getFilesArgs" should "parse --files and tolerate malformed flags" in {
+    assertEquals(
+      List("s3://a/1", "s3://a/2"),
+      K8sSubmitter.getFilesArgs(Array("--files=s3://a/1,s3://a/2", "--other=x"))
+    )
+    assertEquals(Nil, K8sSubmitter.getFilesArgs(Array("--files")))
+    assertEquals(Nil, K8sSubmitter.getFilesArgs(Array("--files=")))
+  }
+
+  it should "use only the first --files when several are present" in {
+    assertEquals(
+      List("first.txt"),
+      K8sSubmitter.getFilesArgs(Array("--files=first.txt", "--files=ignored.txt"))
+    )
+  }
+
+  // Empty env-getter so context-label tests can isolate the label-stamping behavior from the
+  // ambient process env (CHRONON_DAG_ID etc. would otherwise leak through sys.env.get).
+  private val noEnv: String => Option[String] = _ => None
+
+  private val typedJobId = "spark.spark-jobs.my-gb.deadbeefcafe"
+
+  "buildSparkSubmitArgv" should "include expected spark-submit args and wait flag" in {
+    val argv = K8sSubmitter.buildSparkSubmitArgv(
+      submitter = submitter,
+      submissionProperties = Map(
+        MainClass -> "ai.chronon.spark.Driver",
+        JarURI -> "s3://artifacts/cloud_k8s_lib_deploy.jar",
+        MetadataName -> "my-gb",
+        JobId -> "job-123"
+      ),
+      jobProperties = Map("spark.driver.memory" -> "2g"),
+      files = List("s3://warehouse/confs/my-gb.v1"),
+      rawArgs = Array("group-by-backfill", "--conf-path=my-gb.v1", "--local-conf-path=/tmp/my-gb.v1"),
+      jobType = SparkJob,
+      sparkAppName = "my-gb",
+      chrononJobId = typedJobId,
+      waitForAppCompletion = true,
+      contextLabelEnv = noEnv
+    )
+
+    val command = argv.mkString(" ")
+    assertTrue(command.contains("--master k8s://https://cluster.example:6443"))
+    assertTrue(command.contains("--class ai.chronon.spark.Driver"))
+    assertTrue(command.contains("spark.kubernetes.submission.waitAppCompletion=true"))
+    assertTrue(command.contains("spark.kubernetes.driver.deleteOnTermination=false"))
+    assertTrue(command.contains("--files s3://warehouse/confs/my-gb.v1"))
+  }
+
+  it should "stamp the typed chronon-job-id on the driver" in {
+    val argv = K8sSubmitter.buildSparkSubmitArgv(
+      submitter = submitter,
+      submissionProperties = Map(
+        MainClass -> "ai.chronon.spark.Driver",
+        JarURI -> "s3://artifacts/cloud_k8s_lib_deploy.jar",
+        MetadataName -> "my-gb",
+        JobId -> "job-123"
+      ),
+      jobProperties = Map.empty,
+      files = Nil,
+      rawArgs = Array("group-by-backfill"),
+      jobType = SparkJob,
+      sparkAppName = "my-gb",
+      chrononJobId = typedJobId,
+      waitForAppCompletion = false,
+      contextLabelEnv = noEnv
+    )
+    val command = argv.mkString(" ")
+    assertTrue(
+      "driver pod must carry the typed chronon-job-id label",
+      command.contains(s"spark.kubernetes.driver.label.chronon-job-id=$typedJobId")
+    )
+  }
+
+  it should "pin app name, wait, and deleteOnTermination after user/job conf (last --conf wins)" in {
+    val evil = new K8sSubmitter(
+      sparkSubmitPath = "spark-submit",
+      k8sMaster = "k8s://https://cluster.example:6443",
+      namespace = "spark-jobs",
+      serviceAccount = "spark-sa",
+      image = "registry/spark:latest",
+      fileUploadPath = "s3://warehouse/spark-staging",
+      extraSparkConf = Map(
+        "spark.app.name" -> "evil-name",
+        "spark.kubernetes.submission.waitAppCompletion" -> "false",
+        "spark.kubernetes.driver.deleteOnTermination" -> "true"
+      )
+    )
+    val argv = K8sSubmitter.buildSparkSubmitArgv(
+      submitter = evil,
+      submissionProperties = Map(
+        MainClass -> "ai.chronon.spark.Driver",
+        JarURI -> "s3://artifacts/cloud_k8s_lib_deploy.jar",
+        MetadataName -> "my-gb",
+        JobId -> "job-123"
+      ),
+      jobProperties = Map(
+        "spark.app.name" -> "also-evil",
+        "spark.kubernetes.submission.waitAppCompletion" -> "false"
+      ),
+      files = Nil,
+      rawArgs = Array("group-by-backfill"),
+      jobType = SparkJob,
+      sparkAppName = "my-gb",
+      chrononJobId = typedJobId,
+      waitForAppCompletion = true,
+      contextLabelEnv = noEnv
+    )
+    val confValues = argv
+      .sliding(2, 1)
+      .collect { case Seq("--conf", kv) => kv }
+      .toSeq
+    def lastValue(key: String): String =
+      confValues.filter(_.startsWith(key + "=")).map(_.substring(key.length + 1)).last
+    assertEquals("my-gb", lastValue("spark.app.name"))
+    assertEquals("true", lastValue("spark.kubernetes.submission.waitAppCompletion"))
+    assertEquals("false", lastValue("spark.kubernetes.driver.deleteOnTermination"))
+  }
+
+  it should "expand envVars into driver/executor env spark confs" in {
+    // Exercise the trait helper + argv builder rather than submit(), since submit() forks spark-submit.
+    val envVars = Map("MY_SECRET" -> "value1", "ANOTHER" -> "value2")
+    val expanded = submitter.envVarsToSparkProperties(envVars)
+    val argv = K8sSubmitter.buildSparkSubmitArgv(
+      submitter = submitter,
+      submissionProperties = Map(
+        MainClass -> "ai.chronon.spark.Driver",
+        JarURI -> "s3://artifacts/cloud_k8s_lib_deploy.jar",
+        MetadataName -> "my-gb",
+        JobId -> "job-123"
+      ),
+      jobProperties = expanded,
+      files = Nil,
+      rawArgs = Array("group-by-backfill"),
+      jobType = SparkJob,
+      sparkAppName = "my-gb",
+      chrononJobId = typedJobId,
+      waitForAppCompletion = false,
+      contextLabelEnv = noEnv
+    )
+    val command = argv.mkString(" ")
+    assertTrue(command.contains("spark.kubernetes.driverEnv.MY_SECRET=value1"))
+    assertTrue(command.contains("spark.executorEnv.MY_SECRET=value1"))
+    assertTrue(command.contains("spark.kubernetes.driverEnv.ANOTHER=value2"))
+    assertTrue(command.contains("spark.executorEnv.ANOTHER=value2"))
+  }
+
+  it should "stamp execution-context labels on driver and executor for set CHRONON_* env vars" in {
+    val ctxEnv: String => Option[String] = Map(
+      "CHRONON_DAG_ID" -> "chronon_group_bys_my_feature",
+      "CHRONON_TASK_ID" -> "metadata-upload__chronon_group_bys_my_feature",
+      "CHRONON_MODE" -> "metadata-upload",
+      "CHRONON_DS" -> "2026-04-29",
+      "CHRONON_TRY_NUMBER" -> "1",
+      "CHRONON_RUN_ID" -> "manual__2026-04-29T07:00:00+00:00"
+      // CHRONON_DS / TRY / RUN intentionally include hyphens / colons / pluses to exercise
+      // sanitizeLabelValue's slug rewriting.
+    ).get
+
+    val argv = K8sSubmitter.buildSparkSubmitArgv(
+      submitter = submitter,
+      submissionProperties = Map(
+        MainClass -> "ai.chronon.spark.Driver",
+        JarURI -> "s3://artifacts/cloud_k8s_lib_deploy.jar",
+        MetadataName -> "my-gb",
+        JobId -> "job-123"
+      ),
+      jobProperties = Map.empty,
+      files = Nil,
+      rawArgs = Array("group-by-backfill"),
+      jobType = SparkJob,
+      sparkAppName = "my-gb",
+      chrononJobId = typedJobId,
+      waitForAppCompletion = false,
+      contextLabelEnv = ctxEnv
+    )
+    val command = argv.mkString(" ")
+    val expected = Seq(
+      "chronon-dag-id" -> "chronon_group_bys_my_feature",
+      "chronon-task-id" -> "metadata-upload__chronon_group_bys_my_feature",
+      "chronon-mode" -> "metadata-upload",
+      "chronon-ds" -> "2026-04-29",
+      "chronon-try-number" -> "1",
+      "chronon-run-id" -> "manual__2026-04-29T07-00-00-00-00"
+    )
+    expected.foreach { case (key, value) =>
+      assertTrue(s"driver should carry $key=$value", command.contains(s"spark.kubernetes.driver.label.$key=$value"))
+      assertTrue(s"executor should carry $key=$value", command.contains(s"spark.kubernetes.executor.label.$key=$value"))
+    }
+  }
+
+  it should "skip context labels whose CHRONON_* env vars are unset or blank" in {
+    val ctxEnv: String => Option[String] = {
+      case "CHRONON_DAG_ID" => Some("only-dag-id-set")
+      case "CHRONON_DS"     => Some("   ") // blank should be filtered out
+      case _                => None
+    }
+    val argv = K8sSubmitter.buildSparkSubmitArgv(
+      submitter = submitter,
+      submissionProperties = Map(
+        MainClass -> "ai.chronon.spark.Driver",
+        JarURI -> "s3://artifacts/cloud_k8s_lib_deploy.jar",
+        MetadataName -> "my-gb",
+        JobId -> "job-123"
+      ),
+      jobProperties = Map.empty,
+      files = Nil,
+      rawArgs = Array("group-by-backfill"),
+      jobType = SparkJob,
+      sparkAppName = "my-gb",
+      chrononJobId = typedJobId,
+      waitForAppCompletion = false,
+      contextLabelEnv = ctxEnv
+    )
+    val command = argv.mkString(" ")
+    assertTrue(command.contains("spark.kubernetes.driver.label.chronon-dag-id=only-dag-id-set"))
+    assertTrue(!command.contains("spark.kubernetes.driver.label.chronon-ds="))
+    assertTrue(!command.contains("spark.kubernetes.driver.label.chronon-task-id="))
+    assertTrue(!command.contains("spark.kubernetes.driver.label.chronon-mode="))
+    assertTrue(!command.contains("spark.kubernetes.driver.label.chronon-try-number="))
+    assertTrue(!command.contains("spark.kubernetes.driver.label.chronon-run-id="))
+  }
+
+  "mapPodPhaseToStatus" should "map pod phases into JobStatusType" in {
+    val runningPod = new PodBuilder().withStatus(new PodStatusBuilder().withPhase("Running").build()).build()
+    val failedPod = new PodBuilder().withStatus(new PodStatusBuilder().withPhase("Failed").build()).build()
+    assertEquals(JobStatusType.RUNNING, K8sSubmitter.mapPodPhaseToStatus(runningPod))
+    assertEquals(JobStatusType.FAILED, K8sSubmitter.mapPodPhaseToStatus(failedPod))
+  }
+
+  "readDriverTermination" should "extract driver exit code and reason" in {
+    val terminatedState = new ContainerStateBuilder()
+      .withNewTerminated()
+      .withExitCode(137)
+      .withReason("OOMKilled")
+      .endTerminated()
+      .build()
+
+    val driverStatus = new ContainerStatusBuilder()
+      .withName("spark-kubernetes-driver")
+      .withState(terminatedState)
+      .build()
+
+    val pod = new PodBuilder()
+      .withStatus(new PodStatusBuilder().withContainerStatuses(driverStatus).build())
+      .build()
+
+    assertEquals(Some((137, Some("OOMKilled"))), K8sSubmitter.readDriverTermination(pod))
+  }
+
+  "verifyDriverAndCleanup" should "fall back to spark-submit exit code when k8s lookup fails" in {
+    val code = K8sSubmitter.verifyDriverAndCleanup(
+      namespace = "spark-jobs",
+      chrononJobId = typedJobId,
+      sparkSubmitExitCode = 7,
+      configResolver = () => throw new RuntimeException("k8s unavailable")
+    )
+    assertEquals(7, code)
+  }
+
+  private def podWithPhase(phase: String, container: Option[ContainerStatusBuilder] = None): Pod = {
+    val statusBuilder = new PodStatusBuilder().withPhase(phase)
+    container.foreach(c => statusBuilder.withContainerStatuses(c.build()))
+    new PodBuilder().withStatus(statusBuilder.build()).build()
+  }
+
+  private def driverContainer(exitCode: Int, reason: String = null): ContainerStatusBuilder = {
+    val terminatedBuilder = new ContainerStateBuilder().withNewTerminated().withExitCode(exitCode)
+    val terminated =
+      if (reason == null) terminatedBuilder.endTerminated().build()
+      else terminatedBuilder.withReason(reason).endTerminated().build()
+    new ContainerStatusBuilder().withName("spark-kubernetes-driver").withState(terminated)
+  }
+
+  "driverExitCodeFromPod" should "return 0 for Succeeded phase regardless of container state" in {
+    assertEquals(Some(0), K8sSubmitter.driverExitCodeFromPod(podWithPhase("Succeeded")))
+    assertEquals(Some(0), K8sSubmitter.driverExitCodeFromPod(podWithPhase("Succeeded", Some(driverContainer(0)))))
+  }
+
+  it should "return non-zero for Failed phase even when container exit code is 0 (false-success guard)" in {
+    // Regression guard: spark-submit can report 0 for a driver whose pod is `Failed` while the
+    // terminated container state has yet to populate. We must still surface failure.
+    assertEquals(Some(1), K8sSubmitter.driverExitCodeFromPod(podWithPhase("Failed")))
+    assertEquals(Some(1), K8sSubmitter.driverExitCodeFromPod(podWithPhase("Failed", Some(driverContainer(0)))))
+  }
+
+  it should "return the driver container exit code for Failed phase when populated" in {
+    assertEquals(Some(137), K8sSubmitter.driverExitCodeFromPod(podWithPhase("Failed", Some(driverContainer(137)))))
+    assertEquals(
+      Some(137),
+      K8sSubmitter.driverExitCodeFromPod(podWithPhase("Failed", Some(driverContainer(137, "OOMKilled"))))
+    )
+  }
+
+  it should "defer (return None) for non-terminal phases without a non-zero terminated code" in {
+    assertEquals(None, K8sSubmitter.driverExitCodeFromPod(podWithPhase("Running")))
+    assertEquals(None, K8sSubmitter.driverExitCodeFromPod(podWithPhase("Pending")))
+    assertEquals(None, K8sSubmitter.driverExitCodeFromPod(podWithPhase("Unknown")))
+    assertEquals(None, K8sSubmitter.driverExitCodeFromPod(new PodBuilder().build()))
+  }
+
+  it should "still surface a non-zero terminated exit code under non-terminal phase (race window)" in {
+    assertEquals(Some(2), K8sSubmitter.driverExitCodeFromPod(podWithPhase("Running", Some(driverContainer(2)))))
+  }
+
+  private def buildLabeledDriverPod(
+      name: String,
+      sparkAppName: String,
+      chrononJobId: String,
+      phase: String,
+      exitCode: Int
+  ): Pod = {
+    new PodBuilder()
+      .withNewMetadata()
+      .withName(name)
+      .withNamespace("spark-jobs")
+      .addToLabels("spark-app-name", sparkAppName)
+      .addToLabels("spark-app-selector", s"spark-${java.util.UUID.randomUUID().toString.replace("-", "")}")
+      .addToLabels("spark-role", "driver")
+      .addToLabels("chronon-job-id", chrononJobId)
+      .endMetadata()
+      .withStatus(
+        new PodStatusBuilder()
+          .withPhase(phase)
+          .withContainerStatuses(driverContainer(exitCode).build())
+          .build()
+      )
+      .build()
+  }
+
+  private def withMockServer[T](block: KubernetesMockServer => T): T = {
+    val server = new KubernetesMockServer()
+    server.start()
+    try block(server)
+    finally server.destroy()
+  }
+
+  // Driver-pod lookup URL for a given chronon-job-id under the spark-jobs namespace. We URL-
+  // encode `=` and `,` only; dots / dashes / alphanumerics in the typed id pass through
+  // un-escaped (they are unreserved chars per RFC 3986 / fabric8's URLEncoder usage).
+  private def driverLookupPath(chrononJobId: String): String =
+    s"/api/v1/namespaces/spark-jobs/pods?labelSelector=chronon-job-id%3D$chrononJobId%2Cspark-role%3Ddriver"
+
+  "findDriverPod" should "look up pods by chronon-job-id AND spark-role=driver" in {
+    withMockServer { server =>
+      val pod = buildLabeledDriverPod("my-gb-abc-driver", "my-gb", typedJobId, "Failed", 1)
+      server
+        .expect()
+        .get()
+        .withPath(driverLookupPath(typedJobId))
+        .andReturn(200, new PodListBuilder().withItems(List(pod).asJava).build())
+        .always()
+
+      val client = server.createClient()
+      try {
+        val found = K8sSubmitter.findDriverPod(client, "spark-jobs", typedJobId, attempts = 1, sleepMs = 0L)
+        assertTrue("driver pod should be found via chronon-job-id label", found.isDefined)
+        assertEquals("my-gb-abc-driver", found.get.getMetadata.getName)
+      } finally client.close()
+    }
+  }
+
+  it should "return None when no driver pod matches the label selector" in {
+    val missingId = "spark.spark-jobs.missing.000000000000"
+    withMockServer { server =>
+      server
+        .expect()
+        .get()
+        .withPath(driverLookupPath(missingId))
+        .andReturn(200, new PodListBuilder().withItems(List.empty[Pod].asJava).build())
+        .always()
+
+      val client = server.createClient()
+      try {
+        assertEquals(None, K8sSubmitter.findDriverPod(client, "spark-jobs", missingId, attempts = 2, sleepMs = 0L))
+      } finally client.close()
+    }
+  }
+
+  it should "throw IllegalStateException when more than one pod carries the same chronon-job-id" in {
+    withMockServer { server =>
+      val pod1 = buildLabeledDriverPod("my-gb-abc-driver", "my-gb", typedJobId, "Succeeded", 0)
+      val pod2 = buildLabeledDriverPod("my-gb-def-driver", "my-gb", typedJobId, "Failed", 1)
+      server
+        .expect()
+        .get()
+        .withPath(driverLookupPath(typedJobId))
+        .andReturn(200, new PodListBuilder().withItems(List(pod1, pod2).asJava).build())
+        .always()
+
+      val client = server.createClient()
+      try {
+        val ex = intercept[IllegalStateException] {
+          K8sSubmitter.findDriverPod(client, "spark-jobs", typedJobId, attempts = 1, sleepMs = 0L)
+        }
+        assertTrue(ex.getMessage.contains("Multiple driver pods"))
+        assertTrue(ex.getMessage.contains("chronon-job-id"))
+      } finally client.close()
+    }
+  }
+
+  "verifyDriverAndCleanupWith" should
+    "return a non-zero exit code when the driver pod is Failed even if spark-submit returned 0" in {
+      withMockServer { server =>
+        val pod = buildLabeledDriverPod("my-gb-abc-driver", "my-gb", typedJobId, "Failed", 1)
+        server
+          .expect()
+          .get()
+          .withPath(driverLookupPath(typedJobId))
+          .andReturn(200, new PodListBuilder().withItems(List(pod).asJava).build())
+          .always()
+        server
+          .expect()
+          .delete()
+          .withPath("/api/v1/namespaces/spark-jobs/pods/my-gb-abc-driver")
+          .andReturn(200, pod)
+          .once()
+
+        val client = server.createClient()
+        try {
+          val code = K8sSubmitter.verifyDriverAndCleanupWith(
+            client = client,
+            namespace = "spark-jobs",
+            chrononJobId = typedJobId,
+            sparkSubmitExitCode = 0
+          )
+          assertEquals(1, code)
+        } finally client.close()
+      }
+    }
+
+  it should "return 0 when the driver pod is Succeeded even if spark-submit reported a non-zero code" in {
+    withMockServer { server =>
+      val pod = buildLabeledDriverPod("my-gb-abc-driver", "my-gb", typedJobId, "Succeeded", 0)
+      server
+        .expect()
+        .get()
+        .withPath(driverLookupPath(typedJobId))
+        .andReturn(200, new PodListBuilder().withItems(List(pod).asJava).build())
+        .always()
+      server
+        .expect()
+        .delete()
+        .withPath("/api/v1/namespaces/spark-jobs/pods/my-gb-abc-driver")
+        .andReturn(200, pod)
+        .once()
+
+      val client = server.createClient()
+      try {
+        val code = K8sSubmitter.verifyDriverAndCleanupWith(
+          client = client,
+          namespace = "spark-jobs",
+          chrononJobId = typedJobId,
+          sparkSubmitExitCode = 42
+        )
+        assertEquals(0, code)
+      } finally client.close()
+    }
+  }
+
+  it should "isolate by chronon-job-id so a stale Succeeded sibling doesn't mask this run" in {
+    // Regression guard for the false-success bug: pre-fix, lookup-by-spark-app-name would pick
+    // the leftover Succeeded pod from yesterday's run and report SUCCESS for today's Failed
+    // driver. Now the lookup is by chronon-job-id so only this submission's pod is returned.
+    withMockServer { server =>
+      val freshFailedPod = buildLabeledDriverPod("my-gb-fresh-driver", "my-gb", typedJobId, "Failed", 7)
+      // Mock server filters by labelSelector; only the freshly-labeled pod comes back even
+      // though a stale Succeeded sibling shares spark-app-name=my-gb in the namespace.
+      server
+        .expect()
+        .get()
+        .withPath(driverLookupPath(typedJobId))
+        .andReturn(200, new PodListBuilder().withItems(List(freshFailedPod).asJava).build())
+        .always()
+      server
+        .expect()
+        .delete()
+        .withPath("/api/v1/namespaces/spark-jobs/pods/my-gb-fresh-driver")
+        .andReturn(200, freshFailedPod)
+        .once()
+
+      val client = server.createClient()
+      try {
+        val code = K8sSubmitter.verifyDriverAndCleanupWith(
+          client = client,
+          namespace = "spark-jobs",
+          chrononJobId = typedJobId,
+          sparkSubmitExitCode = 0 // spark-submit erroneously reports success
+        )
+        assertEquals(7, code)
+      } finally client.close()
+    }
+  }
+
+  it should "fall back to spark-submit exit code when the driver pod is not observable" in {
+    val nopeId = "spark.spark-jobs.nope.000000000000"
+    withMockServer { server =>
+      server
+        .expect()
+        .get()
+        .withPath(driverLookupPath(nopeId))
+        .andReturn(200, new PodListBuilder().withItems(List.empty[Pod].asJava).build())
+        .always()
+
+      val client = server.createClient()
+      try {
+        val code = K8sSubmitter.verifyDriverAndCleanupWith(
+          client = client,
+          namespace = "spark-jobs",
+          chrononJobId = nopeId,
+          sparkSubmitExitCode = 5,
+          attempts = 1,
+          sleepMs = 0L
+        )
+        assertEquals(5, code)
+      } finally client.close()
+    }
+  }
+
+  // K8s label-value regex (api/.../labels/v1/api.go). Compiled as a String so we can use
+  // java.lang.String.matches under both 2.12 and 2.13 (Scala 2.12 Regex has no `.matches`).
+  private val LabelValueRegex = "^[A-Za-z0-9]([A-Za-z0-9_.-]{0,61}[A-Za-z0-9])?$"
+
+  "formatChrononJobId" should "produce K8s-label-safe ids of the form spark.<ns>.<app>.<uuid12>" in {
+    val id = K8sSubmitter.formatChrononJobId(
+      jobType = SparkJob,
+      namespace = "spark-jobs",
+      sparkAppName = "my-gb",
+      jobIdUuid = "12345678-90ab-cdef-1234-567890abcdef"
+    )
+    assertTrue(s"id '$id' must start with spark.", id.startsWith("spark."))
+    assertTrue(s"id '$id' must end with uuid12 (12 hex)", id.endsWith(".1234567890ab"))
+    assertTrue(s"id '$id' must include the namespace slug", id.contains(".spark-jobs."))
+    assertTrue(s"id '$id' must include the app slug", id.contains(".my-gb."))
+    assertTrue(s"id '$id' must satisfy K8s label-value regex", id.matches(LabelValueRegex))
+  }
+
+  it should "fit in 63 chars even with a long namespace and app name" in {
+    val longNs = "really-long-namespace-name-that-exceeds-the-cap"
+    val longApp = "very-long-app-name-from-a-deeply-nested-team-and-conf-id"
+    val id = K8sSubmitter.formatChrononJobId(
+      jobType = SparkJob,
+      namespace = longNs,
+      sparkAppName = longApp,
+      jobIdUuid = "deadbeef-cafe-babe-1234-567890abcdef"
+    )
+    assertTrue(s"id '$id' length=${id.length} must be <= 63", id.length <= 63)
+    assertTrue(s"id '$id' must satisfy K8s label-value regex", id.matches(LabelValueRegex))
+    assertTrue("uuid12 slot must be preserved verbatim", id.endsWith(".deadbeefcafe"))
+  }
+
+  it should "use a different prefix for FlinkJob (forward-compat scaffold)" in {
+    val id = K8sSubmitter.formatChrononJobId(
+      jobType = FlinkJob,
+      namespace = "ns",
+      sparkAppName = "app",
+      jobIdUuid = "00000000-0000-0000-0000-000000000001"
+    )
+    assertTrue(id.startsWith("flink."))
+  }
+
+  "sanitizeLabelValue" should "rewrite forbidden chars, trim, and cap at 63" in {
+    assertEquals("", K8sSubmitter.sanitizeLabelValue(""))
+    assertEquals("", K8sSubmitter.sanitizeLabelValue(null))
+    assertEquals("", K8sSubmitter.sanitizeLabelValue("---___"))
+    assertEquals("a.b-c", K8sSubmitter.sanitizeLabelValue("-a.b::c-"))
+    val long = K8sSubmitter.sanitizeLabelValue("a" * 100)
+    assertEquals(63, long.length)
+    assertTrue(long.matches(LabelValueRegex))
+    val truncated = K8sSubmitter.sanitizeLabelValue("x" * 60 + "-aaa")
+    assertTrue(truncated.matches(LabelValueRegex))
+  }
+
+  "resolveSparkAppName" should "honor CHRONON_SPARK_APP_NAME over MetadataName / args / jobId" in {
+    val envOverride: String => Option[String] = {
+      case "CHRONON_SPARK_APP_NAME" => Some("metadata-upload__chronon_group_bys_my_feature")
+      case _                        => None
+    }
+    val name = K8sSubmitter.resolveSparkAppName(
+      submissionProperties = Map(MetadataName -> "should-be-ignored", JobId -> "fallback"),
+      args = Array("group-by-backfill"),
+      envLookup = envOverride
+    )
+    assertEquals("metadata-upload-chronon-group-bys-my-feature", name)
+  }
+
+  it should "fall through to MetadataName when the env var is unset" in {
+    val name = K8sSubmitter.resolveSparkAppName(
+      submissionProperties = Map(MetadataName -> "my-gb", JobId -> "fallback"),
+      args = Array("group-by-backfill"),
+      envLookup = _ => None
+    )
+    assertEquals("my-gb", name)
+  }
+
+  "SubmissionMode.parse" should "accept the canonical mode strings" in {
+    assertEquals(SubmissionMode.SparkSubmit, SubmissionMode.parse(""))
+    assertEquals(SubmissionMode.SparkSubmit, SubmissionMode.parse("spark-submit"))
+    assertEquals(SubmissionMode.SparkSubmit, SubmissionMode.parse("  Spark-Submit  "))
+    assertEquals(SubmissionMode.SparkOperator, SubmissionMode.parse("spark-operator"))
+    assertEquals(SubmissionMode.SparkOperator, SubmissionMode.parse("SPARK-OPERATOR"))
+  }
+
+  it should "throw for unknown mode strings" in {
+    val ex = intercept[IllegalArgumentException] { SubmissionMode.parse("dataproc") }
+    assertTrue(ex.getMessage.contains("dataproc"))
+    assertTrue(ex.getMessage.contains(SubmissionMode.EnvVar))
+  }
+
+  "SubmissionMode.resolve" should "prefer submission-properties over job properties over default" in {
+    assertEquals(
+      SubmissionMode.SparkOperator,
+      SubmissionMode.resolve(
+        Map(SubmissionMode.PropertyKey -> "spark-operator"),
+        Map(SubmissionMode.PropertyKey -> "spark-submit")
+      )
+    )
+    assertEquals(
+      SubmissionMode.SparkOperator,
+      SubmissionMode.resolve(Map.empty, Map(SubmissionMode.PropertyKey -> "spark-operator"))
+    )
+    assertEquals(SubmissionMode.Default, SubmissionMode.resolve(Map.empty, Map.empty))
+    assertEquals(
+      SubmissionMode.SparkOperator,
+      SubmissionMode.resolve(Map(SubmissionMode.PropertyKey -> "spark-operator"))
+    )
+    assertEquals(SubmissionMode.Default, SubmissionMode.resolve(Map.empty))
+  }
+
+  "buildSparkSubmitArgv" should "omit submission-mode from spark conf" in {
+    val argv = K8sSubmitter.buildSparkSubmitArgv(
+      submitter = submitter,
+      submissionProperties = Map(
+        MainClass -> "ai.chronon.spark.Driver",
+        JarURI -> "s3://artifacts/cloud_k8s_lib_deploy.jar",
+        JobId -> "job-id",
+        MetadataName -> "gb",
+        ZiplineVersion -> "1.0"
+      ),
+      jobProperties = Map(
+        SubmissionMode.PropertyKey -> "spark-submit",
+        "spark.executor.memory" -> "8g"
+      ),
+      files = Nil,
+      rawArgs = Array("group-by-backfill"),
+      jobType = SparkJob,
+      sparkAppName = "gb",
+      chrononJobId = "spark:spark-jobs:gb:job-id",
+      waitForAppCompletion = false
+    )
+    val confTokens = argv.zip(argv.tail).collect { case ("--conf", kv) => kv }
+    assertTrue(confTokens.exists(_.startsWith("spark.executor.memory=")))
+    assertTrue(!confTokens.exists(_.startsWith(s"${SubmissionMode.PropertyKey}=")))
+  }
+
+  "K8sSubmitter.submit" should "reject spark-operator via CRD ingress stub" in {
+    val ex = intercept[UnsupportedOperationException] {
+      submitter.submit(
+        jobType = SparkJob,
+        submissionProperties = Map(
+          MainClass -> "ai.chronon.spark.Driver",
+          JarURI -> "s3://artifacts/cloud_k8s_lib_deploy.jar",
+          JobId -> "job-uuid",
+          MetadataName -> "test-gb",
+          ZiplineVersion -> "1.0"
+        ),
+        jobProperties = Map(SubmissionMode.PropertyKey -> "spark-operator"),
+        files = Nil,
+        labels = Map.empty,
+        envVars = Map.empty
+      )
+    }
+    assertTrue(ex.getMessage.contains("spark-operator"))
+    assertTrue(ex.getMessage.contains("not implemented"))
+  }
+}

--- a/flink/package.mill
+++ b/flink/package.mill
@@ -38,8 +38,8 @@ trait FlinkModule extends Cross.Module[String] with build.BaseModule {
       .exclude("com.fasterxml.jackson.core" -> "jackson-databind")
       .exclude("com.fasterxml.jackson.core" -> "jackson-annotations"),
   ) ++ Seq(
-    mvn"io.netty:netty-codec-http2:4.1.133.Final",
-    mvn"io.netty:netty-codec-http:4.1.133.Final",
+    mvn"io.netty:netty-codec-http2:${build.Constants.nettyVersion}",
+    mvn"io.netty:netty-codec-http:${build.Constants.nettyVersion}",
   ).map(_.forceVersion())
 
   def mainClass = Some("ai.chronon.flink.FlinkJob")

--- a/flink_connectors/kinesis/package.mill
+++ b/flink_connectors/kinesis/package.mill
@@ -38,8 +38,8 @@ trait KinesisConnectorModule extends Cross.Module[String] with build.BaseModule 
     mvn"software.amazon.awssdk:auth:2.17.295",
     mvn"software.amazon.awssdk:aws-core:2.17.295",
   ) ++ Seq(
-    mvn"io.netty:netty-codec-http2:4.1.133.Final",
-    mvn"io.netty:netty-codec-http:4.1.133.Final",
+    mvn"io.netty:netty-codec-http2:${build.Constants.nettyVersion}",
+    mvn"io.netty:netty-codec-http:${build.Constants.nettyVersion}",
   ).map(_.forceVersion())
 
   object test extends build.BaseTestModule {

--- a/flink_connectors/pubsub/package.mill
+++ b/flink_connectors/pubsub/package.mill
@@ -28,8 +28,8 @@ trait PubSubConnectorModule extends Cross.Module[String] with build.BaseModule {
       .exclude("com.fasterxml.jackson.core" -> "jackson-databind")
       .exclude("com.fasterxml.jackson.core" -> "jackson-annotations"),
   ) ++ Seq(
-    mvn"io.netty:netty-codec-http2:4.1.133.Final",
-    mvn"io.netty:netty-codec-http:4.1.133.Final",
+    mvn"io.netty:netty-codec-http2:${build.Constants.nettyVersion}",
+    mvn"io.netty:netty-codec-http:${build.Constants.nettyVersion}",
   ).map(_.forceVersion())
 
   object test extends build.BaseTestModule {

--- a/python/src/ai/chronon/repo/constants.py
+++ b/python/src/ai/chronon/repo/constants.py
@@ -153,12 +153,13 @@ RENDER_INFO_DEFAULT_SCRIPT = "scripts/render_info.py"
 ZIPLINE_DIRECTORY = "/tmp/zipline"
 
 CLOUD_PROVIDER_KEYWORD = "CLOUD_PROVIDER"
-VALID_CLOUDS = ("gcp", "aws", "azure")
+VALID_CLOUDS = ("gcp", "aws", "azure", "k8s")
 
 # cloud provider
 AWS = "AWS"
 AZURE = "AZURE"
 GCP = "GCP"
+K8S = "K8S"
 
 # arg keywords
 ONLINE_CLASS_ARG = "online_class"

--- a/python/src/ai/chronon/repo/k8s_runner.py
+++ b/python/src/ai/chronon/repo/k8s_runner.py
@@ -1,0 +1,154 @@
+import os
+import uuid
+
+from ai.chronon.logger import get_logger
+from ai.chronon.repo.constants import ROUTES
+from ai.chronon.repo.default_runner import Runner
+from ai.chronon.repo.utils import check_call, extract_filename_from_path, upload_to_blob_store
+
+LOG = get_logger()
+
+K8S_ENTRY = "ai.chronon.integrations.cloud_k8s.K8sSubmitter"
+ZIPLINE_K8S_JAR_DEFAULT = "cloud_k8s_lib_deploy.jar"
+K8S_SUBMISSION_MODE_ENV = "CHRONON_K8S_SUBMISSION_MODE"
+DEFAULT_K8S_SUBMISSION_MODE = "spark-submit"
+
+REQUIRED_ENV_VARS = [
+    "SPARK_K8S_MASTER",
+    "SPARK_K8S_IMAGE",
+    "SPARK_K8S_FILE_UPLOAD_PATH",
+]
+
+
+class K8sRunner(Runner):
+    def __init__(self, args):
+        jar_path = args.get("online_jar") or ""
+        self.job_id = str(uuid.uuid4())
+        self._version = args.get("version") or "local"
+        self._k8s_submission_mode = args.get("k8s_submission_mode")
+        super().__init__(args, os.path.expanduser(jar_path))
+
+    def _resolved_k8s_submission_mode(self) -> str:
+        explicit = self._k8s_submission_mode
+        if explicit is not None and str(explicit).strip():
+            return str(explicit).strip()
+        inherited = os.environ.get(K8S_SUBMISSION_MODE_ENV)
+        if inherited is not None and str(inherited).strip():
+            return str(inherited).strip()
+        return DEFAULT_K8S_SUBMISSION_MODE
+
+    def _subprocess_env_for_k8s_submitter(self):
+        env = os.environ.copy()
+        env[K8S_SUBMISSION_MODE_ENV] = self._resolved_k8s_submission_mode()
+        return env
+
+    def _load_k8s_config(self):
+        self._validate_env()
+        self._file_upload_path = os.environ["SPARK_K8S_FILE_UPLOAD_PATH"]
+        _ = self._parse_extra_conf(os.environ.get("SPARK_K8S_CONF", ""))
+
+    @staticmethod
+    def _validate_env():
+        missing = [v for v in REQUIRED_ENV_VARS if not os.environ.get(v)]
+        if missing:
+            raise ValueError(f"K8sRunner requires these environment variables to be set: {missing}")
+
+    @staticmethod
+    def _parse_extra_conf(raw: str) -> dict:
+        if not raw.strip():
+            return {}
+        if ";" not in raw and "," in raw:
+            raise ValueError("SPARK_K8S_CONF must be semicolon-delimited (;) not comma-delimited (,)")
+
+        result = {}
+        for pair in raw.split(";"):
+            pair = pair.strip()
+            if not pair:
+                continue
+            if "=" not in pair:
+                raise ValueError(f"Malformed token in SPARK_K8S_CONF: {pair!r} (expected key=value)")
+            k, v = pair.split("=", 1)
+            k, v = k.strip(), v.strip()
+            if not k:
+                raise ValueError(f"Empty key in SPARK_K8S_CONF token: {pair!r}")
+            result[k] = v
+        return result
+
+    def _stage_config(self, local_path: str) -> str:
+        filename = extract_filename_from_path(local_path)
+        run_id = uuid.uuid4().hex[:12]
+        remote_uri = f"{self._file_upload_path.rstrip('/')}/{run_id}/{filename}"
+        LOG.info(f"Staging config {local_path} -> {remote_uri}")
+        return upload_to_blob_store(local_path, remote_uri)
+
+    def generate_k8s_submitter_args(self, user_args: str, metadata_conf_path: str = None):
+        staged_files = []
+        if metadata_conf_path:
+            staged_files.append(self._stage_config(metadata_conf_path))
+
+        file_args = f" --files={','.join(staged_files)}" if staged_files else ""
+
+        final_args = (
+            "{user_args} --jar-uri={jar_uri} --job-type=spark --main-class=ai.chronon.spark.Driver "
+            "--zipline-version={zipline_version} --job-id={job_id}"
+        )
+        return final_args.format(
+            user_args=user_args,
+            jar_uri=self.jar_path,
+            zipline_version=self._version,
+            job_id=self.job_id,
+        ) + file_args
+
+    def run(self):
+        command_list = []
+        if self.mode == "info":
+            command_list.append(
+                "python3 {script} --conf {conf} --ds {ds} --repo {repo}".format(
+                    script=self.render_info, conf=self.conf, ds=self.ds, repo=self.repo
+                )
+            )
+        elif self.sub_help or self.mode == "fetch":
+            if not self.jar_path:
+                raise ValueError(
+                    "K8sRunner requires a JAR for sub-help / fetch. Set CHRONON_ONLINE_JAR or pass --online-jar."
+                )
+            entrypoint = "ai.chronon.online.fetcher.FetcherMain" if self.mode == "fetch" else "ai.chronon.spark.Driver"
+            command_list.append(
+                "java -cp {jar} {entrypoint} {subcommand} {args}".format(
+                    jar=self.jar_path,
+                    entrypoint=entrypoint,
+                    args="--help" if self.sub_help else self._gen_final_args(),
+                    subcommand=ROUTES[self.conf_type][self.mode],
+                )
+            )
+        elif self.mode in ["streaming", "streaming-client"]:
+            raise ValueError("Streaming is not yet supported for K8s runner.")
+        else:
+            if not self.jar_path:
+                raise ValueError(
+                    "K8sRunner requires an application JAR for K8sSubmitter. "
+                    "Set CHRONON_ONLINE_JAR or pass --online-jar."
+                )
+
+            self._load_k8s_config()
+            remote_conf_path = extract_filename_from_path(self.conf) if self.conf else None
+            user_args = "{subcommand} {args} {additional_args}".format(
+                subcommand=ROUTES[self.conf_type][self.mode],
+                args=self._gen_final_args(start_ds=self.start_ds, override_conf_path=remote_conf_path),
+                additional_args=os.environ.get("CHRONON_CONFIG_ADDITIONAL_ARGS", ""),
+            )
+            submitter_args = self.generate_k8s_submitter_args(
+                user_args=user_args,
+                metadata_conf_path=self.local_abs_conf_path if self.conf else None,
+            )
+            command = f"java -cp {self.jar_path} {K8S_ENTRY} {submitter_args}"
+            command_list.append(command)
+
+        if len(command_list) == 1:
+            cmd = command_list[0]
+            if K8S_ENTRY in cmd:
+                check_call(cmd, env=self._subprocess_env_for_k8s_submitter())
+            else:
+                check_call(cmd)
+        elif len(command_list) > 1:
+            raise ValueError("Parallel execution is not yet supported for K8s runner.")

--- a/python/src/ai/chronon/repo/run.py
+++ b/python/src/ai/chronon/repo/run.py
@@ -43,6 +43,7 @@ from ai.chronon.repo.constants import (
     AZURE,
     CLOUD_PROVIDER_KEYWORD,
     GCP,
+    K8S,
     MODE_ARGS,
     ONLINE_CLASS_ARG,
     ONLINE_JAR_ARG,
@@ -57,6 +58,7 @@ from ai.chronon.repo.gcp import (
     ZIPLINE_GCP_ONLINE_CLASS_DEFAULT,
     GcpRunner,
 )
+from ai.chronon.repo.k8s_runner import ZIPLINE_K8S_JAR_DEFAULT, K8sRunner
 from ai.chronon.repo.utils import get_environ_arg, resolve_conf, set_runtime_env_v3
 
 
@@ -284,6 +286,13 @@ def validate_additional_jars(ctx, param, value):
     type=click.Choice(["spark", "bigquery"], case_sensitive=False),
     help="Bulk put uploader to use when load data to kv store, applied to upload-to-kv mode",
 )
+@click.option(
+    "--k8s-submission-mode",
+    type=click.Choice(["spark-submit", "spark-operator"], case_sensitive=False),
+    default=None,
+    help="K8s Spark submission mode (sets CHRONON_K8S_SUBMISSION_MODE for the K8sSubmitter JVM). "
+    "When omitted, uses existing env or defaults to spark-submit.",
+)
 @click.pass_context
 def main(
     ctx,
@@ -327,6 +336,7 @@ def main(
     flink_deployment_mode,
     debug,
     uploader,
+    k8s_submission_mode,
 ):
     """Run a Zipline pipeline.
 
@@ -371,6 +381,11 @@ def main(
         ctx.params[ONLINE_CLASS_ARG] = ZIPLINE_AZURE_ONLINE_CLASS_DEFAULT
         ctx.params[CLOUD_PROVIDER_KEYWORD] = cloud_provider
         AzureRunner(ctx.params).run()
+    elif cloud_provider.upper() == K8S:
+        ctx.params[ONLINE_JAR_ARG] = ZIPLINE_K8S_JAR_DEFAULT
+        # K8s uses java -cp ... K8sSubmitter, no online entrypoint to set here.
+        ctx.params[CLOUD_PROVIDER_KEYWORD] = cloud_provider
+        K8sRunner(ctx.params).run()
     else:
         raise ValueError(f"Unsupported cloud provider: {cloud_provider}")
 

--- a/python/src/ai/chronon/repo/utils.py
+++ b/python/src/ai/chronon/repo/utils.py
@@ -72,9 +72,11 @@ def extract_filename_from_path(path):
     return os.path.basename(path)
 
 
-def check_call(cmd):
+def check_call(cmd, env=None):
     LOG.info("Running command: " + cmd)
-    return subprocess.check_call(cmd.split(), bufsize=0)
+    if env is None:
+        return subprocess.check_call(cmd.split(), bufsize=0)
+    return subprocess.check_call(cmd.split(), bufsize=0, env=env)
 
 
 def check_output(cmd, timeout=None, streaming=False):

--- a/python/test/canary/compiled/group_bys/k8s/purchases.v1_dev__0
+++ b/python/test/canary/compiled/group_bys/k8s/purchases.v1_dev__0
@@ -1,0 +1,138 @@
+{
+  "aggregations": [
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 6,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {
+        "k": "10"
+      },
+      "inputColumn": "purchase_price",
+      "operation": 13
+    }
+  ],
+  "keyColumns": [
+    "user_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "purchase_price_average_1d": "925b13d05ef32021b8e42ba18a84528e",
+      "purchase_price_average_3d": "925b13d05ef32021b8e42ba18a84528e",
+      "purchase_price_average_7d": "925b13d05ef32021b8e42ba18a84528e",
+      "purchase_price_count_1d": "925b13d05ef32021b8e42ba18a84528e",
+      "purchase_price_count_3d": "925b13d05ef32021b8e42ba18a84528e",
+      "purchase_price_count_7d": "925b13d05ef32021b8e42ba18a84528e",
+      "purchase_price_last10": "925b13d05ef32021b8e42ba18a84528e",
+      "purchase_price_sum_1d": "925b13d05ef32021b8e42ba18a84528e",
+      "purchase_price_sum_3d": "925b13d05ef32021b8e42ba18a84528e",
+      "purchase_price_sum_7d": "925b13d05ef32021b8e42ba18a84528e",
+      "user_id": "c6fc20fba837006d01bbffb20f2b537c"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3a://warehouse",
+          "CLOUD_PROVIDER": "k8s",
+          "CUSTOMER_ID": "canary",
+          "EVAL_URL": "http://localhost:3904",
+          "FETCHER_URL": "http://localhost:9000",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3a://warehouse"
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily"
+    },
+    "name": "k8s.purchases.v1_dev__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/k8s/purchases.py",
+    "team": "k8s",
+    "version": "0"
+  },
+  "sources": [
+    {
+      "events": {
+        "query": {
+          "selects": {
+            "purchase_price": "purchase_price",
+            "user_id": "user_id"
+          },
+          "startPartition": "2023-11-01",
+          "timeColumn": "ts"
+        },
+        "table": "data.purchases"
+      }
+    }
+  ]
+}

--- a/python/test/canary/compiled/group_bys/k8s/purchases.v1_test__0
+++ b/python/test/canary/compiled/group_bys/k8s/purchases.v1_test__0
@@ -1,0 +1,138 @@
+{
+  "aggregations": [
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 6,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {
+        "k": "10"
+      },
+      "inputColumn": "purchase_price",
+      "operation": 13
+    }
+  ],
+  "keyColumns": [
+    "user_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "purchase_price_average_1d": "6be2182bcb44d01e97ec9e89d8d39562",
+      "purchase_price_average_3d": "6be2182bcb44d01e97ec9e89d8d39562",
+      "purchase_price_average_7d": "6be2182bcb44d01e97ec9e89d8d39562",
+      "purchase_price_count_1d": "6be2182bcb44d01e97ec9e89d8d39562",
+      "purchase_price_count_3d": "6be2182bcb44d01e97ec9e89d8d39562",
+      "purchase_price_count_7d": "6be2182bcb44d01e97ec9e89d8d39562",
+      "purchase_price_last10": "6be2182bcb44d01e97ec9e89d8d39562",
+      "purchase_price_sum_1d": "6be2182bcb44d01e97ec9e89d8d39562",
+      "purchase_price_sum_3d": "6be2182bcb44d01e97ec9e89d8d39562",
+      "purchase_price_sum_7d": "6be2182bcb44d01e97ec9e89d8d39562",
+      "user_id": "7952fd26d2c0c27fec6b932c1ab58480"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3a://warehouse",
+          "CLOUD_PROVIDER": "k8s",
+          "CUSTOMER_ID": "canary",
+          "EVAL_URL": "http://localhost:3904",
+          "FETCHER_URL": "http://localhost:9000",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3a://warehouse"
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily"
+    },
+    "name": "k8s.purchases.v1_test__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/k8s/purchases.py",
+    "team": "k8s",
+    "version": "0"
+  },
+  "sources": [
+    {
+      "events": {
+        "query": {
+          "selects": {
+            "purchase_price": "purchase_price",
+            "user_id": "user_id"
+          },
+          "startPartition": "2023-11-01",
+          "timeColumn": "ts"
+        },
+        "table": "data.purchases"
+      }
+    }
+  ]
+}

--- a/python/test/canary/compiled/joins/k8s/training_set.v1_dev__0
+++ b/python/test/canary/compiled/joins/k8s/training_set.v1_dev__0
@@ -1,0 +1,213 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 6,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {
+              "k": "10"
+            },
+            "inputColumn": "purchase_price",
+            "operation": 13
+          }
+        ],
+        "keyColumns": [
+          "user_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "purchase_price_average_1d": "925b13d05ef32021b8e42ba18a84528e",
+            "purchase_price_average_3d": "925b13d05ef32021b8e42ba18a84528e",
+            "purchase_price_average_7d": "925b13d05ef32021b8e42ba18a84528e",
+            "purchase_price_count_1d": "925b13d05ef32021b8e42ba18a84528e",
+            "purchase_price_count_3d": "925b13d05ef32021b8e42ba18a84528e",
+            "purchase_price_count_7d": "925b13d05ef32021b8e42ba18a84528e",
+            "purchase_price_last10": "925b13d05ef32021b8e42ba18a84528e",
+            "purchase_price_sum_1d": "925b13d05ef32021b8e42ba18a84528e",
+            "purchase_price_sum_3d": "925b13d05ef32021b8e42ba18a84528e",
+            "purchase_price_sum_7d": "925b13d05ef32021b8e42ba18a84528e",
+            "user_id": "c6fc20fba837006d01bbffb20f2b537c"
+          },
+          "executionInfo": {
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.memory": "512m",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "512m",
+                "spark.sql.shuffle.partitions": "10"
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "s3a://warehouse",
+                "CLOUD_PROVIDER": "k8s",
+                "CUSTOMER_ID": "canary",
+                "EVAL_URL": "http://localhost:3904",
+                "FETCHER_URL": "http://localhost:9000",
+                "FRONTEND_URL": "http://localhost:3000",
+                "HUB_URL": "http://localhost:3903",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "s3a://warehouse"
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "k8s.purchases.v1_dev__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "k8s",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "selects": {
+                  "purchase_price": "purchase_price",
+                  "user_id": "user_id"
+                },
+                "startPartition": "2023-11-01",
+                "timeColumn": "ts"
+              },
+              "table": "data.purchases"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "ts": "ts",
+          "user_id": "user_id"
+        },
+        "timeColumn": "ts"
+      },
+      "table": "data.checkouts"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "ts": "a173b2adccfe3c386f262c4cd7ffe9bd",
+      "user_id": "a673c80ffc3260ee5ca173869ba07f7c",
+      "user_id_purchase_price_average_1d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_average_3d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_average_7d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_count_1d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_count_3d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_count_7d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_last10": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_sum_1d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_sum_3d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_sum_7d": "e3351cc3265d17cfd1b99f8da7fb083d"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_checkouts_with_offset_0\", \"spec\": \"data.checkouts/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3a://warehouse",
+          "CLOUD_PROVIDER": "k8s",
+          "CUSTOMER_ID": "canary",
+          "EVAL_URL": "http://localhost:3904",
+          "FETCHER_URL": "http://localhost:9000",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3a://warehouse"
+        }
+      },
+      "offlineSchedule": "@daily"
+    },
+    "name": "k8s.training_set.v1_dev__0",
+    "online": 0,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/k8s/training_set.py",
+    "team": "k8s",
+    "version": "0"
+  },
+  "rowIds": [
+    "user_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/compiled/joins/k8s/training_set.v1_test__0
+++ b/python/test/canary/compiled/joins/k8s/training_set.v1_test__0
@@ -1,0 +1,213 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 6,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {
+              "k": "10"
+            },
+            "inputColumn": "purchase_price",
+            "operation": 13
+          }
+        ],
+        "keyColumns": [
+          "user_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "purchase_price_average_1d": "6be2182bcb44d01e97ec9e89d8d39562",
+            "purchase_price_average_3d": "6be2182bcb44d01e97ec9e89d8d39562",
+            "purchase_price_average_7d": "6be2182bcb44d01e97ec9e89d8d39562",
+            "purchase_price_count_1d": "6be2182bcb44d01e97ec9e89d8d39562",
+            "purchase_price_count_3d": "6be2182bcb44d01e97ec9e89d8d39562",
+            "purchase_price_count_7d": "6be2182bcb44d01e97ec9e89d8d39562",
+            "purchase_price_last10": "6be2182bcb44d01e97ec9e89d8d39562",
+            "purchase_price_sum_1d": "6be2182bcb44d01e97ec9e89d8d39562",
+            "purchase_price_sum_3d": "6be2182bcb44d01e97ec9e89d8d39562",
+            "purchase_price_sum_7d": "6be2182bcb44d01e97ec9e89d8d39562",
+            "user_id": "7952fd26d2c0c27fec6b932c1ab58480"
+          },
+          "executionInfo": {
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.memory": "512m",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "512m",
+                "spark.sql.shuffle.partitions": "10"
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "s3a://warehouse",
+                "CLOUD_PROVIDER": "k8s",
+                "CUSTOMER_ID": "canary",
+                "EVAL_URL": "http://localhost:3904",
+                "FETCHER_URL": "http://localhost:9000",
+                "FRONTEND_URL": "http://localhost:3000",
+                "HUB_URL": "http://localhost:3903",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "s3a://warehouse"
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "k8s.purchases.v1_test__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "k8s",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "selects": {
+                  "purchase_price": "purchase_price",
+                  "user_id": "user_id"
+                },
+                "startPartition": "2023-11-01",
+                "timeColumn": "ts"
+              },
+              "table": "data.purchases"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "ts": "ts",
+          "user_id": "user_id"
+        },
+        "timeColumn": "ts"
+      },
+      "table": "data.checkouts"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "ts": "a173b2adccfe3c386f262c4cd7ffe9bd",
+      "user_id": "a673c80ffc3260ee5ca173869ba07f7c",
+      "user_id_purchase_price_average_1d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_average_3d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_average_7d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_count_1d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_count_3d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_count_7d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_last10": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_sum_1d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_sum_3d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_sum_7d": "e3351cc3265d17cfd1b99f8da7fb083d"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_checkouts_with_offset_0\", \"spec\": \"data.checkouts/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3a://warehouse",
+          "CLOUD_PROVIDER": "k8s",
+          "CUSTOMER_ID": "canary",
+          "EVAL_URL": "http://localhost:3904",
+          "FETCHER_URL": "http://localhost:9000",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3a://warehouse"
+        }
+      },
+      "offlineSchedule": "@daily"
+    },
+    "name": "k8s.training_set.v1_test__0",
+    "online": 0,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/k8s/training_set.py",
+    "team": "k8s",
+    "version": "0"
+  },
+  "rowIds": [
+    "user_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/compiled/staging_queries/k8s/exports.checkouts__0
+++ b/python/test/canary/compiled/staging_queries/k8s/exports.checkouts__0
@@ -1,0 +1,62 @@
+{
+  "engineType": 0,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_checkouts_with_offset_0\", \"spec\": \"checkouts/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3a://warehouse",
+          "CLOUD_PROVIDER": "k8s",
+          "CUSTOMER_ID": "canary",
+          "EVAL_URL": "http://localhost:3904",
+          "FETCHER_URL": "http://localhost:9000",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3a://warehouse"
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "k8s.exports.checkouts__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/k8s/exports.py",
+    "team": "k8s",
+    "version": "0"
+  },
+  "query": "\n    SELECT\n        *\n    FROM checkouts\n    WHERE\n    ds BETWEEN '{{ start_date }}' AND '{{ end_date }}'\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "checkouts"
+      }
+    }
+  ]
+}

--- a/python/test/canary/compiled/staging_queries/k8s/exports.user_activities__0
+++ b/python/test/canary/compiled/staging_queries/k8s/exports.user_activities__0
@@ -1,0 +1,62 @@
+{
+  "engineType": 0,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_user_activities_with_offset_0\", \"spec\": \"user_activities/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3a://warehouse",
+          "CLOUD_PROVIDER": "k8s",
+          "CUSTOMER_ID": "canary",
+          "EVAL_URL": "http://localhost:3904",
+          "FETCHER_URL": "http://localhost:9000",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3a://warehouse"
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "k8s.exports.user_activities__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/k8s/exports.py",
+    "team": "k8s",
+    "version": "0"
+  },
+  "query": "\n    SELECT\n        *\n    FROM user_activities\n    WHERE\n    ds BETWEEN '{{ start_date }}' AND '{{ end_date }}'\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "user_activities"
+      }
+    }
+  ]
+}

--- a/python/test/canary/compiled/teams_metadata/k8s/k8s_team_metadata
+++ b/python/test/canary/compiled/teams_metadata/k8s/k8s_team_metadata
@@ -1,0 +1,30 @@
+{
+  "executionInfo": {
+    "conf": {
+      "common": {
+        "spark.chronon.coalesce.factor": "10",
+        "spark.chronon.partition.column": "ds",
+        "spark.chronon.partition.format": "yyyy-MM-dd",
+        "spark.default.parallelism": "10",
+        "spark.driver.cores": "1",
+        "spark.driver.memory": "512m",
+        "spark.executor.cores": "1",
+        "spark.executor.memory": "512m",
+        "spark.sql.shuffle.partitions": "10"
+      }
+    },
+    "env": {
+      "common": {
+        "ARTIFACT_PREFIX": "s3a://warehouse",
+        "CLOUD_PROVIDER": "k8s",
+        "CUSTOMER_ID": "canary",
+        "EVAL_URL": "http://localhost:3904",
+        "FETCHER_URL": "http://localhost:9000",
+        "FRONTEND_URL": "http://localhost:3000",
+        "HUB_URL": "http://localhost:3903",
+        "VERSION": "latest",
+        "WAREHOUSE_PREFIX": "s3a://warehouse"
+      }
+    }
+  }
+}

--- a/python/test/canary/compiled_canary/group_bys/k8s/purchases.v1_dev__0
+++ b/python/test/canary/compiled_canary/group_bys/k8s/purchases.v1_dev__0
@@ -1,0 +1,136 @@
+{
+  "aggregations": [
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 6,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {
+        "k": "10"
+      },
+      "inputColumn": "purchase_price",
+      "operation": 13
+    }
+  ],
+  "keyColumns": [
+    "user_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "purchase_price_average_1d": "925b13d05ef32021b8e42ba18a84528e",
+      "purchase_price_average_3d": "925b13d05ef32021b8e42ba18a84528e",
+      "purchase_price_average_7d": "925b13d05ef32021b8e42ba18a84528e",
+      "purchase_price_count_1d": "925b13d05ef32021b8e42ba18a84528e",
+      "purchase_price_count_3d": "925b13d05ef32021b8e42ba18a84528e",
+      "purchase_price_count_7d": "925b13d05ef32021b8e42ba18a84528e",
+      "purchase_price_last10": "925b13d05ef32021b8e42ba18a84528e",
+      "purchase_price_sum_1d": "925b13d05ef32021b8e42ba18a84528e",
+      "purchase_price_sum_3d": "925b13d05ef32021b8e42ba18a84528e",
+      "purchase_price_sum_7d": "925b13d05ef32021b8e42ba18a84528e",
+      "user_id": "c6fc20fba837006d01bbffb20f2b537c"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3a://warehouse",
+          "CLOUD_PROVIDER": "k8s",
+          "CUSTOMER_ID": "canary",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3a://warehouse"
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily"
+    },
+    "name": "k8s.purchases.v1_dev__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/k8s/purchases.py",
+    "team": "k8s",
+    "version": "0"
+  },
+  "sources": [
+    {
+      "events": {
+        "query": {
+          "selects": {
+            "purchase_price": "purchase_price",
+            "user_id": "user_id"
+          },
+          "startPartition": "2023-11-01",
+          "timeColumn": "ts"
+        },
+        "table": "data.purchases"
+      }
+    }
+  ]
+}

--- a/python/test/canary/compiled_canary/group_bys/k8s/purchases.v1_test__0
+++ b/python/test/canary/compiled_canary/group_bys/k8s/purchases.v1_test__0
@@ -1,0 +1,136 @@
+{
+  "aggregations": [
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 6,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {
+        "k": "10"
+      },
+      "inputColumn": "purchase_price",
+      "operation": 13
+    }
+  ],
+  "keyColumns": [
+    "user_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "purchase_price_average_1d": "6be2182bcb44d01e97ec9e89d8d39562",
+      "purchase_price_average_3d": "6be2182bcb44d01e97ec9e89d8d39562",
+      "purchase_price_average_7d": "6be2182bcb44d01e97ec9e89d8d39562",
+      "purchase_price_count_1d": "6be2182bcb44d01e97ec9e89d8d39562",
+      "purchase_price_count_3d": "6be2182bcb44d01e97ec9e89d8d39562",
+      "purchase_price_count_7d": "6be2182bcb44d01e97ec9e89d8d39562",
+      "purchase_price_last10": "6be2182bcb44d01e97ec9e89d8d39562",
+      "purchase_price_sum_1d": "6be2182bcb44d01e97ec9e89d8d39562",
+      "purchase_price_sum_3d": "6be2182bcb44d01e97ec9e89d8d39562",
+      "purchase_price_sum_7d": "6be2182bcb44d01e97ec9e89d8d39562",
+      "user_id": "7952fd26d2c0c27fec6b932c1ab58480"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3a://warehouse",
+          "CLOUD_PROVIDER": "k8s",
+          "CUSTOMER_ID": "canary",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3a://warehouse"
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily"
+    },
+    "name": "k8s.purchases.v1_test__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/k8s/purchases.py",
+    "team": "k8s",
+    "version": "0"
+  },
+  "sources": [
+    {
+      "events": {
+        "query": {
+          "selects": {
+            "purchase_price": "purchase_price",
+            "user_id": "user_id"
+          },
+          "startPartition": "2023-11-01",
+          "timeColumn": "ts"
+        },
+        "table": "data.purchases"
+      }
+    }
+  ]
+}

--- a/python/test/canary/compiled_canary/joins/k8s/training_set.v1_dev__0
+++ b/python/test/canary/compiled_canary/joins/k8s/training_set.v1_dev__0
@@ -1,0 +1,209 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 6,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {
+              "k": "10"
+            },
+            "inputColumn": "purchase_price",
+            "operation": 13
+          }
+        ],
+        "keyColumns": [
+          "user_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "purchase_price_average_1d": "925b13d05ef32021b8e42ba18a84528e",
+            "purchase_price_average_3d": "925b13d05ef32021b8e42ba18a84528e",
+            "purchase_price_average_7d": "925b13d05ef32021b8e42ba18a84528e",
+            "purchase_price_count_1d": "925b13d05ef32021b8e42ba18a84528e",
+            "purchase_price_count_3d": "925b13d05ef32021b8e42ba18a84528e",
+            "purchase_price_count_7d": "925b13d05ef32021b8e42ba18a84528e",
+            "purchase_price_last10": "925b13d05ef32021b8e42ba18a84528e",
+            "purchase_price_sum_1d": "925b13d05ef32021b8e42ba18a84528e",
+            "purchase_price_sum_3d": "925b13d05ef32021b8e42ba18a84528e",
+            "purchase_price_sum_7d": "925b13d05ef32021b8e42ba18a84528e",
+            "user_id": "c6fc20fba837006d01bbffb20f2b537c"
+          },
+          "executionInfo": {
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.memory": "512m",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "512m",
+                "spark.sql.shuffle.partitions": "10"
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "s3a://warehouse",
+                "CLOUD_PROVIDER": "k8s",
+                "CUSTOMER_ID": "canary",
+                "FRONTEND_URL": "http://localhost:3000",
+                "HUB_URL": "http://localhost:3903",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "s3a://warehouse"
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "k8s.purchases.v1_dev__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "k8s",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "selects": {
+                  "purchase_price": "purchase_price",
+                  "user_id": "user_id"
+                },
+                "startPartition": "2023-11-01",
+                "timeColumn": "ts"
+              },
+              "table": "data.purchases"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "ts": "ts",
+          "user_id": "user_id"
+        },
+        "timeColumn": "ts"
+      },
+      "table": "data.checkouts"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "ts": "a173b2adccfe3c386f262c4cd7ffe9bd",
+      "user_id": "a673c80ffc3260ee5ca173869ba07f7c",
+      "user_id_purchase_price_average_1d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_average_3d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_average_7d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_count_1d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_count_3d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_count_7d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_last10": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_sum_1d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_sum_3d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_sum_7d": "e3351cc3265d17cfd1b99f8da7fb083d"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_checkouts_with_offset_0\", \"spec\": \"data.checkouts/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3a://warehouse",
+          "CLOUD_PROVIDER": "k8s",
+          "CUSTOMER_ID": "canary",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3a://warehouse"
+        }
+      },
+      "offlineSchedule": "@daily"
+    },
+    "name": "k8s.training_set.v1_dev__0",
+    "online": 0,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/k8s/training_set.py",
+    "team": "k8s",
+    "version": "0"
+  },
+  "rowIds": [
+    "user_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/compiled_canary/joins/k8s/training_set.v1_test__0
+++ b/python/test/canary/compiled_canary/joins/k8s/training_set.v1_test__0
@@ -1,0 +1,209 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 6,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {
+              "k": "10"
+            },
+            "inputColumn": "purchase_price",
+            "operation": 13
+          }
+        ],
+        "keyColumns": [
+          "user_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "purchase_price_average_1d": "6be2182bcb44d01e97ec9e89d8d39562",
+            "purchase_price_average_3d": "6be2182bcb44d01e97ec9e89d8d39562",
+            "purchase_price_average_7d": "6be2182bcb44d01e97ec9e89d8d39562",
+            "purchase_price_count_1d": "6be2182bcb44d01e97ec9e89d8d39562",
+            "purchase_price_count_3d": "6be2182bcb44d01e97ec9e89d8d39562",
+            "purchase_price_count_7d": "6be2182bcb44d01e97ec9e89d8d39562",
+            "purchase_price_last10": "6be2182bcb44d01e97ec9e89d8d39562",
+            "purchase_price_sum_1d": "6be2182bcb44d01e97ec9e89d8d39562",
+            "purchase_price_sum_3d": "6be2182bcb44d01e97ec9e89d8d39562",
+            "purchase_price_sum_7d": "6be2182bcb44d01e97ec9e89d8d39562",
+            "user_id": "7952fd26d2c0c27fec6b932c1ab58480"
+          },
+          "executionInfo": {
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.memory": "512m",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "512m",
+                "spark.sql.shuffle.partitions": "10"
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "s3a://warehouse",
+                "CLOUD_PROVIDER": "k8s",
+                "CUSTOMER_ID": "canary",
+                "FRONTEND_URL": "http://localhost:3000",
+                "HUB_URL": "http://localhost:3903",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "s3a://warehouse"
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "k8s.purchases.v1_test__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "k8s",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "selects": {
+                  "purchase_price": "purchase_price",
+                  "user_id": "user_id"
+                },
+                "startPartition": "2023-11-01",
+                "timeColumn": "ts"
+              },
+              "table": "data.purchases"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "ts": "ts",
+          "user_id": "user_id"
+        },
+        "timeColumn": "ts"
+      },
+      "table": "data.checkouts"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "ts": "a173b2adccfe3c386f262c4cd7ffe9bd",
+      "user_id": "a673c80ffc3260ee5ca173869ba07f7c",
+      "user_id_purchase_price_average_1d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_average_3d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_average_7d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_count_1d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_count_3d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_count_7d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_last10": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_sum_1d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_sum_3d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_sum_7d": "e3351cc3265d17cfd1b99f8da7fb083d"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_checkouts_with_offset_0\", \"spec\": \"data.checkouts/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3a://warehouse",
+          "CLOUD_PROVIDER": "k8s",
+          "CUSTOMER_ID": "canary",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3a://warehouse"
+        }
+      },
+      "offlineSchedule": "@daily"
+    },
+    "name": "k8s.training_set.v1_test__0",
+    "online": 0,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/k8s/training_set.py",
+    "team": "k8s",
+    "version": "0"
+  },
+  "rowIds": [
+    "user_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/compiled_canary/staging_queries/k8s/exports.checkouts__0
+++ b/python/test/canary/compiled_canary/staging_queries/k8s/exports.checkouts__0
@@ -1,0 +1,60 @@
+{
+  "engineType": 0,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_checkouts_with_offset_0\", \"spec\": \"checkouts/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3a://warehouse",
+          "CLOUD_PROVIDER": "k8s",
+          "CUSTOMER_ID": "canary",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3a://warehouse"
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "k8s.exports.checkouts__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/k8s/exports.py",
+    "team": "k8s",
+    "version": "0"
+  },
+  "query": "\n    SELECT\n        *\n    FROM checkouts\n    WHERE\n    ds BETWEEN '{{ start_date }}' AND '{{ end_date }}'\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "checkouts"
+      }
+    }
+  ]
+}

--- a/python/test/canary/compiled_canary/staging_queries/k8s/exports.user_activities__0
+++ b/python/test/canary/compiled_canary/staging_queries/k8s/exports.user_activities__0
@@ -1,0 +1,60 @@
+{
+  "engineType": 0,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_user_activities_with_offset_0\", \"spec\": \"user_activities/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3a://warehouse",
+          "CLOUD_PROVIDER": "k8s",
+          "CUSTOMER_ID": "canary",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3a://warehouse"
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "k8s.exports.user_activities__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/k8s/exports.py",
+    "team": "k8s",
+    "version": "0"
+  },
+  "query": "\n    SELECT\n        *\n    FROM user_activities\n    WHERE\n    ds BETWEEN '{{ start_date }}' AND '{{ end_date }}'\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "user_activities"
+      }
+    }
+  ]
+}

--- a/python/test/canary/compiled_canary/teams_metadata/k8s/k8s_team_metadata
+++ b/python/test/canary/compiled_canary/teams_metadata/k8s/k8s_team_metadata
@@ -1,0 +1,28 @@
+{
+  "executionInfo": {
+    "conf": {
+      "common": {
+        "spark.chronon.coalesce.factor": "10",
+        "spark.chronon.partition.column": "ds",
+        "spark.chronon.partition.format": "yyyy-MM-dd",
+        "spark.default.parallelism": "10",
+        "spark.driver.cores": "1",
+        "spark.driver.memory": "512m",
+        "spark.executor.cores": "1",
+        "spark.executor.memory": "512m",
+        "spark.sql.shuffle.partitions": "10"
+      }
+    },
+    "env": {
+      "common": {
+        "ARTIFACT_PREFIX": "s3a://warehouse",
+        "CLOUD_PROVIDER": "k8s",
+        "CUSTOMER_ID": "canary",
+        "FRONTEND_URL": "http://localhost:3000",
+        "HUB_URL": "http://localhost:3903",
+        "VERSION": "latest",
+        "WAREHOUSE_PREFIX": "s3a://warehouse"
+      }
+    }
+  }
+}

--- a/python/test/canary/group_bys/k8s/purchases.py
+++ b/python/test/canary/group_bys/k8s/purchases.py
@@ -1,0 +1,47 @@
+from ai.chronon.types import (
+    Aggregation,
+    EventSource,
+    GroupBy,
+    Operation,
+    Query,
+    TimeUnit,
+    Window,
+    selects,
+)
+
+source = EventSource(
+    table="data.purchases",
+    query=Query(
+        selects=selects("user_id", "purchase_price"),
+        start_partition="2023-11-01",
+        time_column="ts",
+    ),
+)
+
+window_sizes = [Window(length=day, time_unit=TimeUnit.DAYS) for day in [1, 3, 7]]
+
+v1_dev = GroupBy(
+    sources=[source],
+    keys=["user_id"],
+    online=True,
+    version=0,
+    aggregations=[
+        Aggregation(input_column="purchase_price", operation=Operation.SUM, windows=window_sizes),
+        Aggregation(input_column="purchase_price", operation=Operation.COUNT, windows=window_sizes),
+        Aggregation(input_column="purchase_price", operation=Operation.AVERAGE, windows=window_sizes),
+        Aggregation(input_column="purchase_price", operation=Operation.LAST_K(10)),
+    ],
+)
+
+v1_test = GroupBy(
+    sources=[source],
+    keys=["user_id"],
+    online=True,
+    version=0,
+    aggregations=[
+        Aggregation(input_column="purchase_price", operation=Operation.SUM, windows=window_sizes),
+        Aggregation(input_column="purchase_price", operation=Operation.COUNT, windows=window_sizes),
+        Aggregation(input_column="purchase_price", operation=Operation.AVERAGE, windows=window_sizes),
+        Aggregation(input_column="purchase_price", operation=Operation.LAST_K(10)),
+    ],
+)

--- a/python/test/canary/joins/k8s/training_set.py
+++ b/python/test/canary/joins/k8s/training_set.py
@@ -1,0 +1,29 @@
+from group_bys.k8s import purchases
+
+from ai.chronon.types import EventSource, Join, JoinPart, Query, selects
+
+source = EventSource(
+    table="data.checkouts",
+    query=Query(
+        selects=selects("user_id"),
+        time_column="ts",
+    ),
+)
+
+v1_test = Join(
+    left=source,
+    row_ids="user_id",
+    right_parts=[
+        JoinPart(group_by=purchases.v1_test),
+    ],
+    version=0,
+)
+
+v1_dev = Join(
+    left=source,
+    row_ids="user_id",
+    right_parts=[
+        JoinPart(group_by=purchases.v1_dev),
+    ],
+    version=0,
+)

--- a/python/test/canary/staging_queries/k8s/exports.py
+++ b/python/test/canary/staging_queries/k8s/exports.py
@@ -1,0 +1,23 @@
+from ai.chronon.types import EngineType, StagingQuery, TableDependency
+
+
+def get_native_partition_export(table: str, partition_column: str = "ds", version: int = 0):
+    spark_sql = f"""
+    SELECT
+        *
+    FROM {table}
+    WHERE
+    {partition_column} BETWEEN '{{{{ start_date }}}}' AND '{{{{ end_date }}}}'
+    """
+    return StagingQuery(
+        query=spark_sql,
+        output_namespace="data",
+        engine_type=EngineType.SPARK,
+        dependencies=[TableDependency(table=table, partition_column=partition_column, offset=0)],
+        version=version,
+        step_days=30,
+    )
+
+
+user_activities = get_native_partition_export("user_activities")
+checkouts = get_native_partition_export("checkouts")

--- a/python/test/canary/teams.canary.py
+++ b/python/test/canary/teams.canary.py
@@ -176,7 +176,7 @@ aws = Team(
 
 
 # Show that teams can be imported from other teams.py files
-from teams import aws_databricks, azure, quickstart, aws
+from teams import aws_databricks, azure, quickstart, aws, k8s
 
 # only affects the files in compiled_canary/ to verify that the canary compile uses this teams.canary.py file and not teams.py
 aws_databricks_env: EnvironmentVariables = aws_databricks.env

--- a/python/test/canary/teams.py
+++ b/python/test/canary/teams.py
@@ -247,6 +247,34 @@ quickstart = Team(
     ),
 )
 
+k8s = Team(
+    outputNamespace="data",
+    env=EnvironmentVariables(
+        common={
+            "CLOUD_PROVIDER": "k8s",
+            "CUSTOMER_ID": "canary",
+            "VERSION": "latest",
+            "ARTIFACT_PREFIX": "s3a://warehouse",
+            "WAREHOUSE_PREFIX": "s3a://warehouse",
+            "HUB_URL": "http://localhost:3903",
+            "FRONTEND_URL": "http://localhost:3000",
+        },
+    ),
+    conf=ConfigProperties(
+        common={
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.coalesce.factor": "10",
+            "spark.default.parallelism": "10",
+            "spark.sql.shuffle.partitions": "10",
+            "spark.driver.memory": "512m",
+            "spark.driver.cores": "1",
+            "spark.executor.memory": "512m",
+            "spark.executor.cores": "1",
+        },
+    ),
+)
+
 azure = Team(
     outputNamespace="data",
     env=EnvironmentVariables(

--- a/python/test/integration/conftest.py
+++ b/python/test/integration/conftest.py
@@ -79,7 +79,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--cloud",
         default=os.environ.get("CLOUD", "gcp"),
-        choices=("gcp", "aws", "azure"),
+        choices=("gcp", "aws", "azure", "k8s"),
         help="Cloud provider (env: CLOUD)",
     )
 

--- a/python/test/integration/test_hub_backfill.py
+++ b/python/test/integration/test_hub_backfill.py
@@ -21,6 +21,8 @@ DEMO_DERIVATIONS = {
 @pytest.mark.integration
 def test_backfill_no_data(confs, chronon_root, hub_url, cloud):
     """Backfill with dates that have no input data should result in a failed workflow."""
+    if cloud == "k8s":
+        pytest.skip("k8s canary configs do not yet include demo derivations for hub backfill tests")
     runner = CliRunner()
     compile_configs(runner, chronon_root)
 
@@ -45,6 +47,8 @@ MULTIDAY_BACKFILL = {
 @pytest.mark.integration
 def test_backfill_multiday(confs, chronon_root, hub_url, cloud):
     """Multi-day backfill exercises multi-step allocation."""
+    if cloud == "k8s":
+        pytest.skip("k8s canary configs do not yet include demo derivations for hub backfill tests")
     runner = CliRunner()
     compile_configs(runner, chronon_root)
 

--- a/python/test/integration/test_hub_run_adhoc.py
+++ b/python/test/integration/test_hub_run_adhoc.py
@@ -62,6 +62,8 @@ def test_run_adhoc(confs, chronon_root, hub_url, cloud, flink_cleanup):
 @pytest.mark.integration
 def test_run_adhoc_no_data(confs, chronon_root, hub_url, cloud):
     """run-adhoc with dates that have no input data should fail."""
+    if cloud == "k8s":
+        pytest.skip("k8s canary configs do not yet include a demo join for hub run-adhoc tests")
     runner = CliRunner()
     compile_configs(runner, chronon_root)
 

--- a/python/test/integration/test_hub_schedule.py
+++ b/python/test/integration/test_hub_schedule.py
@@ -19,6 +19,8 @@ DEMO_BACKFILL = {
 @pytest.mark.integration
 def test_schedule_lifecycle(confs, test_id, chronon_root, hub_url, cloud):
     """Deploy a schedule, verify it exists, delete it, verify it's gone."""
+    if cloud == "k8s":
+        pytest.skip("k8s canary configs do not yet include a demo join for hub schedule tests")
     runner = CliRunner()
     compile_configs(runner, chronon_root)
 

--- a/python/test/integration/test_run_quickstart.py
+++ b/python/test/integration/test_run_quickstart.py
@@ -28,12 +28,14 @@ START_DS = {
     "gcp": "2023-11-01",
     "aws": "2026-01-07",
     "azure": "2023-11-01",
+    "k8s": "2023-11-01",
 }
 
 END_DS = {
     "gcp": "2023-11-30",
     "aws": "2026-01-18",
     "azure": "2023-11-30",
+    "k8s": "2023-11-30",
 }
 
 STAGING_QUERY_IMPORT_KEYS = {
@@ -52,18 +54,24 @@ STAGING_QUERY_IMPORT_KEYS = {
         "compiled/staging_queries/azure/exports.user_activities__0",
         "compiled/staging_queries/azure/exports.checkouts__0",
     ],
+    "k8s": [
+        "compiled/staging_queries/k8s/exports.user_activities__0",
+        "compiled/staging_queries/k8s/exports.checkouts__0",
+    ],
 }
 
 GROUP_BY_KEY = {
     "gcp": "compiled/group_bys/gcp/purchases.v1_test__0",
     "aws": "compiled/group_bys/aws/user_activities.v1__1",
     "azure": "compiled/group_bys/azure/purchases.v1_test__0",
+    "k8s": "compiled/group_bys/k8s/purchases.v1_test__0",
 }
 
 JOIN_KEY = {
     "gcp": "compiled/joins/gcp/training_set.v1_test__0",
     "aws": "compiled/joins/aws/demo.v1__1",
     "azure": "compiled/joins/azure/training_set.v1_test__0",
+    "k8s": "compiled/joins/k8s/training_set.v1_test__0",
 }
 
 

--- a/python/test/test_integration_templates.py
+++ b/python/test/test_integration_templates.py
@@ -87,6 +87,9 @@ class TestCompiledConfsExist:
     def test_azure_confs(self):
         self._compile_and_check("azure")
 
+    def test_k8s_confs(self):
+        self._compile_and_check("k8s")
+
 
 class TestDiscoverSources:
     """Verify _discover_sources finds config files for each cloud."""
@@ -112,6 +115,13 @@ class TestDiscoverSources:
         assert "exports.py" in stems
         assert "dim_listings.py" in stems
         assert "demo.py" in stems
+
+    def test_k8s_has_sources(self):
+        sources = _discover_sources(_canary_root, "k8s")
+        stems = {os.path.basename(s) for s in sources}
+        assert "exports.py" in stems
+        assert "purchases.py" in stems
+        assert "training_set.py" in stems
 
 
 class TestRewriteImports:

--- a/python/test/test_k8s_runner.py
+++ b/python/test/test_k8s_runner.py
@@ -1,0 +1,300 @@
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ai.chronon.repo.k8s_runner import (
+    DEFAULT_K8S_SUBMISSION_MODE,
+    K8S_ENTRY,
+    K8S_SUBMISSION_MODE_ENV,
+    K8sRunner,
+)
+
+SAMPLE_CONF = "compiled/group_bys/sample_team/sample_group_by.v1__0"
+
+
+def _make_k8s_env(file_upload_path="gs://my-bucket/spark-staging"):
+    return {
+        "SPARK_K8S_MASTER": "k8s://https://10.0.0.1:6443",
+        "SPARK_K8S_NAMESPACE": "spark-jobs",
+        "SPARK_K8S_SERVICE_ACCOUNT": "spark-sa",
+        "SPARK_K8S_IMAGE": "registry.example.com/spark:latest",
+        "SPARK_K8S_FILE_UPLOAD_PATH": file_upload_path,
+    }
+
+
+@pytest.fixture
+def k8s_env(monkeypatch):
+    for k, v in _make_k8s_env().items():
+        monkeypatch.setenv(k, v)
+    monkeypatch.setenv("CUSTOMER_ID", "test")
+
+
+@pytest.fixture
+def runner_args(repo):
+    return {
+        "repo": repo,
+        "conf": SAMPLE_CONF,
+        "mode": "backfill",
+        "env": "dev",
+        "ds": "2024-01-01",
+        "end_ds": "2024-01-01",
+        "start_ds": None,
+        "app_name": "test_app",
+        "online_jar": "/tmp/test.jar",
+        "online_class": "com.example.MyApiImpl",
+        "online_jar_fetch": None,
+        "sub_help": False,
+        "conf_type": "group_bys",
+        "args": "",
+        "spark_submit_path": "spark-submit",
+        "spark_streaming_submit_path": "spark-submit",
+        "list_apps": "echo []",
+        "render_info": "scripts/render_info.py",
+        "online_args": None,
+        "parallelism": None,
+        "kafka_bootstrap": None,
+        "latest_savepoint": None,
+        "custom_savepoint": None,
+        "no_savepoint": None,
+        "version_check": None,
+        "additional_jars": None,
+        "flink_jars_uri": None,
+        "mock_source": None,
+        "validate": None,
+        "validate_rows": None,
+        "no_cloud_logging": False,
+        "debug": False,
+        "uploader": None,
+        "warehouse_bucket": None,
+        "version": "1.2.3",
+        "k8s_submission_mode": None,
+    }
+
+
+class TestEnvValidation:
+    def test_missing_all_env_vars_raises(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError, match="K8sRunner requires these environment variables"):
+                K8sRunner._validate_env()
+
+    def test_missing_one_env_var_lists_it(self, k8s_env, monkeypatch):
+        monkeypatch.delenv("SPARK_K8S_IMAGE")
+        with pytest.raises(ValueError, match="SPARK_K8S_IMAGE"):
+            K8sRunner._validate_env()
+
+    def test_all_env_vars_set_passes(self, k8s_env):
+        K8sRunner._validate_env()
+
+
+class TestNoK8sEnvRequired:
+    def test_info_mode_without_k8s_env(self, runner_args, monkeypatch):
+        runner_args["mode"] = "info"
+        monkeypatch.setenv("CUSTOMER_ID", "test")
+        monkeypatch.setattr(os.path, "exists", lambda _: True)
+        captured = {}
+        monkeypatch.setattr("ai.chronon.repo.k8s_runner.check_call", lambda cmd: captured.update(cmd=cmd))
+
+        K8sRunner(runner_args).run()
+
+        assert "python3" in captured["cmd"]
+        assert K8S_ENTRY not in captured["cmd"]
+
+    def test_fetch_mode_without_k8s_env(self, runner_args, monkeypatch):
+        runner_args["mode"] = "fetch"
+        monkeypatch.setenv("CUSTOMER_ID", "test")
+        monkeypatch.setattr(os.path, "exists", lambda _: True)
+        captured = {}
+        monkeypatch.setattr("ai.chronon.repo.k8s_runner.check_call", lambda cmd: captured.update(cmd=cmd))
+
+        K8sRunner(runner_args).run()
+
+        assert "ai.chronon.online.fetcher.FetcherMain" in captured["cmd"]
+
+
+class TestParseExtraConf:
+    def test_empty_string(self):
+        assert K8sRunner._parse_extra_conf("") == {}
+
+    def test_single_pair(self):
+        assert K8sRunner._parse_extra_conf("spark.executor.memory=4g") == {"spark.executor.memory": "4g"}
+
+    def test_multiple_pairs(self):
+        raw = "spark.executor.memory=4g;spark.driver.memory=2g"
+        result = K8sRunner._parse_extra_conf(raw)
+        assert result == {
+            "spark.executor.memory": "4g",
+            "spark.driver.memory": "2g",
+        }
+
+    def test_value_with_comma(self):
+        raw = "spark.jars=a.jar,b.jar;spark.executor.memory=4g"
+        result = K8sRunner._parse_extra_conf(raw)
+        assert result == {
+            "spark.jars": "a.jar,b.jar",
+            "spark.executor.memory": "4g",
+        }
+
+    def test_legacy_comma_delimiter_raises(self):
+        with pytest.raises(ValueError, match="semicolon-delimited"):
+            K8sRunner._parse_extra_conf("spark.executor.memory=4g,spark.driver.memory=2g")
+
+    def test_malformed_token_raises(self):
+        with pytest.raises(ValueError, match="Malformed token"):
+            K8sRunner._parse_extra_conf("spark.executor.memory=4g;bad-token")
+
+
+class TestStageConfig:
+    @pytest.mark.parametrize(
+        "upload_path",
+        [
+            "gs://my-bucket/spark-staging",
+            "s3://my-bucket/spark-staging",
+            "abfss://container@account.dfs.core.windows.net/staging",
+        ],
+        ids=["gcs", "s3", "azure"],
+    )
+    def test_stage_config_calls_upload(self, runner_args, monkeypatch, upload_path):
+        for k, v in _make_k8s_env(file_upload_path=upload_path).items():
+            monkeypatch.setenv(k, v)
+        monkeypatch.setenv("CUSTOMER_ID", "test")
+        monkeypatch.setattr(os.path, "exists", lambda _: True)
+
+        runner = K8sRunner(runner_args)
+        runner._load_k8s_config()
+        mock_upload = MagicMock(side_effect=lambda local, remote: remote)
+        monkeypatch.setattr("ai.chronon.repo.k8s_runner.upload_to_blob_store", mock_upload)
+
+        local_path = os.path.join(runner_args["repo"], SAMPLE_CONF)
+        result = runner._stage_config(local_path)
+
+        mock_upload.assert_called_once()
+        actual_remote = mock_upload.call_args[0][1]
+        assert actual_remote.startswith(upload_path + "/")
+        assert actual_remote.endswith("/sample_group_by.v1__0")
+        assert result == actual_remote
+
+
+class TestRunDispatch:
+    @pytest.fixture
+    def captured_check_call(self, monkeypatch):
+        monkeypatch.setattr(os.path, "exists", lambda _: True)
+        captured = {}
+
+        def _mock(cmd, env=None):
+            captured["cmd"] = cmd
+            captured["env"] = env
+
+        monkeypatch.setattr("ai.chronon.repo.k8s_runner.check_call", _mock)
+        return captured
+
+    def test_full_run_backfill_invokes_k8s_submitter(self, k8s_env, runner_args, monkeypatch, captured_check_call):
+        mock_upload = MagicMock(side_effect=lambda local, remote: remote)
+        monkeypatch.setattr("ai.chronon.repo.k8s_runner.upload_to_blob_store", mock_upload)
+
+        K8sRunner(runner_args).run()
+
+        cmd = captured_check_call["cmd"]
+        assert f"java -cp /tmp/test.jar {K8S_ENTRY}" in cmd
+        assert "--job-type=spark" in cmd
+        assert "--main-class=ai.chronon.spark.Driver" in cmd
+        assert "--zipline-version=1.2.3" in cmd
+        assert "--conf-path=sample_group_by.v1__0" in cmd
+        assert "--conf-path=compiled/" not in cmd
+        assert "--files=" in cmd
+
+    def test_online_jar_and_class_passthrough(self, k8s_env, runner_args, monkeypatch, captured_check_call):
+        runner_args["mode"] = "upload-to-kv"
+        mock_upload = MagicMock(side_effect=lambda local, remote: remote)
+        monkeypatch.setattr("ai.chronon.repo.k8s_runner.upload_to_blob_store", mock_upload)
+
+        K8sRunner(runner_args).run()
+
+        cmd = captured_check_call["cmd"]
+        assert "--online-jar=/tmp/test.jar" in cmd
+        assert "--online-class=com.example.MyApiImpl" in cmd
+
+    def test_info_mode_does_not_invoke_k8s_submitter(self, k8s_env, runner_args, captured_check_call):
+        runner_args["mode"] = "info"
+        runner_args["render_info"] = "scripts/render_info.py"
+
+        K8sRunner(runner_args).run()
+
+        cmd = captured_check_call["cmd"]
+        assert K8S_ENTRY not in cmd
+        assert "python3" in cmd
+
+    def test_sub_help_uses_spark_driver_entrypoint(self, k8s_env, runner_args, captured_check_call):
+        runner_args["sub_help"] = True
+        runner_args["mode"] = "backfill"
+
+        K8sRunner(runner_args).run()
+
+        cmd = captured_check_call["cmd"]
+        assert "ai.chronon.spark.Driver" in cmd
+        assert "--help" in cmd
+
+    def test_fetch_mode_uses_fetcher_entrypoint(self, k8s_env, runner_args, captured_check_call):
+        runner_args["mode"] = "fetch"
+
+        K8sRunner(runner_args).run()
+
+        cmd = captured_check_call["cmd"]
+        assert "ai.chronon.online.fetcher.FetcherMain" in cmd
+        assert "ai.chronon.spark.Driver" not in cmd
+
+    def test_missing_app_jar_raises(self, k8s_env, runner_args, captured_check_call):
+        runner_args["online_jar"] = None
+
+        with pytest.raises(ValueError, match="requires an application JAR"):
+            K8sRunner(runner_args).run()
+
+    def test_missing_jar_sub_help_raises(self, k8s_env, runner_args, captured_check_call):
+        runner_args["online_jar"] = None
+        runner_args["sub_help"] = True
+
+        with pytest.raises(ValueError, match="requires a JAR"):
+            K8sRunner(runner_args).run()
+
+    def test_streaming_raises(self, k8s_env, runner_args, captured_check_call):
+        runner_args["mode"] = "streaming"
+
+        with pytest.raises(ValueError, match="Streaming is not yet supported"):
+            K8sRunner(runner_args).run()
+
+    def test_k8s_submitter_sets_default_submission_mode_env(self, k8s_env, runner_args, monkeypatch, captured_check_call):
+        monkeypatch.delenv(K8S_SUBMISSION_MODE_ENV, raising=False)
+        mock_upload = MagicMock(side_effect=lambda local, remote: remote)
+        monkeypatch.setattr("ai.chronon.repo.k8s_runner.upload_to_blob_store", mock_upload)
+
+        K8sRunner(runner_args).run()
+
+        assert captured_check_call["env"] is not None
+        assert captured_check_call["env"][K8S_SUBMISSION_MODE_ENV] == DEFAULT_K8S_SUBMISSION_MODE
+
+    def test_k8s_submission_mode_cli_override(self, k8s_env, runner_args, monkeypatch, captured_check_call):
+        monkeypatch.setenv(K8S_SUBMISSION_MODE_ENV, "spark-submit")
+        runner_args["k8s_submission_mode"] = "spark-operator"
+        mock_upload = MagicMock(side_effect=lambda local, remote: remote)
+        monkeypatch.setattr("ai.chronon.repo.k8s_runner.upload_to_blob_store", mock_upload)
+
+        K8sRunner(runner_args).run()
+
+        assert captured_check_call["env"][K8S_SUBMISSION_MODE_ENV] == "spark-operator"
+
+    def test_k8s_submission_mode_inherits_parent_env(self, k8s_env, runner_args, monkeypatch, captured_check_call):
+        monkeypatch.setenv(K8S_SUBMISSION_MODE_ENV, "spark-operator")
+        mock_upload = MagicMock(side_effect=lambda local, remote: remote)
+        monkeypatch.setattr("ai.chronon.repo.k8s_runner.upload_to_blob_store", mock_upload)
+
+        K8sRunner(runner_args).run()
+
+        assert captured_check_call["env"][K8S_SUBMISSION_MODE_ENV] == "spark-operator"
+
+    def test_info_mode_does_not_set_submission_mode_env(self, k8s_env, runner_args, captured_check_call):
+        runner_args["mode"] = "info"
+        runner_args["render_info"] = "scripts/render_info.py"
+
+        K8sRunner(runner_args).run()
+
+        assert captured_check_call.get("env") is None

--- a/spark/src/main/scala/ai/chronon/spark/submission/SparkSessionBuilder.scala
+++ b/spark/src/main/scala/ai/chronon/spark/submission/SparkSessionBuilder.scala
@@ -94,11 +94,14 @@ object SparkSessionBuilder {
     val warehouseDir = localWarehouseLocation.map(expandUser).getOrElse(DefaultWarehouseDir.getAbsolutePath)
     println(s"Using warehouse dir: $warehouseDir")
 
-    // Read existing Spark config (e.g. from spark-submit --conf) so we don't clobber user settings.
-    val existingConf = new org.apache.spark.SparkConf()
+    // Cluster: honor SparkConf (e.g. spark-submit --conf). Local: always UTC so CI JVM/env defaults
+    // cannot break tests that assume a fixed session time zone.
+    val sessionTimeZone =
+      if (local) "UTC"
+      else new org.apache.spark.SparkConf().get("spark.sql.session.timeZone", "UTC")
 
     val baseConfigs = Map(
-      "spark.sql.session.timeZone" -> existingConf.get("spark.sql.session.timeZone", "UTC"),
+      "spark.sql.session.timeZone" -> sessionTimeZone,
       // needs to be uppercase until https://github.com/GoogleCloudDataproc/spark-bigquery-connector/pull/1313 is available
       "spark.sql.sources.partitionOverwriteMode" -> "DYNAMIC",
       "hive.exec.dynamic.partition" -> "true",


### PR DESCRIPTION
## Summary

This PR adds **Spark on Kubernetes** support for Chronon: a **`K8sSubmitter`** entrypoint that runs **`spark-submit`** against a Kubernetes master (with fabric8-based driver checks where applicable), Python **`K8sRunner`** / **`run.py`** wiring for **`CHRONON_CLOUD_PROVIDER=K8S`**, and **Mill + GitHub Actions** updates so **`cloud_k8s`** is built, scanned, and tested consistently with other cloud modules. Hub / quickstart **integration tests and templates** are adjusted where K8s behavior or environment differs from existing cloud providers.

Long-form design docs are **not** part of this PR (they can follow separately if you want them on `main`).

## What changed

### Scala (`cloud_k8s`)

- **`K8sSubmitter`**: native `spark-submit` to K8s, semicolon-delimited **`SPARK_K8S_CONF`**, critical Spark settings pinned after merged conf so overrides cannot break blocking / driver cleanup, bounded wait for `spark-submit`, driver pod verification and cleanup helpers, multi-pod warnings, safer `--files` handling, and clearer logging from **`main`** on failure paths.
- **`K8sSubmitterTest`**: coverage for argv construction, conf pinning, `getFilesArgs`, pod phase / driver exit helpers, and verify-stage fallback behavior.

### Python

- **`k8s_runner.py`**: required env validation, staging config under **`SPARK_K8S_FILE_UPLOAD_PATH`**, and invocation of **`K8sSubmitter`** via `java -cp …`.
- **`run.py`**: K8S provider defaults (including default online JAR) and a short note on **`ONLINE_CLASS_ARG`** vs other clouds.

### Build & CI

- **`build.mill`** / **`cloud_k8s/package.mill`**: module and artifact wiring as required by this repo.
- **`.github/workflows/`** (`reusable_build_and_push`, `push_to_canary`, `grype_scan_reusable`): **`cloud_k8s`** aligned with existing cloud build / canary / scan patterns.

### Tests

- **`python/test/test_k8s_runner.py`**: unit-style coverage for env validation, `SPARK_K8S_CONF` parsing, staging URIs, and the **`K8sSubmitter`** command line.
- **Integration / templates** (`templates.py`, `conftest.py`, hub tests, `test_run_quickstart.py`, `test_integration_templates.py`): updates for K8s-related template and test behavior (see diff for details).

## How to test

```bash
./mill __.checkFormat
./mill python.ruffCheck
./mill cloud_k8s.compile
./mill cloud_k8s.test
./mill python.test
```