### PR TITLE
Treat empty partition metadata as table is unpartitioned

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/catalog/Format.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/Format.scala
@@ -126,8 +126,12 @@ trait Format {
       sparkSession: SparkSession): Option[String] = {
     // Try metadata-based partition listing first (free for Hive/Iceberg/Delta)
     val metadataResult = Try(primaryPartitions(tableName, partitionColumn, "")(sparkSession)) match {
-      case Success(parts) if parts.nonEmpty => Some(parts.max)
-      case Success(_) => None // Empty result — column not a catalog partition, fall through to data scan
+      case Success(metadata) =>
+        metadata.flatMap(Option(_)) match {
+          // Partition metadata might not exist, if it does not then there are no partitions.
+          case parts if parts.nonEmpty => Some(parts.max)
+          case _                       => None
+        }
       case Failure(ex) =>
         logger.warn(
           s"[NonFatal] Failed to check primary partitions for ${tableName}, falling back to data scan: ${ex.getMessage}");
@@ -173,8 +177,12 @@ trait Format {
   def firstAvailablePartition(tableName: String, partitionColumn: String, partitionSpec: PartitionSpec)(implicit
       sparkSession: SparkSession): Option[String] = {
     val metadataResult = Try(primaryPartitions(tableName, partitionColumn, "")(sparkSession)) match {
-      case Success(parts) if parts.nonEmpty => Some(parts.min)
-      case _                                => None
+      case Success(metadata) =>
+        metadata.flatMap(Option(_)) match {
+          case parts if parts.nonEmpty => Some(parts.min)
+          case _                       => None
+        }
+      case _ => None
     }
     if (metadataResult.isDefined) return metadataResult
 

--- a/spark/src/main/scala/ai/chronon/spark/catalog/Iceberg.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/Iceberg.scala
@@ -79,13 +79,13 @@ case object Iceberg extends Format {
         .select(col(s"partition.$partitionColumn"), col("partition.hr"))
         .collect()
         .filter(_.get(1) == null)
-        .map(_.getString(0))
+        .flatMap(row => Option(row.getString(0)))
         .toList
     } else {
       partitionsDf
         .select(col(s"partition.$partitionColumn").cast("string"))
         .collect()
-        .map(_.getString(0))
+        .flatMap(row => Option(row.getString(0)))
         .toList
     }
   }

--- a/spark/src/test/scala/ai/chronon/spark/catalog/FormatTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/catalog/FormatTest.scala
@@ -1,5 +1,6 @@
 package ai.chronon.spark.catalog
 
+import ai.chronon.api.PartitionSpec
 import ai.chronon.spark.utils.SparkTestBase
 import org.apache.spark.sql.SparkSession
 import org.junit.Assert.assertEquals
@@ -57,6 +58,31 @@ class FormatTest extends SparkTestBase {
     }
     fmt.primaryPartitions("db.table", "ds", "", subPartitionsFilter = Map("hr" -> "12"))(spark) shouldBe
       List("2023-01-01", "2023-01-02")
+  }
+
+  it should "fall back to a table scan when metadata partitions are null" in {
+    val tableName = "format_null_metadata_fallback_test"
+    spark.sql(s"""
+      CREATE OR REPLACE TEMP VIEW $tableName AS
+      SELECT * FROM VALUES
+        (1, '2024-04-01'),
+        (2, '2024-04-03'),
+        (3, '2024-04-02')
+      AS t(id, ds)
+    """)
+
+    val fmt = new Format {
+      override def supportSubPartitionsFilter = false
+      override def partitions(tableName: String, partitionFilters: String)(implicit ss: SparkSession) = Nil
+      override def primaryPartitions(tableName: String,
+                                     partitionColumn: String,
+                                     partitionFilters: String,
+                                     subPartitionsFilter: Map[String, String])(implicit
+          ss: SparkSession) = List(null)
+    }
+
+    fmt.firstAvailablePartition(tableName, "ds", PartitionSpec.daily)(spark) shouldBe Some("2024-04-01")
+    fmt.lastAvailablePartition(tableName, "ds", PartitionSpec.daily)(spark) shouldBe Some("2024-04-03")
   }
 
   it should "resolve table names consistently with Spark SQL" in {


### PR DESCRIPTION
## Summary

In #1689 we routed down this path that previously would be skipped during the forced handling of time partitioned tables. For Databricks Iceberg tables where the table is time partitioned (really clustered over the time col), the partition check grab returns null partition metadata so the `.parts` call fails on a null pointer exception.

## Checklist
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Safer partition metadata handling: treat absent or empty metadata as missing, returning no partition when metadata is empty and falling back to table scans when needed.
  * Exclude null-valued partition entries when building partition lists to avoid invalid entries and downstream errors.

* **Tests**
  * Added coverage verifying fallback behavior when partition metadata is null and ensuring correct min/max partition results from scans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->