### PR TITLE
fix: Rename snowflake private key

### DIFF
--- a/python/test/canary/compiled/group_bys/azure/dim_listings.pc_v3
+++ b/python/test/canary/compiled/group_bys/azure/dim_listings.pc_v3
@@ -1,7 +1,27 @@
 {
-  "engineType": 2,
+  "keyColumns": [
+    "listing_id"
+  ],
   "metaData": {
-    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_user_activities_with_offset_0\", \"spec\": \"user_activities/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "columnHashes": {
+      "brief_description": "d8f700f63471993b54a19d71122ec11b",
+      "currency": "ca2881e80e9a9b877c2824d1072d337d",
+      "headline": "3336296614f6be325954fd9ba86eb0cf",
+      "inventory_count": "31547342ddbeb4a831724186b289ea87",
+      "is_active": "faf50877bb5bd0b8f8d920fa0105bd1d",
+      "is_expensive": "e637a3ddd3c42a1edf54251b574b481f",
+      "is_in_stock": "c5fc4a74834fb45b6d5af196310c0f31",
+      "listing_id": "e486882fe8630828862beed3908c72f6",
+      "long_description": "639ab6183464bef6ec2c16118a2cde83",
+      "main_image_path": "647aece2b7dd9c084a447f06db6c9078",
+      "merchant_id": "f00635e9f0582cc0a4504e90e7bc469f",
+      "price_cents": "89610b09ce4e5c7cdba038c3d9ded2ef",
+      "primary_category": "f7e610e63a0809f8b26f9d196b40d35e",
+      "secondary_image_paths": "f9194618378f2ea3855aa792c0bd9317",
+      "tags": "318519d7ab1453a331685dc7f165bb85",
+      "weight_grams": "f8f34e81434169852c03e62a335c20aa"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_azure_exports_dim_listings_pc__1_with_offset_0\", \"spec\": \"data.azure_exports_dim_listings_pc__1/ds={{ macros.ds_add(ds, 0) }}\"}]}",
     "executionInfo": {
       "conf": {
         "common": {
@@ -42,33 +62,39 @@
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
         }
       },
-      "offlineSchedule": "@daily",
-      "stepDays": 30
+      "historicalBackfill": 0
     },
-    "name": "azure.exports.user_activities__0",
+    "name": "azure.dim_listings.pc_v3",
+    "online": 0,
     "outputNamespace": "data",
-    "sourceFile": "staging_queries/azure/exports.py",
-    "team": "azure",
-    "version": "0"
+    "sourceFile": "group_bys/azure/dim_listings.py",
+    "team": "azure"
   },
-  "query": "\n    SELECT\n        *,\n        DATE_TRUNC('DAY', ds)::DATE as ds\n    FROM user_activities\n    WHERE\n    ds BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
-  "tableDependencies": [
+  "sources": [
     {
-      "endOffset": {
-        "length": 0,
-        "timeUnit": 1
-      },
-      "startOffset": {
-        "length": 0,
-        "timeUnit": 1
-      },
-      "tableInfo": {
-        "partitionColumn": "ds",
-        "partitionInterval": {
-          "length": 1,
-          "timeUnit": 1
+      "entities": {
+        "query": {
+          "selects": {
+            "brief_description": "brief_description",
+            "currency": "currency",
+            "headline": "headline",
+            "inventory_count": "inventory_count",
+            "is_active": "is_active",
+            "is_expensive": "IF(price_cents > 10000, 1, 0)",
+            "is_in_stock": "IF(inventory_count > 0, 1, 0)",
+            "listing_id": "CAST(listing_id AS INT)",
+            "long_description": "long_description",
+            "main_image_path": "main_image_path",
+            "merchant_id": "merchant_id",
+            "price_cents": "price_cents",
+            "primary_category": "primary_category",
+            "secondary_image_paths": "secondary_image_paths",
+            "tags": "tags",
+            "weight_grams": "weight_grams"
+          },
+          "startPartition": "2025-01-01"
         },
-        "table": "user_activities"
+        "snapshotTable": "data.azure_exports_dim_listings_pc__1"
       }
     }
   ]

--- a/python/test/canary/compiled/group_bys/azure/dim_listings.v3
+++ b/python/test/canary/compiled/group_bys/azure/dim_listings.v3
@@ -56,7 +56,7 @@
           "FRONTEND_URL": "https://dev-azure.zipline.ai",
           "HUB_URL": "https://dev-orch-azure.zipline.ai",
           "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-          "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
           "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"

--- a/python/test/canary/compiled/group_bys/azure/dim_merchants.v2
+++ b/python/test/canary/compiled/group_bys/azure/dim_merchants.v2
@@ -42,7 +42,7 @@
           "FRONTEND_URL": "https://dev-azure.zipline.ai",
           "HUB_URL": "https://dev-orch-azure.zipline.ai",
           "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-          "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
           "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"

--- a/python/test/canary/compiled/group_bys/azure/item_event_canary.actions_pubsub_v2__0
+++ b/python/test/canary/compiled/group_bys/azure/item_event_canary.actions_pubsub_v2__0
@@ -91,7 +91,7 @@
           "FRONTEND_URL": "https://dev-azure.zipline.ai",
           "HUB_URL": "https://dev-orch-azure.zipline.ai",
           "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-          "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
           "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"

--- a/python/test/canary/compiled/group_bys/azure/item_event_canary.actions_v1__0
+++ b/python/test/canary/compiled/group_bys/azure/item_event_canary.actions_v1__0
@@ -91,7 +91,7 @@
           "FRONTEND_URL": "https://dev-azure.zipline.ai",
           "HUB_URL": "https://dev-orch-azure.zipline.ai",
           "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-          "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
           "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"

--- a/python/test/canary/compiled/group_bys/azure/logging_schema.v1__2
+++ b/python/test/canary/compiled/group_bys/azure/logging_schema.v1__2
@@ -50,7 +50,7 @@
           "FRONTEND_URL": "https://dev-azure.zipline.ai",
           "HUB_URL": "https://dev-orch-azure.zipline.ai",
           "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-          "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
           "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"

--- a/python/test/canary/compiled/group_bys/azure/purchases.v1_dev__0
+++ b/python/test/canary/compiled/group_bys/azure/purchases.v1_dev__0
@@ -117,7 +117,7 @@
           "FRONTEND_URL": "https://dev-azure.zipline.ai",
           "HUB_URL": "https://dev-orch-azure.zipline.ai",
           "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-          "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
           "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"

--- a/python/test/canary/compiled/group_bys/azure/purchases.v1_dev_notds__0
+++ b/python/test/canary/compiled/group_bys/azure/purchases.v1_dev_notds__0
@@ -117,7 +117,7 @@
           "FRONTEND_URL": "https://dev-azure.zipline.ai",
           "HUB_URL": "https://dev-orch-azure.zipline.ai",
           "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-          "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
           "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"

--- a/python/test/canary/compiled/group_bys/azure/purchases.v1_test__0
+++ b/python/test/canary/compiled/group_bys/azure/purchases.v1_test__0
@@ -117,7 +117,7 @@
           "FRONTEND_URL": "https://dev-azure.zipline.ai",
           "HUB_URL": "https://dev-orch-azure.zipline.ai",
           "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-          "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
           "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"

--- a/python/test/canary/compiled/group_bys/azure/purchases.v1_test_notds__0
+++ b/python/test/canary/compiled/group_bys/azure/purchases.v1_test_notds__0
@@ -117,7 +117,7 @@
           "FRONTEND_URL": "https://dev-azure.zipline.ai",
           "HUB_URL": "https://dev-orch-azure.zipline.ai",
           "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-          "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
           "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"

--- a/python/test/canary/compiled/group_bys/azure/user_activities.v1__1
+++ b/python/test/canary/compiled/group_bys/azure/user_activities.v1__1
@@ -423,7 +423,7 @@
           "FRONTEND_URL": "https://dev-azure.zipline.ai",
           "HUB_URL": "https://dev-orch-azure.zipline.ai",
           "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-          "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
           "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"

--- a/python/test/canary/compiled/group_bys/azure/user_activities_chained.chained_user_gb__0
+++ b/python/test/canary/compiled/group_bys/azure/user_activities_chained.chained_user_gb__0
@@ -57,7 +57,7 @@
           "FRONTEND_URL": "https://dev-azure.zipline.ai",
           "HUB_URL": "https://dev-orch-azure.zipline.ai",
           "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-          "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
           "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
@@ -118,7 +118,7 @@
                         "FRONTEND_URL": "https://dev-azure.zipline.ai",
                         "HUB_URL": "https://dev-orch-azure.zipline.ai",
                         "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-                        "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+                        "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
                         "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
                         "VERSION": "latest",
                         "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
@@ -214,7 +214,7 @@
                   "FRONTEND_URL": "https://dev-azure.zipline.ai",
                   "HUB_URL": "https://dev-orch-azure.zipline.ai",
                   "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-                  "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+                  "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
                   "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
                   "VERSION": "latest",
                   "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"

--- a/python/test/canary/compiled/joins/azure/demo.derivations_v3
+++ b/python/test/canary/compiled/joins/azure/demo.derivations_v3
@@ -80,7 +80,7 @@
                 "FRONTEND_URL": "https://dev-azure.zipline.ai",
                 "HUB_URL": "https://dev-orch-azure.zipline.ai",
                 "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-                "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+                "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
                 "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
                 "VERSION": "latest",
                 "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
@@ -202,7 +202,7 @@
           "FRONTEND_URL": "https://dev-azure.zipline.ai",
           "HUB_URL": "https://dev-orch-azure.zipline.ai",
           "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-          "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
           "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"

--- a/python/test/canary/compiled/joins/azure/demo.pc_v2
+++ b/python/test/canary/compiled/joins/azure/demo.pc_v2
@@ -7,22 +7,22 @@
         ],
         "metaData": {
           "columnHashes": {
-            "brief_description": "3c179cccf0a9f57fda2fdfe3085a239f",
-            "currency": "8477ea4ad6b46f96255ce0905dfed26d",
-            "headline": "6bf685e11e97f4863d36fa953b964800",
-            "inventory_count": "9d63ce6eddf70502ad498603ec8b18b3",
-            "is_active": "9c9adf7999f230fc316c491f829b12d0",
-            "is_expensive": "255e0f554c8337c87a2a7f0b799c8d4b",
-            "is_in_stock": "80d7c029ebb919cfa22a82600ae3a3e1",
-            "listing_id": "e1d191582f23aad87ee1f5422600051f",
-            "long_description": "f3f74af9625f16c5d935e96d96e08698",
-            "main_image_path": "3ff96284663e8d05ad728b37f6acf122",
-            "merchant_id": "56b9c531a57e6d3f5320b72df8d63521",
-            "price_cents": "7be4ba1e811c96c5a4e5023ce1e05c38",
-            "primary_category": "d6beb0afb36cada1f65a9b1acdb5b995",
-            "secondary_image_paths": "de717ca6563464c24d63f8473a75ef85",
-            "tags": "f9ead5f03020ff66ff14e98fec19a774",
-            "weight_grams": "ac84b5b0b11dca76306214d5d2f12fa9"
+            "brief_description": "d8f700f63471993b54a19d71122ec11b",
+            "currency": "ca2881e80e9a9b877c2824d1072d337d",
+            "headline": "3336296614f6be325954fd9ba86eb0cf",
+            "inventory_count": "31547342ddbeb4a831724186b289ea87",
+            "is_active": "faf50877bb5bd0b8f8d920fa0105bd1d",
+            "is_expensive": "e637a3ddd3c42a1edf54251b574b481f",
+            "is_in_stock": "c5fc4a74834fb45b6d5af196310c0f31",
+            "listing_id": "e486882fe8630828862beed3908c72f6",
+            "long_description": "639ab6183464bef6ec2c16118a2cde83",
+            "main_image_path": "647aece2b7dd9c084a447f06db6c9078",
+            "merchant_id": "f00635e9f0582cc0a4504e90e7bc469f",
+            "price_cents": "89610b09ce4e5c7cdba038c3d9ded2ef",
+            "primary_category": "f7e610e63a0809f8b26f9d196b40d35e",
+            "secondary_image_paths": "f9194618378f2ea3855aa792c0bd9317",
+            "tags": "318519d7ab1453a331685dc7f165bb85",
+            "weight_grams": "f8f34e81434169852c03e62a335c20aa"
           },
           "executionInfo": {
             "conf": {
@@ -64,11 +64,10 @@
                 "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
               }
             },
-            "historicalBackfill": 0,
-            "onlineSchedule": "@daily"
+            "historicalBackfill": 0
           },
-          "name": "azure.dim_listings.v3",
-          "online": 1,
+          "name": "azure.dim_listings.pc_v3",
+          "online": 0,
           "outputNamespace": "data",
           "team": "azure"
         },
@@ -96,7 +95,7 @@
                 },
                 "startPartition": "2025-01-01"
               },
