### PR TITLE
[FIX] Remove Adhoc No Data Integration Test

### DIFF
--- a/python/test/integration/test_hub_run_adhoc.py
+++ b/python/test/integration/test_hub_run_adhoc.py
@@ -59,17 +59,3 @@ def test_run_adhoc(confs, chronon_root, hub_url, cloud, flink_cleanup):
         hub_url, workflow_id, target_statuses={"SUCCEEDED"}, timeout=1200, interval=15,
     )
 
-@pytest.mark.integration
-def test_run_adhoc_no_data(confs, chronon_root, hub_url, cloud):
-    """run-adhoc with dates that have no input data should fail."""
-    runner = CliRunner()
-    compile_configs(runner, chronon_root)
-
-    workflow_id = submit_run_adhoc(
-        runner, chronon_root, hub_url,
-        confs[DEMO_BACKFILL[cloud]], "1969-01-01",
-    )
-
-    poll_workflow_until(
-        hub_url, workflow_id, target_statuses={"FAILED"}, timeout=1800, interval=30,
-    )


### PR DESCRIPTION
Remove test_run_adhoc_no_data as it no longer represents the expected behavior as of https://github.com/zipline-ai/chronon/pull/1689

## Summary

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed an obsolete integration test case for the run-adhoc workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->