### PR TITLE
confs: azure user_activities batch table

### DIFF
--- a/python/test/canary/compiled/staging_queries/azure/exports.user_activities__0
+++ b/python/test/canary/compiled/staging_queries/azure/exports.user_activities__0
@@ -1,7 +1,6 @@
 {
-  "engineType": 2,
   "metaData": {
-    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_user_activities_with_offset_0\", \"spec\": \"user_activities/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "customJson": "{\"airflowDependencies\": []}",
     "executionInfo": {
       "conf": {
         "common": {
@@ -52,25 +51,10 @@
     "team": "azure",
     "version": "0"
   },
-  "query": "\n    SELECT\n        *,\n        DATE_TRUNC('DAY', ds)::DATE as ds\n    FROM user_activities\n    WHERE\n    ds BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
-  "tableDependencies": [
-    {
-      "endOffset": {
-        "length": 0,
-        "timeUnit": 1
-      },
-      "startOffset": {
-        "length": 0,
-        "timeUnit": 1
-      },
-      "tableInfo": {
-        "partitionColumn": "ds",
-        "partitionInterval": {
-          "length": 1,
-          "timeUnit": 1
-        },
-        "table": "user_activities"
-      }
-    }
-  ]
+  "query": "\n    SELECT\n        parsed.event_id,\n        parsed.event_time_ms,\n        parsed.ingested_time_ms,\n        parsed.user_id,\n        parsed.session_id,\n        parsed.device_type,\n        parsed.country_code,\n        parsed.listing_id,\n        parsed.event_type,\n        to_date(EnqueuedTimeUtc) AS ds\n    FROM (\n        SELECT *\n          , from_json(CAST(Body AS STRING)\n          , 'event_id STRING, event_time_ms BIGINT, ingested_time_ms BIGINT,\n             user_id STRING, session_id STRING, device_type STRING,\n             country_code STRING, listing_id BIGINT, event_type STRING') AS parsed\n        FROM raw_activities\n        WHERE Body IS NOT NULL\n    )\n    WHERE parsed.event_time_ms >= CAST(to_unix_timestamp({{start_date}}, 'yyyy-MM-dd') * 1000 AS BIGINT)\n      AND parsed.event_time_ms <  CAST(to_unix_timestamp({{end_date}}, 'yyyy-MM-dd') * 1000 AS BIGINT);\n    ",
+  "setups": [
+    "ADD JAR 'abfss://demo@ziplineai2.dfs.core.windows.net/jars/spark-avro_2.12-3.5.3.jar'",
+    "\n                CREATE OR REPLACE TEMPORARY VIEW raw_activities USING avro\n                OPTIONS (\n                  path 'abfss://demo@ziplineai2.dfs.core.windows.net/zipline-demo-events/user-activities/',\n                  recursiveFileLookup 'true'\n                );"
+  ],
+  "tableDependencies": []
 }

--- a/python/test/canary/staging_queries/azure/exports.py
+++ b/python/test/canary/staging_queries/azure/exports.py
@@ -56,7 +56,7 @@ def user_activities_export(version: int = 0):
         parsed.country_code,
         parsed.listing_id,
         parsed.event_type,
-        to_date(EnqueuedTimeUtc) AS ds
+        to_date(from_unixtime(parsed.event_time_ms / 1000)) AS ds
     FROM (
         SELECT *
           , from_json(CAST(Body AS STRING)

--- a/python/test/canary/staging_queries/azure/exports.py
+++ b/python/test/canary/staging_queries/azure/exports.py
@@ -43,9 +43,51 @@ def get_native_partition_export(table: str, partition_column: str, time_partitio
         step_days=30,
     )
 
+def user_activities_export(version: int = 0):
+    """ User activities is generated from the avro packages published by the azure event hub"""
+    sql = f"""
+    SELECT
+        parsed.event_id,
+        parsed.event_time_ms,
+        parsed.ingested_time_ms,
+        parsed.user_id,
+        parsed.session_id,
+        parsed.device_type,
+        parsed.country_code,
+        parsed.listing_id,
+        parsed.event_type,
+        to_date(EnqueuedTimeUtc) AS ds
+    FROM (
+        SELECT *
+          , from_json(CAST(Body AS STRING)
+          , 'event_id STRING, event_time_ms BIGINT, ingested_time_ms BIGINT,
+             user_id STRING, session_id STRING, device_type STRING,
+             country_code STRING, listing_id BIGINT, event_type STRING') AS parsed
+        FROM raw_activities
+        WHERE Body IS NOT NULL
+    )
+    WHERE parsed.event_time_ms >= CAST(to_unix_timestamp({{{{start_date}}}}, 'yyyy-MM-dd') * 1000 AS BIGINT)
+      AND parsed.event_time_ms <  CAST(to_unix_timestamp({{{{end_date}}}}, 'yyyy-MM-dd') * 1000 AS BIGINT);
+    """
+    return StagingQuery(
+            setups=[
+                "ADD JAR 'abfss://demo@ziplineai2.dfs.core.windows.net/jars/spark-avro_2.12-3.5.3.jar'",
+                """
+                CREATE OR REPLACE TEMPORARY VIEW raw_activities USING avro
+                OPTIONS (
+                  path 'abfss://demo@ziplineai2.dfs.core.windows.net/zipline-demo-events/user-activities/',
+                  recursiveFileLookup 'true'
+                );""",
+            ],
+            query=sql,
+            output_namespace="data",
+            dependencies=[],
+            version=version,
+            step_days=30,
+            )
 
 
-user_activities = get_native_partition_export("user_activities", "ds")
+user_activities = user_activities_export(version=0)
 checkouts = get_native_partition_export("checkouts", "ds")
 dim_listings_pc = get_native_partition_export("dim_listings_custom_part", "datest", time_partitioned=True, version=1)
 dim_listings = get_select_star_export("dim_listings", "ds")

--- a/scripts/interactive/azure_spark_shell.sh
+++ b/scripts/interactive/azure_spark_shell.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Launches a local spark-shell connected to the Azure Iceberg warehouse (Polaris/Snowflake Open Catalog).
+# Requires: az CLI logged in, CHRONON_REPO set (defaults to git root).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${CHRONON_REPO:-$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)}"
+JAR="${CHRONON_SPARK_JAR:-$REPO_ROOT/out/cloud_azure/assembly.dest/out.jar}"
+
+if [ ! -f "$JAR" ]; then
+  echo "Assembly JAR not found at $JAR — run: ./mill cloud_azure.assembly"
+  exit 1
+fi
+
+echo "Fetching OC_CREDENTIAL from Azure Key Vault..."
+OC_CREDENTIAL="$(az keyvault secret show \
+  --vault-name dev-zipline-secrets \
+  --name oc-catalog-credential \
+  --query value -o tsv)"
+
+export OC_CREDENTIAL
+
+spark-shell \
+  --master "local[*]" \
+  --jars "$JAR" \
+  --conf "spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions" \
+  --conf "spark.sql.catalog.spark_catalog=org.apache.iceberg.spark.SparkCatalog" \
+  --conf "spark.sql.catalog.spark_catalog.type=rest" \
+  --conf "spark.sql.catalog.spark_catalog.uri=https://vejlulx-azure-oc.snowflakecomputing.com/polaris/api/catalog" \
+  --conf "spark.sql.catalog.spark_catalog.credential=$OC_CREDENTIAL" \
+  --conf "spark.sql.catalog.spark_catalog.warehouse=demo-v2" \
+  --conf "spark.sql.catalog.spark_catalog.scope=PRINCIPAL_ROLE:engine" \
+  --conf "spark.sql.catalog.spark_catalog.header.X-Iceberg-Access-Delegation=vended-credentials" \
+  --conf "spark.sql.defaultCatalog=spark_catalog" \
+  --conf "spark.chronon.table_write.format=iceberg" \
+  --conf "spark.chronon.table.format_provider.class=ai.chronon.integrations.cloud_azure.AzureFormatProvider" \
+  --conf "spark.chronon.partition.format=yyyy-MM-dd" \
+  --conf "spark.chronon.partition.column=ds" \
+  --conf "spark.chronon.coalesce.factor=10" \
+  --conf "spark.default.parallelism=10" \
+  --conf "spark.sql.shuffle.partitions=10" \
+  --conf "spark.driver.memory=1g"


### PR DESCRIPTION
## Summary

Now that we have an eventhub stream writing avro files into our container.
It's time to create an export that behaves like a table.

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [x] Integration tested
https://gist.github.com/cristian-zlai/ba705dc4d642096d13e3f2b10f9bdad9
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Exports now read and parse raw Avro event payloads from cloud storage, select explicit event fields, derive a daily partition, and apply precise start/end time-range filtering at query time instead of relying on pre-processed table partitions.
  * Adds setup to load Avro support and expose cloud data as a temporary view for the export.

* **New Tools**
  * Added an interactive Azure Spark shell helper to launch Spark with cloud catalog/configuration and credential retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->