-              "snapshotTable": "data.azure_exports_dim_listings__0"
+              "snapshotTable": "data.azure_exports_dim_listings_pc__1"
             }
           }
         ]
@@ -105,44 +104,67 @@
     }
   ],
   "left": {
-    "events": {
+    "entities": {
       "query": {
         "selects": {
-          "listing_id": "listing_id",
-          "row_id": "event_id",
-          "ts": "unix_millis(TIMESTAMP(event_time_ms))",
-          "user_id": "user_id"
+          "brief_description": "brief_description",
+          "currency": "currency",
+          "headline": "headline",
+          "inventory_count": "inventory_count",
+          "is_active": "is_active",
+          "is_expensive": "IF(price_cents > 10000, 1, 0)",
+          "is_in_stock": "IF(inventory_count > 0, 1, 0)",
+          "listing_id": "CAST(listing_id AS INT)",
+          "long_description": "long_description",
+          "main_image_path": "main_image_path",
+          "merchant_id": "merchant_id",
+          "price_cents": "price_cents",
+          "primary_category": "primary_category",
+          "secondary_image_paths": "secondary_image_paths",
+          "tags": "tags",
+          "weight_grams": "weight_grams"
         },
-        "timeColumn": "unix_millis(TIMESTAMP(event_time_ms))"
+        "startPartition": "2025-01-01"
       },
-      "table": "data.azure_exports_user_activities__0",
-      "topic": "pubsub://user-activities-v2/project=canary-443022/subscription=user-activities-v2-sub/serde=pubsub_schema/schemaId=user-activities"
+      "snapshotTable": "data.azure_exports_dim_listings_pc__1"
     }
   },
   "metaData": {
     "columnHashes": {
-      "listing_id": "a781ec55d64e705d8ce51d0c587b40e2",
-      "listing_id_brief_description": "b96d5becf2658a66afe8c8a0e9b9f2d5",
-      "listing_id_currency": "45826e45199d48668b21465ff002c2d8",
-      "listing_id_headline": "a1769b8d92ae9b95f2c6446ac41b8229",
-      "listing_id_inventory_count": "986aed22f9c8471e18edce1e828d290a",
-      "listing_id_is_active": "27f958bac2b8eabb23551bf8221a1401",
-      "listing_id_is_expensive": "9acfbac83a11c5d91dc2d1004f85156a",
-      "listing_id_is_in_stock": "4cce091dcbd28805c474bcda0092dce5",
-      "listing_id_listing_id": "1300f351e6450538a6a18b6faa422fc1",
-      "listing_id_long_description": "5d8f289cc48193c21b584ebaa224f6e8",
-      "listing_id_main_image_path": "99ca3d1632007760b2161e57bf9a67ac",
-      "listing_id_merchant_id": "eb1873d87e1f53a6faee6ba43adef019",
-      "listing_id_price_cents": "ef37b2a77b73b56083739233e5c92c35",
-      "listing_id_primary_category": "e10b1e53275e0cd7b1214c8f5778c0b0",
-      "listing_id_secondary_image_paths": "7c400bbaf41234338820447d2074d757",
-      "listing_id_tags": "ddc35d6e9b8ae3b0948a3c083485dc8d",
-      "listing_id_weight_grams": "9ad552c5fceef5c31116f090b6175924",
-      "row_id": "a815aba076a56303f2c896256f1ba0ff",
-      "ts": "32cfb4df811008307e03612be49442ec",
-      "user_id": "275e18a643e12228f787cd9a9b03eaed"
+      "brief_description": "5ae40fa9963d02d1f8afcbae02869b08",
+      "currency": "384574f30fe984988c7f736d83309a1a",
+      "headline": "000015ca5c9b191c2c9b520dcf8e0a1c",
+      "inventory_count": "6a786936e98006983e160915875e593d",
+      "is_active": "133b82620e1c926d0853614ac2002039",
+      "is_expensive": "6eaa23bf9cd94987b8905b1e861a7661",
+      "is_in_stock": "1f3cf734bfd0cf20cb656b2938b9f0cd",
+      "listing_id": "07fa41bbfe808a6524a7a16ab712fd4c",
+      "listing_id_brief_description": "31868234a42424279e00fce7f2520214",
+      "listing_id_currency": "61473201211c1afd3a1d9116fb3a9072",
+      "listing_id_headline": "9146c233c1ea889f05471ba8f3bc46d2",
+      "listing_id_inventory_count": "ff7e89d74ad170478ea1232eb5e41fb9",
+      "listing_id_is_active": "eaf3404ef754943dfa769b255fb351a0",
+      "listing_id_is_expensive": "62317488c4de93bf10d2c0cf09b8506c",
+      "listing_id_is_in_stock": "4d2f1173522465ab4bcd03aa5c5a85c7",
+      "listing_id_listing_id": "0e6bb1208bb63ccc0da0771cb4a2ab1b",
+      "listing_id_long_description": "b293571116db4c10f5f1d2ff42a57b85",
+      "listing_id_main_image_path": "fb103f1f840e9700e5bb6c67c868678e",
+      "listing_id_merchant_id": "dac397a502736222f6984f54074ecb12",
+      "listing_id_price_cents": "587f0eac8381823fb2a546f6fe1fc8b5",
+      "listing_id_primary_category": "7e08626200c9028926bf8af6462b1dd6",
+      "listing_id_secondary_image_paths": "0a44c83cfa2493c8ba715a5833475759",
+      "listing_id_tags": "5979de3fc49571d9ccec8f21e69a31e5",
+      "listing_id_weight_grams": "53700fe5e54d5350be5dacbbc9b8aa0d",
+      "long_description": "756b272483270065098e5d4e7a1e1996",
+      "main_image_path": "ee8f4253c2be3bbc3ab771aebeaff658",
+      "merchant_id": "70e7a60026c000d42380322c75cbb4d3",
+      "price_cents": "992b998ed1d9a9e72b7eec8722225f7f",
+      "primary_category": "f50570d493cbeca365386a2f9c503147",
+      "secondary_image_paths": "9ee5811f3edd43580cb230469677c955",
+      "tags": "a43e930fdfbad711713a725eccb39cbd",
+      "weight_grams": "3563150a7e46318bf3395d3d08e7b27d"
     },
-    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_azure_exports_user_activities__0_with_offset_0\", \"spec\": \"data.azure_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_azure_exports_dim_listings__0_with_offset_0\", \"spec\": \"data.azure_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_azure_exports_dim_listings_pc__1_with_offset_0\", \"spec\": \"data.azure_exports_dim_listings_pc__1/ds={{ macros.ds_add(ds, 0) }}\"}]}",
     "executionInfo": {
       "conf": {
         "common": {
@@ -166,6 +188,7 @@
           "spark.sql.shuffle.partitions": "10"
         }
       },
+      "enableStatsCompute": 0,
       "env": {
         "common": {
           "ARTIFACT_PREFIX": "abfss://dev-zipline-artifacts@ziplineai2.dfs.core.windows.net",
@@ -183,20 +206,17 @@
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
         }
       },
-      "offlineSchedule": "17 0 * * *",
-      "onlineSchedule": "@daily"
+      "offlineSchedule": "@daily",
+      "stepDays": 30
     },
-    "name": "azure.demo_parent.parent_join__0",
-    "online": 1,
+    "name": "azure.demo.pc_v2",
+    "online": 0,
     "outputNamespace": "data",
     "production": 0,
     "samplePercent": 100.0,
-    "sourceFile": "joins/azure/demo_parent.py",
-    "team": "azure",
-    "version": "0"
+    "sourceFile": "joins/azure/demo.py",
+    "team": "azure"
   },
-  "rowIds": [
-    "event_id"
-  ],
+  "rowIds": [],
   "useLongNames": 0
 }

