### PR TITLE
[codex] Fix MegaTile no-batch batch-tail merge

### DIFF
--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileAggregator.scala
@@ -113,16 +113,35 @@ class MegaTileAggregator(aggregations: Seq[Aggregation],
     windowedAggregator.finalize(resultIr)
   }
 
+  private[windowing] def mergeTailHopsForNoBatchColumnsCrossingBatchEnd(ir: Array[Any],
+                                                                        queryTs: Long,
+                                                                        batchEndTs: Long,
+                                                                        batchIr: FinalBatchIr): Array[Any] =
+    mergeTailHopsForColumns(ir, queryTs, batchEndTs, batchIr) { (i, window) =>
+      window != null && window.millis <= tailBufferMillis && queryTailForColumn(i, queryTs, window) < batchEndTs
+    }
+
   // Like mergeTailHops but skips NO BATCH columns (window <= tailBuffer)
   private[windowing] def mergeTailHopsForBatchColumns(ir: Array[Any],
                                                       queryTs: Long,
                                                       batchEndTs: Long,
-                                                      batchIr: FinalBatchIr): Array[Any] = {
+                                                      batchIr: FinalBatchIr): Array[Any] =
+    mergeTailHopsForColumns(ir, queryTs, batchEndTs, batchIr) { (_, window) =>
+      window != null && window.millis > tailBufferMillis
+    }
+
+  private def queryTailForColumn(colIndex: Int, queryTs: Long, window: Window): Long =
+    TsUtils.round(queryTs - window.millis, hopSizes(tailHopIndices(colIndex)))
+
+  private def mergeTailHopsForColumns(ir: Array[Any],
+                                      queryTs: Long,
+                                      batchEndTs: Long,
+                                      batchIr: FinalBatchIr)(shouldMerge: (Int, Window) => Boolean): Array[Any] = {
     var i: Int = 0
     while (i < windowedAggregator.length) {
-      val windowMillis = windowMappings(i).millis
       val window = windowMappings(i).aggregationPart.window
-      if (window != null && window.millis > tailBufferMillis) {
+      if (shouldMerge(i, window)) {
+        val windowMillis = window.millis
         val hopIndex = tailHopIndices(i)
         val queryTail = TsUtils.round(queryTs - windowMillis, hopSizes(hopIndex))
         val alignedCollapsed = alignedCollapsedBoundary(batchEndTs - windowMillis, i)

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileAggregator.scala
@@ -133,7 +133,13 @@ class MegaTileAggregator(aggregations: Seq[Aggregation],
           val hopIr = hopIrs(idx)
           val hopStart = hopIr.last.asInstanceOf[Long]
           if (alignedCollapsed > hopStart && hopStart >= queryTail) {
-            relevantHops += hopIr(baseIrIndices(i))
+            val hopVal = hopIr(baseIrIndices(i))
+            if (relevantHops(0) == null) {
+              // bulkMerge may mutate its first non-null IR; clone cached tail-hop state on that path.
+              relevantHops += windowedAggregator(i).clone(hopVal)
+            } else {
+              relevantHops += hopVal
+            }
           }
           idx += 1
         }

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileMerger.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileMerger.scala
@@ -9,7 +9,8 @@ import ai.chronon.api.TsUtils
   * no-batch windows, then combines them with batch IR into a finalized result.
   *
   * Per-column merge semantics:
-  *   - Small windows (≤ tailBuffer): self-contained in daily entry. Pick today, fall back to yesterday.
+  *   - Small windows (≤ tailBuffer): daily entry, plus optional batch tail when the request path knows
+  *     the streaming entries start at batchEnd.
   *   - Large windows (> tailBuffer): batch collapsed + streaming daily aggregates + tail hops.
   *   - Unwindowed: batch collapsed + streaming daily aggregates (no tail hops).
   */
@@ -58,8 +59,23 @@ class MegaTileMerger(megaTileAgg: MegaTileAggregator) {
             yesterdayIr: Array[Any],
             todayStart: Long,
             queryTs: Long,
-            batchEnd: Long): Array[Any] = {
-    merge(batchIr, Seq(todayStart -> todayIr, (todayStart - DayMillis) -> yesterdayIr), queryTs, batchEnd)
+            batchEnd: Long): Array[Any] =
+    merge(batchIr, todayIr, yesterdayIr, todayStart, queryTs, batchEnd, mergeNoBatchTailFromBatch = false)
+
+  def merge(batchIr: FinalBatchIr,
+            todayIr: Array[Any],
+            yesterdayIr: Array[Any],
+            todayStart: Long,
+            queryTs: Long,
+            batchEnd: Long,
+            mergeNoBatchTailFromBatch: Boolean): Array[Any] = {
+    merge(
+      batchIr,
+      Seq(todayStart -> todayIr, (todayStart - DayMillis) -> yesterdayIr),
+      queryTs,
+      batchEnd,
+      mergeNoBatchTailFromBatch
+    )
   }
 
   /** Merge batch IR + N daily streaming entries into a finalized result.
@@ -70,7 +86,14 @@ class MegaTileMerger(megaTileAgg: MegaTileAggregator) {
     * @param batchEnd     The batch upload boundary timestamp.
     * @return Finalized feature values.
     */
-  def merge(batchIr: FinalBatchIr, dailyTileIrs: Seq[(Long, Array[Any])], queryTs: Long, batchEnd: Long): Array[Any] = {
+  def merge(batchIr: FinalBatchIr, dailyTileIrs: Seq[(Long, Array[Any])], queryTs: Long, batchEnd: Long): Array[Any] =
+    merge(batchIr, dailyTileIrs, queryTs, batchEnd, mergeNoBatchTailFromBatch = false)
+
+  def merge(batchIr: FinalBatchIr,
+            dailyTileIrs: Seq[(Long, Array[Any])],
+            queryTs: Long,
+            batchEnd: Long,
+            mergeNoBatchTailFromBatch: Boolean): Array[Any] = {
 
     val resultIr =
       if (batchIr != null) windowedAggregator.clone(batchIr.collapsed)
@@ -82,9 +105,8 @@ class MegaTileMerger(megaTileAgg: MegaTileAggregator) {
     var col = 0
     while (col < windowedAggregator.length) {
       if (isNoBatch(col)) {
-        // Small window: self-contained in daily entry, ignore batch.
         // Fall back to an older day only if the newer entry is missing entirely,
-        // not if a newer entry exists but this column value is null.
+        // not if a newer entry exists but this column value is null (no events in window).
         val newestAvailableIr = nonNullDailyTileIrs.collectFirst {
           case (dayStart, dayIr) if dayStart >= oldestNoBatchDayStart => dayIr
         }.orNull
@@ -101,8 +123,11 @@ class MegaTileMerger(megaTileAgg: MegaTileAggregator) {
       col += 1
     }
 
-    // Tail hops for large windowed columns (skips small + unwindowed)
+    // Tail hops for large windowed columns, plus optional small-window batch tails for post-batch entries.
     if (batchIr != null) {
+      if (mergeNoBatchTailFromBatch) {
+        megaTileAgg.mergeTailHopsForNoBatchColumnsCrossingBatchEnd(resultIr, queryTs, batchEnd, batchIr)
+      }
       megaTileAgg.mergeTailHopsForBatchColumns(resultIr, queryTs, batchEnd, batchIr)
     }
 

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileMerger.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileMerger.scala
@@ -4,8 +4,9 @@ import ai.chronon.api.TsUtils
 
 /** Fetcher-side merge logic for the per-day MegaTile KV scheme.
   *
-  * Flink writes at most 2 entries per entity per day: (key, today_midnight) and (key, yesterday_midnight).
-  * The fetcher reads both entries plus the batch IR and this class combines them into a finalized result.
+  * Flink writes one entry per entity/day key and may also update yesterday's key for late events.
+  * The fetcher reads the day keys needed to bridge batchEnd -> queryTs plus one fallback key for
+  * no-batch windows, then combines them with batch IR into a finalized result.
   *
   * Per-column merge semantics:
   *   - Small windows (≤ tailBuffer): self-contained in daily entry. Pick today, fall back to yesterday.
@@ -25,7 +26,24 @@ class MegaTileMerger(megaTileAgg: MegaTileAggregator) {
     (todayStart, todayStart - DayMillis)
   }
 
-  /** Merge batch IR + up to 2 daily streaming entries into a finalized result.
+  /** Returns the day keys that must be fetched to merge stream and batch exactly.
+    *
+    * Batch-backed columns need every daily entry from the batch day through today.
+    * No-batch columns still need one extra previous-day fallback key when today's row is missing.
+    * Keys are returned newest-first so callers preserve fallback order for no-batch columns.
+    */
+  def streamingDayKeys(queryTs: Long, batchEnd: Long): Seq[Long] = {
+    val todayStart = TsUtils.round(queryTs, DayMillis)
+    val batchDayStart = TsUtils.round(batchEnd, DayMillis)
+    val oldestDayStart = Math.min(batchDayStart, todayStart - DayMillis)
+
+    Iterator
+      .iterate(todayStart)(_ - DayMillis)
+      .takeWhile(_ >= oldestDayStart)
+      .toSeq
+  }
+
+  /** Merge batch IR + today's and yesterday's daily streaming entries into a finalized result.
     *
     * @param batchIr     Finalized batch IR (collapsed + tail hops). May be null.
     * @param todayIr     Today's daily entry from stream KV. May be null.
@@ -41,30 +59,47 @@ class MegaTileMerger(megaTileAgg: MegaTileAggregator) {
             todayStart: Long,
             queryTs: Long,
             batchEnd: Long): Array[Any] = {
+    merge(batchIr, Seq(todayStart -> todayIr, (todayStart - DayMillis) -> yesterdayIr), queryTs, batchEnd)
+  }
+
+  /** Merge batch IR + N daily streaming entries into a finalized result.
+    *
+    * @param batchIr      Finalized batch IR (collapsed + tail hops). May be null.
+    * @param dailyTileIrs Daily streaming entries keyed by day start, newest-first preferred. Null IRs are allowed.
+    * @param queryTs      The query timestamp (wall-clock now).
+    * @param batchEnd     The batch upload boundary timestamp.
+    * @return Finalized feature values.
+    */
+  def merge(batchIr: FinalBatchIr,
+            dailyTileIrs: Seq[(Long, Array[Any])],
+            queryTs: Long,
+            batchEnd: Long): Array[Any] = {
 
     val resultIr =
       if (batchIr != null) windowedAggregator.clone(batchIr.collapsed)
       else windowedAggregator.init
+    val oldestNoBatchDayStart = TsUtils.round(queryTs, DayMillis) - DayMillis
+    val batchDayStart = TsUtils.round(batchEnd, DayMillis)
+    val nonNullDailyTileIrs = dailyTileIrs.filter(_._2 != null).sortBy(_._1).reverse
 
     var col = 0
     while (col < windowedAggregator.length) {
       if (isNoBatch(col)) {
         // Small window: self-contained in daily entry, ignore batch.
-        // Fall back to yesterday only if today's ENTRY is missing (null array),
-        // not if today exists but the column value is null (no events in window).
-        if (todayIr != null) {
-          resultIr(col) = todayIr(col)
-        } else if (yesterdayIr != null) {
-          resultIr(col) = yesterdayIr(col)
-        }
+        // Fall back to an older day only if the newer entry is missing entirely,
+        // not if a newer entry exists but this column value is null.
+        val newestAvailableIr = nonNullDailyTileIrs.collectFirst {
+          case (dayStart, dayIr) if dayStart >= oldestNoBatchDayStart => dayIr
+        }.orNull
+        resultIr(col) = if (newestAvailableIr != null) newestAvailableIr(col) else null
       } else {
         // Large window / unwindowed: batch collapsed + streaming daily aggregates
         // resultIr(col) already has batchIr.collapsed(col) from clone
-        if (todayIr != null && todayIr(col) != null) {
-          resultIr(col) = windowedAggregator.columnAggregators(col).merge(resultIr(col), todayIr(col))
-        }
-        if (batchEnd < todayStart && yesterdayIr != null && yesterdayIr(col) != null) {
-          resultIr(col) = windowedAggregator.columnAggregators(col).merge(resultIr(col), yesterdayIr(col))
+        nonNullDailyTileIrs.reverseIterator.foreach {
+          case (dayStart, dayIr) =>
+            if (dayStart >= batchDayStart && dayIr(col) != null) {
+              resultIr(col) = windowedAggregator.columnAggregators(col).merge(resultIr(col), dayIr(col))
+            }
         }
       }
       col += 1

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileMerger.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileMerger.scala
@@ -70,10 +70,7 @@ class MegaTileMerger(megaTileAgg: MegaTileAggregator) {
     * @param batchEnd     The batch upload boundary timestamp.
     * @return Finalized feature values.
     */
-  def merge(batchIr: FinalBatchIr,
-            dailyTileIrs: Seq[(Long, Array[Any])],
-            queryTs: Long,
-            batchEnd: Long): Array[Any] = {
+  def merge(batchIr: FinalBatchIr, dailyTileIrs: Seq[(Long, Array[Any])], queryTs: Long, batchEnd: Long): Array[Any] = {
 
     val resultIr =
       if (batchIr != null) windowedAggregator.clone(batchIr.collapsed)
@@ -95,11 +92,10 @@ class MegaTileMerger(megaTileAgg: MegaTileAggregator) {
       } else {
         // Large window / unwindowed: batch collapsed + streaming daily aggregates
         // resultIr(col) already has batchIr.collapsed(col) from clone
-        nonNullDailyTileIrs.reverseIterator.foreach {
-          case (dayStart, dayIr) =>
-            if (dayStart >= batchDayStart && dayIr(col) != null) {
-              resultIr(col) = windowedAggregator.columnAggregators(col).merge(resultIr(col), dayIr(col))
-            }
+        nonNullDailyTileIrs.reverseIterator.foreach { case (dayStart, dayIr) =>
+          if (dayStart >= batchDayStart && dayIr(col) != null) {
+            resultIr(col) = windowedAggregator.columnAggregators(col).merge(resultIr(col), dayIr(col))
+          }
         }
       }
       col += 1

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileStreamProcessor.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileStreamProcessor.scala
@@ -138,28 +138,25 @@ class MegaTileStreamProcessor(val megaTileAgg: MegaTileAggregator, val store: Ti
 
     val todayStart = currentDayStart
 
-    // Evict stale tiles
+    // Classify stale vs retained tiles in one pass because Flink-backed iterators decode on access.
     val staleEntries = mutable.ArrayBuffer.empty[(Long, Long)]
-    val iter = store.tileIterator
-    while (iter.hasNext) {
-      val (hopSize, tileStart, _) = iter.next()
-      if (smallWindowTiers.contains(hopSize)) {
-        val floor = megaTileAgg.retentionFloor(hopSize, timerTs, todayStart)
-        if (tileStart < floor) staleEntries += ((hopSize, tileStart))
-      }
-    }
-    staleEntries.foreach { case (h, t) => store.removeTile(h, t) }
-
-    // Rebuild cachedSmallWindowIr from remaining tiles
     val tiles: Map[Long, mutable.Map[Long, Array[Any]]] =
       smallWindowTiers.map(hop => hop -> mutable.Map.empty[Long, Array[Any]]).toMap
     var newEarliest = Long.MaxValue
-    val rebuildIter = store.tileIterator
-    while (rebuildIter.hasNext) {
-      val (hopSize, tileStart, ir) = rebuildIter.next()
-      tiles.get(hopSize).foreach(_(tileStart) = ir)
-      if (tileStart < newEarliest) newEarliest = tileStart
+    val iter = store.tileIterator
+    while (iter.hasNext) {
+      val (hopSize, tileStart, ir) = iter.next()
+      if (smallWindowTiers.contains(hopSize)) {
+        val floor = megaTileAgg.retentionFloor(hopSize, timerTs, todayStart)
+        if (tileStart < floor) {
+          staleEntries += ((hopSize, tileStart))
+        } else {
+          tiles(hopSize)(tileStart) = ir
+          if (tileStart < newEarliest) newEarliest = tileStart
+        }
+      }
     }
+    staleEntries.foreach { case (h, t) => store.removeTile(h, t) }
     store.putEarliestTileStart(newEarliest)
 
     val rebuiltIr = megaTileAgg.buildMegaTileIr(tiles, now = timerTs, batchEnd = todayStart)

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileStreamProcessor.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileStreamProcessor.scala
@@ -38,7 +38,10 @@ class MegaTileStreamProcessor(val megaTileAgg: MegaTileAggregator, val store: Ti
   val hasSmallWindows: Boolean = smallWindowTiers.nonEmpty
   val minSmallWindowTileSize: Long = if (hasSmallWindows) smallWindowTiers.min else DayMillis
 
-  def onEvent(row: Row, eventTs: Long): EmitResult = {
+  /** Ingest an event at eventTs, but bound cached small-window emission as of smallWindowAsOfTs.
+    * Base tile state still uses eventTs so retained late events remain available for future rebuilds.
+    */
+  def onEvent(row: Row, eventTs: Long, smallWindowAsOfTs: Long): EmitResult = {
     var currentDayStart = store.getCurrentDayStart
     if (currentDayStart == -1L) {
       currentDayStart = TsUtils.round(eventTs, DayMillis)
@@ -50,7 +53,7 @@ class MegaTileStreamProcessor(val megaTileAgg: MegaTileAggregator, val store: Ti
 
     // Update tiles + cachedSmallWindowIr for small-window tiers
     if (hasSmallWindows) {
-      var tilesUpdated = false
+      val acceptedTileStarts = mutable.Map.empty[Long, Long]
       val tileStarts = megaTileAgg.tileStartsForEvent(eventTs)
       for ((hopSize, tileStart) <- tileStarts) {
         if (smallWindowTiers.contains(hopSize)) {
@@ -63,23 +66,38 @@ class MegaTileStreamProcessor(val megaTileAgg: MegaTileAggregator, val store: Ti
             store.putTile(hopSize, tileStart, ir)
             val earliest = store.getEarliestTileStart
             if (tileStart < earliest) store.putEarliestTileStart(tileStart)
-            tilesUpdated = true
+            acceptedTileStarts(hopSize) = tileStart
           }
         }
       }
 
-      // Sawtooth: merge event into running IR for all small-window columns.
-      if (tilesUpdated) {
-        val cachedIr = store.getCachedSmallWindowIr
+      // Sawtooth: merge event into the running IR only for columns whose tile belongs
+      // in the as-of window being emitted. The base tile remains retained even when
+      // a late event is outside a smaller current serving horizon.
+      if (acceptedTileStarts.nonEmpty) {
+        var cachedIr: Array[Any] = null
+        var cachedIrUpdated = false
         var col = 0
         while (col < windowedAgg.length) {
           if (isNoBatch(col)) {
-            windowedAgg.columnAggregators(col).update(cachedIr, row)
+            val hopSize = columnHopSize(col)
+            acceptedTileStarts.get(hopSize).foreach { tileStart =>
+              val effectiveStart = megaTileAgg.effectiveStart(col, smallWindowAsOfTs, currentDayStart)
+              // The retained base tile can accept older late events, but the sawtooth cache represents
+              // the value emitted as of smallWindowAsOfTs.
+              if (tileStart >= effectiveStart && tileStart < smallWindowAsOfTs) {
+                if (cachedIr == null) cachedIr = store.getCachedSmallWindowIr
+                windowedAgg.columnAggregators(col).update(cachedIr, row)
+                cachedIrUpdated = true
+              }
+            }
           }
           col += 1
         }
-        store.putCachedSmallWindowIr(cachedIr)
-        todayDirty = true
+        if (cachedIrUpdated) {
+          store.putCachedSmallWindowIr(cachedIr)
+          todayDirty = true
+        }
       }
     }
 

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileStreamProcessor.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileStreamProcessor.scala
@@ -138,7 +138,7 @@ class MegaTileStreamProcessor(val megaTileAgg: MegaTileAggregator, val store: Ti
 
     val todayStart = currentDayStart
 
-    // Classify stale vs retained tiles in one pass because Flink-backed iterators decode on access.
+    // Build the retained-tile snapshot while collecting stale keys, then delete stale state after iteration.
     val staleEntries = mutable.ArrayBuffer.empty[(Long, Long)]
     val tiles: Map[Long, mutable.Map[Long, Array[Any]]] =
       smallWindowTiers.map(hop => hop -> mutable.Map.empty[Long, Array[Any]]).toMap

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/MegaTileAggregatorTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/MegaTileAggregatorTest.scala
@@ -260,6 +260,32 @@ class MegaTileAggregatorTest extends AnyFlatSpec {
     compareResults(megaResults, naiveResults, queryTimes, "batchEnd_boundary")
   }
 
+  it should "not mutate batch tail hops across repeated serves" in {
+    val batchEnd = TsUtils.round(1700000000000L, new Window(1, TimeUnit.DAYS).millis)
+    val queryTs = batchEnd + 3600 * 1000L
+    val schema: Seq[(String, DataType)] = Seq("ts" -> LongType, "amount" -> DoubleType)
+    val aggregations: Seq[Aggregation] = Seq(
+      Builders.Aggregation(Operation.AVERAGE, "amount", Seq(new Window(3, TimeUnit.DAYS)))
+    )
+
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val onlineAgg =
+      new SawtoothOnlineAggregator(batchEnd, aggregations, schema, tailBufferMillis = TailBufferMillis)
+    var batchIr = onlineAgg.init
+    batchIr = onlineAgg.update(batchIr, new TestRow(batchEnd - 26 * 3600 * 1000L, 2.0)(0))
+    batchIr = onlineAgg.update(batchIr, new TestRow(batchEnd - 25 * 3600 * 1000L, 4.0)(0))
+    val finalBatchIr = onlineAgg.finalizeSnapshot(batchIr)
+
+    val megaTileIr = megaTileAgg.buildMegaTileIr(Map.empty[Long, collection.Map[Long, Array[Any]]],
+                                                now = queryTs,
+                                                batchEnd = batchEnd)
+    val firstServe = megaTileAgg.serveMegaTile(finalBatchIr, megaTileIr, queryTs, batchEnd)
+    val secondServe = megaTileAgg.serveMegaTile(finalBatchIr, megaTileIr, queryTs, batchEnd)
+
+    assertEquals(3.0, firstServe.head.asInstanceOf[Double], Epsilon)
+    assertTrue(approxEqual(firstServe, secondServe))
+  }
+
   it should "match naive with multiple aggregation types" in {
     val (events, schema) = generateEvents(10, 10000)
     val maxTs = events.map(_.ts).max

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/MegaTileMergerTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/MegaTileMergerTest.scala
@@ -128,6 +128,71 @@ class MegaTileMergerTest extends AnyFlatSpec {
     assertEquals(5L, merged(1))
   }
 
+  it should "include batch tail for same-day 1d no-batch windows when streaming only covers after batchEnd" in {
+    val schema: Seq[(String, DataType)] = Seq("ts" -> LongType, "num" -> LongType)
+    val batchEnd = 1776297600000L // 2026-04-16T00:00:00Z
+    val queryTs = batchEnd + 16 * 3600 * 1000L // 2026-04-16T16:00:00Z
+    val todayStart = TsUtils.round(queryTs, DayMillis)
+    val oneHourMillis = new Window(1, TimeUnit.HOURS).millis
+    val aggregations: Seq[Aggregation] = Seq(
+      Builders.Aggregation(Operation.SUM, "num", Seq(new Window(1, TimeUnit.DAYS))),
+      Builders.Aggregation(Operation.SUM, "num", Seq(new Window(7, TimeUnit.DAYS)))
+    )
+    val batchRows = Array(
+      TestRow(batchEnd - 6 * 3600 * 1000L, 100L) // 2026-04-15T18:00:00Z, inside the query 1d window
+    )
+    val streamingRows = Array(
+      TestRow(batchEnd + 1 * 3600 * 1000L, 10L),
+      TestRow(batchEnd + 15 * 3600 * 1000L, 1L)
+    )
+    val allRows = batchRows ++ streamingRows
+
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val merger = new MegaTileMerger(megaTileAgg)
+    val onlineAgg = new SawtoothOnlineAggregator(batchEnd, aggregations, schema, tailBufferMillis = TailBufferMillis)
+
+    var batchIr = onlineAgg.init
+    batchRows.foreach(row => batchIr = onlineAgg.update(batchIr, row))
+    val finalBatchIr = onlineAgg.finalizeSnapshot(batchIr)
+
+    val tiles: Map[Long, mutable.Map[Long, Array[Any]]] =
+      megaTileAgg.activeTiers.map(hop => hop -> mutable.Map.empty[Long, Array[Any]]).toMap
+    streamingRows.foreach { row =>
+      megaTileAgg.tileStartsForEvent(row.ts).foreach {
+        case (hopSize, tileStart) =>
+          val ir = tiles(hopSize).getOrElseUpdate(tileStart, megaTileAgg.baseAggregator.init)
+          megaTileAgg.baseAggregator.update(ir, row)
+      }
+    }
+
+    val todayIr = megaTileAgg.buildMegaTileIr(tiles, now = queryTs, batchEnd = todayStart)
+    val dailyTileIrs: Seq[(Long, Array[Any])] = Seq(
+      todayStart -> todayIr,
+      (todayStart - DayMillis) -> null
+    )
+
+    val mega = merger.merge(finalBatchIr, dailyTileIrs, queryTs, batchEnd, mergeNoBatchTailFromBatch = true)
+    val megaWithoutBatch = merger.merge(null, dailyTileIrs, queryTs, batchEnd)
+    val naive = naiveAggregate(allRows, Array(queryTs), aggregations, schema).head
+    val vanillaTiles = mutable.Map.empty[Long, Array[Any]]
+    streamingRows.foreach { row =>
+      val tileStart = TsUtils.round(row.ts, oneHourMillis)
+      val ir = vanillaTiles.getOrElseUpdate(tileStart, megaTileAgg.windowedAggregator.init)
+      megaTileAgg.windowedAggregator.update(ir, row)
+    }
+    val vanilla = onlineAgg.lambdaAggregateFinalizedTiled(
+      finalBatchIr,
+      vanillaTiles.toSeq.map { case (tileStart, ir) => TiledIr(tileStart, ir) }.iterator,
+      queryTs
+    )
+
+    assertEquals("sanity: last 1d should include pre-batch tail plus streaming rows", 111L, naive(0))
+    assertEquals("sanity: vanilla tiled path includes the batch tail", naive(0), vanilla(0))
+    assertEquals("sanity: without batch, the mega daily entry is only the post-batch streaming portion", 11L, megaWithoutBatch(0))
+    assertEquals("1d no-batch path should include the pre-batch tail when the window crosses batchEnd", naive(0), mega(0))
+    assertEquals("control: batch-backed 7d still merges the batch tail", naive(1), mega(1))
+  }
+
   def naiveAggregate(allEvents: Array[TestRow],
                      queryTimes: Array[Long],
                      aggregations: Seq[Aggregation],

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/MegaTileMergerTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/MegaTileMergerTest.scala
@@ -66,6 +66,68 @@ class MegaTileMergerTest extends AnyFlatSpec {
     (data.rows, columns.map(_.schema))
   }
 
+  it should "fetch day keys from batch day through today plus one no-batch fallback day" in {
+    val aggregations: Seq[Aggregation] = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows)
+    )
+    val schema: Seq[(String, DataType)] = Seq("ts" -> LongType, "num" -> LongType)
+    val merger = new MegaTileMerger(new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis))
+
+    val todayStart = 1712275200000L // 2024-04-05T00:00:00Z
+    val queryTs = todayStart + 90 * 60 * 1000L
+    val batchEnd = 1711929600000L // 2024-04-01T00:00:00Z
+
+    assertEquals(
+      Seq(
+        todayStart,
+        1712188800000L,
+        1712102400000L,
+        1712016000000L,
+        1711929600000L
+      ),
+      merger.streamingDayKeys(queryTs, batchEnd)
+    )
+
+    assertEquals(
+      Seq(
+        todayStart,
+        1712188800000L
+      ),
+      merger.streamingDayKeys(queryTs, todayStart)
+    )
+  }
+
+  it should "clear no-batch columns when no daily rows exist" in {
+    val aggregations: Seq[Aggregation] = Seq(
+      Builders.Aggregation(Operation.SUM, "num", Seq(new Window(6, TimeUnit.HOURS))),
+      Builders.Aggregation(Operation.SUM, "num", Seq(new Window(7, TimeUnit.DAYS)))
+    )
+    val schema: Seq[(String, DataType)] = Seq("ts" -> LongType, "num" -> LongType)
+    val batchEnd = 1712275200000L // 2024-04-05T00:00:00Z
+    val queryTs = batchEnd + 6 * 3600 * 1000L
+
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val merger = new MegaTileMerger(megaTileAgg)
+    val onlineAgg = new SawtoothOnlineAggregator(batchEnd, aggregations, schema, tailBufferMillis = TailBufferMillis)
+
+    var batchIr = onlineAgg.init
+    batchIr = onlineAgg.update(batchIr, new TestRow(batchEnd - 3600 * 1000L, 5L)(0))
+    val finalBatchIr = onlineAgg.finalizeSnapshot(batchIr)
+
+    val merged = merger.merge(
+      finalBatchIr,
+      Seq(
+        TsUtils.round(queryTs, DayMillis) -> null,
+        (TsUtils.round(queryTs, DayMillis) - DayMillis) -> null
+      ),
+      queryTs,
+      batchEnd
+    )
+
+    assertNull(merged(0))
+    assertEquals(5L, merged(1))
+  }
+
   def naiveAggregate(allEvents: Array[TestRow],
                      queryTimes: Array[Long],
                      aggregations: Seq[Aggregation],

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/MegaTileStreamProcessorTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/MegaTileStreamProcessorTest.scala
@@ -9,6 +9,7 @@ import org.junit.Assert._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.slf4j.LoggerFactory
 
+import java.time.Instant
 import scala.collection.mutable
 
 /**
@@ -83,6 +84,11 @@ class MegaTileStreamProcessorTest extends AnyFlatSpec {
     (data.rows, columns.map(_.schema))
   }
 
+  def toMillis(instant: String): Long = Instant.parse(instant).toEpochMilli
+
+  def finalizeEntry(megaTileAgg: MegaTileAggregator, entry: Array[Any]): Array[Any] =
+    megaTileAgg.windowedAggregator.finalize(entry.clone())
+
   def naiveAggregate(allEvents: Array[TestRow], queryTimes: Array[Long], aggregations: Seq[Aggregation], schema: Seq[(String, DataType)]): Array[Array[Any]] = {
     val unpackedParts = aggregations.flatMap(_.unpack)
     val unpacked = unpackedParts.map(_.window).toArray
@@ -154,7 +160,7 @@ class MegaTileStreamProcessorTest extends AnyFlatSpec {
         processor.advanceWatermark(event.ts)
 
         // Process event
-        val result = processor.onEvent(event, event.ts)
+        val result = processor.onEvent(event, event.ts, queryTs)
         if (result.todayEntry != null) kvStore(result.todayStart) = result.todayEntry
         if (result.yesterdayEntry != null) kvStore(result.yesterdayStart) = result.yesterdayEntry
 
@@ -315,6 +321,57 @@ class MegaTileStreamProcessorTest extends AnyFlatSpec {
     val results = streamProcessorAggregate(events, queryTimes, aggregations, schema, batchEnd)
     val naive = naiveAggregate(events, queryTimes, aggregations, schema)
     compareResults(results, naive, queryTimes, "stream_multi_day_gap")
+  }
+
+  it should "not update cached small windows for a retained late event outside the as-of horizon" in {
+    val oneHour = new Window(1, TimeUnit.HOURS)
+    val oneDay = new Window(1, TimeUnit.DAYS)
+    val threeDays = new Window(3, TimeUnit.DAYS)
+    val aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(oneHour, oneDay, threeDays)))
+    val schema: Seq[(String, DataType)] = Seq("ts" -> LongType, "num" -> LongType)
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val processor = new MegaTileStreamProcessor(megaTileAgg, new InMemoryTileStore(megaTileAgg.windowedAggregator))
+
+    val todayStart = toMillis("2025-07-22T00:00:00Z")
+    val asOfTs = toMillis("2025-07-22T00:10:00Z")
+
+    val currentEvent = TestRow(todayStart, 1L)
+    val currentResult = processor.onEvent(currentEvent, currentEvent.ts, asOfTs)
+    val currentFinalized = finalizeEntry(megaTileAgg, currentResult.todayEntry)
+    assertEquals("1h sum after current event", 1L, currentFinalized(0))
+    assertEquals("1d sum after current event", 1L, currentFinalized(1))
+
+    val retainedButOutsideOneHour = TestRow(toMillis("2025-07-21T00:00:00Z"), 1L)
+    val lateResult = processor.onEvent(retainedButOutsideOneHour, retainedButOutsideOneHour.ts, asOfTs)
+    val lateFinalized = finalizeEntry(megaTileAgg, lateResult.todayEntry)
+
+    assertEquals("1h sum should exclude stale retained late event", 1L, lateFinalized(0))
+    assertEquals("1d sum should still include retained late event", 2L, lateFinalized(1))
+    assertNotNull("large-window yesterday entry should still be emitted", lateResult.yesterdayEntry)
+  }
+
+  it should "update cached small windows for a retained late event inside the as-of horizon" in {
+    val oneHour = new Window(1, TimeUnit.HOURS)
+    val oneDay = new Window(1, TimeUnit.DAYS)
+    val threeDays = new Window(3, TimeUnit.DAYS)
+    val aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(oneHour, oneDay, threeDays)))
+    val schema: Seq[(String, DataType)] = Seq("ts" -> LongType, "num" -> LongType)
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val processor = new MegaTileStreamProcessor(megaTileAgg, new InMemoryTileStore(megaTileAgg.windowedAggregator))
+
+    val todayStart = toMillis("2025-07-22T00:00:00Z")
+    val asOfTs = toMillis("2025-07-22T00:10:00Z")
+
+    val currentEvent = TestRow(todayStart, 1L)
+    processor.onEvent(currentEvent, currentEvent.ts, asOfTs)
+
+    val retainedInsideOneHour = TestRow(toMillis("2025-07-21T23:30:00Z"), 1L)
+    val lateResult = processor.onEvent(retainedInsideOneHour, retainedInsideOneHour.ts, asOfTs)
+    val lateFinalized = finalizeEntry(megaTileAgg, lateResult.todayEntry)
+
+    assertEquals("1h sum should include retained late event inside as-of horizon", 2L, lateFinalized(0))
+    assertEquals("1d sum should include retained late event", 2L, lateFinalized(1))
+    assertNotNull("large-window yesterday entry should still be emitted", lateResult.yesterdayEntry)
   }
 
   it should "match naive with complex aggregations (buckets, approx_unique, histogram, last_k)" in {

--- a/docs/source/megatile.md
+++ b/docs/source/megatile.md
@@ -75,6 +75,44 @@ Bookkeeping:
   earliestTileStart: ValueState<Long>
 ```
 
+## Flink ProcessFunction Mental Model
+
+There are two clocks in this operator:
+
+- **event time/watermark**: where Flink believes the stream has progressed in event time.
+- **processing time (PT)**: wall clock in the Flink task.
+
+There are two primary operating modes:
+
+**Live**: watermark is close enough to PT. The small-window cache and eviction use PT as the as-of
+time, matching vanilla tiled serving where reads enumerate tiles for wall-clock query time.
+
+**ActiveCatchup**: watermark is far behind PT for an active key, often because replay is lagged or
+allowed out-of-orderness is intentionally high. Event time is then decoupled from wall clock, so
+event-path cache updates and timer-path eviction both use `nextSmallWindowHop(watermark)` instead
+of PT. This avoids aging out replay tiles that are still current relative to the event-time
+frontier.
+
+Important details that are easy to mix up:
+
+- `processor.onEvent(row, eventTs, smallWindowAsOfTs)` receives `eventTs` separately so the
+  processor can choose the retained tile/day that the input row mutates. Mode does not choose that
+  tile; it chooses the as-of timestamp for cache and eviction behavior.
+- `smallWindowAsOfTs` is the event-path timestamp for deciding whether the touched tile contributes
+  to the cached small-window IR. The small-window cache is the Flink implementation of Chronon's
+  no-batch windows.
+- `evictionTime` is the timer-path timestamp for making state accurate as of that point: it can
+  roll day state, permanently drop expired retained tiles, and rebuild cached small-window IR.
+- `NoWatermark` is startup/bootstrap behavior: the event path uses the row's event hop, while timer
+  callbacks use PT because there is no watermark clock to trust yet.
+- `SparseKeyLag` is the idle-key fallback: the global watermark may lag because of other input, but
+  this key is not actively replaying, so timer callbacks use PT and values decay or roll forward
+  with wall clock.
+- Output buffering is write coalescing only. It uses PT timers to avoid emitting on every event or
+  eviction; it does not change event-time mutation or as-of selection.
+
+The code-order step-by-step walkthrough lives in `MegaTileProcessFunction.scala`.
+
 ### On Event
 
 1. **Update tiles** (small-window tiers only):
@@ -85,43 +123,59 @@ Bookkeeping:
    - ~2 tile codec ops per event (one per small-window tier)
 
 2. **Update cachedSmallWindowIr** (sawtooth):
-   - Merge event into running IR for all small-window columns (unconditional)
-   - Over-inclusive at the tail — eviction corrects this
-   - 1 windowed IR codec op
+   - `MegaTileProcessFunction` passes `smallWindowAsOfTs` separately from `eventTs`
+   - For each no-batch column, merge the event only when its accepted tile falls inside
+     `[effectiveStart(col, smallWindowAsOfTs, currentDayStart), smallWindowAsOfTs)`
+   - The base tile still uses `eventTs`, so retained late events can update wider current windows
+     or future rebuilds without re-inflating a stale small window that is outside the current as-of
+     horizon
+   - Up to 1 windowed IR codec op when a cached column is actually updated
 
 3. **Update large window daily IR** — route by event day:
+   - `eventTs >= nextDayStart` → clamp to today (future event; day transitions are not event-driven)
    - `eventTs >= todayStart` → update `largeTodayIr`
-   - `eventTs >= yesterdayStart` → update `largeYesterdayIr` (late event, within 2d tolerance)
-   - `eventTs >= nextDayStart` → clamp to today (future event; day transitions are watermark-driven)
-   - `eventTs < yesterdayStart` → drop for large windows (> 2d late)
+   - `eventTs >= yesterdayStart` → update `largeYesterdayIr` (retained late event)
+   - `eventTs < yesterdayStart` → no large-window update; Flink drops this before processor mutation
+     once `currentDayStart` is initialized
    - 1 windowed IR codec op
 
 4. **Emit** to KV store (only dirty targets):
    - Today's entry: pack `cachedSmallWindowIr` + `largeTodayIr` → `(entity, todayStart)`
    - Yesterday's entry (only if late event touched it): pack `null` + `largeYesterdayIr` → `(entity, yesterdayStart)`
 
-**Total hot-path cost per event: ~6 codec ops** (vs ~102 with bulk restore/persist).
+**Total hot-path cost per event: up to ~6 codec ops** (vs ~102 with bulk restore/persist).
 
 ### Day Transitions (advanceWatermark)
 
-Day transitions are **watermark-driven only** — never triggered by event timestamps. This prevents
-future-timestamped events from prematurely rotating state.
+Day transitions are never triggered directly by event timestamps. This prevents future-timestamped
+events from prematurely rotating state.
+
+- Event ingestion calls `advanceWatermark` with the current Flink watermark before applying the row.
+- Eviction timers call `advanceWatermark` with the selected eviction time: watermark-hop time in
+  `ActiveCatchup`, and PT in `NoWatermark`, `SparseKeyLag`, and `Live`.
+- Before an adjacent one-day roll, `MegaTileProcessFunction` emits any dirty today row under the
+  previous day key so buffered small-window state is not lost.
 
 ```
-wmDay = round(watermarkTs, DayMillis)
-if wmDay > currentDayStart:
+transitionDay = round(dayTransitionTs, DayMillis)
+if transitionDay > currentDayStart:
   // Single-day hop: carry today's aggregate to yesterday
   // Multi-day hop (e.g., after long idle): clear yesterday (stale beyond 2d tolerance)
-  largeYesterdayIr = if (wmDay == currentDayStart + DayMillis) largeTodayIr else init
+  largeYesterdayIr = if (transitionDay == currentDayStart + DayMillis) largeTodayIr else init
   largeTodayIr = init
-  currentDayStart = wmDay
+  currentDayStart = transitionDay
 ```
 
-### Eviction (onEviction, fires every minSmallWindowTileSize)
+### Eviction (onEviction, triggered by PT timer)
 
-1. Compute `retentionFloor` per small-window tier
+`MegaTileProcessFunction` keeps one PT eviction timer per key at the next min-hop boundary. The
+timer passes a mode-specific eviction time into `processor.onEviction`: watermark-hop time during
+active catchup, otherwise PT.
+
+1. Compute `retentionFloor` per small-window tier using the eviction time
 2. Remove tiles below floor
-3. **Rebuild `cachedSmallWindowIr`** from remaining tiles via `buildMegaTileIr(tiles, now, todayStart)`
+3. **Rebuild `cachedSmallWindowIr`** from remaining tiles via
+   `buildMegaTileIr(tiles, evictionTime, todayStart)`
    — corrects the sawtooth tail by scoping each column to its `effectiveStart`
 4. Emit updated today entry
 
@@ -204,13 +258,18 @@ unwindowed base aggregator schema (one IR slot per aggregation bucket).
 
 - **Batch staleness**: Fetcher covers every daily stream key from the batch day through query day,
   so large-window coverage remains continuous even when batch lags by multiple days.
-- **Sawtooth approximation**: Accepted for all aggregation types. Between evictions, small-window
-  columns are over-inclusive by up to one tile interval at the tail.
-- **Late events**: Up to 2 days late are handled (routed to yesterday's large-window IR).
-  Events > 2 days late are dropped for large windows (tiles may still capture them for small windows
-  if within retention).
-- **Future events**: Clamped to today for large windows. Day transitions are watermark-driven,
-  so future timestamps cannot corrupt state.
+- **Sawtooth approximation**: Accepted for all aggregation types. Between evictions, cached
+  small-window columns can be over-inclusive by up to one tile interval at the tail. Retained late
+  events outside the current `smallWindowAsOfTs` horizon do not update stale cached columns.
+- **Late events**: Flink admits events with `eventTs >= currentDayStart - 1d`. A retained late
+  event always uses `eventTs` for base tile and large-window day routing, but it updates cached
+  small-window columns only when the touched tile is inside that column's current as-of horizon.
+  Events older than yesterday relative to `currentDayStart` are dropped before mutating state.
+- **Sparse-key lag**: If a key is idle while another input keeps the global watermark stale,
+  `SparseKeyLag` uses PT for eviction. That can roll `currentDayStart` forward and later cause old
+  backlog events to be dropped as older-than-yesterday for that key.
+- **Future events**: Clamped to today for large windows. Day transitions are driven by watermark or
+  timer eviction mode, not directly by event timestamps, so future timestamps cannot corrupt state.
 
 ## Scenario Tables
 
@@ -274,13 +333,16 @@ Shared pipeline tails (BaseFlinkJob):
 
 ## Test Coverage
 
-Tests at three layers, all comparing against NaiveAggregator:
+Tests at five layers, with aggregator/codec tests comparing against NaiveAggregator:
 
-1. **MegaTileAggregatorTest** — tile building + serveMegaTile merge (6 tests)
+1. **MegaTileAggregatorTest** — tile building + serveMegaTile merge (7 tests)
 2. **MegaTileMergerTest** — per-day entry split + MegaTileMerger.merge (7 tests)
-3. **MegaTileStreamProcessorTest** — full Flink simulation with sawtooth + eviction (6 tests,
-   including multi-day watermark gap)
-4. **MegaTileCodecRoundTripTest** — serde round-trips via SerdeTileStore + key switch (4 tests)
+3. **MegaTileStreamProcessorTest** — full processor simulation with sawtooth, as-of bounded late
+   events, and eviction (9 tests)
+4. **MegaTileCodecRoundTripTest** — serde round-trips via SerdeTileStore + key switch (5 tests)
+5. **MegaTileProcessFunctionTest** — Flink keyed process-function lifecycle coverage for Live,
+   ActiveCatchup, SparseKeyLag, buffered emit jitter, timer restore, malformed rows, and UTC day
+   boundaries (22 tests)
 
 Windows tested: 6h, 1d, 47h, 2d, 49h, 3d, 7d.
 Aggregation types: SUM, COUNT, AVERAGE, MIN, MAX, LAST, FIRST.

--- a/docs/source/megatile.md
+++ b/docs/source/megatile.md
@@ -10,7 +10,8 @@ amplification and serving latency.
 
 Write **one mega tile per entity per day** to the KV store. The mega tile contains a **windowed IR**
 where each column has the correct aggregate for its specific window. This reduces KV store reads from
-O(N tiles) to 3 point gets: `(entity, today)` + `(entity, yesterday)` from stream KV + `(entity)` from batch KV.
+O(N tiles) to one batch point get plus one stream point get per daily key from query day back to
+the batch day, with one extra previous-day fallback key for no-batch columns.
 
 ## Opt-in
 
@@ -32,12 +33,14 @@ tailBuffer = 2d (default)
 Small windows (≤ tailBuffer):
   effectiveStart = now - window.millis
   Flink covers full window via tiles + sawtooth running IR.
-  Fetcher uses today's mega tile entry directly (self-contained).
+  Fetcher uses the newest available daily mega tile entry at or after yesterdayStart
+  (self-contained).
 
 Large windows (> tailBuffer) + unwindowed:
   effectiveStart = batchEnd (on fetcher side) or dayStart (on Flink side, per-day)
   Flink accumulates a daily running IR per day (today + yesterday).
-  Fetcher merges batch collapsed + tail hops + streaming daily aggregates.
+  Fetcher merges batch collapsed + tail hops + every available daily streaming aggregate from
+  the batch day through query day.
 ```
 
 ## Tier Assignment
@@ -146,26 +149,28 @@ read from different tiers and different time ranges but the same bucket index in
 
 ## Fetcher Merge (MegaTileMerger)
 
-Fetcher reads 3 entries: `(entity, today)`, `(entity, yesterday)` from stream KV + `(entity)` from batch KV.
+Fetcher reads one stream entry per daily key from query day back to the batch day, plus one extra
+previous-day fallback key for no-batch columns, and one batch entry `(entity)` from batch KV.
 
 ```
-def merge(batchIr, todayIr, yesterdayIr, todayStart, queryTs, batchEnd):
+def merge(batchIr, dailyTileIrs, queryTs, batchEnd):
   resultIr = clone(batchIr.collapsed) or init
+  batchDayStart = round(batchEnd, 1d)
+  noBatchFallbackDayStart = round(queryTs, 1d) - 1d
 
   for col in 0 until windowedAggregator.length:
     window = windowMappings(col).window
 
     if window != null and window.millis <= tailBufferMillis:   // SMALL WINDOW
-      // Self-contained in daily entry. Fall back to yesterday only if
-      // today's entire entry is absent (null array), not if column is null.
-      resultIr(col) = if todayIr != null then todayIr(col)
-                       else if yesterdayIr != null then yesterdayIr(col)
+      // Self-contained in daily entry. Use the newest non-null column value from
+      // query day or fallback day; clear stale batch values when all daily rows are absent.
+      resultIr(col) = newest dailyTileIr(col) where dayStart >= noBatchFallbackDayStart
 
     else:                                                       // LARGE WINDOW / UNWINDOWED
-      // Batch collapsed + streaming daily aggregates
-      if todayIr(col) != null: resultIr(col) = merge(resultIr(col), todayIr(col))
-      if batchEnd < todayStart and yesterdayIr(col) != null:
-        resultIr(col) = merge(resultIr(col), yesterdayIr(col))
+      // Batch collapsed + historical streaming daily aggregates, merged oldest -> newest.
+      for (dayStart, dailyIr) in dailyTileIrs if dayStart >= batchDayStart:
+        if dailyIr != null and dailyIr(col) != null:
+          resultIr(col) = merge(resultIr(col), dailyIr(col))
 
   // Tail hops for large windowed columns only (not small, not unwindowed)
   mergeTailHopsForBatchColumns(resultIr, queryTs, batchEnd, batchIr)
@@ -180,9 +185,9 @@ with `tileSizeMs = DayMillis`. Each day is a separate point-get key.
 
 - Flink emits `todayStart` (not raw `eventTs`) as the tile timestamp, so the codec always writes
   to the correct daily key even for future-timestamped events.
-- Fetcher constructs two explicit `GetRequest`s for today and yesterday using
-  `MegaTileMerger.streamingDayKeys(queryTs)`. Query time is resolved once and propagated to
-  avoid midnight-boundary inconsistency.
+- Fetcher constructs explicit `GetRequest`s for
+  `MegaTileMerger.streamingDayKeys(queryTs, batchEnd)`. Query time is resolved once and
+  propagated to avoid midnight-boundary inconsistency.
 
 ## Codec (MegaTileCodec)
 
@@ -192,12 +197,13 @@ Windowed IR (mega tile entries): `encode(ir)` / `decode(bytes)` using the window
 Base IR (individual tiles in Flink state): `encodeBaseIr(ir)` / `decodeBaseIr(bytes)` using the
 unwindowed base aggregator schema (one IR slot per aggregation bucket).
 
-AvroCodec instances are cached as `@transient lazy val` to avoid schema parsing per decode.
+`AvroCodec.of` internally uses `ThreadLocal`, so `MegaTileCodec` resolves codec instances through
+`def` accessors instead of sharing a single lazy instance across concurrent fetcher requests.
 
 ## Constraints
 
-- **Max batch staleness**: 2 days. Beyond that, large windows have a coverage gap between
-  batchEnd and yesterdayStart. Alert if batch is > 2 days stale.
+- **Batch staleness**: Fetcher covers every daily stream key from the batch day through query day,
+  so large-window coverage remains continuous even when batch lags by multiple days.
 - **Sawtooth approximation**: Accepted for all aggregation types. Between evictions, small-window
   columns are over-inclusive by up to one tile interval at the tail.
 - **Late events**: Up to 2 days late are handled (routed to yesterday's large-window IR).
@@ -231,8 +237,9 @@ All windows, tailBuffer = 2d, batchEnd = Mar 25 00:00.
 | 49h | 1hr | LARGE | — | [Mar 25 00:00, Mar 25 02:00) = 2h | [Mar 24 00:00, Mar 25 00:00) = 24h | yesterday + today + collapsed + tail |
 | 3d | 1hr | LARGE | — | [Mar 25 00:00, Mar 25 02:00) = 2h | [Mar 24 00:00, Mar 25 00:00) = 24h | yesterday + today + collapsed + tail |
 
-For large windows with stale batch (`batchEnd < todayStart`): fetcher sums yesterday + today
-to cover `[batchEnd, now)`, then merges with batch collapsed + tail hops.
+For large windows with stale batch (`batchEnd < todayStart`): fetcher sums all daily stream entries
+from `batchDayStart` through `todayStart` to cover `[batchEnd, now)`, then merges with batch
+collapsed + tail hops.
 
 ### Flink state size (max tiles per tier)
 
@@ -254,10 +261,10 @@ Flink write path:
     → AsyncKVStoreWriter
 
 Fetcher read path:
-  GroupByFetcher: 2 point-get requests (today + yesterday)
+  GroupByFetcher: daily stream point gets from query day back to batch day (+ fallback day)
     → GroupByResponseHandler.mergeMegaTilesFromStreaming
-    → MegaTileCodec.decode (today + yesterday entries)
-    → MegaTileMerger.merge (batch + today + yesterday → finalized result)
+    → MegaTileCodec.decode (daily stream entries)
+    → MegaTileMerger.merge (batch + daily stream entries → finalized result)
 
 Shared pipeline tails (BaseFlinkJob):
   buildTiledTail: keyBy → window aggregate → TiledAvroCodecFn → KV write
@@ -270,10 +277,10 @@ Shared pipeline tails (BaseFlinkJob):
 Tests at three layers, all comparing against NaiveAggregator:
 
 1. **MegaTileAggregatorTest** — tile building + serveMegaTile merge (6 tests)
-2. **MegaTileMergerTest** — per-day entry split + MegaTileMerger.merge (5 tests)
+2. **MegaTileMergerTest** — per-day entry split + MegaTileMerger.merge (7 tests)
 3. **MegaTileStreamProcessorTest** — full Flink simulation with sawtooth + eviction (6 tests,
    including multi-day watermark gap)
-4. **MegaTileCodecRoundTripTest** — serde round-trips via SerdeTileStore + key switch (3 tests)
+4. **MegaTileCodecRoundTripTest** — serde round-trips via SerdeTileStore + key switch (4 tests)
 
 Windows tested: 6h, 1d, 47h, 2d, 49h, 3d, 7d.
 Aggregation types: SUM, COUNT, AVERAGE, MIN, MAX, LAST, FIRST.

--- a/flink/package.mill
+++ b/flink/package.mill
@@ -48,6 +48,7 @@ trait FlinkModule extends Cross.Module[String] with build.BaseModule {
       mvn"org.apache.flink:flink-test-utils:$flinkVersion"
         .exclude("org.apache.logging.log4j" -> "log4j-slf4j-impl")
         .exclude("log4j" -> "log4j"),
+      mvn"org.apache.flink:flink-streaming-java:$flinkVersion;classifier=tests",
       mvn"org.apache.spark::spark-hive:${build.Constants.sparkVersion}",
       mvn"org.apache.spark::spark-core:${build.Constants.sparkVersion}"
         .exclude("com.fasterxml.jackson.core" -> "jackson-core")

--- a/flink/src/main/scala/ai/chronon/flink/FlinkGroupByStreamingJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkGroupByStreamingJob.scala
@@ -45,6 +45,10 @@ class FlinkGroupByStreamingJob(eventSrc: FlinkSource[ProjectedEvent],
     .getProperty("kv_concurrency", props, topicInfo)
     .map(_.toInt)
     .getOrElse(AsyncKVStoreWriter.kvStoreConcurrency)
+  private val bufferingOutputTimeMillis =
+    FlinkUtils.getNonNegativeLongProperty("buffering_output_time_millis", props, topicInfo)
+  private val bufferingOutputJitterMillis =
+    FlinkUtils.getNonNegativeLongProperty("buffering_output_jitter_millis", props, topicInfo)
 
   // The source of our Flink application is a  topic
   val topic: String = groupByServingInfoParsed.groupBy.streamingSource.get.topic
@@ -126,7 +130,14 @@ class FlinkGroupByStreamingJob(eventSrc: FlinkSource[ProjectedEvent],
   override def runMegaTiledGroupByJob(env: StreamExecutionEnvironment): DataStream[WriteResponse] = {
     logger.info(f"Running Mega Tiled Flink job for groupByName=${groupByName}, Topic=${topic}.")
     val preparedStream = buildSourceStream(env)
-    buildMegaTiledTail(preparedStream, inputSchema, parallelism, sinkFn, kvStoreCapacity, enableDebug)
+    buildMegaTiledTail(preparedStream,
+                       inputSchema,
+                       parallelism,
+                       sinkFn,
+                       kvStoreCapacity,
+                       enableDebug,
+                       bufferingOutputTimeMillis,
+                       bufferingOutputJitterMillis)
   }
 
   private def buildSourceStream(env: StreamExecutionEnvironment): DataStream[ProjectedEvent] = {

--- a/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
@@ -135,11 +135,18 @@ abstract class BaseFlinkJob {
       parallelism: Int,
       sinkFn: RichAsyncFunction[AvroCodecOutput, WriteResponse],
       kvStoreCapacity: Int,
-      enableDebug: Boolean
+      enableDebug: Boolean,
+      bufferingOutputTimeMillis: Long,
+      bufferingOutputJitterMillis: Long
   ): DataStream[WriteResponse] = {
     val megaTileDS = preparedStream
       .keyBy(KeySelectorBuilder.build(groupByServingInfoParsed.groupBy))
-      .process(new MegaTileProcessFunction(groupByServingInfoParsed.groupBy, schema, enableDebug))
+      .process(
+        new MegaTileProcessFunction(groupByServingInfoParsed.groupBy,
+                                    schema,
+                                    enableDebug,
+                                    bufferingOutputTimeMillis,
+                                    bufferingOutputJitterMillis))
       .uid(s"mega-tiling-$groupByName")
       .name(s"Mega Tiling for $groupByName")
       .setParallelism(parallelism)
@@ -206,6 +213,8 @@ object FlinkJob {
   // Keep windows open for a bit longer before closing to ensure we don't lose data due to late arrivals (needed in case of
   // tiling implementation)
   val AllowedOutOfOrderness: Duration = Duration.ofMinutes(5)
+
+  val CatchupWatermarkLagSlackMillis: Long = 30 * 1000L
 
   // Set an idleness timeout to keep time moving in case of very low traffic event streams as well as late events during
   // large backlog catchups

--- a/flink/src/main/scala/ai/chronon/flink/FlinkUtils.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkUtils.scala
@@ -48,6 +48,21 @@ object FlinkUtils {
       }
       .getOrElse(0L)
   }
+
+  def getNonNegativeLongProperty(key: String, props: Map[String, String], topicInfo: TopicInfo): Long = {
+    getProperty(key, props, topicInfo)
+      .map(_.trim)
+      .filter(_.nonEmpty)
+      .map { value =>
+        val parsed = Try(value.toLong).getOrElse {
+          throw new IllegalArgumentException(
+            s"FlinkUtils.getNonNegativeLongProperty: invalid $key value '$value', must be a valid integer"
+          )
+        }
+        if (parsed < 0L) 0L else parsed
+      }
+      .getOrElse(0L)
+  }
 }
 
 /** This was moved to flink-rpc-akka in Flink 1.16 and made private, so we reproduce the direct execution context here

--- a/flink/src/main/scala/ai/chronon/flink/chaining/ChainedGroupByJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/chaining/ChainedGroupByJob.scala
@@ -66,6 +66,10 @@ class ChainedGroupByJob(eventSrc: FlinkSource[ProjectedEvent],
     .getProperty("kv_concurrency", props, topicInfo)
     .map(_.toInt)
     .getOrElse(AsyncKVStoreWriter.kvStoreConcurrency)
+  private val bufferingOutputTimeMillis =
+    FlinkUtils.getNonNegativeLongProperty("buffering_output_time_millis", props, topicInfo)
+  private val bufferingOutputJitterMillis =
+    FlinkUtils.getNonNegativeLongProperty("buffering_output_jitter_millis", props, topicInfo)
 
   /** Build the tiled version of the Flink GroupBy job that chains features using a JoinSource.
     *  The operators are structured as follows:
@@ -89,7 +93,14 @@ class ChainedGroupByJob(eventSrc: FlinkSource[ProjectedEvent],
       s"Building mega tiled Flink streaming job for groupBy: $groupByName that chains join: " +
         s"${joinSource.getJoin.getMetaData.getName} using topic: $topic")
     val (processedStream, schema) = buildEnrichedStream(env)
-    buildMegaTiledTail(processedStream, schema, parallelism, sinkFn, kvStoreCapacity, enableDebug)
+    buildMegaTiledTail(processedStream,
+                       schema,
+                       parallelism,
+                       sinkFn,
+                       kvStoreCapacity,
+                       enableDebug,
+                       bufferingOutputTimeMillis,
+                       bufferingOutputJitterMillis)
   }
 
   /** Build the source → watermark → enrichment → query transform pipeline.

--- a/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
@@ -1,8 +1,8 @@
 package ai.chronon.flink.window
 
 import ai.chronon.aggregator.windowing.{MegaTileAggregator, MegaTileStreamProcessor, TileStore}
+import ai.chronon.api.ScalaJavaConversions.ListOps
 import ai.chronon.api.{Constants, DataType, GroupBy, TsUtils}
-import ai.chronon.api.ScalaJavaConversions.IteratorOps
 import ai.chronon.flink.deser.ProjectedEvent
 import ai.chronon.flink.types.TimestampedTile
 import ai.chronon.online.MegaTileCodec
@@ -112,7 +112,7 @@ class MegaTileProcessFunction(
 
   private def initializeTransients(): Unit = {
     val inputCols = inputSchema.map { case (name, dt) => (name, dt) }
-    val megaTileAgg = new MegaTileAggregator(groupBy.getAggregations.iterator().toScala.toSeq, inputCols)
+    val megaTileAgg = new MegaTileAggregator(groupBy.getAggregations.toScala.toSeq, inputCols)
     megaTileCodec = new MegaTileCodec(groupBy, inputCols)
     flinkStore = new FlinkTileStore(megaTileAgg, megaTileCodec)
     processor = new MegaTileStreamProcessor(megaTileAgg, flinkStore)
@@ -149,15 +149,10 @@ class MegaTileProcessFunction(
       val timerService = ctx.timerService()
       val watermark = timerService.currentWatermark()
       val processingTs = timerService.currentProcessingTime()
-      val dayStartBeforeAdvance = flinkStore.getCurrentDayStart
       lastEventProcessingTsState.update(processingTs)
 
       // Step 2.
-      emitTodayIfNeededThenRollDay(dayStartBeforeAdvance,
-                                   watermark,
-                                   ctx.getCurrentKey,
-                                   event.startProcessingTimeMillis,
-                                   out)
+      emitTodayIfNeededThenRollDay(watermark, ctx.getCurrentKey, event.startProcessingTimeMillis, out)
       if (isOlderThanYesterdayForCurrentDay(tsMills)) {
         scheduleEvictTimerIfNeeded(timerService, processingTs)
         emitDirtyOrSchedule(event.startProcessingTimeMillis, processingTs, timerService, out)
@@ -205,21 +200,19 @@ class MegaTileProcessFunction(
         nextEvictPtTimerState.clear()
       }
 
-      if (isEvictTimer) {
+      if (isEvictTimer && isEmitTimer) {
         // Step 7 and Step 8.
         runEvictionTimer(ctx.getCurrentKey, timestamp, processingTs, watermark, timerService, out)
-      }
-
-      if (!isEmitTimer && !isEvictTimer) {
-        return
-      }
-
-      if (isEmitTimer || !bufferingEnabled) {
-        // Step 9.
+        // Step 9: this timestamp is also the buffered emit timer, so emit once after Step 8 rebuilt state.
         emitDirtyMegaTiles(ctx.getCurrentKey, processingTs, out)
       } else if (isEvictTimer) {
+        // Step 7 and Step 8.
+        runEvictionTimer(ctx.getCurrentKey, timestamp, processingTs, watermark, timerService, out)
         // Step 9: eviction changed state; if buffering is enabled, arm one emit timer.
-        scheduleEmitTimerIfNeeded(timerService, processingTs)
+        emitDirtyOrSchedule(processingTs, processingTs, timerService, out)
+      } else if (isEmitTimer) {
+        // Step 7 and Step 9.
+        emitDirtyMegaTiles(ctx.getCurrentKey, processingTs, out)
       }
     } catch {
       case e: Exception =>
@@ -257,9 +250,8 @@ class MegaTileProcessFunction(
                                watermark: Long,
                                timerService: TimerService,
                                out: Collector[TimestampedTile]): Unit = {
-    val previousDayStart = flinkStore.getCurrentDayStart
     val evictionTime = evictionTimeForProcessingTimer(processingTs, watermark)
-    emitTodayIfNeededThenRollDay(previousDayStart, evictionTime, currentKey, processingTs, out)
+    emitTodayIfNeededThenRollDay(evictionTime, currentKey, processingTs, out)
 
     val result = processor.onEviction(evictionTime)
     markDirtyState(result.todayEntry != null, hasYesterdayUpdate = false)
@@ -273,12 +265,16 @@ class MegaTileProcessFunction(
     }
   }
 
-  /** Advance day state at `dayTransitionTs` without losing a buffered pre-rollover today row. */
-  private def emitTodayIfNeededThenRollDay(previousDayStart: Long,
-                                           dayTransitionTs: Long,
+  /** Advance day state at `dayTransitionTs` without losing a buffered pre-rollover today row.
+    *
+    * Emitting under `previousDayStart` preserves the logical daily key across rollover; `MegaTileAvroCodecFn`
+    * uses that day-start timestamp when constructing the external `TileKey`.
+    */
+  private def emitTodayIfNeededThenRollDay(dayTransitionTs: Long,
                                            keys: java.util.List[Any],
                                            processingTsMillis: Long,
                                            out: Collector[TimestampedTile]): Unit = {
+    val previousDayStart = flinkStore.getCurrentDayStart
     val nextDayStart = previousDayStart + processor.DayMillis
     val shouldEmitPreviousTodayRow =
       previousDayStart != -1L &&

--- a/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
@@ -3,7 +3,6 @@ package ai.chronon.flink.window
 import ai.chronon.aggregator.windowing.{MegaTileAggregator, MegaTileStreamProcessor, TileStore}
 import ai.chronon.api.{Constants, DataType, GroupBy, TsUtils}
 import ai.chronon.api.ScalaJavaConversions.IteratorOps
-import ai.chronon.flink.FlinkJob
 import ai.chronon.flink.deser.ProjectedEvent
 import ai.chronon.flink.types.TimestampedTile
 import ai.chronon.online.MegaTileCodec
@@ -22,19 +21,33 @@ import scala.util.Try
   * Delegates all aggregation logic to MegaTileStreamProcessor.
   * State access goes through FlinkTileStore — only touched entries are serialized/deserialized.
   *
-  * Timer strategy:
-  * - During catchup (watermark far behind wall clock): event-time timers only.
-  *   Eviction fires as watermark advances through the backlog at the correct cadence.
-  * - During live operation (watermark near wall clock): processing-time timers aligned
-  *   to hop boundaries. Fires at wall-clock intervals so idle entities get timely
-  *   sawtooth correction without waiting for the next event to advance the watermark.
-  * - Late event-time timers can coexist with processing-time timers in live mode to correct
-  *   sawtooth state after out-of-order arrivals.
+  * Step-by-step mental model in code order:
+  *
+  * Event path (`processElement`)
+  * 1. Bind the current Flink key to its private MegaTile state box, then parse the event into
+  *    `(eventTs, row)`.
+  * 2. Roll day state using the Flink watermark, not this event's timestamp. If the watermark crosses
+  *    midnight while today's row is still buffered, emit the old-day row first.
+  * 3. Drop events older than yesterday relative to `currentDayStart`; otherwise call
+  *    `processor.onEvent(row, eventTs)`. Event time chooses the small-window tile and
+  *    today/yesterday bucket that gets updated.
+  * 4. Mark `todayDirty` / `yesterdayDirty` from the processor result.
+  * 5. Keep one processing-time eviction timer per key at the next hop boundary.
+  * 6. Emit now if buffering is disabled; otherwise keep one processing-time emit timer per key.
+  *
+  * Timer path (`onTimer`)
+  * 7. Dispatch each processing-time callback into exactly one branch: evict+emit collision,
+  *    evict-only, or emit-only.
+  * 8. On an eviction timer, choose the eviction timestamp, maybe emit today's pre-rollover row,
+  *    roll day state, rebuild today's small-window state, mark dirty state, and re-arm eviction
+  *    while small-window tiles still exist.
+  * 9. On an emit timer, serialize and emit each dirty day row once, then clear its dirty bit.
   */
 class MegaTileProcessFunction(
     groupBy: GroupBy,
     inputSchema: Seq[(String, DataType)],
-    enableDebug: Boolean = false
+    enableDebug: Boolean = false,
+    bufferingOutputTimeMillis: Long = 0L
 ) extends KeyedProcessFunction[java.util.List[Any], ProjectedEvent, TimestampedTile] {
 
   @transient lazy val logger: Logger = LoggerFactory.getLogger(getClass)
@@ -57,8 +70,11 @@ class MegaTileProcessFunction(
   private var currentDayStartState: ValueState[java.lang.Long] = _
   private var earliestTileStartState: ValueState[java.lang.Long] = _
 
-  private var nextEventTimerState: ValueState[java.lang.Long] = _
-  private var nextProcessingTimerState: ValueState[java.lang.Long] = _
+  private var nextEvictPtTimerState: ValueState[java.lang.Long] = _
+  private var nextEmitPtTimerState: ValueState[java.lang.Long] = _
+  private var lastEventProcessingTsState: ValueState[java.lang.Long] = _
+  private var todayDirtyState: ValueState[java.lang.Boolean] = _
+  private var yesterdayDirtyState: ValueState[java.lang.Boolean] = _
 
   override def open(parameters: Configuration): Unit = {
     super.open(parameters)
@@ -80,10 +96,16 @@ class MegaTileProcessFunction(
       new ValueStateDescriptor[java.lang.Long]("mega-tile-day-start", classOf[java.lang.Long]))
     earliestTileStartState = getRuntimeContext.getState(
       new ValueStateDescriptor[java.lang.Long]("mega-tile-earliest-tile", classOf[java.lang.Long]))
-    nextEventTimerState = getRuntimeContext.getState(
-      new ValueStateDescriptor[java.lang.Long]("mega-tile-next-event-timer", classOf[java.lang.Long]))
-    nextProcessingTimerState = getRuntimeContext.getState(
-      new ValueStateDescriptor[java.lang.Long]("mega-tile-next-processing-timer", classOf[java.lang.Long]))
+    nextEvictPtTimerState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Long]("mega-tile-next-evict-pt-timer", classOf[java.lang.Long]))
+    nextEmitPtTimerState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Long]("mega-tile-next-emit-pt-timer", classOf[java.lang.Long]))
+    lastEventProcessingTsState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Long]("mega-tile-last-event-processing-ts", classOf[java.lang.Long]))
+    todayDirtyState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Boolean]("mega-tile-today-dirty", classOf[java.lang.Boolean]))
+    yesterdayDirtyState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Boolean]("mega-tile-yesterday-dirty", classOf[java.lang.Boolean]))
 
     initializeTransients()
   }
@@ -116,41 +138,41 @@ class MegaTileProcessFunction(
     try {
       if (processor == null) initializeTransients()
 
+      ensureStateBound(ctx.getCurrentKey)
+
       val element = event.fields
       val tsMills = Try(element(timeColumnAlias).asInstanceOf[Long])
         .getOrElse(element(timeColumnAlias).asInstanceOf[Double].toLong)
       val values: Array[Any] = valueColumns.map(element(_))
       val row = new ArrayRow(values, tsMills)
 
-      ensureStateBound(ctx.getCurrentKey)
       val timerService = ctx.timerService()
       val watermark = timerService.currentWatermark()
       val processingTs = timerService.currentProcessingTime()
+      val dayStartBeforeAdvance = flinkStore.getCurrentDayStart
+      lastEventProcessingTsState.update(processingTs)
 
-      processor.advanceWatermark(watermark)
+      // Step 2.
+      emitTodayIfNeededThenRollDay(dayStartBeforeAdvance,
+                                   watermark,
+                                   ctx.getCurrentKey,
+                                   event.startProcessingTimeMillis,
+                                   out)
+      if (isOlderThanYesterdayForCurrentDay(tsMills)) {
+        scheduleEvictTimerIfNeeded(timerService, processingTs)
+        emitDirtyOrSchedule(event.startProcessingTimeMillis, processingTs, timerService, out)
+        return
+      }
+
+      // Step 3.
       val result = processor.onEvent(row, tsMills)
+      // Step 4.
+      markDirtyState(result.todayEntry != null, result.yesterdayEntry != null)
 
-      // Emit results
-      val keys = ctx.getCurrentKey
-      if (result.todayEntry != null) {
-        out.collect(
-          new TimestampedTile(keys,
-                              megaTileCodec.encode(result.todayEntry),
-                              result.todayStart,
-                              event.startProcessingTimeMillis))
-      }
-      if (result.yesterdayEntry != null) {
-        out.collect(
-          new TimestampedTile(keys,
-                              megaTileCodec.encode(result.yesterdayEntry),
-                              result.yesterdayStart,
-                              event.startProcessingTimeMillis))
-      }
-
-      scheduleSmallWindowTimers(computeSmallWindowTimerMode(tsMills, watermark, processingTs),
-                                tsMills,
-                                processingTs,
-                                timerService)
+      // Step 5.
+      scheduleEvictTimerIfNeeded(timerService, processingTs)
+      // Step 6.
+      emitDirtyOrSchedule(event.startProcessingTimeMillis, processingTs, timerService, out)
     } catch {
       case e: Exception =>
         logger.error(s"Error processing mega tile event for groupBy=${groupBy.getMetaData.getName}", e)
@@ -167,59 +189,38 @@ class MegaTileProcessFunction(
       if (processor == null) initializeTransients()
 
       ensureStateBound(ctx.getCurrentKey)
-      val timerService = ctx.timerService()
-      val watermark = timerService.currentWatermark()
-      val processingTs = timerService.currentProcessingTime()
-      val caughtUp = isCaughtUp(watermark, processingTs)
-      clearFiredTimerState(ctx.timeDomain(), timestamp)
-
-      if (ctx.timeDomain() == TimeDomain.PROCESSING_TIME && !caughtUp) {
-        if (watermark == Long.MinValue) {
-          // Restored processing-time timers can fire before the source emits its first watermark.
-          if (hasActiveSmallWindowState) {
-            scheduleProcessingTimeTimerIfNeeded(
-              timerService,
-              TsUtils.round(processingTs, processor.minSmallWindowTileSize) + processor.minSmallWindowTileSize)
-          }
-          return
-        }
-
-        cancelProcessingTimeTimerIfPresent(timerService)
-        if (hasActiveSmallWindowState) {
-          scheduleEventTimeTimerIfNeeded(
-            timerService,
-            TsUtils.round(watermark, processor.minSmallWindowTileSize) + processor.minSmallWindowTileSize)
-        }
+      if (ctx.timeDomain() != TimeDomain.PROCESSING_TIME) {
         return
       }
 
-      val evictionTime =
-        if (ctx.timeDomain() == TimeDomain.PROCESSING_TIME) {
-          processor.advanceWatermark(timestamp)
-          timestamp
-        } else if (caughtUp) {
-          // Late event-time timers in live mode should rebuild at wall clock, not stale event time.
-          processor.advanceWatermark(processingTs)
-          processingTs
-        } else {
-          processor.advanceWatermark(watermark)
-          timestamp
-        }
-
-      val result = processor.onEviction(evictionTime)
-
-      if (result.todayEntry != null) {
-        out.collect(
-          new TimestampedTile(ctx.getCurrentKey,
-                              megaTileCodec.encode(result.todayEntry),
-                              result.todayStart,
-                              System.currentTimeMillis()))
+      val timerService = ctx.timerService()
+      val processingTs = timerService.currentProcessingTime()
+      val watermark = timerService.currentWatermark()
+      val isEmitTimer = isCurrentEmitTimer(timestamp)
+      val isEvictTimer = isCurrentEvictTimer(timestamp)
+      if (isEmitTimer) {
+        nextEmitPtTimerState.clear()
+      }
+      if (isEvictTimer) {
+        nextEvictPtTimerState.clear()
       }
 
-      scheduleSmallWindowTimers(computeSmallWindowTimerMode(evictionTime, watermark, processingTs),
-                                evictionTime,
-                                processingTs,
-                                timerService)
+      if (isEvictTimer) {
+        // Step 7 and Step 8.
+        runEvictionTimer(ctx.getCurrentKey, timestamp, processingTs, watermark, timerService, out)
+      }
+
+      if (!isEmitTimer && !isEvictTimer) {
+        return
+      }
+
+      if (isEmitTimer || !bufferingEnabled) {
+        // Step 9.
+        emitDirtyMegaTiles(ctx.getCurrentKey, processingTs, out)
+      } else if (isEvictTimer) {
+        // Step 9: eviction changed state; if buffering is enabled, arm one emit timer.
+        scheduleEmitTimerIfNeeded(timerService, processingTs)
+      }
     } catch {
       case e: Exception =>
         logger.error(s"Error in mega tile eviction for groupBy=${groupBy.getMetaData.getName}", e)
@@ -231,116 +232,162 @@ class MegaTileProcessFunction(
     processor.hasSmallWindows &&
       Option(earliestTileStartState.value()).exists(_.longValue() != Long.MaxValue)
 
-  // Treat watermark within ~2x allowed out-of-orderness of wall clock as caught up.
-  private val CatchupThresholdMillis: Long =
-    2 * FlinkJob.AllowedOutOfOrderness.toMillis
+  private def isOlderThanYesterdayForCurrentDay(eventTs: Long): Boolean = {
+    val currentDayStart = flinkStore.getCurrentDayStart
+    currentDayStart != -1L && eventTs < currentDayStart - processor.DayMillis
+  }
 
-  private def isCaughtUp(watermark: Long, processingTs: Long): Boolean =
-    watermark > 0 && (processingTs - watermark) <= CatchupThresholdMillis
+  private def bufferingEnabled: Boolean =
+    bufferingOutputTimeMillis > 0L
 
-  private def computeSmallWindowTimerMode(
-      eventTs: Long,
-      watermark: Long,
-      processingTs: Long): SmallWindowTimerMode = {
-    if (!hasActiveSmallWindowState) {
-      SmallWindowTimerMode.NoSmallState
-    } else if (!isCaughtUp(watermark, processingTs)) {
-      SmallWindowTimerMode.CatchupEventTimeOnly
-    } else if (eventTs < processingTs - processor.minSmallWindowTileSize) {
-      SmallWindowTimerMode.LiveProcessingTimeAndLateEventTime
+  private def isTodayDirty: Boolean =
+    Option(todayDirtyState.value()).exists(_.booleanValue())
+
+  private def isYesterdayDirty: Boolean =
+    Option(yesterdayDirtyState.value()).exists(_.booleanValue())
+
+  private def markDirtyState(hasTodayUpdate: Boolean, hasYesterdayUpdate: Boolean): Unit = {
+    if (hasTodayUpdate) todayDirtyState.update(java.lang.Boolean.TRUE)
+    if (hasYesterdayUpdate) yesterdayDirtyState.update(java.lang.Boolean.TRUE)
+  }
+
+  private def runEvictionTimer(currentKey: java.util.List[Any],
+                               timestamp: Long,
+                               processingTs: Long,
+                               watermark: Long,
+                               timerService: TimerService,
+                               out: Collector[TimestampedTile]): Unit = {
+    val previousDayStart = flinkStore.getCurrentDayStart
+    val evictionTime = evictionTimeForProcessingTimer(processingTs, watermark)
+    emitTodayIfNeededThenRollDay(previousDayStart, evictionTime, currentKey, processingTs, out)
+
+    val result = processor.onEviction(evictionTime)
+    markDirtyState(result.todayEntry != null, hasYesterdayUpdate = false)
+    scheduleEvictTimerIfNeeded(timerService, processingTs)
+
+    if (enableDebug) {
+      logger.info(s"MegaTile eviction groupBy=${groupBy.getMetaData.getName}, key=$currentKey, " +
+        s"timerTs=$timestamp, evictionTime=$evictionTime, " +
+        s"watermark=$watermark, processingTs=$processingTs, dayStart=${flinkStore.getCurrentDayStart}, " +
+        s"todayDirty=$isTodayDirty, yesterdayDirty=$isYesterdayDirty")
+    }
+  }
+
+  /** Advance day state at `dayTransitionTs` without losing a buffered pre-rollover today row. */
+  private def emitTodayIfNeededThenRollDay(previousDayStart: Long,
+                                           dayTransitionTs: Long,
+                                           keys: java.util.List[Any],
+                                           processingTsMillis: Long,
+                                           out: Collector[TimestampedTile]): Unit = {
+    val nextDayStart = previousDayStart + processor.DayMillis
+    val shouldEmitPreviousTodayRow =
+      previousDayStart != -1L &&
+        isTodayDirty &&
+        TsUtils.round(dayTransitionTs, processor.DayMillis) == nextDayStart
+    if (shouldEmitPreviousTodayRow) {
+      emitMegaTileIfPresent(keys, processor.packTodayEntry(), previousDayStart, processingTsMillis, out)
+      todayDirtyState.clear()
+    }
+
+    processor.advanceWatermark(dayTransitionTs)
+  }
+
+  private def evictionTimeForProcessingTimer(processingTs: Long, watermark: Long): Long = {
+    val lastEventProcessingTs =
+      Option(lastEventProcessingTsState.value()).map(_.longValue()).getOrElse(Long.MinValue)
+    val backlogIsActive =
+      watermark > Long.MinValue &&
+        processingTs - watermark > processor.minSmallWindowTileSize &&
+        lastEventProcessingTs != Long.MinValue &&
+        processingTs - lastEventProcessingTs <= processor.minSmallWindowTileSize
+    if (backlogIsActive) {
+      TsUtils.round(watermark, processor.minSmallWindowTileSize) + processor.minSmallWindowTileSize
     } else {
-      SmallWindowTimerMode.LiveProcessingTimeOnly
+      processingTs
     }
   }
 
-  private def scheduleSmallWindowTimers(mode: SmallWindowTimerMode,
-                                        eventTs: Long,
-                                        processingTs: Long,
-                                        timerService: TimerService): Unit = {
-    mode match {
-      case SmallWindowTimerMode.NoSmallState =>
-        cancelEventTimeTimerIfPresent(timerService)
-        cancelProcessingTimeTimerIfPresent(timerService)
-
-      case SmallWindowTimerMode.CatchupEventTimeOnly =>
-        cancelProcessingTimeTimerIfPresent(timerService)
-        scheduleEventTimeTimerIfNeeded(
-          timerService,
-          TsUtils.round(eventTs, processor.minSmallWindowTileSize) + processor.minSmallWindowTileSize)
-
-      case SmallWindowTimerMode.LiveProcessingTimeOnly =>
-        cancelEventTimeTimerIfPresent(timerService)
-        scheduleProcessingTimeTimerIfNeeded(
-          timerService,
-          TsUtils.round(processingTs, processor.minSmallWindowTileSize) + processor.minSmallWindowTileSize)
-
-      case SmallWindowTimerMode.LiveProcessingTimeAndLateEventTime =>
-        scheduleProcessingTimeTimerIfNeeded(
-          timerService,
-          TsUtils.round(processingTs, processor.minSmallWindowTileSize) + processor.minSmallWindowTileSize)
-        scheduleEventTimeTimerIfNeeded(
-          timerService,
-          TsUtils.round(eventTs, processor.minSmallWindowTileSize) + processor.minSmallWindowTileSize)
+  private def scheduleEvictTimerIfNeeded(timerService: TimerService, processingTs: Long): Unit = {
+    if (!hasActiveSmallWindowState) {
+      cancelEvictTimerIfPresent(timerService)
+      return
     }
+
+    val current = nextEvictPtTimerState.value()
+    if (current != null) return
+
+    val timestamp =
+      TsUtils.round(processingTs, processor.minSmallWindowTileSize) + processor.minSmallWindowTileSize
+    timerService.registerProcessingTimeTimer(timestamp)
+    nextEvictPtTimerState.update(timestamp)
   }
 
-  private def scheduleEventTimeTimerIfNeeded(timerService: TimerService, timestamp: Long): Unit = {
-    val current = nextEventTimerState.value()
-    if (current == null || timestamp < current.longValue()) {
-      if (current != null) timerService.deleteEventTimeTimer(current.longValue())
-      timerService.registerEventTimeTimer(timestamp)
-      nextEventTimerState.update(timestamp)
+  private def emitDirtyOrSchedule(outputProcessingTsMillis: Long,
+                                  processingTs: Long,
+                                  timerService: TimerService,
+                                  out: Collector[TimestampedTile]): Unit = {
+    if (!bufferingEnabled) {
+      emitDirtyMegaTiles(lastKey, outputProcessingTsMillis, out)
+      return
     }
+    scheduleEmitTimerIfNeeded(timerService, processingTs)
   }
 
-  private def scheduleProcessingTimeTimerIfNeeded(timerService: TimerService, timestamp: Long): Unit = {
-    val current = nextProcessingTimerState.value()
-    if (current == null || timestamp < current.longValue()) {
-      if (current != null) timerService.deleteProcessingTimeTimer(current.longValue())
+  private def scheduleEmitTimerIfNeeded(timerService: TimerService, processingTs: Long): Unit = {
+    if (!isTodayDirty && !isYesterdayDirty) return
+
+    val current = nextEmitPtTimerState.value()
+    if (current == null) {
+      val timestamp = processingTs + bufferingOutputTimeMillis
       timerService.registerProcessingTimeTimer(timestamp)
-      nextProcessingTimerState.update(timestamp)
+      nextEmitPtTimerState.update(timestamp)
     }
   }
 
-  private def cancelEventTimeTimerIfPresent(timerService: TimerService): Unit = {
-    val current = nextEventTimerState.value()
-    if (current != null) {
-      timerService.deleteEventTimeTimer(current.longValue())
-      nextEventTimerState.clear()
-    }
-  }
-
-  private def cancelProcessingTimeTimerIfPresent(timerService: TimerService): Unit = {
-    val current = nextProcessingTimerState.value()
+  private def cancelEvictTimerIfPresent(timerService: TimerService): Unit = {
+    val current = nextEvictPtTimerState.value()
     if (current != null) {
       timerService.deleteProcessingTimeTimer(current.longValue())
-      nextProcessingTimerState.clear()
+      nextEvictPtTimerState.clear()
     }
   }
 
-  private def clearFiredTimerState(timeDomain: TimeDomain, timestamp: Long): Unit = {
-    timeDomain match {
-      case TimeDomain.EVENT_TIME =>
-        val current = nextEventTimerState.value()
-        if (current != null && current.longValue() == timestamp) {
-          nextEventTimerState.clear()
-        }
-      case TimeDomain.PROCESSING_TIME =>
-        val current = nextProcessingTimerState.value()
-        if (current != null && current.longValue() == timestamp) {
-          nextProcessingTimerState.clear()
-        }
+  private def isCurrentEmitTimer(timestamp: Long): Boolean = {
+    val current = nextEmitPtTimerState.value()
+    current != null && current.longValue() == timestamp
+  }
+
+  private def isCurrentEvictTimer(timestamp: Long): Boolean = {
+    val current = nextEvictPtTimerState.value()
+    current != null && current.longValue() == timestamp
+  }
+
+  private def emitDirtyMegaTiles(keys: java.util.List[Any],
+                                 processingTsMillis: Long,
+                                 out: Collector[TimestampedTile]): Unit = {
+    val currentDayStart = flinkStore.getCurrentDayStart
+    if (isTodayDirty) {
+      emitMegaTileIfPresent(keys, processor.packTodayEntry(), currentDayStart, processingTsMillis, out)
+      todayDirtyState.clear()
+    }
+    if (isYesterdayDirty) {
+      emitMegaTileIfPresent(keys,
+                            processor.packYesterdayEntry(),
+                            currentDayStart - processor.DayMillis,
+                            processingTsMillis,
+                            out)
+      yesterdayDirtyState.clear()
     }
   }
-}
 
-sealed private trait SmallWindowTimerMode
-
-private object SmallWindowTimerMode {
-  case object NoSmallState extends SmallWindowTimerMode
-  case object CatchupEventTimeOnly extends SmallWindowTimerMode
-  case object LiveProcessingTimeOnly extends SmallWindowTimerMode
-  case object LiveProcessingTimeAndLateEventTime extends SmallWindowTimerMode
+  private def emitMegaTileIfPresent(keys: java.util.List[Any],
+                                    entry: Array[Any],
+                                    dayStartMillis: Long,
+                                    processingTsMillis: Long,
+                                    out: Collector[TimestampedTile]): Unit = {
+    if (entry == null) return
+    out.collect(new TimestampedTile(keys, megaTileCodec.encode(entry), dayStartMillis, processingTsMillis))
+  }
 }
 
 /** TileStore backed by Flink's keyed MapState/ValueState.

--- a/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
@@ -231,11 +231,12 @@ class MegaTileProcessFunction(
     processor.hasSmallWindows &&
       Option(earliestTileStartState.value()).exists(_.longValue() != Long.MaxValue)
 
-  private def catchupThresholdMillis: Long =
-    FlinkJob.AllowedOutOfOrderness.toMillis + processor.minSmallWindowTileSize
+  // Treat watermark within ~2x allowed out-of-orderness of wall clock as caught up.
+  private val CatchupThresholdMillis: Long =
+    2 * FlinkJob.AllowedOutOfOrderness.toMillis
 
   private def isCaughtUp(watermark: Long, processingTs: Long): Boolean =
-    watermark > 0 && (processingTs - watermark) <= catchupThresholdMillis
+    watermark > 0 && (processingTs - watermark) <= CatchupThresholdMillis
 
   private def computeSmallWindowTimerMode(
       eventTs: Long,

--- a/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
@@ -3,6 +3,7 @@ package ai.chronon.flink.window
 import ai.chronon.aggregator.windowing.{MegaTileAggregator, MegaTileStreamProcessor, TileStore}
 import ai.chronon.api.{Constants, DataType, GroupBy, TsUtils}
 import ai.chronon.api.ScalaJavaConversions.IteratorOps
+import ai.chronon.flink.FlinkJob
 import ai.chronon.flink.deser.ProjectedEvent
 import ai.chronon.flink.types.TimestampedTile
 import ai.chronon.online.MegaTileCodec
@@ -10,7 +11,7 @@ import ai.chronon.online.serde.ArrayRow
 import org.apache.flink.api.common.state.{MapState, MapStateDescriptor, ValueState, ValueStateDescriptor}
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.metrics.Counter
-import org.apache.flink.streaming.api.TimeDomain
+import org.apache.flink.streaming.api.{TimeDomain, TimerService}
 import org.apache.flink.streaming.api.functions.KeyedProcessFunction
 import org.apache.flink.util.Collector
 import org.slf4j.{Logger, LoggerFactory}
@@ -27,7 +28,8 @@ import scala.util.Try
   * - During live operation (watermark near wall clock): processing-time timers aligned
   *   to hop boundaries. Fires at wall-clock intervals so idle entities get timely
   *   sawtooth correction without waiting for the next event to advance the watermark.
-  * - Transition is one-way: catchup → live. Once caught up, stays in live mode.
+  * - Late event-time timers can coexist with processing-time timers in live mode to correct
+  *   sawtooth state after out-of-order arrivals.
   */
 class MegaTileProcessFunction(
     groupBy: GroupBy,
@@ -55,15 +57,8 @@ class MegaTileProcessFunction(
   private var currentDayStartState: ValueState[java.lang.Long] = _
   private var earliestTileStartState: ValueState[java.lang.Long] = _
 
-  // Tracks whether this entity has a processing-time timer registered.
-  // Not persisted — after checkpoint restore, first event re-registers.
-  @transient private var hasProcessingTimeTimer: Boolean = false
-
-  // Once true, stays true for the lifetime of this subtask.
-  @transient private var isLive: Boolean = false
-
-  // Threshold: watermark within 2× the allowed lateness of wall clock → caught up.
-  private val CatchupThresholdMillis: Long = 2 * 60 * 1000L // 2 minutes
+  private var nextEventTimerState: ValueState[java.lang.Long] = _
+  private var nextProcessingTimerState: ValueState[java.lang.Long] = _
 
   override def open(parameters: Configuration): Unit = {
     super.open(parameters)
@@ -85,6 +80,10 @@ class MegaTileProcessFunction(
       new ValueStateDescriptor[java.lang.Long]("mega-tile-day-start", classOf[java.lang.Long]))
     earliestTileStartState = getRuntimeContext.getState(
       new ValueStateDescriptor[java.lang.Long]("mega-tile-earliest-tile", classOf[java.lang.Long]))
+    nextEventTimerState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Long]("mega-tile-next-event-timer", classOf[java.lang.Long]))
+    nextProcessingTimerState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Long]("mega-tile-next-processing-timer", classOf[java.lang.Long]))
 
     initializeTransients()
   }
@@ -109,9 +108,6 @@ class MegaTileProcessFunction(
     }
   }
 
-  private def isCaughtUp(watermark: Long, procNow: Long): Boolean =
-    watermark > 0 && (procNow - watermark) <= CatchupThresholdMillis
-
   override def processElement(
       event: ProjectedEvent,
       ctx: KeyedProcessFunction[java.util.List[Any], ProjectedEvent, TimestampedTile]#Context,
@@ -127,7 +123,11 @@ class MegaTileProcessFunction(
       val row = new ArrayRow(values, tsMills)
 
       ensureStateBound(ctx.getCurrentKey)
-      processor.advanceWatermark(ctx.timerService().currentWatermark())
+      val timerService = ctx.timerService()
+      val watermark = timerService.currentWatermark()
+      val processingTs = timerService.currentProcessingTime()
+
+      processor.advanceWatermark(watermark)
       val result = processor.onEvent(row, tsMills)
 
       // Emit results
@@ -147,31 +147,10 @@ class MegaTileProcessFunction(
                               event.startProcessingTimeMillis))
       }
 
-      // Schedule eviction timer if small windows exist
-      if (processor.hasSmallWindows) {
-        val hopSize = processor.minSmallWindowTileSize
-        val watermark = ctx.timerService().currentWatermark()
-        val procNow = ctx.timerService().currentProcessingTime()
-
-        if (!isLive && isCaughtUp(watermark, procNow)) {
-          isLive = true
-          if (enableDebug) logger.info(s"Transitioning to live mode: watermark=$watermark procNow=$procNow")
-        }
-
-        if (isLive) {
-          // Live: processing-time timer aligned to hop boundary from wall clock.
-          // Fires at wall-clock intervals so idle entities get timely sawtooth correction.
-          if (!hasProcessingTimeTimer) {
-            val nextEviction = TsUtils.round(procNow, hopSize) + hopSize
-            ctx.timerService().registerProcessingTimeTimer(nextEviction)
-            hasProcessingTimeTimer = true
-          }
-        } else {
-          // Catchup: event-time timer. Fires as watermark advances through the backlog.
-          val nextEviction = TsUtils.round(tsMills, hopSize) + hopSize
-          ctx.timerService().registerEventTimeTimer(nextEviction)
-        }
-      }
+      scheduleSmallWindowTimers(computeSmallWindowTimerMode(tsMills, watermark, processingTs),
+                                tsMills,
+                                processingTs,
+                                timerService)
     } catch {
       case e: Exception =>
         logger.error(s"Error processing mega tile event for groupBy=${groupBy.getMetaData.getName}", e)
@@ -188,12 +167,46 @@ class MegaTileProcessFunction(
       if (processor == null) initializeTransients()
 
       ensureStateBound(ctx.getCurrentKey)
-      processor.advanceWatermark(ctx.timerService().currentWatermark())
+      val timerService = ctx.timerService()
+      val watermark = timerService.currentWatermark()
+      val processingTs = timerService.currentProcessingTime()
+      val caughtUp = isCaughtUp(watermark, processingTs)
+      clearFiredTimerState(ctx.timeDomain(), timestamp)
 
-      // Both event-time and processing-time timers run the same eviction logic.
-      // The timerTs is the eviction point — either the event-time boundary (catchup)
-      // or the wall-clock boundary (live).
-      val result = processor.onEviction(timestamp)
+      if (ctx.timeDomain() == TimeDomain.PROCESSING_TIME && !caughtUp) {
+        if (watermark == Long.MinValue) {
+          // Restored processing-time timers can fire before the source emits its first watermark.
+          if (hasActiveSmallWindowState) {
+            scheduleProcessingTimeTimerIfNeeded(
+              timerService,
+              TsUtils.round(processingTs, processor.minSmallWindowTileSize) + processor.minSmallWindowTileSize)
+          }
+          return
+        }
+
+        cancelProcessingTimeTimerIfPresent(timerService)
+        if (hasActiveSmallWindowState) {
+          scheduleEventTimeTimerIfNeeded(
+            timerService,
+            TsUtils.round(watermark, processor.minSmallWindowTileSize) + processor.minSmallWindowTileSize)
+        }
+        return
+      }
+
+      val evictionTime =
+        if (ctx.timeDomain() == TimeDomain.PROCESSING_TIME) {
+          processor.advanceWatermark(timestamp)
+          timestamp
+        } else if (caughtUp) {
+          // Late event-time timers in live mode should rebuild at wall clock, not stale event time.
+          processor.advanceWatermark(processingTs)
+          processingTs
+        } else {
+          processor.advanceWatermark(watermark)
+          timestamp
+        }
+
+      val result = processor.onEviction(evictionTime)
 
       if (result.todayEntry != null) {
         out.collect(
@@ -203,24 +216,130 @@ class MegaTileProcessFunction(
                               System.currentTimeMillis()))
       }
 
-      // Re-register the next timer
-      if (processor.hasSmallWindows) {
-        val hopSize = processor.minSmallWindowTileSize
-        if (ctx.timeDomain() == TimeDomain.PROCESSING_TIME) {
-          // Live mode: re-register next processing-time timer at next hop boundary
-          val nextEviction = TsUtils.round(timestamp, hopSize) + hopSize
-          ctx.timerService().registerProcessingTimeTimer(nextEviction)
-        } else {
-          // Catchup mode: re-register next event-time timer
-          ctx.timerService().registerEventTimeTimer(timestamp + hopSize)
-        }
-      }
+      scheduleSmallWindowTimers(computeSmallWindowTimerMode(evictionTime, watermark, processingTs),
+                                evictionTime,
+                                processingTs,
+                                timerService)
     } catch {
       case e: Exception =>
         logger.error(s"Error in mega tile eviction for groupBy=${groupBy.getMetaData.getName}", e)
         eventProcessingErrorCounter.inc()
     }
   }
+
+  private def hasActiveSmallWindowState: Boolean =
+    processor.hasSmallWindows &&
+      Option(earliestTileStartState.value()).exists(_.longValue() != Long.MaxValue)
+
+  private def catchupThresholdMillis: Long =
+    FlinkJob.AllowedOutOfOrderness.toMillis + processor.minSmallWindowTileSize
+
+  private def isCaughtUp(watermark: Long, processingTs: Long): Boolean =
+    watermark > 0 && (processingTs - watermark) <= catchupThresholdMillis
+
+  private def computeSmallWindowTimerMode(
+      eventTs: Long,
+      watermark: Long,
+      processingTs: Long): SmallWindowTimerMode = {
+    if (!hasActiveSmallWindowState) {
+      SmallWindowTimerMode.NoSmallState
+    } else if (!isCaughtUp(watermark, processingTs)) {
+      SmallWindowTimerMode.CatchupEventTimeOnly
+    } else if (eventTs < processingTs - processor.minSmallWindowTileSize) {
+      SmallWindowTimerMode.LiveProcessingTimeAndLateEventTime
+    } else {
+      SmallWindowTimerMode.LiveProcessingTimeOnly
+    }
+  }
+
+  private def scheduleSmallWindowTimers(mode: SmallWindowTimerMode,
+                                        eventTs: Long,
+                                        processingTs: Long,
+                                        timerService: TimerService): Unit = {
+    mode match {
+      case SmallWindowTimerMode.NoSmallState =>
+        cancelEventTimeTimerIfPresent(timerService)
+        cancelProcessingTimeTimerIfPresent(timerService)
+
+      case SmallWindowTimerMode.CatchupEventTimeOnly =>
+        cancelProcessingTimeTimerIfPresent(timerService)
+        scheduleEventTimeTimerIfNeeded(
+          timerService,
+          TsUtils.round(eventTs, processor.minSmallWindowTileSize) + processor.minSmallWindowTileSize)
+
+      case SmallWindowTimerMode.LiveProcessingTimeOnly =>
+        cancelEventTimeTimerIfPresent(timerService)
+        scheduleProcessingTimeTimerIfNeeded(
+          timerService,
+          TsUtils.round(processingTs, processor.minSmallWindowTileSize) + processor.minSmallWindowTileSize)
+
+      case SmallWindowTimerMode.LiveProcessingTimeAndLateEventTime =>
+        scheduleProcessingTimeTimerIfNeeded(
+          timerService,
+          TsUtils.round(processingTs, processor.minSmallWindowTileSize) + processor.minSmallWindowTileSize)
+        scheduleEventTimeTimerIfNeeded(
+          timerService,
+          TsUtils.round(eventTs, processor.minSmallWindowTileSize) + processor.minSmallWindowTileSize)
+    }
+  }
+
+  private def scheduleEventTimeTimerIfNeeded(timerService: TimerService, timestamp: Long): Unit = {
+    val current = nextEventTimerState.value()
+    if (current == null || timestamp < current.longValue()) {
+      if (current != null) timerService.deleteEventTimeTimer(current.longValue())
+      timerService.registerEventTimeTimer(timestamp)
+      nextEventTimerState.update(timestamp)
+    }
+  }
+
+  private def scheduleProcessingTimeTimerIfNeeded(timerService: TimerService, timestamp: Long): Unit = {
+    val current = nextProcessingTimerState.value()
+    if (current == null || timestamp < current.longValue()) {
+      if (current != null) timerService.deleteProcessingTimeTimer(current.longValue())
+      timerService.registerProcessingTimeTimer(timestamp)
+      nextProcessingTimerState.update(timestamp)
+    }
+  }
+
+  private def cancelEventTimeTimerIfPresent(timerService: TimerService): Unit = {
+    val current = nextEventTimerState.value()
+    if (current != null) {
+      timerService.deleteEventTimeTimer(current.longValue())
+      nextEventTimerState.clear()
+    }
+  }
+
+  private def cancelProcessingTimeTimerIfPresent(timerService: TimerService): Unit = {
+    val current = nextProcessingTimerState.value()
+    if (current != null) {
+      timerService.deleteProcessingTimeTimer(current.longValue())
+      nextProcessingTimerState.clear()
+    }
+  }
+
+  private def clearFiredTimerState(timeDomain: TimeDomain, timestamp: Long): Unit = {
+    timeDomain match {
+      case TimeDomain.EVENT_TIME =>
+        val current = nextEventTimerState.value()
+        if (current != null && current.longValue() == timestamp) {
+          nextEventTimerState.clear()
+        }
+      case TimeDomain.PROCESSING_TIME =>
+        val current = nextProcessingTimerState.value()
+        if (current != null && current.longValue() == timestamp) {
+          nextProcessingTimerState.clear()
+        }
+    }
+  }
+}
+
+sealed private trait SmallWindowTimerMode
+
+private object SmallWindowTimerMode {
+  case object NoSmallState extends SmallWindowTimerMode
+  case object CatchupEventTimeOnly extends SmallWindowTimerMode
+  case object LiveProcessingTimeOnly extends SmallWindowTimerMode
+  case object LiveProcessingTimeAndLateEventTime extends SmallWindowTimerMode
 }
 
 /** TileStore backed by Flink's keyed MapState/ValueState.

--- a/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
@@ -20,54 +20,104 @@ import scala.util.Try
 
 /** Flink KeyedProcessFunction that maintains per-entity mega tile state.
   * Delegates all aggregation logic to MegaTileStreamProcessor.
-  * State access goes through FlinkTileStore — only touched entries are serialized/deserialized.
+  * State access goes through FlinkTileStore - only touched entries are serialized/deserialized.
+  *
+  * Mental model:
+  *
+  * There are two clocks in this operator:
+  *   - event time/watermark: where Flink believes the stream has progressed in event time.
+  *   - processing time (PT): wall clock in the Flink task.
+  *
+  * There are two primary operating modes:
+  *   - Live: watermark is close enough to PT. The small-window cache and eviction use PT as the
+  *     as-of time, matching vanilla tiled serving where reads enumerate tiles for wall-clock query
+  *     time.
+  *   - ActiveCatchup: watermark is far behind PT for an active key, often because replay is lagged
+  *     or allowed out-of-orderness is intentionally high. Event time is then decoupled from wall
+  *     clock, so event-path cache updates and timer-path eviction both use
+  *     nextSmallWindowHop(watermark) instead of PT. This avoids aging out replay tiles that are
+  *     still current relative to the event-time frontier.
+  *
+  * Important details that are easy to mix up:
+  *   - `processor.onEvent(row, eventTs, smallWindowAsOfTs)` receives `eventTs` separately so the
+  *     processor can choose the retained tile/day that the input row mutates. Mode does not choose
+  *     that tile; it chooses the as-of timestamp for cache and eviction behavior.
+  *   - `smallWindowAsOfTs` is the event-path timestamp for deciding whether the touched tile
+  *     contributes to the cached small-window IR. The small-window cache is the Flink
+  *     implementation of Chronon's no-batch windows.
+  *   - `evictionTime` is the timer-path timestamp for making state accurate as of that point: it
+  *     can roll day state, permanently drop expired retained tiles, and rebuild cached
+  *     small-window IR.
+  *   - `NoWatermark` is startup/bootstrap behavior: the event path uses the row's event hop, while
+  *     timer callbacks use PT because there is no watermark clock to trust yet.
+  *   - `SparseKeyLag` is the idle-key fallback: the global watermark may lag because of other
+  *     input, but this key is not actively replaying, so timer callbacks use PT and values decay or
+  *     roll forward with wall clock.
+  *   - Output buffering is write coalescing only. It uses PT timers to avoid emitting on every
+  *     event or eviction; it does not change event-time mutation or as-of selection.
   *
   * Step-by-step mental model in code order:
   *
   * Event path (`processElement`)
-  * 1. Bind the current Flink key to its private MegaTile state box, then parse the event into
-  *    `(eventTs, row)`.
+  * 1. Bind the current Flink key to its private MegaTile state box, then parse the projected event
+  *    into `(eventTs, row)`.
   *    - Example: `List("user_123")` and `List("user_456")` each have separate tiles, day state,
   *      dirty bits, and timers. An event with `ts = 11:03:17` becomes one row applied only to that
   *      key's state.
   *
-  * 2. Roll day state using the Flink watermark, not this event's timestamp. If the watermark crosses
-  *    midnight while today's row is still buffered, emit the old-day row first.
-  *    - Why watermark: if one bad/future event arrives with `eventTs = tomorrow 00:01` and day state
-  *      rotated from that event timestamp, later valid `today 23:50` events could be misclassified
-  *      into yesterday or dropped. The watermark means Flink believes the stream as a whole has
-  *      progressed past that event-time point.
+  * 2. Roll day state using the Flink watermark, not this event's timestamp or processing time (PT).
+  *    If the watermark crosses midnight while today's row is still buffered, emit the old-day row
+  *    first.
+  *    - Why watermark: if one bad/future event arrives with `eventTs = tomorrow 00:01` and we
+  *      rotated day state from that event timestamp, then later valid events from `today 23:50`
+  *      would get misclassified into yesterday or dropped. The watermark means the stream has
+  *      progressed past this event-time point, so day rollover only happens when Flink believes the
+  *      whole stream is safely past midnight.
+  *    - Where the watermark comes from: `FlinkJob.watermarkStrategy` assigns event timestamps and
+  *      builds a bounded-out-of-orderness watermark. Each operator subtask sees the minimum
+  *      watermark over its active partitions/input channels, so one input that is still behind can
+  *      hold the watermark back.
   *
   * 3. Drop events older than yesterday relative to `currentDayStart`; otherwise call
-  *    `processor.onEvent(row, eventTs, smallWindowAsOfTs)`. Event time chooses the retained tile
-  *    and today/yesterday bucket; smallWindowAsOfTs bounds the cached no-batch small-window row.
+  *    `processor.onEvent(row, eventTs, smallWindowAsOfTs)`. The processor uses `eventTs` for the
+  *    base tile and today/yesterday bucket; `smallWindowAsOfTs` is the as-of timestamp for the
+  *    cached small-window IR.
   *    - Example: with `currentDayStart = Apr 2 00:00`, `Apr 2 11:03` updates today's 11:00-11:05
   *      tile, `Apr 1 23:59` updates yesterday's large-window bucket, and `Mar 31 23:59` is dropped.
   *
   * 4. Mark `todayDirty` / `yesterdayDirty` from the processor result.
-  *    - Why: state mutation and KV writes are decoupled. Dirty bits track which day rows still need
-  *      to be published.
+  *    - Why: state mutation and downstream writes are decoupled. Dirty bits remember which day rows
+  *      need to be published later.
   *
-  * 5. Keep one processing-time eviction timer per key at the next hop boundary.
-  *    - Eviction's job is correctness of in-memory state: drop expired small-window tiles, rebuild
-  *      the sawtooth IR, and mark today's row dirty if the rebuilt row changed.
+  * 5. Keep one PT eviction timer per key at the next hop boundary.
+  *    - Eviction's job is correctness of the in-memory state: drop expired 5-minute tiles, rebuild
+  *      the small-window sawtooth IR, and mark today's row dirty if the rebuilt row changed.
+  *    - Example: an 11:03 event lands in the 11:00-11:05 tile; the 11:05 eviction timer rebuilds
+  *      the 1h value from retained 5-minute tiles so old tiles eventually fall out and values decay.
   *
-  * 6. Emit now if buffering is disabled; otherwise keep one processing-time emit timer per key.
-  *    - Emission's job is write coalescing only. The first dirty update arms the timer; later
-  *      updates only flip dirty bits so hot keys do not emit once per event.
+  * 6. Emit immediately if buffering is disabled; otherwise keep one PT emit timer per key.
+  *    - Emission's job is write coalescing only: if today/yesterday is dirty, serialize the current
+  *      row and write it downstream. The first dirty update arms the timer; later updates only set
+  *      dirty bits so hot keys do not emit once per event.
+  *    - Example: with `bufferingOutputTimeMillis = 1000`, 100 events in one second produce one emit
+  *      at `processingTs + 1s + stable key jitter`, not 100 downstream writes.
   *
   * Timer path (`onTimer`)
-  * 7. Dispatch each processing-time callback into exactly one branch: evict+emit collision,
-  *    evict-only, or emit-only.
+  * 7. Dispatch each PT callback into exactly one branch: evict+emit collision, evict-only, or
+  *    emit-only.
   *
-  * 8. On an eviction timer, choose the eviction timestamp, maybe emit today's pre-rollover row,
-  *    roll day state, rebuild today's small-window state, mark dirty state, and re-arm eviction
-  *    while small-window tiles still exist.
+  * 8. On an eviction timer, choose the eviction as-of timestamp, maybe emit today's pre-rollover
+  *    row, roll day state, drop expired small-window tiles, rebuild today's small-window state,
+  *    mark dirty state, and re-arm the eviction heartbeat while small-window tiles still exist.
   *    - During replay lag, eviction uses the next watermark hop while this key is actively receiving
-  *      events; otherwise eviction uses wall-clock processing time.
-  *    - Example: if wall clock is Apr 2 11:00 but replayed events are from Mar 31 11:00, wall-clock
-  *      eviction would jump `currentDayStart` to Apr 2 and make valid Mar 31 rows look older than
-  *      yesterday. A watermark-aligned eviction time avoids that while replay is active.
+  *      events; otherwise eviction uses PT.
+  *    - Example: if PT is Apr 2 11:00 but replayed events are from Mar 31 11:00, eviction should
+  *      use Mar 31 watermark time while replay is active; otherwise PT eviction would jump
+  *      `currentDayStart` to Apr 2 and make valid Mar 31 rows look older than yesterday.
+  *    - In a normal live stream, watermark is already close to PT, so the otherwise branch is the
+  *      expected path. A small slack above one hop prevents normal watermark jitter from looking
+  *      like replay. If upstream stops for a key, that same branch keeps PT eviction running so
+  *      values still decay with no new events.
   *
   * 9. On an emit timer, serialize and emit each dirty day row once, then clear its dirty bit.
   */
@@ -472,7 +522,7 @@ class MegaTileProcessFunction(
 }
 
 /** TileStore backed by Flink's keyed MapState/ValueState.
-  * Encodes/decodes only the entries actually accessed — no bulk restore/persist.
+  * Encodes/decodes only the entries actually accessed - no bulk restore/persist.
   * Windowed IR get/put is memoized to avoid redundant decodes within the same event
   * (e.g., onEvent reads cachedSmallWindowIr, then packTodayEntry reads it again).
   * Cache is invalidated on key switch via bindFlinkState.
@@ -488,7 +538,7 @@ class FlinkTileStore(megaTileAgg: MegaTileAggregator, codec: MegaTileCodec) exte
   private var earliestTileStartState: ValueState[java.lang.Long] = _
 
   // Per-access decode cache for windowed IRs. Avoids redundant Avro decodes
-  // when the same IR is read multiple times within one event (get → update → pack).
+  // when the same IR is read multiple times within one event (get -> update -> pack).
   // Invalidated on key switch (bindFlinkState) and updated on put.
   private var cachedSmallDecoded: Array[Any] = _
   private var cachedSmallValid: Boolean = false

--- a/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
@@ -3,6 +3,7 @@ package ai.chronon.flink.window
 import ai.chronon.aggregator.windowing.{MegaTileAggregator, MegaTileStreamProcessor, TileStore}
 import ai.chronon.api.ScalaJavaConversions.ListOps
 import ai.chronon.api.{Constants, DataType, GroupBy, TsUtils}
+import ai.chronon.flink.FlinkJob
 import ai.chronon.flink.deser.ProjectedEvent
 import ai.chronon.flink.types.TimestampedTile
 import ai.chronon.online.MegaTileCodec
@@ -38,8 +39,8 @@ import scala.util.Try
   *      progressed past that event-time point.
   *
   * 3. Drop events older than yesterday relative to `currentDayStart`; otherwise call
-  *    `processor.onEvent(row, eventTs)`. Event time chooses the small-window tile and
-  *    today/yesterday bucket that gets updated.
+  *    `processor.onEvent(row, eventTs, smallWindowAsOfTs)`. Event time chooses the retained tile
+  *    and today/yesterday bucket; smallWindowAsOfTs bounds the cached no-batch small-window row.
   *    - Example: with `currentDayStart = Apr 2 00:00`, `Apr 2 11:03` updates today's 11:00-11:05
   *      tile, `Apr 1 23:59` updates yesterday's large-window bucket, and `Mar 31 23:59` is dropped.
   *
@@ -74,7 +75,8 @@ class MegaTileProcessFunction(
     groupBy: GroupBy,
     inputSchema: Seq[(String, DataType)],
     enableDebug: Boolean = false,
-    bufferingOutputTimeMillis: Long = 0L
+    bufferingOutputTimeMillis: Long = 0L,
+    bufferingOutputJitterMillis: Long = 0L
 ) extends KeyedProcessFunction[java.util.List[Any], ProjectedEvent, TimestampedTile] {
 
   @transient lazy val logger: Logger = LoggerFactory.getLogger(getClass)
@@ -187,8 +189,10 @@ class MegaTileProcessFunction(
         return
       }
 
+      val mode = currentMode(processingTs, watermark)
+      val smallWindowAsOfTs = smallWindowAsOfTsForEvent(mode, tsMills, processingTs, watermark)
       // Step 3.
-      val result = processor.onEvent(row, tsMills)
+      val result = processor.onEvent(row, tsMills, smallWindowAsOfTs)
       // Step 4.
       markDirtyState(result.todayEntry != null, result.yesterdayEntry != null)
 
@@ -278,7 +282,8 @@ class MegaTileProcessFunction(
                                watermark: Long,
                                timerService: TimerService,
                                out: Collector[TimestampedTile]): Unit = {
-    val evictionTime = evictionTimeForProcessingTimer(processingTs, watermark)
+    val mode = currentMode(processingTs, watermark)
+    val evictionTime = evictionTimeForProcessingTimer(mode, processingTs, watermark)
     emitTodayIfNeededThenRollDay(evictionTime, currentKey, processingTs, out)
 
     val result = processor.onEviction(evictionTime)
@@ -286,10 +291,11 @@ class MegaTileProcessFunction(
     scheduleEvictTimerIfNeeded(timerService, processingTs)
 
     if (enableDebug) {
-      logger.info(s"MegaTile eviction groupBy=${groupBy.getMetaData.getName}, key=$currentKey, " +
-        s"timerTs=$timestamp, evictionTime=$evictionTime, " +
-        s"watermark=$watermark, processingTs=$processingTs, dayStart=${flinkStore.getCurrentDayStart}, " +
-        s"todayDirty=$isTodayDirty, yesterdayDirty=$isYesterdayDirty")
+      logger.info(
+        s"MegaTile eviction groupBy=${groupBy.getMetaData.getName}, key=$currentKey, " +
+          s"timerTs=$timestamp, evictionTime=$evictionTime, mode=$mode, " +
+          s"watermark=$watermark, processingTs=$processingTs, dayStart=${flinkStore.getCurrentDayStart}, " +
+          s"todayDirty=$isTodayDirty, yesterdayDirty=$isYesterdayDirty")
     }
   }
 
@@ -325,34 +331,57 @@ class MegaTileProcessFunction(
     processor.advanceWatermark(dayTransitionTs)
   }
 
-  private def evictionTimeForProcessingTimer(processingTs: Long, watermark: Long): Long = {
+  sealed private trait Mode
+
+  private case object NoWatermark extends Mode
+
+  private case object ActiveCatchup extends Mode
+
+  private case object SparseKeyLag extends Mode
+
+  private case object Live extends Mode
+
+  private def currentMode(processingTs: Long, watermark: Long): Mode = {
     val lastEventProcessingTs =
       Option(lastEventProcessingTsState.value()).map(_.longValue()).getOrElse(Long.MinValue)
-    val watermarkLaggingWallClock =
+    val watermarkLaggingProcessingTime =
       watermark > Long.MinValue &&
-        processingTs - watermark > processor.minSmallWindowTileSize
+        processingTs - watermark > processor.minSmallWindowTileSize + FlinkJob.CatchupWatermarkLagSlackMillis
     val keyRecentlySeenEvent =
-      lastEventProcessingTs != Long.MinValue &&
+      lastEventProcessingTs > Long.MinValue &&
         processingTs - lastEventProcessingTs <= processor.minSmallWindowTileSize
 
     if (watermark == Long.MinValue) {
-      // No watermark has arrived yet, so fall back to wall-clock PT.
-      processingTs
-    } else if (watermarkLaggingWallClock && keyRecentlySeenEvent) {
-      // Active catchup: this key recently saw events, but event-time watermark is still far behind
-      // wall clock, so evict at the next watermark-aligned hop.
-      TsUtils.round(watermark, processor.minSmallWindowTileSize) + processor.minSmallWindowTileSize
-    } else if (watermarkLaggingWallClock && !keyRecentlySeenEvent) {
-      // Sparse-key backlog fallback: this key is idle while another key/partition holds watermark
-      // behind wall clock. Keep PT eviction running so values still decay for the idle key.
-      processingTs
+      NoWatermark
+    } else if (watermarkLaggingProcessingTime && keyRecentlySeenEvent) {
+      ActiveCatchup
+    } else if (watermarkLaggingProcessingTime && !keyRecentlySeenEvent) {
+      SparseKeyLag
     } else {
-      // Live path: watermark lag is within one hop, so use PT eviction to match serving semantics.
-      // The read path enumerates currently valid tiles at query wall-clock time, independent of how
-      // events were produced, so the write side should age out expired hops on the same PT clock.
-      processingTs
+      Live
     }
   }
+
+  private def evictionTimeForProcessingTimer(mode: Mode, processingTs: Long, watermark: Long): Long =
+    mode match {
+      case ActiveCatchup =>
+        nextSmallWindowHop(watermark)
+      case NoWatermark | SparseKeyLag | Live =>
+        processingTs
+    }
+
+  private def smallWindowAsOfTsForEvent(mode: Mode, eventTs: Long, processingTs: Long, watermark: Long): Long =
+    mode match {
+      case ActiveCatchup =>
+        nextSmallWindowHop(watermark)
+      case NoWatermark =>
+        nextSmallWindowHop(eventTs)
+      case SparseKeyLag | Live =>
+        nextSmallWindowHop(processingTs)
+    }
+
+  private def nextSmallWindowHop(ts: Long): Long =
+    TsUtils.round(ts, processor.minSmallWindowTileSize) + processor.minSmallWindowTileSize
 
   private def scheduleEvictTimerIfNeeded(timerService: TimerService, processingTs: Long): Unit = {
     if (!hasActiveSmallWindowState) {
@@ -385,11 +414,16 @@ class MegaTileProcessFunction(
 
     val current = nextEmitPtTimerState.value()
     if (current == null) {
-      val timestamp = processingTs + bufferingOutputTimeMillis
+      val timestamp =
+        processingTs + bufferingOutputTimeMillis + stableJitterMillis(lastKey, bufferingOutputJitterMillis)
       timerService.registerProcessingTimeTimer(timestamp)
       nextEmitPtTimerState.update(timestamp)
     }
   }
+
+  private def stableJitterMillis(key: java.util.List[Any], maxJitterMillis: Long): Long =
+    if (maxJitterMillis <= 0L) 0L
+    else Math.floorMod(key.hashCode().toLong, maxJitterMillis + 1L)
 
   private def cancelEvictTimerIfPresent(timerService: TimerService): Unit = {
     val current = nextEvictPtTimerState.value()

--- a/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
@@ -26,21 +26,48 @@ import scala.util.Try
   * Event path (`processElement`)
   * 1. Bind the current Flink key to its private MegaTile state box, then parse the event into
   *    `(eventTs, row)`.
+  *    - Example: `List("user_123")` and `List("user_456")` each have separate tiles, day state,
+  *      dirty bits, and timers. An event with `ts = 11:03:17` becomes one row applied only to that
+  *      key's state.
+  *
   * 2. Roll day state using the Flink watermark, not this event's timestamp. If the watermark crosses
   *    midnight while today's row is still buffered, emit the old-day row first.
+  *    - Why watermark: if one bad/future event arrives with `eventTs = tomorrow 00:01` and day state
+  *      rotated from that event timestamp, later valid `today 23:50` events could be misclassified
+  *      into yesterday or dropped. The watermark means Flink believes the stream as a whole has
+  *      progressed past that event-time point.
+  *
   * 3. Drop events older than yesterday relative to `currentDayStart`; otherwise call
   *    `processor.onEvent(row, eventTs)`. Event time chooses the small-window tile and
   *    today/yesterday bucket that gets updated.
+  *    - Example: with `currentDayStart = Apr 2 00:00`, `Apr 2 11:03` updates today's 11:00-11:05
+  *      tile, `Apr 1 23:59` updates yesterday's large-window bucket, and `Mar 31 23:59` is dropped.
+  *
   * 4. Mark `todayDirty` / `yesterdayDirty` from the processor result.
+  *    - Why: state mutation and KV writes are decoupled. Dirty bits track which day rows still need
+  *      to be published.
+  *
   * 5. Keep one processing-time eviction timer per key at the next hop boundary.
+  *    - Eviction's job is correctness of in-memory state: drop expired small-window tiles, rebuild
+  *      the sawtooth IR, and mark today's row dirty if the rebuilt row changed.
+  *
   * 6. Emit now if buffering is disabled; otherwise keep one processing-time emit timer per key.
+  *    - Emission's job is write coalescing only. The first dirty update arms the timer; later
+  *      updates only flip dirty bits so hot keys do not emit once per event.
   *
   * Timer path (`onTimer`)
   * 7. Dispatch each processing-time callback into exactly one branch: evict+emit collision,
   *    evict-only, or emit-only.
+  *
   * 8. On an eviction timer, choose the eviction timestamp, maybe emit today's pre-rollover row,
   *    roll day state, rebuild today's small-window state, mark dirty state, and re-arm eviction
   *    while small-window tiles still exist.
+  *    - During replay lag, eviction uses the next watermark hop while this key is actively receiving
+  *      events; otherwise eviction uses wall-clock processing time.
+  *    - Example: if wall clock is Apr 2 11:00 but replayed events are from Mar 31 11:00, wall-clock
+  *      eviction would jump `currentDayStart` to Apr 2 and make valid Mar 31 rows look older than
+  *      yesterday. A watermark-aligned eviction time avoids that while replay is active.
+  *
   * 9. On an emit timer, serialize and emit each dirty day row once, then clear its dirty bit.
   */
 class MegaTileProcessFunction(
@@ -118,7 +145,7 @@ class MegaTileProcessFunction(
     processor = new MegaTileStreamProcessor(megaTileAgg, flinkStore)
   }
 
-  private def ensureStateBound(currentKey: java.util.List[Any]): Unit = {
+  private def bindCurrentKey(currentKey: java.util.List[Any]): Unit = {
     if (lastKey == null || !lastKey.equals(currentKey)) {
       lastKey = currentKey
       flinkStore.bindFlinkState(tileState,
@@ -138,7 +165,7 @@ class MegaTileProcessFunction(
     try {
       if (processor == null) initializeTransients()
 
-      ensureStateBound(ctx.getCurrentKey)
+      bindCurrentKey(ctx.getCurrentKey)
 
       val element = event.fields
       val tsMills = Try(element(timeColumnAlias).asInstanceOf[Long])
@@ -151,7 +178,8 @@ class MegaTileProcessFunction(
       val processingTs = timerService.currentProcessingTime()
       lastEventProcessingTsState.update(processingTs)
 
-      // Step 2.
+      // Step 2. Event ingestion rolls day state from watermark, not processing time, so a brief
+      // source lag near midnight does not move `currentDayStart` too early.
       emitTodayIfNeededThenRollDay(watermark, ctx.getCurrentKey, event.startProcessingTimeMillis, out)
       if (isOlderThanYesterdayForCurrentDay(tsMills)) {
         scheduleEvictTimerIfNeeded(timerService, processingTs)
@@ -183,7 +211,7 @@ class MegaTileProcessFunction(
     try {
       if (processor == null) initializeTransients()
 
-      ensureStateBound(ctx.getCurrentKey)
+      bindCurrentKey(ctx.getCurrentKey)
       if (ctx.timeDomain() != TimeDomain.PROCESSING_TIME) {
         return
       }
@@ -267,6 +295,15 @@ class MegaTileProcessFunction(
 
   /** Advance day state at `dayTransitionTs` without losing a buffered pre-rollover today row.
     *
+    * Both input events and processing-time eviction timers can cross a day boundary:
+    *   - `processElement` uses the current Flink watermark before applying the event.
+    *   - `runEvictionTimer` uses either a watermark-aligned replay timestamp or wall-clock PT.
+    *
+    * If that timestamp moves `currentDayStart` forward by exactly one day and today's row is still
+    * dirty, emit `packTodayEntry()` under the previous day key first. Then advance the processor's
+    * day state. This keeps the final small-window row for the old day from being lost when
+    * `advanceWatermark(...)` rotates `largeTodayIr` into yesterday and resets today.
+    *
     * Emitting under `previousDayStart` preserves the logical daily key across rollover; `MegaTileAvroCodecFn`
     * uses that day-start timestamp when constructing the external `TileKey`.
     */
@@ -291,14 +328,28 @@ class MegaTileProcessFunction(
   private def evictionTimeForProcessingTimer(processingTs: Long, watermark: Long): Long = {
     val lastEventProcessingTs =
       Option(lastEventProcessingTsState.value()).map(_.longValue()).getOrElse(Long.MinValue)
-    val backlogIsActive =
+    val watermarkLaggingWallClock =
       watermark > Long.MinValue &&
-        processingTs - watermark > processor.minSmallWindowTileSize &&
-        lastEventProcessingTs != Long.MinValue &&
+        processingTs - watermark > processor.minSmallWindowTileSize
+    val keyRecentlySeenEvent =
+      lastEventProcessingTs != Long.MinValue &&
         processingTs - lastEventProcessingTs <= processor.minSmallWindowTileSize
-    if (backlogIsActive) {
+
+    if (watermark == Long.MinValue) {
+      // No watermark has arrived yet, so fall back to wall-clock PT.
+      processingTs
+    } else if (watermarkLaggingWallClock && keyRecentlySeenEvent) {
+      // Active catchup: this key recently saw events, but event-time watermark is still far behind
+      // wall clock, so evict at the next watermark-aligned hop.
       TsUtils.round(watermark, processor.minSmallWindowTileSize) + processor.minSmallWindowTileSize
+    } else if (watermarkLaggingWallClock && !keyRecentlySeenEvent) {
+      // Sparse-key backlog fallback: this key is idle while another key/partition holds watermark
+      // behind wall clock. Keep PT eviction running so values still decay for the idle key.
+      processingTs
     } else {
+      // Live path: watermark lag is within one hop, so use PT eviction to match serving semantics.
+      // The read path enumerates currently valid tiles at query wall-clock time, independent of how
+      // events were produced, so the write side should age out expired hops on the same PT clock.
       processingTs
     }
   }

--- a/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
@@ -19,42 +19,8 @@ import org.slf4j.{Logger, LoggerFactory}
 import scala.util.Try
 
 /** Flink KeyedProcessFunction that maintains per-entity mega tile state.
-  * Delegates all aggregation logic to MegaTileStreamProcessor.
-  * State access goes through FlinkTileStore - only touched entries are serialized/deserialized.
-  *
-  * Mental model:
-  *
-  * There are two clocks in this operator:
-  *   - event time/watermark: where Flink believes the stream has progressed in event time.
-  *   - processing time (PT): wall clock in the Flink task.
-  *
-  * There are two primary operating modes:
-  *   - Live: watermark is close enough to PT. The small-window cache and eviction use PT as the
-  *     as-of time, matching vanilla tiled serving where reads enumerate tiles for wall-clock query
-  *     time.
-  *   - ActiveCatchup: watermark is far behind PT for an active key, often because replay is lagged
-  *     or allowed out-of-orderness is intentionally high. Event time is then decoupled from wall
-  *     clock, so event-path cache updates and timer-path eviction both use
-  *     nextSmallWindowHop(watermark) instead of PT. This avoids aging out replay tiles that are
-  *     still current relative to the event-time frontier.
-  *
-  * Important details that are easy to mix up:
-  *   - `processor.onEvent(row, eventTs, smallWindowAsOfTs)` receives `eventTs` separately so the
-  *     processor can choose the retained tile/day that the input row mutates. Mode does not choose
-  *     that tile; it chooses the as-of timestamp for cache and eviction behavior.
-  *   - `smallWindowAsOfTs` is the event-path timestamp for deciding whether the touched tile
-  *     contributes to the cached small-window IR. The small-window cache is the Flink
-  *     implementation of Chronon's no-batch windows.
-  *   - `evictionTime` is the timer-path timestamp for making state accurate as of that point: it
-  *     can roll day state, permanently drop expired retained tiles, and rebuild cached
-  *     small-window IR.
-  *   - `NoWatermark` is startup/bootstrap behavior: the event path uses the row's event hop, while
-  *     timer callbacks use PT because there is no watermark clock to trust yet.
-  *   - `SparseKeyLag` is the idle-key fallback: the global watermark may lag because of other
-  *     input, but this key is not actively replaying, so timer callbacks use PT and values decay or
-  *     roll forward with wall clock.
-  *   - Output buffering is write coalescing only. It uses PT timers to avoid emitting on every
-  *     event or eviction; it does not change event-time mutation or as-of selection.
+  * Delegates aggregation logic to MegaTileStreamProcessor and uses FlinkTileStore for keyed state.
+  * See docs/source/megatile.md for the high-level clock/mode mental model.
   *
   * Step-by-step mental model in code order:
   *

--- a/flink/src/test/scala/ai/chronon/flink/test/AllowedLatenessConfigTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/AllowedLatenessConfigTest.scala
@@ -117,4 +117,43 @@ class AllowedLatenessConfigTest extends AnyFlatSpec with Matchers {
     }
     exception.getMessage should include("exceeds maximum")
   }
+
+  "buffering output millis config" should "be parsed from props before topicInfo params" in {
+    val props = Map("buffering_output_time_millis" -> "1000")
+    val topicInfo = TopicInfo("test-topic", "kafka", Map("buffering_output_time_millis" -> "2000"))
+
+    FlinkUtils.getNonNegativeLongProperty("buffering_output_time_millis", props, topicInfo) shouldBe 1000L
+  }
+
+  it should "be parsed from topicInfo params when props are absent" in {
+    val topicInfo = TopicInfo("test-topic", "kafka", Map("buffering_output_jitter_millis" -> "250"))
+
+    FlinkUtils.getNonNegativeLongProperty("buffering_output_jitter_millis", Map.empty, topicInfo) shouldBe 250L
+  }
+
+  it should "default missing empty whitespace and negative values to 0" in {
+    val emptyTopicInfo = TopicInfo("test-topic", "kafka", Map("buffering_output_time_millis" -> ""))
+    val whitespaceTopicInfo = TopicInfo("test-topic", "kafka", Map.empty)
+    val negativeTopicInfo = TopicInfo("test-topic", "kafka", Map.empty)
+
+    FlinkUtils.getNonNegativeLongProperty("buffering_output_time_millis", Map.empty, emptyTopicInfo) shouldBe 0L
+    FlinkUtils.getNonNegativeLongProperty(
+      "buffering_output_time_millis",
+      Map("buffering_output_time_millis" -> "   "),
+      whitespaceTopicInfo) shouldBe 0L
+    FlinkUtils.getNonNegativeLongProperty(
+      "buffering_output_time_millis",
+      Map("buffering_output_time_millis" -> "-1"),
+      negativeTopicInfo) shouldBe 0L
+  }
+
+  it should "throw IllegalArgumentException for non-numeric values" in {
+    val props = Map("buffering_output_jitter_millis" -> "nope")
+    val topicInfo = TopicInfo("test-topic", "kafka", Map.empty)
+
+    val exception = the[IllegalArgumentException] thrownBy {
+      FlinkUtils.getNonNegativeLongProperty("buffering_output_jitter_millis", props, topicInfo)
+    }
+    exception.getMessage should include("invalid buffering_output_jitter_millis value")
+  }
 }

--- a/flink/src/test/scala/ai/chronon/flink/test/FlinkJobEventIntegrationTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/FlinkJobEventIntegrationTest.scala
@@ -2,13 +2,17 @@ package ai.chronon.flink.test
 
 import ai.chronon.api.Extensions.{GroupByOps, WindowOps}
 import ai.chronon.api.ScalaJavaConversions._
-import ai.chronon.api.{GroupBy, OnlineStrategy, TilingUtils, TimeUnit, TsUtils, Window}
-import ai.chronon.flink.{FlinkGroupByStreamingJob, SparkExpressionEval, SparkExpressionEvalFn}
+import ai.chronon.api.{Accuracy, Builders, Constants, GroupBy, OnlineStrategy, Operation, TilingUtils, TimeUnit, TsUtils, Window}
+import ai.chronon.flink.deser.ProjectedEvent
+import ai.chronon.flink.{FlinkGroupByStreamingJob, FlinkJob, SparkExpressionEval, SparkExpressionEvalFn}
 import ai.chronon.flink.types.TimestampedIR
 import ai.chronon.flink.types.TimestampedTile
 import ai.chronon.flink.types.WriteResponse
 import ai.chronon.online.{Api, GroupByServingInfoParsed, TopicInfo}
 import ai.chronon.online.serde.SparkConversions
+import org.apache.flink.api.common.eventtime.{TimestampAssignerSupplier, Watermark, WatermarkGeneratorSupplier, WatermarkOutput}
+import org.apache.flink.metrics.MetricGroup
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.test.util.MiniClusterWithClientResource
@@ -19,6 +23,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import org.scalatestplus.mockito.MockitoSugar.mock
 
+import java.time.Instant
 
 
 // Flink Job Integration Test for Event-based GroupBys
@@ -235,6 +240,86 @@ class FlinkJobEventIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
     currentDaySums shouldBe Seq(2.0)
   }
 
+  it should "mega tiled flink job watermark strategy models stale UTC-midnight catchup" in {
+    val strategy = FlinkJob.watermarkStrategy
+    val assigner = strategy.createTimestampAssigner(WatermarkTestContext)
+    val generator = strategy.createWatermarkGenerator(WatermarkTestContext)
+    val output = new RecordingWatermarkOutput
+
+    val beforeMidnight =
+      ProjectedEvent(Map(Constants.TimeColumn -> toMillis("2026-04-11T23:59:00Z")), 0L)
+    val beforeMidnightTs = assigner.extractTimestamp(beforeMidnight, -1L)
+    beforeMidnightTs shouldBe toMillis("2026-04-11T23:59:00Z")
+    generator.onEvent(beforeMidnight, beforeMidnightTs, output)
+    generator.onPeriodicEmit(output)
+
+    output.lastWatermarkTimestamp shouldBe toMillis("2026-04-11T23:54:00Z") - 1L
+
+    val afterMidnight =
+      ProjectedEvent(Map(Constants.TimeColumn -> toMillis("2026-04-12T00:06:00Z")), 0L)
+    val afterMidnightTs = assigner.extractTimestamp(afterMidnight, -1L)
+    afterMidnightTs shouldBe toMillis("2026-04-12T00:06:00Z")
+    generator.onEvent(afterMidnight, afterMidnightTs, output)
+    generator.onPeriodicEmit(output)
+
+    output.lastWatermarkTimestamp shouldBe toMillis("2026-04-12T00:01:00Z") - 1L
+  }
+
+  it should "mega tiled flink job writes mixed small and large window daily snapshots" in {
+    implicit val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setParallelism(1)
+
+    val elements = Seq(
+      E2ETestEvent(id = "id1", int_val = 1, double_val = 1.5, created = 1712277000000L),
+      E2ETestEvent(id = "id1", int_val = 2, double_val = 2.0, created = 1712277900000L)
+    )
+
+    val groupBy = Builders.GroupBy(
+      sources = Seq(
+        Builders.Source.events(
+          table = "events.my_stream_raw",
+          topic = "events.my_stream",
+          query = Builders.Query(
+            selects = Map(
+              "id" -> "id",
+              "int_val" -> "int_val",
+              "double_val" -> "double_val"
+            ),
+            timeColumn = "created",
+            startPartition = "20231106"
+          )
+        )
+      ),
+      keyColumns = Seq("id"),
+      aggregations = Seq(
+        Builders.Aggregation(
+          operation = Operation.SUM,
+          inputColumn = "double_val",
+          windows = Seq(new Window(1, TimeUnit.HOURS), new Window(1, TimeUnit.DAYS), new Window(3, TimeUnit.DAYS))
+        )
+      ),
+      metaData = Builders.MetaData(name = "e2e-mixed-megatile"),
+      accuracy = Accuracy.TEMPORAL
+    )
+    groupBy.setOnlineStrategy(OnlineStrategy.STREAMING_MEGATILES)
+    val (job, groupByServingInfoParsed) = buildFlinkJob(groupBy, elements)
+
+    job.runMegaTiledGroupByJob(env).addSink(new CollectSink)
+    env.execute("MegaTiledFlinkJobMixedWindowsTest")
+
+    val dayMillis = new Window(1, TimeUnit.DAYS).millis
+    val dayStart = TsUtils.round(elements.head.created, dayMillis)
+    val decodedValues = CollectSink.values.toScala
+      .filter(_.status)
+      .filter(response => TilingUtils.deserializeTileKey(response.keyBytes).tileStartTimestampMillis == dayStart)
+      .map(response => groupByServingInfoParsed.megaTileCodec.decode(response.valueBytes))
+      .map(ir => groupByServingInfoParsed.megaTileCodec.rowAggregator.finalize(ir).toSeq)
+      .sortBy(_.head.asInstanceOf[Double])
+
+    decodedValues.head shouldBe Seq(1.5, 1.5, 1.5)
+    decodedValues.last shouldBe Seq(3.5, 3.5, 3.5)
+  }
+
   private def buildFlinkJob(groupBy: GroupBy, elements: Seq[E2ETestEvent]): (FlinkGroupByStreamingJob, GroupByServingInfoParsed) = {
     val query = SparkExpressionEval.queryFromGroupBy(groupBy)
     val sparkExpressionEvalFn = new SparkExpressionEvalFn(Encoders.product[E2ETestEvent], query, groupBy.metaData.name, groupBy.dataModel)
@@ -260,5 +345,29 @@ class FlinkJobEventIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
                   props = Map.empty,
                   topicInfo = topicInfo),
      groupByServingInfoParsed)
+  }
+
+  private def toMillis(iso: String): Long =
+    Instant.parse(iso).toEpochMilli
+
+  private object WatermarkTestContext
+      extends TimestampAssignerSupplier.Context
+      with WatermarkGeneratorSupplier.Context {
+    override def getMetricGroup: MetricGroup =
+      UnregisteredMetricGroups.createUnregisteredOperatorMetricGroup()
+  }
+
+  final private class RecordingWatermarkOutput extends WatermarkOutput {
+    private var emittedWatermarkTimestamps: List[Long] = Nil
+
+    override def emitWatermark(watermark: Watermark): Unit =
+      emittedWatermarkTimestamps = emittedWatermarkTimestamps :+ watermark.getTimestamp
+
+    override def markIdle(): Unit = ()
+
+    override def markActive(): Unit = ()
+
+    def lastWatermarkTimestamp: Long =
+      emittedWatermarkTimestamps.last
   }
 }

--- a/flink/src/test/scala/ai/chronon/flink/test/FlinkJobEventIntegrationTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/FlinkJobEventIntegrationTest.scala
@@ -1,8 +1,8 @@
 package ai.chronon.flink.test
 
-import ai.chronon.api.Extensions.GroupByOps
-import ai.chronon.api.{GroupBy, TilingUtils}
+import ai.chronon.api.Extensions.{GroupByOps, WindowOps}
 import ai.chronon.api.ScalaJavaConversions._
+import ai.chronon.api.{GroupBy, OnlineStrategy, TilingUtils, TimeUnit, TsUtils, Window}
 import ai.chronon.flink.{FlinkGroupByStreamingJob, SparkExpressionEval, SparkExpressionEvalFn}
 import ai.chronon.flink.types.TimestampedIR
 import ai.chronon.flink.types.TimestampedTile
@@ -153,6 +153,54 @@ class FlinkJobEventIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
     )
 
     expectedFinalIRsPerKey shouldBe finalIRsPerKey
+  }
+
+  it should "mega tiled flink job writes day-start keyed daily snapshots end to end" in {
+    implicit val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setParallelism(1)
+
+    val elements = Seq(
+      E2ETestEvent(id = "id1", int_val = 1, double_val = 1.5, created = 1712277000000L),
+      E2ETestEvent(id = "id1", int_val = 2, double_val = 2.0, created = 1712277900000L)
+    )
+
+    val groupBy = FlinkTestUtils.makeGroupBy(Seq("id"))
+    groupBy.setOnlineStrategy(OnlineStrategy.STREAMING_MEGATILES)
+    val (job, groupByServingInfoParsed) = buildFlinkJob(groupBy, elements)
+    groupByServingInfoParsed.groupBy.isMegaTilingEnabled shouldBe true
+
+    job.runMegaTiledGroupByJob(env).addSink(new CollectSink)
+    env.execute("MegaTiledFlinkJobIntegrationTest")
+
+    val writeResponses = CollectSink.values.toScala
+    writeResponses.nonEmpty shouldBe true
+    writeResponses.forall(_.status) shouldBe true
+    writeResponses.map(_.dataset).distinct shouldBe Seq(groupByServingInfoParsed.groupBy.streamingDataset)
+
+    val dayMillis = new Window(1, TimeUnit.DAYS).millis
+    val dayStart = TsUtils.round(elements.head.created, dayMillis)
+    val decodedTileKeys = writeResponses.map(response => TilingUtils.deserializeTileKey(response.keyBytes))
+    decodedTileKeys.map(_.tileSizeMillis).distinct shouldBe Seq(dayMillis)
+    decodedTileKeys.map(_.tileStartTimestampMillis).contains(dayStart) shouldBe true
+    decodedTileKeys.forall(tileKey => TsUtils.round(tileKey.tileStartTimestampMillis, dayMillis) == tileKey.tileStartTimestampMillis) shouldBe true
+
+    val decodedEntityKeys = decodedTileKeys.map { tileKey =>
+      val keyBytes = tileKey.keyBytes.toScala.toArray.map(_.asInstanceOf[Byte])
+      val record = groupByServingInfoParsed.keyCodec.decode(keyBytes)
+      record.get("id").toString
+    }
+    decodedEntityKeys.distinct shouldBe Seq("id1")
+
+    val decodedSums = writeResponses
+      .zip(decodedTileKeys)
+      .filter { case (_, tileKey) => tileKey.tileStartTimestampMillis == dayStart }
+      .map(_._1)
+      .map(response => groupByServingInfoParsed.megaTileCodec.decode(response.valueBytes))
+      .map(ir => groupByServingInfoParsed.megaTileCodec.rowAggregator.finalize(ir).head.asInstanceOf[Double])
+      .sorted
+
+    decodedSums.head shouldBe 1.5
+    decodedSums.last shouldBe 3.5
   }
 
   private def buildFlinkJob(groupBy: GroupBy, elements: Seq[E2ETestEvent]): (FlinkGroupByStreamingJob, GroupByServingInfoParsed) = {

--- a/flink/src/test/scala/ai/chronon/flink/test/FlinkJobEventIntegrationTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/FlinkJobEventIntegrationTest.scala
@@ -203,6 +203,38 @@ class FlinkJobEventIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
     decodedSums.last shouldBe 3.5
   }
 
+  it should "mega tiled flink job drops events older than yesterday" in {
+    implicit val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setParallelism(1)
+
+    val currentDayEventTs = 1712277000000L // 2024-04-05T00:30:00Z
+    val staleEventTs = currentDayEventTs - 2 * new Window(1, TimeUnit.DAYS).millis
+    val elements = Seq(
+      E2ETestEvent(id = "id1", int_val = 1, double_val = 2.0, created = currentDayEventTs),
+      E2ETestEvent(id = "id1", int_val = 2, double_val = 9.5, created = staleEventTs)
+    )
+
+    val groupBy = FlinkTestUtils.makeGroupBy(Seq("id"))
+    groupBy.setOnlineStrategy(OnlineStrategy.STREAMING_MEGATILES)
+    val (job, groupByServingInfoParsed) = buildFlinkJob(groupBy, elements)
+
+    job.runMegaTiledGroupByJob(env).addSink(new CollectSink)
+    env.execute("MegaTiledFlinkJobDropsStaleEventsTest")
+
+    val dayMillis = new Window(1, TimeUnit.DAYS).millis
+    val currentDayStart = TsUtils.round(currentDayEventTs, dayMillis)
+    val currentDaySums = CollectSink.values.toScala
+      .filter(_.status)
+      .filter { response =>
+        TilingUtils.deserializeTileKey(response.keyBytes).tileStartTimestampMillis == currentDayStart
+      }
+      .map(response => groupByServingInfoParsed.megaTileCodec.decode(response.valueBytes))
+      .map(ir => groupByServingInfoParsed.megaTileCodec.rowAggregator.finalize(ir).head.asInstanceOf[Double])
+      .distinct
+
+    currentDaySums shouldBe Seq(2.0)
+  }
+
   private def buildFlinkJob(groupBy: GroupBy, elements: Seq[E2ETestEvent]): (FlinkGroupByStreamingJob, GroupByServingInfoParsed) = {
     val query = SparkExpressionEval.queryFromGroupBy(groupBy)
     val sparkExpressionEvalFn = new SparkExpressionEvalFn(Encoders.product[E2ETestEvent], query, groupBy.metaData.name, groupBy.dataModel)

--- a/flink/src/test/scala/ai/chronon/flink/test/window/MegaTileProcessFunctionTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/window/MegaTileProcessFunctionTest.scala
@@ -21,21 +21,36 @@ import scala.collection.JavaConverters._
 class MegaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
   import MegaTileProcessFunctionTest._
 
-  "MegaTileProcessFunction" should "keep watermark constants aligned with MegaTile eviction lifecycle" in {
+  /*
+   * Output values use the order from the test GroupBy:
+   *   windowValues(oneHour, oneDay, threeDay)
+   *
+   * Each value is the count of view_by rows for that window. null means that window has no
+   * aggregate value after eviction.
+   */
+
+  "MegaTileProcessFunction" should "watermark constants stay aligned with MegaTile eviction lifecycle" in {
+    // With a 5-minute hop, a 5-minute bounded-out-of-orderness watermark keeps late events near the
+    // hop boundary available until the processor has a chance to rebuild cached small-window state.
     FlinkJob.AllowedOutOfOrderness.toMillis shouldEqual 5 * 60 * 1000L
+    // Idleness keeps watermarks moving when an upstream partition or low-volume key goes quiet.
     FlinkJob.IdlenessTimeout.toMillis shouldEqual 30 * 1000L
+    // The extra slack prevents normal one-hop watermark jitter from being treated as active catchup.
     FlinkJob.CatchupWatermarkLagSlackMillis shouldEqual 30 * 1000L
   }
 
-  it should "use processing-time eviction when watermark lag is inside one hop plus slack" in {
+  it should "Live vs ActiveCatchup boundary: one-hop watermark lag plus slack still uses PT eviction" in {
     withDriver(bufferingOutputTimeMillis = 0L) { driver =>
       seedOldTileBeforeLiveCatchupBoundary(driver, "gen_live_slack")
 
+      // The watermark is 5m15s behind PT, which is still inside one hop plus the 30s slack. The
+      // current event is therefore treated as live and immediately sees the old tile in the cache.
       driver.processWatermark("2025-07-21T11:29:45Z")
       driver.setProcessingTime("2025-07-21T11:34:00Z")
       driver.processEvent("gen_live_slack", "2025-07-21T11:34:00Z", "user_current")
       driver.drainNewOutputs().last.values shouldEqual windowValues(3L, 3L, 3L)
 
+      // The 11:35 PT eviction rebuilds 1h over [10:35, 11:35), so the old 10:30 tile falls out.
       driver.setProcessingTime("2025-07-21T11:35:00Z")
       assertSingleOutput(
         driver.drainNewOutputs(),
@@ -45,15 +60,18 @@ class MegaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     }
   }
 
-  it should "use watermark-time eviction when active catchup is beyond slack" in {
+  it should "Live vs ActiveCatchup boundary: active catchup beyond slack uses watermark-time eviction" in {
     withDriver(bufferingOutputTimeMillis = 0L) { driver =>
       seedOldTileBeforeLiveCatchupBoundary(driver, "gen_catchup")
 
+      // This watermark is 5m31s behind PT, just beyond one hop plus slack. A recently active key
+      // stays in ActiveCatchup, so eviction follows the next watermark hop instead of wall-clock PT.
       driver.processWatermark("2025-07-21T11:29:29Z")
       driver.setProcessingTime("2025-07-21T11:34:00Z")
       driver.processEvent("gen_catchup", "2025-07-21T11:34:00Z", "user_current")
       driver.drainNewOutputs().last.values shouldEqual windowValues(3L, 3L, 3L)
 
+      // The watermark-aligned rebuild is as of 11:30, so the old 10:30 tile is still inside 1h.
       driver.setProcessingTime("2025-07-21T11:35:00Z")
       assertSingleOutput(
         driver.drainNewOutputs(),
@@ -63,8 +81,9 @@ class MegaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     }
   }
 
-  it should "roll day state at watermark midnight without losing the previous dirty row" in {
+  it should "Live mode lifecycle: continuous events before, during, and after day transition" in {
     withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      // Seed the final Jul21 tile before either PT or watermark day rollover occurs.
       driver.setProcessingTime("2025-07-21T23:59:00Z")
       driver.processEvent("gen_steady", "2025-07-21T23:59:00Z", "user_before_roll")
       assertSingleOutput(
@@ -73,9 +92,11 @@ class MegaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
         expectedDayStart = dayStart("2025-07-21T00:00:00Z"),
         expectedValues = windowValues(1L, 1L, 1L))
 
+      // PT eviction can fire first; it should not rely on the watermark crossing midnight.
       driver.setProcessingTime("2025-07-22T00:00:01Z")
       driver.drainNewOutputs() should not be empty
 
+      // Once the watermark crosses midnight, the processor emits the old day before applying Jul22.
       driver.processWatermark("2025-07-22T00:00:00Z")
       driver.processEvent("gen_steady", "2025-07-22T00:00:00Z", "user_after_roll")
       val rolloverOutputs = driver.drainNewOutputs()
@@ -85,6 +106,7 @@ class MegaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
         expectedDayStart = dayStart("2025-07-22T00:00:00Z"),
         expectedValues = windowValues(2L, 2L, 1L))
 
+      // After the first Jul22 hop boundary, an exact-hop Jul22 event updates both no-batch windows.
       driver.setProcessingTime("2025-07-22T00:05:01Z")
       driver.drainNewOutputs() should not be empty
 
@@ -95,13 +117,15 @@ class MegaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     }
   }
 
-  it should "route late previous-day events to current small windows and yesterday large windows after PT midnight roll" in {
+  it should "Live mode lifecycle: PT midnight roll before watermark routes late previous-day events to both day rows" in {
     withDriver(bufferingOutputTimeMillis = 1000L) { driver =>
+      // Keep watermark just before midnight but close enough to PT that this key remains Live.
       driver.processWatermark("2025-07-21T23:54:55.999Z")
       driver.setProcessingTime("2025-07-21T23:59:56.900Z")
       driver.processEvent("gen_midnight_live", "2025-07-21T23:59:56Z", "user_before_midnight")
       driver.drainNewOutputs() shouldBe empty
 
+      // Buffered emit publishes the Jul21 row once the 1s delay expires.
       driver.setProcessingTime("2025-07-21T23:59:57.900Z")
       assertSingleOutput(
         driver.drainNewOutputs(),
@@ -109,13 +133,18 @@ class MegaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
         expectedDayStart = dayStart("2025-07-21T00:00:00Z"),
         expectedValues = windowValues(1L, 1L, 1L))
 
+      // PT reaches midnight before the watermark. The buffered new-day row should not emit yet.
       driver.setProcessingTime("2025-07-22T00:00:00.001Z")
       driver.drainNewOutputs() shouldBe empty
 
+      // A pre-midnight event arriving after the PT roll is still admissible. It belongs to Jul22
+      // small windows because it is inside [23:05, 00:05), and to Jul21 large-window yesterday IR.
       driver.setProcessingTime("2025-07-22T00:00:00.006Z")
       driver.processEvent("gen_midnight_live", "2025-07-21T23:59:58Z", "user_previous_day_after_roll")
       driver.drainNewOutputs() shouldBe empty
 
+      // The delayed callback emits both affected day rows: current small windows for Jul22 and
+      // batch-backed yesterday state for Jul21.
       driver.setProcessingTime("2025-07-22T00:00:01.001Z")
       val boundaryOutputs = driver.drainNewOutputs()
       boundaryOutputs should have size 2
@@ -126,49 +155,68 @@ class MegaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     }
   }
 
-  it should "update retained yesterday-start for 1d but not stale 1h" in {
+  it should "Live mode: retained yesterdayStart updates 1d without incrementing stale 1h" in {
     withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      // Anchor the current-day cache at Jul22 start.
       driver.setProcessingTime("2025-07-22T00:10:00Z")
       driver.processEvent("gen_boundary", "2025-07-22T00:00:00Z", "user_today_start")
       driver.drainNewOutputs() should have size 1
 
+      // The exact Jul21 boundary is retained as yesterday, but as of Jul22 00:15 the 1h horizon is
+      // [Jul21 23:15, Jul22 00:15), so only 1d and 3d may include it.
       driver.processWatermark("2025-07-22T00:05:00Z")
       driver.processEvent("gen_boundary", "2025-07-21T00:00:00Z", "user_yesterday_start")
       val outputs = driver.drainNewOutputs()
       outputs should have size 2
+      // Current-day packed row keeps 1h at one event while 1d includes the retained boundary event.
       outputs.find(_.dayStartMillis == dayStart("2025-07-22T00:00:00Z")).map(_.values) shouldEqual
         Some(windowValues(1L, 2L, 1L))
+      // Yesterday's emitted row carries only batch-backed columns; no-batch columns are current-day cache only.
       outputs.find(_.dayStartMillis == dayStart("2025-07-21T00:00:00Z")).map(_.values) shouldEqual
         Some(windowValues(null, null, 1L))
     }
   }
 
-  it should "decay during a short upstream stop and recover on live-time resume" in {
+  it should "Live mode lifecycle: PT eviction decays during a short stop and recovers on resume" in {
     withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      // Initial event starts all three windows in Live mode.
+      driver.processWatermark("2025-07-21T10:25:00Z")
       driver.setProcessingTime("2025-07-21T10:30:00Z")
       driver.processEvent("gen_stop_short", "2025-07-21T10:30:00Z", "user_initial")
       driver.drainNewOutputs().last.values shouldEqual windowValues(1L, 1L, 1L)
 
+      // Keep the watermark close enough that the next two PT timers remain Live.
+      driver.processWatermark("2025-07-21T11:25:00Z")
+      // At 11:30 the 10:30 tile is still inside the 1h window.
       driver.setProcessingTime("2025-07-21T11:30:00Z")
       driver.drainNewOutputs().last.values shouldEqual windowValues(1L, 1L, 1L)
 
+      driver.processWatermark("2025-07-21T11:29:30Z")
+      // At 11:35 the 1h window starts at 10:35, so only the stopped key's 1h value decays.
       driver.setProcessingTime("2025-07-21T11:35:00Z")
       driver.drainNewOutputs().last.values shouldEqual windowValues(null, 1L, 1L)
 
+      // A live resume event restarts 1h and increments the longer windows.
       driver.processEvent("gen_stop_short", "2025-07-21T11:36:00Z", "user_resume")
       driver.drainNewOutputs().last.values shouldEqual windowValues(1L, 2L, 2L)
     }
   }
 
-  it should "not re-inflate 1h for a retained late tile outside current small-window as-of" in {
+  it should "Live mode lifecycle: late retained tile outside smallWindowAsOfTs does not re-inflate 1h" in {
     withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      // 10:30 lands in the 10:30-10:35 tile in Live mode and starts every window.
+      driver.processWatermark("2025-07-21T10:25:00Z")
       driver.setProcessingTime("2025-07-21T10:30:00Z")
       driver.processEvent("gen_late_same_day", "2025-07-21T10:30:00Z", "user_on_time")
       driver.drainNewOutputs().last.values shouldEqual windowValues(1L, 1L, 1L)
 
+      // PT eviction at 11:35 rebuilds 1h over [10:35, 11:35), so the 10:30 tile falls out.
+      driver.processWatermark("2025-07-21T11:29:30Z")
       driver.setProcessingTime("2025-07-21T11:35:00Z")
       driver.drainNewOutputs().last.values shouldEqual windowValues(null, 1L, 1L)
 
+      // A late 10:32 event still updates the retained base tile and longer windows, but its tile is
+      // outside the current 1h as-of horizon and must not re-inflate cached 1h.
       driver.setProcessingTime("2025-07-21T11:36:00Z")
       driver.processWatermark("2025-07-21T11:30:00Z")
       driver.processEvent("gen_late_same_day", "2025-07-21T10:32:00Z", "user_late_expired_hop")
@@ -176,54 +224,71 @@ class MegaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     }
   }
 
-  it should "expire 1d after a long stop but preserve fresh resume behavior" in {
+  it should "SparseKeyLag lifecycle: long idle stop expires 1d, then Live resume restarts all windows" in {
     withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      // Seed the key, then let PT move more than one day ahead with no new events.
+      driver.processWatermark("2025-07-21T10:25:00Z")
       driver.setProcessingTime("2025-07-21T10:30:00Z")
       driver.processEvent("gen_stop_long", "2025-07-21T10:30:00Z", "user_initial")
       driver.drainNewOutputs() should have size 1
 
+      // The key is idle while the watermark is stale, so SparseKeyLag uses PT for eviction. The
+      // timer rolls to Jul22 and rebuilds an empty current-day row for no-batch windows.
       driver.setProcessingTime("2025-07-22T11:35:00Z")
       driver.drainNewOutputs().last.values shouldEqual windowValues(null, null, null)
 
+      // A fresh Jul22 event restarts every current serving window once the watermark catches up
+      // enough for Live mode.
+      driver.processWatermark("2025-07-22T11:31:00Z")
       driver.processEvent("gen_stop_long", "2025-07-22T11:36:00Z", "user_resume")
       driver.drainNewOutputs().last.values shouldEqual windowValues(1L, 1L, 1L)
     }
   }
 
-  it should "update retained yesterday-start for 1d but not stale 1h after resume" in {
+  it should "Live mode after idle eviction: retained yesterdayStart updates 1d without incrementing stale 1h" in {
     withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      // Anchor current-day state, then let one PT hop eviction run while the key is otherwise idle.
+      driver.processWatermark("2025-07-22T00:05:00Z")
       driver.setProcessingTime("2025-07-22T00:10:00Z")
       driver.processEvent("gen_stop_boundary", "2025-07-22T00:10:00Z", "user_anchor")
       driver.drainNewOutputs() should have size 1
 
+      driver.processWatermark("2025-07-22T00:09:30Z")
       driver.setProcessingTime("2025-07-22T00:15:00Z")
       driver.drainNewOutputs() should not be empty
 
-      driver.processWatermark("2025-07-22T00:10:00Z")
+      // The retained Jul21 boundary updates Jul22 1d, but remains outside Jul22 1h after the idle
+      // PT eviction has already advanced the processor.
       driver.processEvent("gen_stop_boundary", "2025-07-21T00:00:00Z", "user_yesterday_start")
       val outputs = driver.drainNewOutputs()
       outputs should have size 2
+      // Current day sees the retained boundary in 1d only.
       outputs.find(_.dayStartMillis == dayStart("2025-07-22T00:00:00Z")).map(_.values) shouldEqual
         Some(windowValues(1L, 2L, 1L))
+      // Yesterday row carries only the batch-backed 3d contribution.
       outputs.find(_.dayStartMillis == dayStart("2025-07-21T00:00:00Z")).map(_.values) shouldEqual
         Some(windowValues(null, null, 1L))
 
+      // Just older than retained yesterday is dropped before it can mutate tile or large-window state.
       driver.processEvent("gen_stop_boundary", "2025-07-20T23:59:59.999Z", "user_too_old")
       driver.drainNewOutputs() shouldBe empty
     }
   }
 
-  it should "keep active replay on watermark time before sparse-key PT fallback" in {
+  it should "ActiveCatchup lifecycle: active backlog uses watermark-time eviction, then SparseKeyLag fallback uses PT" in {
     withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      // Replay starts two days behind PT; active per-key traffic keeps eviction on watermark time.
       driver.setProcessingTime("2025-07-23T10:30:00Z")
       driver.processWatermark("2025-07-21T10:30:00Z")
       driver.processEvent("gen_replay", "2025-07-21T10:30:00Z", "user_replay_1")
       driver.drainNewOutputs().last.dayStartMillis shouldEqual dayStart("2025-07-21T00:00:00Z")
 
+      // The second replayed event stays in the Jul21 day because the key is still active.
       driver.setProcessingTime("2025-07-23T10:35:00Z")
       driver.processEvent("gen_replay", "2025-07-21T10:31:00Z", "user_replay_2")
       driver.drainNewOutputs().last.values shouldEqual windowValues(2L, 2L, 2L)
 
+      // Once the key is idle for more than one hop, sparse-key fallback rolls to the PT day.
       driver.setProcessingTime("2025-07-23T10:50:00Z")
       val idleFallback = driver.drainNewOutputs().last
       idleFallback.dayStartMillis shouldEqual dayStart("2025-07-23T00:00:00Z")
@@ -231,20 +296,33 @@ class MegaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     }
   }
 
-  it should "retain an event ahead of stale watermark until eviction catches up" in {
+  it should "ActiveCatchup lifecycle: event ahead of stale watermark is retained, then appears after rebuild catches up" in {
     withDriver(bufferingOutputTimeMillis = 0L) { driver =>
       driver.processWatermark("2025-07-21T22:31:23.999Z")
       driver.setProcessingTime("2025-07-21T23:40:01Z")
+      // ActiveCatchup evaluates no-batch cache as of the next watermark hop, so the current 23:40
+      // event is retained but not immediately visible in 1h/1d.
       driver.processEvent("gen_resume_stale_watermark", "2025-07-21T23:40:00Z", "user_resume")
       driver.drainNewOutputs().last.values shouldEqual windowValues(null, null, 1L)
 
+      // Once the watermark reaches the event-time frontier, the scheduled eviction rebuild includes
+      // the retained 23:40 tile.
       driver.processWatermark("2025-07-21T23:40:00Z")
       driver.setProcessingTime("2025-07-21T23:45:00Z")
       driver.drainNewOutputs().last.values shouldEqual windowValues(1L, 1L, 1L)
     }
   }
 
-  it should "handle catchup UTC day-boundary scenarios" in {
+  it should "catchup UTC day-boundary scenario matrix documents the four branch-driving axes" in {
+    /*
+     * These scenarios cover four independent axes that drive admission and rebuild behavior:
+     *
+     * 1. Resume timing: PT crosses UTC midnight before, near, or long after the stream watermark.
+     * 2. Watermark state: watermark may be close enough for Live mode or stale enough for catchup.
+     * 3. Key activity: an active key uses ActiveCatchup, while an idle key falls back to SparseKeyLag.
+     * 4. Event age: exact yesterday-start rows are still retained, while one millisecond older rows
+     *    are rejected before they can mutate state.
+     */
     val scenarios = Seq(
       activeKeyResumesAfterUtcMidnightWithStaleWatermarkThenCatchesUp _,
       sparseKeyResumesAfterUtcMidnightWithStaleWatermark _,
@@ -257,22 +335,28 @@ class MegaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     }
   }
 
-  it should "not emit an old dirty day as an adjacent rollover after multi-day downtime" in {
+  it should "catchup UTC day-boundary: multi-day downtime jump does not emit old dirty day as adjacent rollover" in {
     withDriver(bufferingOutputTimeMillis = 3L * DayMillis) { driver =>
+      // Buffer an Apr11 dirty row, but do not let its long delayed emit fire yet.
       driver.setProcessingTime("2026-04-11T23:50:00Z")
       driver.processEvent("axis_multi_day_jump", "2026-04-11T23:50:00Z", "user_seed")
       driver.drainNewOutputs() shouldBe empty
 
+      // A PT jump to Apr13 is not an adjacent Apr11->Apr12 rollover. The guarded rollover emit
+      // must not publish the old Apr11 row at the Apr13 boundary.
       driver.setProcessingTime("2026-04-13T00:10:00Z")
       driver.drainNewOutputs() shouldBe empty
 
+      // After the PT day roll, Apr11 backlog is older than the retained yesterday boundary and is
+      // dropped before mutating state.
       driver.processEvent("axis_multi_day_jump", "2026-04-11T23:59:00Z", "user_backlog_too_old_after_jump")
       driver.drainNewOutputs() shouldBe empty
     }
   }
 
-  it should "update replayed yesterday-start for 1d but not stale 1h" in {
+  it should "ActiveCatchup lifecycle: replayed yesterdayStart updates 1d but not stale 1h" in {
     withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      // Start replay on Jul22 event time while PT is already Jul24.
       driver.setProcessingTime("2025-07-24T10:00:00Z")
       driver.processWatermark("2025-07-22T00:00:00Z")
       driver.processEvent("gen_replay_boundary", "2025-07-22T00:00:00Z", "user_today_start")
@@ -282,22 +366,27 @@ class MegaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
         expectedDayStart = dayStart("2025-07-22T00:00:00Z"),
         expectedValues = windowValues(1L, 1L, 1L))
 
+      // Watermark rollover makes the duplicate Jul22 row a retained yesterday row for Jul23 output.
       driver.processWatermark("2025-07-23T00:00:00Z")
       driver.processEvent("gen_replay_boundary", "2025-07-22T00:00:00Z", "user_yesterday_start")
       val outputs = driver.drainNewOutputs()
       outputs should have size 2
+      // In replay mode, the small-window as-of timestamp follows the watermark hop: 1d can include
+      // the duplicate boundary row, while 1h must not double-count after the Jul23 day roll.
       outputs.find(_.dayStartMillis == dayStart("2025-07-23T00:00:00Z")).map(_.values) shouldEqual
         Some(windowValues(1L, 2L, null))
       outputs.find(_.dayStartMillis == dayStart("2025-07-22T00:00:00Z")).map(_.values) shouldEqual
         Some(windowValues(null, null, 2L))
 
+      // Older-than-yesterday replay data is dropped relative to the post-roll currentDayStart.
       driver.processEvent("gen_replay_boundary", "2025-07-21T23:59:59.999Z", "user_too_old")
       driver.drainNewOutputs() shouldBe empty
     }
   }
 
-  it should "drop sparse-key backlog older than yesterday after PT fallback day roll" in {
+  it should "SparseKeyLag lifecycle: sparse-key PT fallback can permanently drop backlog events older than yesterday after day roll" in {
     withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      // Seed a sparse key during replay; the key then goes idle while the global watermark remains behind.
       driver.setProcessingTime("2025-07-23T10:30:00Z")
       driver.processWatermark("2025-07-21T10:30:00Z")
       driver.processEvent("gen_sparse_replay_drop", "2025-07-21T10:30:00Z", "user_seed")
@@ -307,6 +396,7 @@ class MegaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
         expectedDayStart = dayStart("2025-07-21T00:00:00Z"),
         expectedValues = windowValues(1L, 1L, 1L))
 
+      // After one idle hop, SparseKeyLag uses PT eviction and rolls currentDayStart to Jul23.
       driver.setProcessingTime("2025-07-23T10:40:00Z")
       assertSingleOutput(
         driver.drainNewOutputs(),
@@ -314,19 +404,23 @@ class MegaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
         expectedDayStart = dayStart("2025-07-23T00:00:00Z"),
         expectedValues = windowValues(null, null, null))
 
+      // A later Jul21 backlog event would be valid under active replay, but after the PT roll it is
+      // older than currentDayStart - 1d and must be dropped permanently.
       driver.setProcessingTime("2025-07-23T10:41:00Z")
       driver.processEvent("gen_sparse_replay_drop", "2025-07-21T23:59:00Z", "user_backlog_too_late")
       driver.drainNewOutputs() shouldBe empty
     }
   }
 
-  it should "roll cold-start backlog rows without dropping valid events" in {
+  it should "Cold start backlog lifecycle: stream starts 2d behind and rolls old-day rows without dropping valid events" in {
     withDriver(bufferingOutputTimeMillis = 120000L) { driver =>
+      // Cold start begins with PT on Jul23 but watermark/event time on Jul21.
       driver.setProcessingTime("2025-07-23T10:30:00Z")
       driver.processWatermark("2025-07-21T23:59:00Z")
       driver.processEvent("gen_cold_start", "2025-07-21T23:59:00Z", "user_day_1")
       driver.drainNewOutputs() shouldBe empty
 
+      // Crossing the Jul22 watermark emits the buffered Jul21 row before applying the Jul22 event.
       driver.processWatermark("2025-07-22T00:00:01Z")
       driver.processEvent("gen_cold_start", "2025-07-22T00:00:00Z", "user_day_2")
       assertSingleOutput(
@@ -335,23 +429,30 @@ class MegaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
         expectedDayStart = dayStart("2025-07-21T00:00:00Z"),
         expectedValues = windowValues(1L, 1L, 1L))
 
+      // Add rows around the Jul22 00:05 hop, plus one retained previous-day row and one too-old row.
       driver.processEvent("gen_cold_start", "2025-07-22T00:05:00Z", "user_exact_hop")
       driver.processEvent("gen_cold_start", "2025-07-22T00:05:01Z", "user_after_hop")
       driver.processEvent("gen_cold_start", "2025-07-21T00:00:00Z", "user_prev_day")
       driver.processEvent("gen_cold_start", "2025-07-20T23:59:59.999Z", "user_too_old")
       driver.drainNewOutputs() shouldBe empty
 
+      // Buffered emit fires before the first watermark-aligned eviction rebuild.
       driver.setProcessingTime("2025-07-23T10:32:00Z")
       val preEvictionOutputs = driver.drainNewOutputs()
       preEvictionOutputs should have size 2
+      // The retained Jul21 daily row has only batch-backed 3d state packed for yesterday.
       preEvictionOutputs.find(_.dayStartMillis == dayStart("2025-07-21T00:00:00Z")).map(_.values) shouldEqual
         Some(windowValues(null, null, 2L))
+      // Before the rebuild, cached 1h is bounded by watermark-hop smallWindowAsOfTs: Jul21 23:59
+      // and Jul22 00:00 count for 1h; Jul21 00:00 is retained only for 1d/3d.
       preEvictionOutputs.find(_.dayStartMillis == dayStart("2025-07-22T00:00:00Z")).map(_.values) shouldEqual
         Some(windowValues(2L, 5L, 3L))
 
+      // The 10:35 PT callback is the eviction timer; output remains buffered until 10:37.
       driver.setProcessingTime("2025-07-23T10:35:00Z")
       driver.drainNewOutputs() shouldBe empty
 
+      // Buffered output after eviction reflects the watermark-aligned rebuild.
       driver.setProcessingTime("2025-07-23T10:37:00Z")
       assertSingleOutput(
         driver.drainNewOutputs(),
@@ -361,27 +462,31 @@ class MegaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     }
   }
 
-  it should "drop events older than yesterday before mutating state" in {
+  it should "Stale event lifecycle: events older than yesterday are dropped before mutating state" in {
     withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      // Anchor currentDayStart at Apr12.
       driver.processWatermark("2026-04-12T00:05:00Z")
       driver.setProcessingTime("2026-04-12T00:10:00Z")
       driver.processEvent("gen_stale", "2026-04-12T00:10:00Z", "user_anchor")
       driver.drainNewOutputs() should have size 1
 
+      // Apr10 23:59:59.999 is one millisecond older than retained yesterday and should not dirty state.
       driver.processEvent("gen_stale", "2026-04-10T23:59:59.999Z", "user_too_old")
       driver.drainNewOutputs() shouldBe empty
     }
   }
 
-  it should "restore pending timers, dirty bits, and key isolation from checkpoint" in {
+  it should "Failure/recovery lifecycle: checkpoint restore preserves pending timers, dirty bits, and key isolation" in {
     val originalHarness = harness(bufferingOutputTimeMillis = 10 * 60 * 1000L)
     originalHarness.open()
     val baseProcessingTs = toMillis("2025-07-21T10:30:00Z")
+    // Buffer two dirty keys, then snapshot before either key's emit timer fires.
     originalHarness.setProcessingTime(baseProcessingTs)
     originalHarness.processElement(event("gen_restore_a", "2025-07-21T10:30:00Z", "user_a_1", baseProcessingTs), 0L)
     originalHarness.processElement(event("gen_restore_b", "2025-07-21T10:31:00Z", "user_b_1", baseProcessingTs), 0L)
     originalHarness.extractOutputValues().asScala.toList shouldBe empty
 
+    // Snapshot must capture dirty bits, pending timers, and per-key MegaTile state.
     val snapshot = originalHarness.snapshot(7L, baseProcessingTs + 1000L)
     originalHarness.close()
 
@@ -390,15 +495,18 @@ class MegaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     restoredHarness.initializeState(snapshot)
     restoredHarness.open()
 
+    // Pending timers survive restore but are not due yet.
     restoredHarness.setProcessingTime(toMillis("2025-07-21T10:35:00Z"))
     restoredHarness.extractOutputValues().asScala.toList shouldBe empty
 
+    // The original dirty rows emit once their restored timers become due.
     restoredHarness.setProcessingTime(toMillis("2025-07-21T10:40:00Z"))
     val outputs = restoredHarness.extractOutputValues().asScala.toList.map(decodeOutput)
     outputs should have size 2
     outputs.find(_.keys == List("gen_restore_a")).map(_.values) shouldEqual Some(windowValues(1L, 1L, 1L))
     outputs.find(_.keys == List("gen_restore_b")).map(_.values) shouldEqual Some(windowValues(1L, 1L, 1L))
 
+    // A post-restore event for key A must not mutate key B's restored state.
     restoredHarness.processElement(
       event("gen_restore_a", "2025-07-21T10:41:00Z", "user_a_2", toMillis("2025-07-21T10:40:00Z")),
       0L)
@@ -409,23 +517,27 @@ class MegaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     restoredHarness.close()
   }
 
-  it should "skip malformed timestamp rows without corrupting later valid rows" in {
+  it should "Failure/recovery lifecycle: malformed timestamp rows are skipped without corrupting later valid rows" in {
     withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      // Bad timestamp rows should increment error handling and leave keyed state untouched.
       driver.setProcessingTime("2025-07-21T10:30:00Z")
       driver.processMalformedTimestamp("gen_bad", "bad_ts", "user_bad")
       driver.drainNewOutputs() shouldBe empty
 
+      // A later valid row for the same key should behave like the first accepted event.
       driver.processEvent("gen_bad", "2025-07-21T10:31:00Z", "user_good")
       driver.drainNewOutputs().last.values shouldEqual windowValues(1L, 1L, 1L)
     }
   }
 
-  it should "emit once when buffered emit and eviction timers share the same timestamp" in {
+  it should "Failure/recovery lifecycle: emit and eviction timers at the same PT instant coalesce into one row" in {
     withDriver(bufferingOutputTimeMillis = 5 * 60 * 1000L) { driver =>
+      // The event arms both an eviction timer and a buffered emit timer for 10:35.
       driver.setProcessingTime("2025-07-21T10:30:00Z")
       driver.processEvent("gen_collision", "2025-07-21T10:30:00Z", "user_1")
       driver.drainNewOutputs() shouldBe empty
 
+      // A shared callback timestamp should rebuild and emit once, not duplicate the dirty row.
       driver.setProcessingTime("2025-07-21T10:35:00Z")
       assertSingleOutput(
         driver.drainNewOutputs(),
@@ -435,7 +547,7 @@ class MegaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     }
   }
 
-  it should "add stable per-key jitter to buffered emissions" in {
+  it should "buffered emissions add stable per-key jitter" in {
     val key = "gen_jitter"
     val baseProcessingTs = toMillis("2025-07-21T10:30:00Z")
     val bufferMillis = 1000L
@@ -444,15 +556,18 @@ class MegaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     val expectedEmitTs = baseProcessingTs + bufferMillis + expectedJitter
 
     withDriver(bufferingOutputTimeMillis = bufferMillis, bufferingOutputJitterMillis = maxJitterMillis) { driver =>
+      // The first dirty row schedules an emit at base delay plus stable key jitter.
       driver.setProcessingTimeMillis(baseProcessingTs)
       driver.processEvent(key, "2025-07-21T10:30:00Z", "user_1")
       driver.drainNewOutputs() shouldBe empty
 
+      // Nothing should emit before the jittered timestamp.
       if (expectedEmitTs > baseProcessingTs) {
         driver.setProcessingTimeMillis(expectedEmitTs - 1L)
         driver.drainNewOutputs() shouldBe empty
       }
 
+      // At the jittered timestamp exactly one buffered output is emitted.
       driver.setProcessingTimeMillis(expectedEmitTs)
       val outputs = driver.drainNewOutputs()
       assertSingleOutput(
@@ -504,6 +619,8 @@ object MegaTileProcessFunctionTest extends Matchers {
   private def windowValues(oneHour: Any, oneDay: Any, threeDay: Any): Seq[Any] =
     Seq(oneHour, oneDay, threeDay)
 
+  // Shared setup for the live/catchup boundary tests: create an old 10:30-10:35 tile, then
+  // advance PT so the 11:35 callback decides whether that tile is still in 1h.
   private def seedOldTileBeforeLiveCatchupBoundary(driver: Driver, key: String): Unit = {
     driver.setProcessingTime("2025-07-21T10:30:00Z")
     driver.processEvent(key, "2025-07-21T10:30:00Z", "user_old_1")
@@ -519,6 +636,8 @@ object MegaTileProcessFunctionTest extends Matchers {
     driver.processWatermark("2026-04-11T23:54:00Z")
     driver.setProcessingTime("2026-04-12T00:01:00Z")
 
+    // The key is active and watermark is more than one hop plus slack behind PT, so the 00:00:30
+    // tile is retained but not merged into no-batch windows as of the 23:55 watermark hop.
     driver.processEvent(key, "2026-04-12T00:00:30Z", "user_after_midnight")
     assertSingleOutput(
       driver.drainNewOutputs(),
@@ -526,6 +645,8 @@ object MegaTileProcessFunctionTest extends Matchers {
       expectedDayStart = dayStart("2026-04-12T00:00:00Z"),
       expectedValues = windowValues(null, null, 1L))
 
+    // Once watermark crosses midnight and is close enough to PT, the next PT eviction rebuilds the
+    // small-window cache as live time and the retained 00:00 tile appears.
     driver.processWatermark("2026-04-12T00:00:30Z")
     driver.setProcessingTime("2026-04-12T00:05:00Z")
     assertSingleOutput(
@@ -546,6 +667,8 @@ object MegaTileProcessFunctionTest extends Matchers {
       expectedDayStart = dayStart("2026-04-11T00:00:00Z"),
       expectedValues = windowValues(1L, 1L, 1L))
 
+    // At 00:10 the key has been idle for more than one hop, so stale-watermark mode is SparseKeyLag.
+    // The overdue PT eviction rolls currentDayStart to Apr12 and rebuilds small windows as of PT.
     driver.processWatermark("2026-04-11T23:54:00Z")
     driver.setProcessingTime("2026-04-12T00:10:00Z")
     assertSingleOutput(
@@ -566,6 +689,7 @@ object MegaTileProcessFunctionTest extends Matchers {
       expectedDayStart = dayStart("2026-04-12T00:00:00Z"),
       expectedValues = windowValues(1L, 1L, 1L))
 
+    // Exact yesterday-start is admissible. It updates current 1d/3d state, but not current 1h.
     driver.processEvent(key, "2026-04-11T00:00:00Z", "user_yesterday_start")
     val outputs = driver.drainNewOutputs()
     outputs should have size 2
@@ -586,6 +710,7 @@ object MegaTileProcessFunctionTest extends Matchers {
       expectedDayStart = dayStart("2026-04-12T00:00:00Z"),
       expectedValues = windowValues(1L, 1L, 1L))
 
+    // One millisecond older than yesterday is rejected before processor.onEvent can mutate state.
     driver.processEvent(key, "2026-04-10T23:59:59.999Z", "user_too_old")
     driver.drainNewOutputs() shouldBe empty
   }

--- a/flink/src/test/scala/ai/chronon/flink/test/window/MegaTileProcessFunctionTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/window/MegaTileProcessFunctionTest.scala
@@ -1,0 +1,703 @@
+package ai.chronon.flink.test.window
+
+import ai.chronon.api._
+import ai.chronon.api.Extensions.WindowOps
+import ai.chronon.flink.FlinkJob
+import ai.chronon.flink.deser.ProjectedEvent
+import ai.chronon.flink.types.TimestampedTile
+import ai.chronon.flink.window.MegaTileProcessFunction
+import ai.chronon.online.MegaTileCodec
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.functions.KeySelector
+import org.apache.flink.streaming.api.operators.KeyedProcessOperator
+import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.time.Instant
+import java.util
+import scala.collection.JavaConverters._
+
+class MegaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
+  import MegaTileProcessFunctionTest._
+
+  "MegaTileProcessFunction" should "keep watermark constants aligned with MegaTile eviction lifecycle" in {
+    FlinkJob.AllowedOutOfOrderness.toMillis shouldEqual 5 * 60 * 1000L
+    FlinkJob.IdlenessTimeout.toMillis shouldEqual 30 * 1000L
+    FlinkJob.CatchupWatermarkLagSlackMillis shouldEqual 30 * 1000L
+  }
+
+  it should "use processing-time eviction when watermark lag is inside one hop plus slack" in {
+    withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      seedOldTileBeforeLiveCatchupBoundary(driver, "gen_live_slack")
+
+      driver.processWatermark("2025-07-21T11:29:45Z")
+      driver.setProcessingTime("2025-07-21T11:34:00Z")
+      driver.processEvent("gen_live_slack", "2025-07-21T11:34:00Z", "user_current")
+      driver.drainNewOutputs().last.values shouldEqual windowValues(3L, 3L, 3L)
+
+      driver.setProcessingTime("2025-07-21T11:35:00Z")
+      assertSingleOutput(
+        driver.drainNewOutputs(),
+        expectedKey = "gen_live_slack",
+        expectedDayStart = dayStart("2025-07-21T00:00:00Z"),
+        expectedValues = windowValues(1L, 3L, 3L))
+    }
+  }
+
+  it should "use watermark-time eviction when active catchup is beyond slack" in {
+    withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      seedOldTileBeforeLiveCatchupBoundary(driver, "gen_catchup")
+
+      driver.processWatermark("2025-07-21T11:29:29Z")
+      driver.setProcessingTime("2025-07-21T11:34:00Z")
+      driver.processEvent("gen_catchup", "2025-07-21T11:34:00Z", "user_current")
+      driver.drainNewOutputs().last.values shouldEqual windowValues(3L, 3L, 3L)
+
+      driver.setProcessingTime("2025-07-21T11:35:00Z")
+      assertSingleOutput(
+        driver.drainNewOutputs(),
+        expectedKey = "gen_catchup",
+        expectedDayStart = dayStart("2025-07-21T00:00:00Z"),
+        expectedValues = windowValues(2L, 3L, 3L))
+    }
+  }
+
+  it should "roll day state at watermark midnight without losing the previous dirty row" in {
+    withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      driver.setProcessingTime("2025-07-21T23:59:00Z")
+      driver.processEvent("gen_steady", "2025-07-21T23:59:00Z", "user_before_roll")
+      assertSingleOutput(
+        driver.drainNewOutputs(),
+        expectedKey = "gen_steady",
+        expectedDayStart = dayStart("2025-07-21T00:00:00Z"),
+        expectedValues = windowValues(1L, 1L, 1L))
+
+      driver.setProcessingTime("2025-07-22T00:00:01Z")
+      driver.drainNewOutputs() should not be empty
+
+      driver.processWatermark("2025-07-22T00:00:00Z")
+      driver.processEvent("gen_steady", "2025-07-22T00:00:00Z", "user_after_roll")
+      val rolloverOutputs = driver.drainNewOutputs()
+      assertSingleOutput(
+        rolloverOutputs,
+        expectedKey = "gen_steady",
+        expectedDayStart = dayStart("2025-07-22T00:00:00Z"),
+        expectedValues = windowValues(2L, 2L, 1L))
+
+      driver.setProcessingTime("2025-07-22T00:05:01Z")
+      driver.drainNewOutputs() should not be empty
+
+      driver.processEvent("gen_steady", "2025-07-22T00:05:00Z", "user_exact_hop")
+      val todayOutputs = driver.drainNewOutputs()
+      todayOutputs.last.dayStartMillis shouldEqual dayStart("2025-07-22T00:00:00Z")
+      todayOutputs.last.values shouldEqual windowValues(3L, 3L, 2L)
+    }
+  }
+
+  it should "route late previous-day events to current small windows and yesterday large windows after PT midnight roll" in {
+    withDriver(bufferingOutputTimeMillis = 1000L) { driver =>
+      driver.processWatermark("2025-07-21T23:54:55.999Z")
+      driver.setProcessingTime("2025-07-21T23:59:56.900Z")
+      driver.processEvent("gen_midnight_live", "2025-07-21T23:59:56Z", "user_before_midnight")
+      driver.drainNewOutputs() shouldBe empty
+
+      driver.setProcessingTime("2025-07-21T23:59:57.900Z")
+      assertSingleOutput(
+        driver.drainNewOutputs(),
+        expectedKey = "gen_midnight_live",
+        expectedDayStart = dayStart("2025-07-21T00:00:00Z"),
+        expectedValues = windowValues(1L, 1L, 1L))
+
+      driver.setProcessingTime("2025-07-22T00:00:00.001Z")
+      driver.drainNewOutputs() shouldBe empty
+
+      driver.setProcessingTime("2025-07-22T00:00:00.006Z")
+      driver.processEvent("gen_midnight_live", "2025-07-21T23:59:58Z", "user_previous_day_after_roll")
+      driver.drainNewOutputs() shouldBe empty
+
+      driver.setProcessingTime("2025-07-22T00:00:01.001Z")
+      val boundaryOutputs = driver.drainNewOutputs()
+      boundaryOutputs should have size 2
+      boundaryOutputs.find(_.dayStartMillis == dayStart("2025-07-22T00:00:00Z")).map(_.values) shouldEqual
+        Some(windowValues(2L, 2L, null))
+      boundaryOutputs.find(_.dayStartMillis == dayStart("2025-07-21T00:00:00Z")).map(_.values) shouldEqual
+        Some(windowValues(null, null, 2L))
+    }
+  }
+
+  it should "update retained yesterday-start for 1d but not stale 1h" in {
+    withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      driver.setProcessingTime("2025-07-22T00:10:00Z")
+      driver.processEvent("gen_boundary", "2025-07-22T00:00:00Z", "user_today_start")
+      driver.drainNewOutputs() should have size 1
+
+      driver.processWatermark("2025-07-22T00:05:00Z")
+      driver.processEvent("gen_boundary", "2025-07-21T00:00:00Z", "user_yesterday_start")
+      val outputs = driver.drainNewOutputs()
+      outputs should have size 2
+      outputs.find(_.dayStartMillis == dayStart("2025-07-22T00:00:00Z")).map(_.values) shouldEqual
+        Some(windowValues(1L, 2L, 1L))
+      outputs.find(_.dayStartMillis == dayStart("2025-07-21T00:00:00Z")).map(_.values) shouldEqual
+        Some(windowValues(null, null, 1L))
+    }
+  }
+
+  it should "decay during a short upstream stop and recover on live-time resume" in {
+    withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      driver.setProcessingTime("2025-07-21T10:30:00Z")
+      driver.processEvent("gen_stop_short", "2025-07-21T10:30:00Z", "user_initial")
+      driver.drainNewOutputs().last.values shouldEqual windowValues(1L, 1L, 1L)
+
+      driver.setProcessingTime("2025-07-21T11:30:00Z")
+      driver.drainNewOutputs().last.values shouldEqual windowValues(1L, 1L, 1L)
+
+      driver.setProcessingTime("2025-07-21T11:35:00Z")
+      driver.drainNewOutputs().last.values shouldEqual windowValues(null, 1L, 1L)
+
+      driver.processEvent("gen_stop_short", "2025-07-21T11:36:00Z", "user_resume")
+      driver.drainNewOutputs().last.values shouldEqual windowValues(1L, 2L, 2L)
+    }
+  }
+
+  it should "not re-inflate 1h for a retained late tile outside current small-window as-of" in {
+    withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      driver.setProcessingTime("2025-07-21T10:30:00Z")
+      driver.processEvent("gen_late_same_day", "2025-07-21T10:30:00Z", "user_on_time")
+      driver.drainNewOutputs().last.values shouldEqual windowValues(1L, 1L, 1L)
+
+      driver.setProcessingTime("2025-07-21T11:35:00Z")
+      driver.drainNewOutputs().last.values shouldEqual windowValues(null, 1L, 1L)
+
+      driver.setProcessingTime("2025-07-21T11:36:00Z")
+      driver.processWatermark("2025-07-21T11:30:00Z")
+      driver.processEvent("gen_late_same_day", "2025-07-21T10:32:00Z", "user_late_expired_hop")
+      driver.drainNewOutputs().last.values shouldEqual windowValues(null, 2L, 2L)
+    }
+  }
+
+  it should "expire 1d after a long stop but preserve fresh resume behavior" in {
+    withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      driver.setProcessingTime("2025-07-21T10:30:00Z")
+      driver.processEvent("gen_stop_long", "2025-07-21T10:30:00Z", "user_initial")
+      driver.drainNewOutputs() should have size 1
+
+      driver.setProcessingTime("2025-07-22T11:35:00Z")
+      driver.drainNewOutputs().last.values shouldEqual windowValues(null, null, null)
+
+      driver.processEvent("gen_stop_long", "2025-07-22T11:36:00Z", "user_resume")
+      driver.drainNewOutputs().last.values shouldEqual windowValues(1L, 1L, 1L)
+    }
+  }
+
+  it should "update retained yesterday-start for 1d but not stale 1h after resume" in {
+    withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      driver.setProcessingTime("2025-07-22T00:10:00Z")
+      driver.processEvent("gen_stop_boundary", "2025-07-22T00:10:00Z", "user_anchor")
+      driver.drainNewOutputs() should have size 1
+
+      driver.setProcessingTime("2025-07-22T00:15:00Z")
+      driver.drainNewOutputs() should not be empty
+
+      driver.processWatermark("2025-07-22T00:10:00Z")
+      driver.processEvent("gen_stop_boundary", "2025-07-21T00:00:00Z", "user_yesterday_start")
+      val outputs = driver.drainNewOutputs()
+      outputs should have size 2
+      outputs.find(_.dayStartMillis == dayStart("2025-07-22T00:00:00Z")).map(_.values) shouldEqual
+        Some(windowValues(1L, 2L, 1L))
+      outputs.find(_.dayStartMillis == dayStart("2025-07-21T00:00:00Z")).map(_.values) shouldEqual
+        Some(windowValues(null, null, 1L))
+
+      driver.processEvent("gen_stop_boundary", "2025-07-20T23:59:59.999Z", "user_too_old")
+      driver.drainNewOutputs() shouldBe empty
+    }
+  }
+
+  it should "keep active replay on watermark time before sparse-key PT fallback" in {
+    withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      driver.setProcessingTime("2025-07-23T10:30:00Z")
+      driver.processWatermark("2025-07-21T10:30:00Z")
+      driver.processEvent("gen_replay", "2025-07-21T10:30:00Z", "user_replay_1")
+      driver.drainNewOutputs().last.dayStartMillis shouldEqual dayStart("2025-07-21T00:00:00Z")
+
+      driver.setProcessingTime("2025-07-23T10:35:00Z")
+      driver.processEvent("gen_replay", "2025-07-21T10:31:00Z", "user_replay_2")
+      driver.drainNewOutputs().last.values shouldEqual windowValues(2L, 2L, 2L)
+
+      driver.setProcessingTime("2025-07-23T10:50:00Z")
+      val idleFallback = driver.drainNewOutputs().last
+      idleFallback.dayStartMillis shouldEqual dayStart("2025-07-23T00:00:00Z")
+      idleFallback.values shouldEqual windowValues(null, null, null)
+    }
+  }
+
+  it should "retain an event ahead of stale watermark until eviction catches up" in {
+    withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      driver.processWatermark("2025-07-21T22:31:23.999Z")
+      driver.setProcessingTime("2025-07-21T23:40:01Z")
+      driver.processEvent("gen_resume_stale_watermark", "2025-07-21T23:40:00Z", "user_resume")
+      driver.drainNewOutputs().last.values shouldEqual windowValues(null, null, 1L)
+
+      driver.processWatermark("2025-07-21T23:40:00Z")
+      driver.setProcessingTime("2025-07-21T23:45:00Z")
+      driver.drainNewOutputs().last.values shouldEqual windowValues(1L, 1L, 1L)
+    }
+  }
+
+  it should "handle catchup UTC day-boundary scenarios" in {
+    val scenarios = Seq(
+      activeKeyResumesAfterUtcMidnightWithStaleWatermarkThenCatchesUp _,
+      sparseKeyResumesAfterUtcMidnightWithStaleWatermark _,
+      yesterdayBoundaryEventAfterResumeIsAdmitted _,
+      olderThanYesterdayEventAfterResumeIsDropped _
+    )
+
+    scenarios.foreach { scenario =>
+      withDriver(bufferingOutputTimeMillis = 0L)(scenario)
+    }
+  }
+
+  it should "not emit an old dirty day as an adjacent rollover after multi-day downtime" in {
+    withDriver(bufferingOutputTimeMillis = 3L * DayMillis) { driver =>
+      driver.setProcessingTime("2026-04-11T23:50:00Z")
+      driver.processEvent("axis_multi_day_jump", "2026-04-11T23:50:00Z", "user_seed")
+      driver.drainNewOutputs() shouldBe empty
+
+      driver.setProcessingTime("2026-04-13T00:10:00Z")
+      driver.drainNewOutputs() shouldBe empty
+
+      driver.processEvent("axis_multi_day_jump", "2026-04-11T23:59:00Z", "user_backlog_too_old_after_jump")
+      driver.drainNewOutputs() shouldBe empty
+    }
+  }
+
+  it should "update replayed yesterday-start for 1d but not stale 1h" in {
+    withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      driver.setProcessingTime("2025-07-24T10:00:00Z")
+      driver.processWatermark("2025-07-22T00:00:00Z")
+      driver.processEvent("gen_replay_boundary", "2025-07-22T00:00:00Z", "user_today_start")
+      assertSingleOutput(
+        driver.drainNewOutputs(),
+        expectedKey = "gen_replay_boundary",
+        expectedDayStart = dayStart("2025-07-22T00:00:00Z"),
+        expectedValues = windowValues(1L, 1L, 1L))
+
+      driver.processWatermark("2025-07-23T00:00:00Z")
+      driver.processEvent("gen_replay_boundary", "2025-07-22T00:00:00Z", "user_yesterday_start")
+      val outputs = driver.drainNewOutputs()
+      outputs should have size 2
+      outputs.find(_.dayStartMillis == dayStart("2025-07-23T00:00:00Z")).map(_.values) shouldEqual
+        Some(windowValues(1L, 2L, null))
+      outputs.find(_.dayStartMillis == dayStart("2025-07-22T00:00:00Z")).map(_.values) shouldEqual
+        Some(windowValues(null, null, 2L))
+
+      driver.processEvent("gen_replay_boundary", "2025-07-21T23:59:59.999Z", "user_too_old")
+      driver.drainNewOutputs() shouldBe empty
+    }
+  }
+
+  it should "drop sparse-key backlog older than yesterday after PT fallback day roll" in {
+    withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      driver.setProcessingTime("2025-07-23T10:30:00Z")
+      driver.processWatermark("2025-07-21T10:30:00Z")
+      driver.processEvent("gen_sparse_replay_drop", "2025-07-21T10:30:00Z", "user_seed")
+      assertSingleOutput(
+        driver.drainNewOutputs(),
+        expectedKey = "gen_sparse_replay_drop",
+        expectedDayStart = dayStart("2025-07-21T00:00:00Z"),
+        expectedValues = windowValues(1L, 1L, 1L))
+
+      driver.setProcessingTime("2025-07-23T10:40:00Z")
+      assertSingleOutput(
+        driver.drainNewOutputs(),
+        expectedKey = "gen_sparse_replay_drop",
+        expectedDayStart = dayStart("2025-07-23T00:00:00Z"),
+        expectedValues = windowValues(null, null, null))
+
+      driver.setProcessingTime("2025-07-23T10:41:00Z")
+      driver.processEvent("gen_sparse_replay_drop", "2025-07-21T23:59:00Z", "user_backlog_too_late")
+      driver.drainNewOutputs() shouldBe empty
+    }
+  }
+
+  it should "roll cold-start backlog rows without dropping valid events" in {
+    withDriver(bufferingOutputTimeMillis = 120000L) { driver =>
+      driver.setProcessingTime("2025-07-23T10:30:00Z")
+      driver.processWatermark("2025-07-21T23:59:00Z")
+      driver.processEvent("gen_cold_start", "2025-07-21T23:59:00Z", "user_day_1")
+      driver.drainNewOutputs() shouldBe empty
+
+      driver.processWatermark("2025-07-22T00:00:01Z")
+      driver.processEvent("gen_cold_start", "2025-07-22T00:00:00Z", "user_day_2")
+      assertSingleOutput(
+        driver.drainNewOutputs(),
+        expectedKey = "gen_cold_start",
+        expectedDayStart = dayStart("2025-07-21T00:00:00Z"),
+        expectedValues = windowValues(1L, 1L, 1L))
+
+      driver.processEvent("gen_cold_start", "2025-07-22T00:05:00Z", "user_exact_hop")
+      driver.processEvent("gen_cold_start", "2025-07-22T00:05:01Z", "user_after_hop")
+      driver.processEvent("gen_cold_start", "2025-07-21T00:00:00Z", "user_prev_day")
+      driver.processEvent("gen_cold_start", "2025-07-20T23:59:59.999Z", "user_too_old")
+      driver.drainNewOutputs() shouldBe empty
+
+      driver.setProcessingTime("2025-07-23T10:32:00Z")
+      val preEvictionOutputs = driver.drainNewOutputs()
+      preEvictionOutputs should have size 2
+      preEvictionOutputs.find(_.dayStartMillis == dayStart("2025-07-21T00:00:00Z")).map(_.values) shouldEqual
+        Some(windowValues(null, null, 2L))
+      preEvictionOutputs.find(_.dayStartMillis == dayStart("2025-07-22T00:00:00Z")).map(_.values) shouldEqual
+        Some(windowValues(2L, 5L, 3L))
+
+      driver.setProcessingTime("2025-07-23T10:35:00Z")
+      driver.drainNewOutputs() shouldBe empty
+
+      driver.setProcessingTime("2025-07-23T10:37:00Z")
+      assertSingleOutput(
+        driver.drainNewOutputs(),
+        expectedKey = "gen_cold_start",
+        expectedDayStart = dayStart("2025-07-22T00:00:00Z"),
+        expectedValues = windowValues(2L, 5L, 3L))
+    }
+  }
+
+  it should "drop events older than yesterday before mutating state" in {
+    withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      driver.processWatermark("2026-04-12T00:05:00Z")
+      driver.setProcessingTime("2026-04-12T00:10:00Z")
+      driver.processEvent("gen_stale", "2026-04-12T00:10:00Z", "user_anchor")
+      driver.drainNewOutputs() should have size 1
+
+      driver.processEvent("gen_stale", "2026-04-10T23:59:59.999Z", "user_too_old")
+      driver.drainNewOutputs() shouldBe empty
+    }
+  }
+
+  it should "restore pending timers, dirty bits, and key isolation from checkpoint" in {
+    val originalHarness = harness(bufferingOutputTimeMillis = 10 * 60 * 1000L)
+    originalHarness.open()
+    val baseProcessingTs = toMillis("2025-07-21T10:30:00Z")
+    originalHarness.setProcessingTime(baseProcessingTs)
+    originalHarness.processElement(event("gen_restore_a", "2025-07-21T10:30:00Z", "user_a_1", baseProcessingTs), 0L)
+    originalHarness.processElement(event("gen_restore_b", "2025-07-21T10:31:00Z", "user_b_1", baseProcessingTs), 0L)
+    originalHarness.extractOutputValues().asScala.toList shouldBe empty
+
+    val snapshot = originalHarness.snapshot(7L, baseProcessingTs + 1000L)
+    originalHarness.close()
+
+    val restoredHarness = harness(bufferingOutputTimeMillis = 10 * 60 * 1000L)
+    restoredHarness.setup()
+    restoredHarness.initializeState(snapshot)
+    restoredHarness.open()
+
+    restoredHarness.setProcessingTime(toMillis("2025-07-21T10:35:00Z"))
+    restoredHarness.extractOutputValues().asScala.toList shouldBe empty
+
+    restoredHarness.setProcessingTime(toMillis("2025-07-21T10:40:00Z"))
+    val outputs = restoredHarness.extractOutputValues().asScala.toList.map(decodeOutput)
+    outputs should have size 2
+    outputs.find(_.keys == List("gen_restore_a")).map(_.values) shouldEqual Some(windowValues(1L, 1L, 1L))
+    outputs.find(_.keys == List("gen_restore_b")).map(_.values) shouldEqual Some(windowValues(1L, 1L, 1L))
+
+    restoredHarness.processElement(
+      event("gen_restore_a", "2025-07-21T10:41:00Z", "user_a_2", toMillis("2025-07-21T10:40:00Z")),
+      0L)
+    restoredHarness.setProcessingTime(toMillis("2025-07-21T10:51:00Z"))
+    val postRestore = restoredHarness.extractOutputValues().asScala.toList.map(decodeOutput)
+    postRestore.filter(_.keys == List("gen_restore_a")).last.values shouldEqual windowValues(2L, 2L, 2L)
+    postRestore.filter(_.keys == List("gen_restore_b")).last.values shouldEqual windowValues(1L, 1L, 1L)
+    restoredHarness.close()
+  }
+
+  it should "skip malformed timestamp rows without corrupting later valid rows" in {
+    withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      driver.setProcessingTime("2025-07-21T10:30:00Z")
+      driver.processMalformedTimestamp("gen_bad", "bad_ts", "user_bad")
+      driver.drainNewOutputs() shouldBe empty
+
+      driver.processEvent("gen_bad", "2025-07-21T10:31:00Z", "user_good")
+      driver.drainNewOutputs().last.values shouldEqual windowValues(1L, 1L, 1L)
+    }
+  }
+
+  it should "emit once when buffered emit and eviction timers share the same timestamp" in {
+    withDriver(bufferingOutputTimeMillis = 5 * 60 * 1000L) { driver =>
+      driver.setProcessingTime("2025-07-21T10:30:00Z")
+      driver.processEvent("gen_collision", "2025-07-21T10:30:00Z", "user_1")
+      driver.drainNewOutputs() shouldBe empty
+
+      driver.setProcessingTime("2025-07-21T10:35:00Z")
+      assertSingleOutput(
+        driver.drainNewOutputs(),
+        expectedKey = "gen_collision",
+        expectedDayStart = dayStart("2025-07-21T00:00:00Z"),
+        expectedValues = windowValues(1L, 1L, 1L))
+    }
+  }
+
+  it should "add stable per-key jitter to buffered emissions" in {
+    val key = "gen_jitter"
+    val baseProcessingTs = toMillis("2025-07-21T10:30:00Z")
+    val bufferMillis = 1000L
+    val maxJitterMillis = 1000L
+    val expectedJitter = Math.floorMod(keyList(key).hashCode().toLong, maxJitterMillis + 1L)
+    val expectedEmitTs = baseProcessingTs + bufferMillis + expectedJitter
+
+    withDriver(bufferingOutputTimeMillis = bufferMillis, bufferingOutputJitterMillis = maxJitterMillis) { driver =>
+      driver.setProcessingTimeMillis(baseProcessingTs)
+      driver.processEvent(key, "2025-07-21T10:30:00Z", "user_1")
+      driver.drainNewOutputs() shouldBe empty
+
+      if (expectedEmitTs > baseProcessingTs) {
+        driver.setProcessingTimeMillis(expectedEmitTs - 1L)
+        driver.drainNewOutputs() shouldBe empty
+      }
+
+      driver.setProcessingTimeMillis(expectedEmitTs)
+      val outputs = driver.drainNewOutputs()
+      assertSingleOutput(
+        outputs,
+        expectedKey = key,
+        expectedDayStart = dayStart("2025-07-21T00:00:00Z"),
+        expectedValues = windowValues(1L, 1L, 1L))
+      outputs.head.processingTsMillis shouldEqual expectedEmitTs
+    }
+  }
+}
+
+object MegaTileProcessFunctionTest extends Matchers {
+  private val DayMillis = new Window(1, TimeUnit.DAYS).millis
+
+  private val inputSchema: Seq[(String, DataType)] =
+    Seq("view_by" -> StringType, Constants.TimeColumn -> LongType)
+
+  private val groupBy: GroupBy = {
+    val gb = Builders.GroupBy(
+      sources = Seq(
+        Builders.Source.events(
+          table = "events.test_stream",
+          topic = "events.test_stream",
+          query = Builders.Query(
+            selects = Map("id" -> "id", "view_by" -> "view_by"),
+            timeColumn = Constants.TimeColumn,
+            startPartition = "20250101"
+          )
+        )
+      ),
+      keyColumns = Seq("id"),
+      aggregations = Seq(
+        Builders.Aggregation(
+          operation = Operation.COUNT,
+          inputColumn = "view_by",
+          windows = Seq(new Window(1, TimeUnit.HOURS), new Window(1, TimeUnit.DAYS), new Window(3, TimeUnit.DAYS))
+        )
+      ),
+      metaData = Builders.MetaData(name = "mega_tile_process_function_test"),
+      accuracy = Accuracy.TEMPORAL
+    )
+    gb.setOnlineStrategy(OnlineStrategy.STREAMING_MEGATILES)
+    gb
+  }
+
+  private val megaTileCodec = new MegaTileCodec(groupBy, inputSchema)
+
+  private def windowValues(oneHour: Any, oneDay: Any, threeDay: Any): Seq[Any] =
+    Seq(oneHour, oneDay, threeDay)
+
+  private def seedOldTileBeforeLiveCatchupBoundary(driver: Driver, key: String): Unit = {
+    driver.setProcessingTime("2025-07-21T10:30:00Z")
+    driver.processEvent(key, "2025-07-21T10:30:00Z", "user_old_1")
+    driver.processEvent(key, "2025-07-21T10:31:00Z", "user_old_2")
+    driver.drainNewOutputs().last.values shouldEqual windowValues(2L, 2L, 2L)
+
+    driver.setProcessingTime("2025-07-21T11:30:00Z")
+    driver.drainNewOutputs().last.values shouldEqual windowValues(2L, 2L, 2L)
+  }
+
+  private def activeKeyResumesAfterUtcMidnightWithStaleWatermarkThenCatchesUp(driver: Driver): Unit = {
+    val key = "axis_active_after_midnight"
+    driver.processWatermark("2026-04-11T23:54:00Z")
+    driver.setProcessingTime("2026-04-12T00:01:00Z")
+
+    driver.processEvent(key, "2026-04-12T00:00:30Z", "user_after_midnight")
+    assertSingleOutput(
+      driver.drainNewOutputs(),
+      expectedKey = key,
+      expectedDayStart = dayStart("2026-04-12T00:00:00Z"),
+      expectedValues = windowValues(null, null, 1L))
+
+    driver.processWatermark("2026-04-12T00:00:30Z")
+    driver.setProcessingTime("2026-04-12T00:05:00Z")
+    assertSingleOutput(
+      driver.drainNewOutputs(),
+      expectedKey = key,
+      expectedDayStart = dayStart("2026-04-12T00:00:00Z"),
+      expectedValues = windowValues(1L, 1L, 1L))
+  }
+
+  private def sparseKeyResumesAfterUtcMidnightWithStaleWatermark(driver: Driver): Unit = {
+    val key = "axis_sparse_after_midnight"
+    driver.processWatermark("2026-04-11T23:49:00Z")
+    driver.setProcessingTime("2026-04-11T23:50:00Z")
+    driver.processEvent(key, "2026-04-11T23:50:00Z", "user_seed")
+    assertSingleOutput(
+      driver.drainNewOutputs(),
+      expectedKey = key,
+      expectedDayStart = dayStart("2026-04-11T00:00:00Z"),
+      expectedValues = windowValues(1L, 1L, 1L))
+
+    driver.processWatermark("2026-04-11T23:54:00Z")
+    driver.setProcessingTime("2026-04-12T00:10:00Z")
+    assertSingleOutput(
+      driver.drainNewOutputs(),
+      expectedKey = key,
+      expectedDayStart = dayStart("2026-04-12T00:00:00Z"),
+      expectedValues = windowValues(1L, 1L, null))
+  }
+
+  private def yesterdayBoundaryEventAfterResumeIsAdmitted(driver: Driver): Unit = {
+    val key = "axis_yesterday_boundary"
+    driver.processWatermark("2026-04-12T00:05:00Z")
+    driver.setProcessingTime("2026-04-12T00:10:00Z")
+    driver.processEvent(key, "2026-04-12T00:10:00Z", "user_anchor")
+    assertSingleOutput(
+      driver.drainNewOutputs(),
+      expectedKey = key,
+      expectedDayStart = dayStart("2026-04-12T00:00:00Z"),
+      expectedValues = windowValues(1L, 1L, 1L))
+
+    driver.processEvent(key, "2026-04-11T00:00:00Z", "user_yesterday_start")
+    val outputs = driver.drainNewOutputs()
+    outputs should have size 2
+    outputs.find(_.dayStartMillis == dayStart("2026-04-12T00:00:00Z")).map(_.values) shouldEqual
+      Some(windowValues(1L, 2L, 1L))
+    outputs.find(_.dayStartMillis == dayStart("2026-04-11T00:00:00Z")).map(_.values) shouldEqual
+      Some(windowValues(null, null, 1L))
+  }
+
+  private def olderThanYesterdayEventAfterResumeIsDropped(driver: Driver): Unit = {
+    val key = "axis_older_than_yesterday"
+    driver.processWatermark("2026-04-12T00:05:00Z")
+    driver.setProcessingTime("2026-04-12T00:10:00Z")
+    driver.processEvent(key, "2026-04-12T00:10:00Z", "user_anchor")
+    assertSingleOutput(
+      driver.drainNewOutputs(),
+      expectedKey = key,
+      expectedDayStart = dayStart("2026-04-12T00:00:00Z"),
+      expectedValues = windowValues(1L, 1L, 1L))
+
+    driver.processEvent(key, "2026-04-10T23:59:59.999Z", "user_too_old")
+    driver.drainNewOutputs() shouldBe empty
+  }
+
+  private case class DecodedOutput(
+      keys: List[Any],
+      dayStartMillis: Long,
+      processingTsMillis: Long,
+      values: Seq[Any])
+
+  final private class Driver(bufferingOutputTimeMillis: Long, bufferingOutputJitterMillis: Long) {
+    private val testHarness = harness(bufferingOutputTimeMillis, bufferingOutputJitterMillis)
+    private var emittedCount = 0
+    private var currentProcessingTs = 0L
+
+    testHarness.open()
+
+    def setProcessingTime(iso: String): Unit =
+      setProcessingTimeMillis(toMillis(iso))
+
+    def setProcessingTimeMillis(ts: Long): Unit = {
+      currentProcessingTs = ts
+      testHarness.setProcessingTime(ts)
+    }
+
+    def processWatermark(iso: String): Unit =
+      testHarness.processWatermark(toMillis(iso))
+
+    def processEvent(id: String, eventIso: String, viewBy: String): Unit =
+      testHarness.processElement(event(id, eventIso, viewBy, currentProcessingTs), 0L)
+
+    def processMalformedTimestamp(id: String, malformedTs: String, viewBy: String): Unit =
+      testHarness.processElement(
+        ProjectedEvent(Map("id" -> id, "view_by" -> viewBy, Constants.TimeColumn -> malformedTs), currentProcessingTs),
+        0L)
+
+    def drainNewOutputs(): List[DecodedOutput] = {
+      val allOutputs = testHarness.extractOutputValues().asScala.toList.map(decodeOutput)
+      val newOutputs = allOutputs.drop(emittedCount)
+      emittedCount = allOutputs.size
+      newOutputs
+    }
+
+    def close(): Unit =
+      testHarness.close()
+  }
+
+  private def withDriver(bufferingOutputTimeMillis: Long, bufferingOutputJitterMillis: Long = 0L)(
+      fn: Driver => Unit): Unit = {
+    val driver = new Driver(bufferingOutputTimeMillis, bufferingOutputJitterMillis)
+    try {
+      fn(driver)
+    } finally {
+      driver.close()
+    }
+  }
+
+  private def harness(bufferingOutputTimeMillis: Long,
+                      bufferingOutputJitterMillis: Long = 0L)
+      : KeyedOneInputStreamOperatorTestHarness[java.util.List[Any], ProjectedEvent, TimestampedTile] = {
+    new KeyedOneInputStreamOperatorTestHarness[java.util.List[Any], ProjectedEvent, TimestampedTile](
+      new KeyedProcessOperator[java.util.List[Any], ProjectedEvent, TimestampedTile](
+        new MegaTileProcessFunction(
+          groupBy,
+          inputSchema,
+          bufferingOutputTimeMillis = bufferingOutputTimeMillis,
+          bufferingOutputJitterMillis = bufferingOutputJitterMillis
+        )),
+      new KeySelector[ProjectedEvent, java.util.List[Any]] {
+        override def getKey(value: ProjectedEvent): java.util.List[Any] =
+          keyList(value.fields("id"))
+      },
+      TypeInformation.of(classOf[java.util.List[_]]).asInstanceOf[TypeInformation[java.util.List[Any]]]
+    )
+  }
+
+  private def event(id: String, eventIso: String, viewBy: String, processingTs: Long): ProjectedEvent =
+    ProjectedEvent(
+      Map("id" -> id, "view_by" -> viewBy, Constants.TimeColumn -> toMillis(eventIso)),
+      processingTs
+    )
+
+  private def keyList(key: Any): java.util.List[Any] = {
+    val result = new util.ArrayList[Any](1)
+    result.add(key)
+    result
+  }
+
+  private def assertSingleOutput(
+      outputs: List[DecodedOutput],
+      expectedKey: String,
+      expectedDayStart: Long,
+      expectedValues: Seq[Any]): Unit = {
+    outputs should have size 1
+    outputs.head.keys shouldEqual List(expectedKey)
+    outputs.head.dayStartMillis shouldEqual expectedDayStart
+    outputs.head.values shouldEqual expectedValues
+  }
+
+  private def decodeOutput(tile: TimestampedTile): DecodedOutput =
+    DecodedOutput(
+      keys = tile.keys.asScala.toList,
+      dayStartMillis = tile.latestTsMillis,
+      processingTsMillis = tile.startProcessingTime,
+      values = megaTileCodec.rowAggregator
+        .finalize(megaTileCodec.decode(tile.tileBytes))
+        .toSeq
+    )
+
+  private def dayStart(iso: String): Long =
+    TsUtils.round(toMillis(iso), DayMillis)
+
+  private def toMillis(iso: String): Long =
+    Instant.parse(iso).toEpochMilli
+}

--- a/online/src/main/scala/ai/chronon/online/MegaTileCodec.scala
+++ b/online/src/main/scala/ai/chronon/online/MegaTileCodec.scala
@@ -27,7 +27,9 @@ class MegaTileCodec(groupBy: GroupBy, inputSchema: Seq[(String, DataType)]) {
 
   def encode(ir: Array[Any]): Array[Byte] = encodeFn(rowAggregator.normalize(ir))
 
-  @transient private lazy val avroCodec: AvroCodec = AvroCodec.of(avroSchema)
+  // AvroCodec.of is backed by a ThreadLocal cache; resolve it per decode so concurrent
+  // requests do not share one mutable decoder instance through a cached lazy val.
+  private def avroCodec: AvroCodec = AvroCodec.of(avroSchema)
 
   def decode(bytes: Array[Byte]): Array[Any] = {
     val record = avroCodec.decode(bytes).asInstanceOf[GenericData.Record]
@@ -47,7 +49,7 @@ class MegaTileCodec(groupBy: GroupBy, inputSchema: Seq[(String, DataType)]) {
 
   def encodeBaseIr(ir: Array[Any]): Array[Byte] = baseEncodeFn(baseRowAggregator.normalize(ir))
 
-  @transient private lazy val baseAvroCodec: AvroCodec = AvroCodec.of(baseAvroSchema)
+  private def baseAvroCodec: AvroCodec = AvroCodec.of(baseAvroSchema)
 
   def decodeBaseIr(bytes: Array[Byte]): Array[Any] = {
     val record = baseAvroCodec.decode(bytes).asInstanceOf[GenericData.Record]

--- a/online/src/main/scala/ai/chronon/online/MegaTileCodec.scala
+++ b/online/src/main/scala/ai/chronon/online/MegaTileCodec.scala
@@ -27,8 +27,8 @@ class MegaTileCodec(groupBy: GroupBy, inputSchema: Seq[(String, DataType)]) {
 
   def encode(ir: Array[Any]): Array[Byte] = encodeFn(rowAggregator.normalize(ir))
 
-  // AvroCodec.of is backed by a ThreadLocal cache; resolve it per decode so concurrent
-  // requests do not share one mutable decoder instance through a cached lazy val.
+  // AvroCodec.of returns a per-thread cached codec keyed by schema string, so this avoids
+  // cross-thread decoder reuse without reparsing the schema on every decode call.
   private def avroCodec: AvroCodec = AvroCodec.of(avroSchema)
 
   def decode(bytes: Array[Byte]): Array[Any] = {
@@ -49,6 +49,7 @@ class MegaTileCodec(groupBy: GroupBy, inputSchema: Seq[(String, DataType)]) {
 
   def encodeBaseIr(ir: Array[Any]): Array[Byte] = baseEncodeFn(baseRowAggregator.normalize(ir))
 
+  // Same per-thread cache behavior as avroCodec above.
   private def baseAvroCodec: AvroCodec = AvroCodec.of(baseAvroSchema)
 
   def decodeBaseIr(bytes: Array[Byte]): Array[Any] = {

--- a/online/src/main/scala/ai/chronon/online/fetcher/GroupByFetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/GroupByFetcher.scala
@@ -191,7 +191,8 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
       LRUCache.collectCaffeineCacheMetrics(caffeineMetricsContext, cache.cache, cache.cacheName))
 
     val allRequestsToFetch: Seq[GetRequest] = groupByRequestToKvRequest.flatMap {
-      case (_, Success(LambdaKvRequest(_, _, batchRequest, streamingRequestOpt, megaTileHistoricalRequestsOpt, _, _))) =>
+      case (_,
+            Success(LambdaKvRequest(_, _, batchRequest, streamingRequestOpt, megaTileHistoricalRequestsOpt, _, _))) =>
         // If a batch request is cached, don't include it in the list of requests to fetch because the batch IRs already cached
         val batchReqs = if (cachedRequests.contains(batchRequest)) Seq.empty else Seq(batchRequest)
         batchReqs ++ streamingRequestOpt.toSeq ++ megaTileHistoricalRequestsOpt.getOrElse(Seq.empty).map(_._2)
@@ -257,9 +258,8 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
             val megaTileHistoricalResponses =
               megaTileHistoricalRequestsOpt
                 .getOrElse(Seq.empty)
-                .map {
-                  case (dayStart, historyRequest) =>
-                    dayStart -> responsesMap.getOrElse(historyRequest, Success(Seq.empty)).getOrElse(Seq.empty)
+                .map { case (dayStart, historyRequest) =>
+                  dayStart -> responsesMap.getOrElse(historyRequest, Success(Seq.empty)).getOrElse(Seq.empty)
                 }
 
             val queryTs = endTs.getOrElse(request.atMillis.getOrElse(System.currentTimeMillis()))

--- a/online/src/main/scala/ai/chronon/online/fetcher/GroupByFetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/GroupByFetcher.scala
@@ -94,13 +94,14 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
       // Resolve query time once to avoid inconsistency across midnight boundaries
       val resolvedQueryTs = request.atMillis.getOrElse(System.currentTimeMillis())
 
-      val (streamingRequestOpt, megaTileYesterdayRequestOpt) =
+      val (streamingRequestOpt, megaTileHistoricalRequestsOpt) =
         groupByServingInfo.groupByOps.inferredAccuracy match {
           case Accuracy.TEMPORAL if groupByServingInfo.groupByOps.isMegaTilingEnabled =>
-            // Mega tiling: 2 point gets — (key, today) + (key, yesterday)
+            // Mega tiling: one daily point get per day from today back to batch day,
+            // plus one extra fallback day for no-batch windows.
             val DayMillis = 24 * 3600 * 1000L
-            val (todayStart, yesterdayStart) =
-              groupByServingInfo.megaTileMerger.streamingDayKeys(resolvedQueryTs)
+            val dayStarts = groupByServingInfo.megaTileMerger
+              .streamingDayKeys(resolvedQueryTs, groupByServingInfo.batchEndTsMillis)
             val dataset = groupByServingInfo.groupByOps.streamingDataset
 
             def megaTileRequest(dayStart: Long): GetRequest = {
@@ -109,7 +110,8 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
               GetRequest(TilingUtils.serializeTileKey(tileKey), dataset)
             }
 
-            (Some(megaTileRequest(todayStart)), Some(megaTileRequest(yesterdayStart)))
+            (dayStarts.headOption.map(megaTileRequest),
+             Some(dayStarts.drop(1).map(dayStart => dayStart -> megaTileRequest(dayStart))))
 
           case Accuracy.TEMPORAL =>
             // Standard tiling or raw streaming
@@ -138,7 +140,7 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
                       castedRequest,
                       batchRequest,
                       streamingRequestOpt,
-                      megaTileYesterdayRequestOpt,
+                      megaTileHistoricalRequestsOpt,
                       Some(resolvedQueryTs),
                       context)
 
@@ -189,10 +191,10 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
       LRUCache.collectCaffeineCacheMetrics(caffeineMetricsContext, cache.cache, cache.cacheName))
 
     val allRequestsToFetch: Seq[GetRequest] = groupByRequestToKvRequest.flatMap {
-      case (_, Success(LambdaKvRequest(_, _, batchRequest, streamingRequestOpt, megaTileYesterdayOpt, _, _))) =>
+      case (_, Success(LambdaKvRequest(_, _, batchRequest, streamingRequestOpt, megaTileHistoricalRequestsOpt, _, _))) =>
         // If a batch request is cached, don't include it in the list of requests to fetch because the batch IRs already cached
         val batchReqs = if (cachedRequests.contains(batchRequest)) Seq.empty else Seq(batchRequest)
-        batchReqs ++ streamingRequestOpt ++ megaTileYesterdayOpt
+        batchReqs ++ streamingRequestOpt.toSeq ++ megaTileHistoricalRequestsOpt.getOrElse(Seq.empty).map(_._2)
 
       case _ => Seq.empty
     }
@@ -225,7 +227,7 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
                                 castedRequest,
                                 batchRequest,
                                 streamingRequestOpt,
-                                megaTileYesterdayOpt,
+                                megaTileHistoricalRequestsOpt,
                                 endTs,
                                 context) = requestMeta
 
@@ -252,8 +254,13 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
 
             val streamingResponsesOpt =
               streamingRequestOpt.map(responsesMap.getOrElse(_, Success(Seq.empty)).getOrElse(Seq.empty))
-            val megaTileYesterdayResponsesOpt =
-              megaTileYesterdayOpt.map(responsesMap.getOrElse(_, Success(Seq.empty)).getOrElse(Seq.empty))
+            val megaTileHistoricalResponses =
+              megaTileHistoricalRequestsOpt
+                .getOrElse(Seq.empty)
+                .map {
+                  case (dayStart, historyRequest) =>
+                    dayStart -> responsesMap.getOrElse(historyRequest, Success(Seq.empty)).getOrElse(Seq.empty)
+                }
 
             val queryTs = endTs.getOrElse(request.atMillis.getOrElse(System.currentTimeMillis()))
             val requestContext = RequestContext(groupByServingInfo, queryTs, startTimeMs, context, request.keys)
@@ -265,7 +272,7 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
                     s"Constructing response for groupBy: ${groupByServingInfo.groupByOps.metaData.getName} " +
                       s"for keys: ${request.keys}")
 
-                decodeAndMerge(batchResponses, streamingResponsesOpt, megaTileYesterdayResponsesOpt, requestContext)
+                decodeAndMerge(batchResponses, streamingResponsesOpt, megaTileHistoricalResponses, requestContext)
 
               } catch {
 
@@ -360,6 +367,6 @@ case class LambdaKvRequest(groupByServingInfoParsed: GroupByServingInfoParsed,
                            castedGroupByRequest: Fetcher.Request,
                            batchRequest: GetRequest,
                            streamingRequestOpt: Option[GetRequest],
-                           megaTileYesterdayRequestOpt: Option[GetRequest] = None,
+                           megaTileHistoricalRequestsOpt: Option[Seq[(Long, GetRequest)]] = None,
                            endTs: Option[Long],
                            context: metrics.Metrics.Context)

--- a/online/src/main/scala/ai/chronon/online/fetcher/GroupByResponseHandler.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/GroupByResponseHandler.scala
@@ -317,8 +317,13 @@ class GroupByResponseHandler(fetchContext: FetchContext, metadataStore: Metadata
     }
 
     val aggregatorStartTime = System.currentTimeMillis()
-    val result =
-      servingInfo.megaTileMerger.merge(batchIr, dailyTileIrs, requestContext.queryTimeMs, servingInfo.batchEndTsMillis)
+    val result = servingInfo.megaTileMerger.merge(
+      batchIr,
+      dailyTileIrs,
+      requestContext.queryTimeMs,
+      servingInfo.batchEndTsMillis,
+      mergeNoBatchTailFromBatch = true
+    )
     requestContext.metricsContext.distribution("group_by.aggregator.latency.millis",
                                                System.currentTimeMillis() - aggregatorStartTime)
     result

--- a/online/src/main/scala/ai/chronon/online/fetcher/GroupByResponseHandler.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/GroupByResponseHandler.scala
@@ -270,13 +270,15 @@ class GroupByResponseHandler(fetchContext: FetchContext, metadataStore: Metadata
                                           todayResponses: Seq[TimedValue],
                                           megaTileHistoricalResponses: Seq[(Long, Seq[TimedValue])],
                                           batchBytes: Array[Byte]): Array[Any] = {
-    val hasNoHistoricalData = megaTileHistoricalResponses.forall {
-      case (_, responses) => responses == null || responses.isEmpty
+    val hasNoHistoricalData = megaTileHistoricalResponses.forall { case (_, responses) =>
+      responses == null || responses.isEmpty
     }
-    if ((todayResponses == null || todayResponses.isEmpty) &&
-        hasNoHistoricalData &&
-        batchResponses.isInstanceOf[KvStoreBatchResponse] &&
-        batchBytes == null) {
+    if (
+      (todayResponses == null || todayResponses.isEmpty) &&
+      hasNoHistoricalData &&
+      batchResponses.isInstanceOf[KvStoreBatchResponse] &&
+      batchBytes == null
+    ) {
       if (fetchContext.debug) {
         logger.info("Batch, today's streaming data, and historical streaming data are all null")
       }
@@ -298,8 +300,8 @@ class GroupByResponseHandler(fetchContext: FetchContext, metadataStore: Metadata
     val allStreamingIrDecodeStartTime = System.currentTimeMillis()
     val todayStart = servingInfo.megaTileMerger.streamingDayKeys(requestContext.queryTimeMs)._1
     val dailyTileIrs =
-      (Seq(todayStart -> todayResponses) ++ megaTileHistoricalResponses).map {
-        case (dayStart, responses) => dayStart -> decodeLatestMegaTile(responses, servingInfo)
+      (Seq(todayStart -> todayResponses) ++ megaTileHistoricalResponses).map { case (dayStart, responses) =>
+        dayStart -> decodeLatestMegaTile(responses, servingInfo)
       }
     requestContext.metricsContext.distribution("group_by.all_streamingir_decode.latency.millis",
                                                System.currentTimeMillis() - allStreamingIrDecodeStartTime)
@@ -315,10 +317,8 @@ class GroupByResponseHandler(fetchContext: FetchContext, metadataStore: Metadata
     }
 
     val aggregatorStartTime = System.currentTimeMillis()
-    val result = servingInfo.megaTileMerger.merge(batchIr,
-                                                  dailyTileIrs,
-                                                  requestContext.queryTimeMs,
-                                                  servingInfo.batchEndTsMillis)
+    val result =
+      servingInfo.megaTileMerger.merge(batchIr, dailyTileIrs, requestContext.queryTimeMs, servingInfo.batchEndTsMillis)
     requestContext.metricsContext.distribution("group_by.aggregator.latency.millis",
                                                System.currentTimeMillis() - aggregatorStartTime)
     result

--- a/online/src/main/scala/ai/chronon/online/fetcher/GroupByResponseHandler.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/GroupByResponseHandler.scala
@@ -30,7 +30,7 @@ class GroupByResponseHandler(fetchContext: FetchContext, metadataStore: Metadata
 
   def decodeAndMerge(batchResponses: BatchResponses,
                      streamingResponsesOpt: Option[Seq[TimedValue]],
-                     megaTileYesterdayResponsesOpt: Option[Seq[TimedValue]] = None,
+                     megaTileHistoricalResponses: Seq[(Long, Seq[TimedValue])] = Seq.empty,
                      requestContext: RequestContext): Map[String, AnyRef] = {
 
     val newServingInfo = getServingInfo(requestContext.servingInfo, batchResponses)
@@ -70,7 +70,7 @@ class GroupByResponseHandler(fetchContext: FetchContext, metadataStore: Metadata
                                         newServingInfo,
                                         batchResponses,
                                         streamingResponses,
-                                        megaTileYesterdayResponsesOpt.getOrElse(Seq.empty),
+                                        megaTileHistoricalResponses,
                                         batchBytes)
           } else {
             mergeWithStreaming(batchResponses, streamingResponses, batchBytes, updatedContext)
@@ -268,24 +268,78 @@ class GroupByResponseHandler(fetchContext: FetchContext, metadataStore: Metadata
                                           servingInfo: GroupByServingInfoParsed,
                                           batchResponses: BatchResponses,
                                           todayResponses: Seq[TimedValue],
-                                          yesterdayResponses: Seq[TimedValue],
+                                          megaTileHistoricalResponses: Seq[(Long, Seq[TimedValue])],
                                           batchBytes: Array[Byte]): Array[Any] = {
+    val hasNoHistoricalData = megaTileHistoricalResponses.forall {
+      case (_, responses) => responses == null || responses.isEmpty
+    }
+    if ((todayResponses == null || todayResponses.isEmpty) &&
+        hasNoHistoricalData &&
+        batchResponses.isInstanceOf[KvStoreBatchResponse] &&
+        batchBytes == null) {
+      if (fetchContext.debug) {
+        logger.info("Batch, today's streaming data, and historical streaming data are all null")
+      }
+      return null
+    }
+
+    val allStreamingResponses =
+      Option(todayResponses).getOrElse(Seq.empty) ++
+        megaTileHistoricalResponses.flatMap { case (_, responses) => Option(responses).getOrElse(Seq.empty) }
+    reportKvResponse(requestContext.metricsContext.withSuffix("streaming"),
+                     allStreamingResponses,
+                     requestContext.queryTimeMs)
+
+    val batchIrDecodeStartTime = System.currentTimeMillis()
     val batchIr = getBatchIrFromBatchResponse(batchResponses, batchBytes, servingInfo, toBatchIr, requestContext.keys)
-    val todayIr = decodeLatestMegaTile(todayResponses, servingInfo)
-    val yesterdayIr = decodeLatestMegaTile(yesterdayResponses, servingInfo)
-    val (todayStart, _) = servingInfo.megaTileMerger.streamingDayKeys(requestContext.queryTimeMs)
-    servingInfo.megaTileMerger.merge(batchIr,
-                                     todayIr,
-                                     yesterdayIr,
-                                     todayStart,
-                                     requestContext.queryTimeMs,
-                                     servingInfo.batchEndTsMillis)
+    requestContext.metricsContext.distribution("group_by.batchir_decode.latency.millis",
+                                               System.currentTimeMillis() - batchIrDecodeStartTime)
+
+    val allStreamingIrDecodeStartTime = System.currentTimeMillis()
+    val todayStart = servingInfo.megaTileMerger.streamingDayKeys(requestContext.queryTimeMs)._1
+    val dailyTileIrs =
+      (Seq(todayStart -> todayResponses) ++ megaTileHistoricalResponses).map {
+        case (dayStart, responses) => dayStart -> decodeLatestMegaTile(responses, servingInfo)
+      }
+    requestContext.metricsContext.distribution("group_by.all_streamingir_decode.latency.millis",
+                                               System.currentTimeMillis() - allStreamingIrDecodeStartTime)
+
+    if (fetchContext.debug) {
+      val gson = new Gson()
+      logger.info(s"""
+                     |batch ir: ${gson.toJson(batchIr)}
+                     |dailyTileIrs: ${gson.toJson(dailyTileIrs)}
+                     |batchEnd in millis: ${servingInfo.batchEndTsMillis}
+                     |queryTime in millis: ${requestContext.queryTimeMs}
+                     |""".stripMargin)
+    }
+
+    val aggregatorStartTime = System.currentTimeMillis()
+    val result = servingInfo.megaTileMerger.merge(batchIr,
+                                                  dailyTileIrs,
+                                                  requestContext.queryTimeMs,
+                                                  servingInfo.batchEndTsMillis)
+    requestContext.metricsContext.distribution("group_by.aggregator.latency.millis",
+                                               System.currentTimeMillis() - aggregatorStartTime)
+    result
   }
 
   private def decodeLatestMegaTile(responses: Seq[TimedValue], servingInfo: GroupByServingInfoParsed): Array[Any] = {
     if (responses == null || responses.isEmpty) return null
     val latest = responses.maxBy(_.millis)
-    servingInfo.megaTileCodec.decode(latest.bytes)
+    Try(servingInfo.megaTileCodec.decode(latest.bytes)) match {
+      case Success(ir) => ir
+      case Failure(_) =>
+        logger.error(
+          s"Failed to decode mega tile ir for groupBy ${servingInfo.groupByOps.metaData.getName}" +
+            "Streaming mega tile IRs will be ignored")
+        if (servingInfo.groupByOps.dontThrowOnDecodeFailFlag) {
+          null
+        } else {
+          throw new RuntimeException(
+            s"Failed to decode mega tile ir for groupBy ${servingInfo.groupByOps.metaData.getName}")
+        }
+    }
   }
 
   private def reportKvResponse(ctx: Metrics.Context, response: Seq[TimedValue], queryTsMillis: Long): Unit = {

--- a/online/src/test/scala/ai/chronon/online/test/MegaTileCodecRoundTripTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/MegaTileCodecRoundTripTest.scala
@@ -12,7 +12,10 @@ import org.junit.Assert._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.slf4j.LoggerFactory
 
+import java.util
 import scala.collection.mutable
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.Random
 
 /**
@@ -321,6 +324,61 @@ class MegaTileCodecRoundTripTest extends AnyFlatSpec {
       assertTrue(
         s"serde_complex_aggs: mismatch at query ${queryTimes(i)}\n  expected: ${gson.toJson(naive(i))}\n  got:      ${gson.toJson(results(i))}",
         approxEqual(results(i), naive(i), sketchTolerance = 0.05))
+    }
+  }
+
+  it should "decode mega tile bytes safely across threads" in {
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.HISTOGRAM, "category", AllWindows),
+      Builders.Aggregation(Operation.LAST_K, "num", AllWindows, argMap = Map("k" -> "3"))
+    )
+    val codec = new MegaTileCodec(buildGroupBy(aggregations), SchemaWithCategory)
+
+    def histogramIr(): util.HashMap[String, java.lang.Long] = {
+      val ir = new util.HashMap[String, java.lang.Long]()
+      ir.put("alpha", Long.box(1L))
+      ir.put("beta", Long.box(2L))
+      ir
+    }
+
+    def lastKIr(): util.ArrayList[util.ArrayList[Any]] = {
+      val ir = new util.ArrayList[util.ArrayList[Any]]()
+      ir.add(ai.chronon.aggregator.base.TimeTuple.make(1775001000000L, Long.box(10L)))
+      ir.add(ai.chronon.aggregator.base.TimeTuple.make(1775000400000L, Long.box(9L)))
+      ir.add(ai.chronon.aggregator.base.TimeTuple.make(1774999800000L, Long.box(8L)))
+      ir
+    }
+
+    val ir = Array[Any](
+      histogramIr(),
+      histogramIr(),
+      histogramIr(),
+      histogramIr(),
+      histogramIr(),
+      histogramIr(),
+      histogramIr(),
+      lastKIr(),
+      lastKIr(),
+      lastKIr(),
+      lastKIr(),
+      lastKIr(),
+      lastKIr(),
+      lastKIr()
+    )
+
+    val bytes = codec.encode(ir)
+    assertTrue(approxEqual(ir, codec.decode(bytes)))
+
+    val executor = java.util.concurrent.Executors.newFixedThreadPool(8)
+    implicit val ec: ExecutionContext = ExecutionContext.fromExecutorService(executor)
+    try {
+      val decoded = Await.result(
+        Future.sequence((0 until 2000).map(_ => Future(codec.decode(bytes)))),
+        30.seconds
+      )
+      decoded.foreach(result => assertTrue(approxEqual(ir, result)))
+    } finally {
+      executor.shutdownNow()
     }
   }
 }

--- a/online/src/test/scala/ai/chronon/online/test/MegaTileCodecRoundTripTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/MegaTileCodecRoundTripTest.scala
@@ -182,7 +182,7 @@ class MegaTileCodecRoundTripTest extends AnyFlatSpec {
         firePendingEvictions(event.ts)
         processor.advanceWatermark(event.ts)
 
-        val result = processor.onEvent(event, event.ts)
+        val result = processor.onEvent(event, event.ts, queryTs)
         if (result.todayEntry != null) kvStore(result.todayStart) = result.todayEntry
         if (result.yesterdayEntry != null) kvStore(result.yesterdayStart) = result.yesterdayEntry
 
@@ -272,7 +272,8 @@ class MegaTileCodecRoundTripTest extends AnyFlatSpec {
     val processorA = new MegaTileStreamProcessor(megaTileAgg, storeA)
     for (event <- events.sortBy(_.ts)) {
       processorA.advanceWatermark(event.ts)
-      processorA.onEvent(event, event.ts)
+      val smallWindowAsOfTs = TsUtils.round(event.ts, processorA.minSmallWindowTileSize) + processorA.minSmallWindowTileSize
+      processorA.onEvent(event, event.ts, smallWindowAsOfTs)
     }
     // Verify key A has non-empty state
     assertTrue("key A should have tiles", storeA.tiles.nonEmpty)


### PR DESCRIPTION
## Summary

Stacked on #1680. This branch is based on `mickjermsurawong-openai:dev/mickj-cdx/megatile-port`, the head branch for #1680. GitHub cannot use that fork-only branch as the base for a PR in `zipline-ai/chronon`, so this PR targets `nikhil/megatile` and will show the clean incremental diff once #1680 lands or the base branch is mirrored into `zipline-ai/chronon`.

Ports the no-batch batch-tail merge fix from openai/chronon-private#45 into the public Zipline branch.

## Changes

- Adds an opt-in MegaTile batch-tail merge for no-batch windows that cross batchEnd.
- Keeps default merger behavior unchanged for processor-style callers.
- Enables the opt-in for online MegaTile serving.
- Adds a same-day 1d regression test covering batch tail plus streaming daily entries.

## Validation

- `./mill aggregator.compile online.compile`
- `./mill aggregator.test.testOnly "ai.chronon.aggregator.test.MegaTileMergerTest"`
- `git diff --check`
