### PR TITLE
redact sensitive values for spark conf logging

### DIFF
--- a/cloud_aws/src/main/scala/ai/chronon/integrations/aws/EmrServerlessSubmitter.scala
+++ b/cloud_aws/src/main/scala/ai/chronon/integrations/aws/EmrServerlessSubmitter.scala
@@ -177,15 +177,13 @@ class EmrServerlessSubmitter(
           s"${EmrServerlessSubmitter.MaxPropertiesPerClassification} per classification; " +
           s"routing ${overflowProps.size} through sparkSubmitParameters as --conf flags")
     }
-    val overflowConf = overflowProps.toSeq
-      .sortBy(_._1)
-      .map { case (k, v) =>
-        s"--conf ${EmrServerlessSubmitter.maybeShellQuote(s"$k=$v")}"
-      }
-      .mkString(" ")
-
-    val sparkSubmitParams =
-      Seq(s"--class $mainClass", filesParam, overflowConf).filter(_.nonEmpty).mkString(" ")
+    val overflowArgs = overflowProps.toSeq.flatMap { case (k, v) =>
+      Seq("--conf", EmrServerlessSubmitter.maybeShellQuote(s"$k=$v"))
+    }
+    val sparkSubmitArgs =
+      Seq("--class", mainClass) ++ (if (filesParam.nonEmpty) Seq("--files", files.mkString(","))
+                                    else Seq.empty) ++ overflowArgs
+    val sparkSubmitParams = sparkSubmitArgs.mkString(" ")
 
     val jobName = submissionProperties.getOrElse(JobId, s"chronon-job-${System.currentTimeMillis()}")
     logger.info(
@@ -194,9 +192,18 @@ class EmrServerlessSubmitter(
     if (inlineProps.nonEmpty) {
       logger.info(
         s"spark-defaults classification for $jobName:\n  " +
-          inlineProps.toSeq.sortBy(_._1).map { case (k, v) => s"$k = $v" }.mkString("\n  "))
+          SparkPropertyRedaction.redactPropertiesWithFormat(resolvedProps, inlineProps.toSeq) { properties =>
+            properties.map { case (key, value) => s"$key = $value" }.mkString("\n  ")
+          })
     }
-    logger.info(s"sparkSubmitParameters for $jobName: $sparkSubmitParams")
+    val redactedSparkSubmitParams =
+      SparkPropertyRedaction.redactPropertiesWithFormat(resolvedProps, overflowProps.toSeq) { redactedOverflowProps =>
+        (Seq("--class", mainClass) ++ (if (filesParam.nonEmpty) Seq("--files", files.mkString(","))
+                                       else Seq.empty) ++ redactedOverflowProps
+          .flatMap { case (key, value) => Seq("--conf", EmrServerlessSubmitter.maybeShellQuote(s"$key=$value")) })
+          .mkString(" ")
+      }
+    logger.info(s"sparkSubmitParameters for $jobName: $redactedSparkSubmitParams")
 
     val jobDriverBuilder = JobDriver
       .builder()

--- a/cloud_aws/src/main/scala/ai/chronon/integrations/aws/EmrSubmitter.scala
+++ b/cloud_aws/src/main/scala/ai/chronon/integrations/aws/EmrSubmitter.scala
@@ -218,26 +218,33 @@ class EmrSubmitter(customerId: String,
 
     // Escape single quotes for safe shell interpolation inside bash -c '...'
     // Values referencing the Databricks OAuth token use double quotes to allow shell variable expansion
-    val confArgs = jobProperties
-      .map { case (k, v) =>
-        if (v.contains(DatabricksOAuthTokenVar)) {
-          val escapedKey = k.replace("\"", "\\\"")
-          val escapedValue = v.replace("\"", "\\\"")
-          s"""--conf "$escapedKey=$escapedValue""""
-        } else {
-          val escapedKey = k.replace("'", "'\\''")
-          val escapedValue = v.replace("'", "'\\''")
-          s"--conf '$escapedKey=$escapedValue'"
+    val tokenExpandingKeys = jobProperties.collect { case (k, v) if v.contains(DatabricksOAuthTokenVar) => k }.toSet
+    def renderConfArgs(properties: Seq[(String, String)]): String =
+      properties
+        .map { case (k, v) =>
+          if (tokenExpandingKeys.contains(k)) {
+            val escapedKey = k.replace("\"", "\\\"")
+            val escapedValue = v.replace("\"", "\\\"")
+            s"""--conf "$escapedKey=$escapedValue""""
+          } else {
+            val escapedKey = k.replace("'", "'\\''")
+            val escapedValue = v.replace("'", "'\\''")
+            s"--conf '$escapedKey=$escapedValue'"
+          }
         }
-      }
-      .mkString(" ")
+        .mkString(" ")
+    val confArgs = renderConfArgs(jobProperties.toSeq)
     val mainClass = submissionProperties(MainClass)
     val jarUri = submissionProperties(JarURI)
     val sparkSubmitCmd =
       s"${tokenFetchScript.getOrElse("")}spark-submit $confArgs --class $mainClass $jarUri ${args.mkString(" ")}"
 
     val finalArgs = List("bash", "-c", (awsS3CpArgs ++ List(sparkSubmitCmd)).mkString("; \n"))
-    logger.debug(s"Step config args: $finalArgs")
+    val redactedSparkSubmitCmd =
+      s"${tokenFetchScript.getOrElse("")}spark-submit ${SparkPropertyRedaction
+          .redactPropertiesWithFormat(jobProperties, jobProperties.toSeq.sortBy(_._1))(properties => renderConfArgs(properties))} --class $mainClass $jarUri ${args.mkString(" ")}"
+    val redactedFinalArgs = List("bash", "-c", (awsS3CpArgs ++ List(redactedSparkSubmitCmd)).mkString("; \n"))
+    logger.debug(s"Step config args: $redactedFinalArgs")
     StepConfig
       .builder()
       .name("Run Zipline Job")

--- a/cloud_aws/src/main/scala/ai/chronon/integrations/aws/SparkPropertyRedaction.scala
+++ b/cloud_aws/src/main/scala/ai/chronon/integrations/aws/SparkPropertyRedaction.scala
@@ -1,7 +1,6 @@
 package ai.chronon.integrations.aws
 
 import java.util.regex.Pattern
-import scala.util.Try
 
 private[aws] object SparkPropertyRedaction {
   private val SparkRedactionRegexKey = "spark.redaction.regex"
@@ -12,7 +11,8 @@ private[aws] object SparkPropertyRedaction {
       sparkProperties: Map[String, String],
       properties: Seq[(String, String)]
   ): Seq[(String, String)] = {
-    val pattern = compilePattern(sparkProperties.getOrElse(SparkRedactionRegexKey, DefaultSparkRedactionRegex))
+    val regex = sparkProperties.getOrElse(SparkRedactionRegexKey, DefaultSparkRedactionRegex)
+    val pattern = compilePattern(regex)
     properties.map { case (key, value) =>
       if (pattern.matcher(key).find()) key -> RedactedValue else key -> value
     }
@@ -25,5 +25,5 @@ private[aws] object SparkPropertyRedaction {
     render(redactProperties(sparkProperties, properties))
 
   private def compilePattern(regex: String): Pattern =
-    Try(Pattern.compile(regex)).getOrElse(Pattern.compile(DefaultSparkRedactionRegex))
+    Pattern.compile(regex)
 }

--- a/cloud_aws/src/main/scala/ai/chronon/integrations/aws/SparkPropertyRedaction.scala
+++ b/cloud_aws/src/main/scala/ai/chronon/integrations/aws/SparkPropertyRedaction.scala
@@ -1,0 +1,29 @@
+package ai.chronon.integrations.aws
+
+import java.util.regex.Pattern
+import scala.util.Try
+
+private[aws] object SparkPropertyRedaction {
+  private val SparkRedactionRegexKey = "spark.redaction.regex"
+  private val DefaultSparkRedactionRegex = "(?i)secret|password|token|access[.]?key"
+  private val RedactedValue = "<redacted>"
+
+  def redactProperties(
+      sparkProperties: Map[String, String],
+      properties: Seq[(String, String)]
+  ): Seq[(String, String)] = {
+    val pattern = compilePattern(sparkProperties.getOrElse(SparkRedactionRegexKey, DefaultSparkRedactionRegex))
+    properties.map { case (key, value) =>
+      if (pattern.matcher(key).find()) key -> RedactedValue else key -> value
+    }
+  }
+
+  def redactPropertiesWithFormat[T](
+      sparkProperties: Map[String, String],
+      properties: Seq[(String, String)]
+  )(render: Seq[(String, String)] => T): T =
+    render(redactProperties(sparkProperties, properties))
+
+  private def compilePattern(regex: String): Pattern =
+    Try(Pattern.compile(regex)).getOrElse(Pattern.compile(DefaultSparkRedactionRegex))
+}

--- a/cloud_aws/src/test/scala/ai/chronon/integrations/aws/EmrServerlessSubmitterTest.scala
+++ b/cloud_aws/src/test/scala/ai/chronon/integrations/aws/EmrServerlessSubmitterTest.scala
@@ -5,6 +5,9 @@ import ai.chronon.integrations.cloud_k8s.K8sFlinkSubmitter
 import ai.chronon.spark.submission
 import ai.chronon.spark.submission.JobSubmitterConstants._
 import ai.chronon.spark.submission.{FlinkJob, StorageClient}
+import ch.qos.logback.classic.{Level, Logger}
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
 import org.junit.Assert.assertEquals
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers._
@@ -12,6 +15,7 @@ import org.mockito.Mockito._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
+import org.slf4j.LoggerFactory
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.emrserverless.EmrServerlessClient
 import software.amazon.awssdk.services.emrserverless.model._
@@ -78,6 +82,23 @@ class EmrServerlessSubmitterTest extends AnyFlatSpec with Matchers with MockitoS
     )
   }
 
+  private def captureLogMessages(loggerName: String, level: Level = Level.INFO)(body: => Unit): Seq[String] = {
+    val underlying = LoggerFactory.getLogger(loggerName).asInstanceOf[Logger]
+    val appender = new ListAppender[ILoggingEvent]()
+    val previousLevel = underlying.getLevel
+    appender.start()
+    underlying.setLevel(level)
+    underlying.addAppender(appender)
+    try {
+      body
+      appender.list.asScala.map(_.getFormattedMessage).toSeq
+    } finally {
+      underlying.detachAppender(appender)
+      underlying.setLevel(previousLevel)
+      appender.stop()
+    }
+  }
+
   "EmrServerlessSubmitter" should "submit a Spark job using app ID from submission props" in {
     val mockClient = mock[EmrServerlessClient]
     val applicationId = "app-123456"
@@ -113,6 +134,82 @@ class EmrServerlessSubmitterTest extends AnyFlatSpec with Matchers with MockitoS
     val requestCaptor = ArgumentCaptor.forClass(classOf[StartJobRunRequest])
     verify(mockClient).startJobRun(requestCaptor.capture())
     assertEquals(applicationId, requestCaptor.getValue.applicationId())
+  }
+
+  it should "redact secret-looking values from EMR Serverless submission logs" in {
+    val mockClient = mock[EmrServerlessClient]
+    val applicationId = "app-redacted-default"
+
+    when(mockClient.startJobRun(any[StartJobRunRequest]))
+      .thenReturn(StartJobRunResponse.builder().applicationId(applicationId).jobRunId("job-redacted-default").build())
+
+    val submitter = createSubmitter(mockClient)
+    val rawSecret = "super-secret-value"
+
+    val messages = captureLogMessages(classOf[EmrServerlessSubmitter].getName) {
+      submitter.submit(
+        submission.SparkJob,
+        Map(
+          MainClass -> "ai.chronon.spark.Driver",
+          JarURI -> "s3://my-bucket/jars/cloud-aws.jar",
+          JobId -> "test-redacted-default",
+          submitter.clusterIdentifierKey -> applicationId
+        ),
+        Map(
+          "spark.executor.memory" -> "4g",
+          "spark.sql.catalog.workspace.client.secret" -> rawSecret
+        ),
+        List.empty,
+        Map.empty
+      )
+    }
+
+    val combined = messages.mkString("\n")
+    combined should include("spark.sql.catalog.workspace.client.secret")
+    combined should not include rawSecret
+
+    val requestCaptor = ArgumentCaptor.forClass(classOf[StartJobRunRequest])
+    verify(mockClient).startJobRun(requestCaptor.capture())
+    val props = requestCaptor.getValue.configurationOverrides().applicationConfiguration().get(0).properties()
+    props.get("spark.sql.catalog.workspace.client.secret") shouldBe rawSecret
+  }
+
+  it should "use spark.redaction.regex from SparkConf when redacting submission logs" in {
+    val mockClient = mock[EmrServerlessClient]
+    val applicationId = "app-redacted-override"
+
+    when(mockClient.startJobRun(any[StartJobRunRequest]))
+      .thenReturn(StartJobRunResponse.builder().applicationId(applicationId).jobRunId("job-redacted-override").build())
+
+    val submitter = createSubmitter(mockClient)
+    val rawCredential = "override-redaction-value"
+
+    val messages = captureLogMessages(classOf[EmrServerlessSubmitter].getName) {
+      submitter.submit(
+        submission.SparkJob,
+        Map(
+          MainClass -> "ai.chronon.spark.Driver",
+          JarURI -> "s3://my-bucket/jars/cloud-aws.jar",
+          JobId -> "test-redacted-override",
+          submitter.clusterIdentifierKey -> applicationId
+        ),
+        Map(
+          "spark.redaction.regex" -> "(?i)credential",
+          "spark.custom.credential" -> rawCredential
+        ),
+        List.empty,
+        Map.empty
+      )
+    }
+
+    val combined = messages.mkString("\n")
+    combined should include("spark.custom.credential")
+    combined should not include rawCredential
+
+    val requestCaptor = ArgumentCaptor.forClass(classOf[StartJobRunRequest])
+    verify(mockClient).startJobRun(requestCaptor.capture())
+    val props = requestCaptor.getValue.configurationOverrides().applicationConfiguration().get(0).properties()
+    props.get("spark.custom.credential") shouldBe rawCredential
   }
 
   it should "resolve app by name via ListApplications when no app ID in submission props" in {

--- a/cloud_aws/src/test/scala/ai/chronon/integrations/aws/EmrSubmitterTest.scala
+++ b/cloud_aws/src/test/scala/ai/chronon/integrations/aws/EmrSubmitterTest.scala
@@ -5,6 +5,9 @@ import ai.chronon.integrations.cloud_k8s.K8sFlinkSubmitter
 import ai.chronon.api.ScalaJavaConversions.ListOps
 import ai.chronon.spark.submission.JobSubmitterConstants._
 import ai.chronon.spark.submission.{FlinkJob, SparkJob, StorageClient}
+import ch.qos.logback.classic.{Level, Logger}
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
 import io.fabric8.kubernetes.client.Config
 import org.junit.Assert.assertEquals
 import org.mockito.ArgumentMatchers.anyString
@@ -12,11 +15,31 @@ import org.mockito.Mockito.{verify, when}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
+import org.slf4j.LoggerFactory
 import software.amazon.awssdk.services.ec2.Ec2Client
 import software.amazon.awssdk.services.emr.EmrClient
 import software.amazon.awssdk.services.emr.model.{AddJobFlowStepsRequest, AddJobFlowStepsResponse}
 
+import scala.jdk.CollectionConverters._
+
 class EmrSubmitterTest extends AnyFlatSpec with Matchers with MockitoSugar {
+  private def captureLogMessages(loggerName: String, level: Level)(body: => Unit): Seq[String] = {
+    val underlying = LoggerFactory.getLogger(loggerName).asInstanceOf[Logger]
+    val appender = new ListAppender[ILoggingEvent]()
+    val previousLevel = underlying.getLevel
+    appender.start()
+    underlying.setLevel(level)
+    underlying.addAppender(appender)
+    try {
+      body
+      appender.list.asScala.map(_.getFormattedMessage).toSeq
+    } finally {
+      underlying.detachAppender(appender)
+      underlying.setLevel(previousLevel)
+      appender.stop()
+    }
+  }
+
   "EmrSubmitterClient" should "return job id when a job is submitted and assert EMR request args" in {
     val stepId = "mock-step-id"
     val clusterId = "j-MOCKCLUSTERID123"
@@ -79,6 +102,44 @@ class EmrSubmitterTest extends AnyFlatSpec with Matchers with MockitoSugar {
     assert(actualArgs.contains(s"--class $expectedMainClass"))
     assert(actualArgs.contains(expectedJarURI))
     assert(actualArgs.contains(expectedApplicationArgs.mkString(" ")))
+  }
+
+  it should "use spark.redaction.regex from SparkConf when logging EMR step args" in {
+    val stepId = "mock-step-id"
+    val clusterId = "j-MOCKCLUSTERID123"
+
+    val mockEmrClient = mock[EmrClient]
+    val mockEc2Client = mock[Ec2Client]
+    val mockEksSubmitter = mock[K8sFlinkSubmitter]
+
+    when(mockEmrClient.addJobFlowSteps(org.mockito.ArgumentMatchers.any(classOf[AddJobFlowStepsRequest])))
+      .thenReturn(AddJobFlowStepsResponse.builder().stepIds(stepId).build())
+
+    val submitter = new EmrSubmitter("canary", mockEmrClient, mockEc2Client, Some(mockEksSubmitter))
+    val rawCredential = "classic-redaction-value"
+
+    val messages = captureLogMessages(classOf[EmrSubmitter].getName, Level.DEBUG) {
+      submitter.submit(
+        jobType = SparkJob,
+        submissionProperties = Map(
+          MainClass -> "some-main-class",
+          JarURI -> "s3://-random-jar-uri",
+          ClusterId -> clusterId
+        ),
+        jobProperties = Map(
+          "spark.redaction.regex" -> "(?i)credential",
+          "spark.custom.credential" -> rawCredential
+        ),
+        files = List.empty,
+        labels = Map.empty,
+        "arg1"
+      )
+    }
+
+    val combined = messages.mkString("\n")
+    combined should include("Step config args:")
+    combined should include("spark.custom.credential")
+    combined should not include rawCredential
   }
 
   it should "test createSubmissionPropsMap for Spark job on EMR on EC2" in {


### PR DESCRIPTION
## Summary

We want to redact values for keys that match Spark's `spark.redaction.regex` config value. Currently they are not always redacted as the raw values are instead fetched before it is redacted, we must then lift the redaction into our own Zipline-level space. We _do_ hit the issue that Spark's [Utils.redact](https://spark.apache.org/docs/latest/api/java/org/apache/spark/util/Utils.html#redact(scala.collection.Map)) method is not exposed so either we expose it (via reflection) or we just write our own redactor that reuses the simple regex check it provides (I opted for the latter). 

Tests confirm that it is logging the sensitive values as of now despite the default redaction regex existing. 

## Checklist
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable property redaction for Spark/EMR submissions to prevent sensitive values (secrets, passwords, tokens, access keys) from appearing in logs.
  * Safer assembly/logging of submission arguments so overflow config is redacted before being logged.

* **Tests**
  * Added unit tests validating log redaction behavior for EMR and EMR Serverless submissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->