--- a/python/test/canary/compiled/joins/azure/demo.v2
+++ b/python/test/canary/compiled/joins/azure/demo.v2
@@ -58,7 +58,7 @@
                 "FRONTEND_URL": "https://dev-azure.zipline.ai",
                 "HUB_URL": "https://dev-orch-azure.zipline.ai",
                 "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-                "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+                "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
                 "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
                 "VERSION": "latest",
                 "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
@@ -147,7 +147,7 @@
                 "FRONTEND_URL": "https://dev-azure.zipline.ai",
                 "HUB_URL": "https://dev-orch-azure.zipline.ai",
                 "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-                "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+                "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
                 "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
                 "VERSION": "latest",
                 "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
@@ -255,7 +255,7 @@
           "FRONTEND_URL": "https://dev-azure.zipline.ai",
           "HUB_URL": "https://dev-orch-azure.zipline.ai",
           "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-          "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
           "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"

--- a/python/test/canary/compiled/joins/azure/demo_chaining.downstream_join__0
+++ b/python/test/canary/compiled/joins/azure/demo_chaining.downstream_join__0
@@ -59,7 +59,7 @@
                 "FRONTEND_URL": "https://dev-azure.zipline.ai",
                 "HUB_URL": "https://dev-orch-azure.zipline.ai",
                 "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-                "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+                "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
                 "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
                 "VERSION": "latest",
                 "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
@@ -119,7 +119,7 @@
                               "FRONTEND_URL": "https://dev-azure.zipline.ai",
                               "HUB_URL": "https://dev-orch-azure.zipline.ai",
                               "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-                              "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+                              "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
                               "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
                               "VERSION": "latest",
                               "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
@@ -215,7 +215,7 @@
                         "FRONTEND_URL": "https://dev-azure.zipline.ai",
                         "HUB_URL": "https://dev-orch-azure.zipline.ai",
                         "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-                        "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+                        "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
                         "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
                         "VERSION": "latest",
                         "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
@@ -310,7 +310,7 @@
           "FRONTEND_URL": "https://dev-azure.zipline.ai",
           "HUB_URL": "https://dev-orch-azure.zipline.ai",
           "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-          "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
           "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"

--- a/python/test/canary/compiled/joins/azure/item_event_join.canary_batch_v1__0
+++ b/python/test/canary/compiled/joins/azure/item_event_join.canary_batch_v1__0
@@ -119,7 +119,7 @@
                 "FRONTEND_URL": "https://dev-azure.zipline.ai",
                 "HUB_URL": "https://dev-orch-azure.zipline.ai",
                 "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-                "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+                "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
                 "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
                 "VERSION": "latest",
                 "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
@@ -217,7 +217,7 @@
           "FRONTEND_URL": "https://dev-azure.zipline.ai",
           "HUB_URL": "https://dev-orch-azure.zipline.ai",
           "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-          "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
           "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"

--- a/python/test/canary/compiled/joins/azure/item_event_join.canary_combined_v1__0
+++ b/python/test/canary/compiled/joins/azure/item_event_join.canary_combined_v1__0
@@ -93,7 +93,7 @@
                 "FRONTEND_URL": "https://dev-azure.zipline.ai",
                 "HUB_URL": "https://dev-orch-azure.zipline.ai",
                 "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-                "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+                "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
                 "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
                 "VERSION": "latest",
                 "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
@@ -251,7 +251,7 @@
                 "FRONTEND_URL": "https://dev-azure.zipline.ai",
                 "HUB_URL": "https://dev-orch-azure.zipline.ai",
                 "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-                "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+                "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
                 "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
                 "VERSION": "latest",
                 "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
@@ -353,7 +353,7 @@
           "FRONTEND_URL": "https://dev-azure.zipline.ai",
           "HUB_URL": "https://dev-orch-azure.zipline.ai",
           "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-          "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
           "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"

--- a/python/test/canary/compiled/joins/azure/item_event_join.canary_streaming_v1__0
+++ b/python/test/canary/compiled/joins/azure/item_event_join.canary_streaming_v1__0
@@ -93,7 +93,7 @@
                 "FRONTEND_URL": "https://dev-azure.zipline.ai",
                 "HUB_URL": "https://dev-orch-azure.zipline.ai",
                 "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-                "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+                "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
                 "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
                 "VERSION": "latest",
                 "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
@@ -191,7 +191,7 @@
           "FRONTEND_URL": "https://dev-azure.zipline.ai",
           "HUB_URL": "https://dev-orch-azure.zipline.ai",
           "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-          "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
           "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"

--- a/python/test/canary/compiled/joins/azure/training_set.v1_dev__0
+++ b/python/test/canary/compiled/joins/azure/training_set.v1_dev__0
@@ -119,7 +119,7 @@
                 "FRONTEND_URL": "https://dev-azure.zipline.ai",
                 "HUB_URL": "https://dev-orch-azure.zipline.ai",
                 "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-                "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+                "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
                 "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
                 "VERSION": "latest",
                 "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
@@ -215,7 +215,7 @@
           "FRONTEND_URL": "https://dev-azure.zipline.ai",
           "HUB_URL": "https://dev-orch-azure.zipline.ai",
           "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-          "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
           "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"

--- a/python/test/canary/compiled/joins/azure/training_set.v1_dev_notds__0
+++ b/python/test/canary/compiled/joins/azure/training_set.v1_dev_notds__0
@@ -119,7 +119,7 @@
                 "FRONTEND_URL": "https://dev-azure.zipline.ai",
                 "HUB_URL": "https://dev-orch-azure.zipline.ai",
                 "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-                "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+                "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
                 "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
                 "VERSION": "latest",
                 "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
@@ -217,7 +217,7 @@
           "FRONTEND_URL": "https://dev-azure.zipline.ai",
           "HUB_URL": "https://dev-orch-azure.zipline.ai",
           "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-          "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
           "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"

--- a/python/test/canary/compiled/joins/azure/training_set.v1_hub__0
+++ b/python/test/canary/compiled/joins/azure/training_set.v1_hub__0
@@ -119,7 +119,7 @@
                 "FRONTEND_URL": "https://dev-azure.zipline.ai",
                 "HUB_URL": "https://dev-orch-azure.zipline.ai",
                 "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-                "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+                "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
                 "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
                 "VERSION": "latest",
                 "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
@@ -215,7 +215,7 @@
           "FRONTEND_URL": "https://dev-azure.zipline.ai",
           "HUB_URL": "https://dev-orch-azure.zipline.ai",
           "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-          "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
           "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"

--- a/python/test/canary/compiled/joins/azure/training_set.v1_test__0
+++ b/python/test/canary/compiled/joins/azure/training_set.v1_test__0
@@ -119,7 +119,7 @@
                 "FRONTEND_URL": "https://dev-azure.zipline.ai",
                 "HUB_URL": "https://dev-orch-azure.zipline.ai",
                 "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-                "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+                "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
                 "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
                 "VERSION": "latest",
                 "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
@@ -215,7 +215,7 @@
           "FRONTEND_URL": "https://dev-azure.zipline.ai",
           "HUB_URL": "https://dev-orch-azure.zipline.ai",
           "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-          "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
           "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"

--- a/python/test/canary/compiled/joins/azure/training_set.v1_test_notds__0
+++ b/python/test/canary/compiled/joins/azure/training_set.v1_test_notds__0
@@ -119,7 +119,7 @@
                 "FRONTEND_URL": "https://dev-azure.zipline.ai",
                 "HUB_URL": "https://dev-orch-azure.zipline.ai",
                 "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-                "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+                "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
                 "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
                 "VERSION": "latest",
                 "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"
@@ -217,7 +217,7 @@
           "FRONTEND_URL": "https://dev-azure.zipline.ai",
           "HUB_URL": "https://dev-orch-azure.zipline.ai",
           "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-          "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
           "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"

--- a/python/test/canary/compiled/staging_queries/azure/ctr_labels.v1__0
+++ b/python/test/canary/compiled/staging_queries/azure/ctr_labels.v1__0
@@ -35,7 +35,7 @@
           "FRONTEND_URL": "https://dev-azure.zipline.ai",
           "HUB_URL": "https://dev-orch-azure.zipline.ai",
           "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-          "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
           "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"

--- a/python/test/canary/compiled/staging_queries/azure/exports.checkouts__0
+++ b/python/test/canary/compiled/staging_queries/azure/exports.checkouts__0
@@ -36,7 +36,7 @@
           "FRONTEND_URL": "https://dev-azure.zipline.ai",
           "HUB_URL": "https://dev-orch-azure.zipline.ai",
           "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-          "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
           "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"

--- a/python/test/canary/compiled/staging_queries/azure/exports.dim_listings__0
+++ b/python/test/canary/compiled/staging_queries/azure/exports.dim_listings__0
@@ -36,7 +36,7 @@
           "FRONTEND_URL": "https://dev-azure.zipline.ai",
           "HUB_URL": "https://dev-orch-azure.zipline.ai",
           "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-          "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
           "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"

--- a/python/test/canary/compiled/staging_queries/azure/exports.dim_listings_pc__1
+++ b/python/test/canary/compiled/staging_queries/azure/exports.dim_listings_pc__1
@@ -36,7 +36,7 @@
           "FRONTEND_URL": "https://dev-azure.zipline.ai",
           "HUB_URL": "https://dev-orch-azure.zipline.ai",
           "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-          "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
           "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"

--- a/python/test/canary/compiled/staging_queries/azure/exports.dim_merchants__0
+++ b/python/test/canary/compiled/staging_queries/azure/exports.dim_merchants__0
@@ -36,7 +36,7 @@
           "FRONTEND_URL": "https://dev-azure.zipline.ai",
           "HUB_URL": "https://dev-orch-azure.zipline.ai",
           "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-          "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
           "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"

--- a/python/test/canary/compiled/staging_queries/azure/exports.dim_users__0
+++ b/python/test/canary/compiled/staging_queries/azure/exports.dim_users__0
@@ -36,7 +36,7 @@
           "FRONTEND_URL": "https://dev-azure.zipline.ai",
           "HUB_URL": "https://dev-orch-azure.zipline.ai",
           "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-          "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
           "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"

--- a/python/test/canary/compiled/staging_queries/azure/local_staging_query.simple__0
+++ b/python/test/canary/compiled/staging_queries/azure/local_staging_query.simple__0
@@ -35,7 +35,7 @@
           "FRONTEND_URL": "https://dev-azure.zipline.ai",
           "HUB_URL": "https://dev-orch-azure.zipline.ai",
           "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-          "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
           "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"

--- a/python/test/canary/compiled/staging_queries/azure/partitioned_logging.v0__2
+++ b/python/test/canary/compiled/staging_queries/azure/partitioned_logging.v0__2
@@ -35,7 +35,7 @@
           "FRONTEND_URL": "https://dev-azure.zipline.ai",
           "HUB_URL": "https://dev-orch-azure.zipline.ai",
           "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-          "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
           "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"

--- a/python/test/canary/compiled/teams_metadata/azure/azure_team_metadata
+++ b/python/test/canary/compiled/teams_metadata/azure/azure_team_metadata
@@ -33,7 +33,7 @@
         "FRONTEND_URL": "https://dev-azure.zipline.ai",
         "HUB_URL": "https://dev-orch-azure.zipline.ai",
         "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-        "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+        "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
         "SPARK_CLUSTER_NAME": "http://kyuubi-dev.westus.cloudapp.azure.com:10099",
         "VERSION": "latest",
         "WAREHOUSE_PREFIX": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net"

--- a/python/test/canary/teams.py
+++ b/python/test/canary/teams.py
@@ -240,7 +240,7 @@ azure = Team(
             "FRONTEND_URL": "https://dev-azure.zipline.ai",
             "HUB_URL": "https://dev-orch-azure.zipline.ai",
             "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=public&warehouse=demo_wh",
-            "SNOWFLAKE_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+            "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
             "EVAL_URL": "https://dev-azure.zipline.ai/services/eval",
             "AUTH_SCOPE": "api://dev-zipline-auth"
         },


### PR DESCRIPTION
## Summary

  - Rename SNOWFLAKE_VAULT_URI → SNOWFLAKE_PRIVATE_KEY_VAULT_URI in the Azure team config

  SecretResolver strips the _VAULT_URI suffix to produce the resolved env var name. The old name resolved
  to SNOWFLAKE, but SnowflakeConnector.getPrivateKeyPem looks for SNOWFLAKE_PRIVATE_KEY. This caused Spark
   driver pods to fail with "Snowflake private key not found" even though the key was successfully fetched
   from Key Vault and injected into the pod — just under the wrong name.

  Checklist

  - Added Unit Tests
  - Covered by existing CI
  - Integration tested
  - Documentation update

 
## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":""}
```
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new data pipeline configurations for Azure deployments.

* **Chores**
  * Updated environment variable naming conventions across multiple Azure job configurations to reference Snowflake private key credentials more explicitly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->