### PR TITLE
Enable transforming key values in GroupBy aggregations

### DIFF
--- a/api/src/main/scala/ai/chronon/api/Builders.scala
+++ b/api/src/main/scala/ai/chronon/api/Builders.scala
@@ -144,7 +144,9 @@ object Builders {
         keyColumns: Seq[String] = null,
         aggregations: Seq[Aggregation] = null,
         accuracy: Accuracy = null,
-        derivations: Seq[Derivation] = null
+        derivations: Seq[Derivation] = null,
+        keyTransforms: Map[String, String] = null,
+        setups: Seq[String] = null
     ): GroupBy = {
       val result = new GroupBy()
       result.setMetaData(metaData)
@@ -158,6 +160,10 @@ object Builders {
         result.setAccuracy(accuracy)
       if (derivations != null)
         result.setDerivations(derivations.toJava)
+      if (keyTransforms != null)
+        result.setKeyTransforms(keyTransforms.toJava)
+      if (setups != null)
+        result.setSetups(setups.toJava)
       result
     }
   }

--- a/api/src/main/scala/ai/chronon/api/Extensions.scala
+++ b/api/src/main/scala/ai/chronon/api/Extensions.scala
@@ -579,15 +579,21 @@ object Extensions {
       if (validTopics.nonEmpty) Accuracy.TEMPORAL else Accuracy.SNAPSHOT
     }
 
-    def setups: Seq[String] = {
-      groupBy.sources
-        .iterator()
-        .toScala
+    def allSetups: Seq[String] = {
+      val sourceSetups = Option(groupBy.sources)
+        .map(_.toScala)
+        .getOrElse(Seq.empty)
         .map(_.query.setups)
         .flatMap(setupList => Option(setupList).map(_.iterator().toScala).getOrElse(Iterator.empty))
         .toSeq
-        .distinct
+      val groupBySetups = Option(groupBy.setups).map(_.toScala.toSeq).getOrElse(Seq.empty)
+      (groupBySetups ++ sourceSetups).distinct
     }
+
+    def keyTransformsScala: Map[String, String] =
+      Option(groupBy.keyTransforms).map(_.toScala.toMap).getOrElse(Map.empty)
+
+    def hasKeyTransforms: Boolean = keyTransformsScala.nonEmpty
 
     def copyForVersioningComparison: GroupBy = {
       val newGroupBy = groupBy.deepCopy()
@@ -1141,7 +1147,7 @@ object Extensions {
 
     def setups: Seq[String] =
       (join.left.query.setupsSeq ++ join.joinParts.toScala
-        .flatMap(_.groupBy.setups)).distinct
+        .flatMap(_.groupBy.allSetups)).distinct
 
     lazy val joinPartOps: Seq[JoinPartOps] =
       Option(join.joinParts)

--- a/online/src/main/scala/ai/chronon/online/CatalystUtil.scala
+++ b/online/src/main/scala/ai/chronon/online/CatalystUtil.scala
@@ -59,9 +59,9 @@ object CatalystUtil {
     spark
   }
 
-  case class PoolKey(expressions: Seq[(String, String)], inputSchema: StructType)
+  case class PoolKey(expressions: Seq[(String, String)], inputSchema: StructType, setups: Seq[String])
   val poolMap: PoolMap[PoolKey, CatalystUtil] = new PoolMap[PoolKey, CatalystUtil](pi =>
-    new CatalystUtil(pi.inputSchema, pi.expressions))
+    new CatalystUtil(pi.inputSchema, pi.expressions, setups = pi.setups))
 }
 
 class PoolMap[Key, Value](createFunc: Key => Value, maxSize: Int = 100, initialSize: Int = 2) {
@@ -97,9 +97,9 @@ class PoolMap[Key, Value](createFunc: Key => Value, maxSize: Int = 100, initialS
   }
 }
 
-class PooledCatalystUtil(expressions: Seq[(String, String)], inputSchema: StructType) {
-  private val poolKey = PoolKey(expressions, inputSchema)
-  private val cuPool = poolMap.getPool(PoolKey(expressions, inputSchema))
+class PooledCatalystUtil(expressions: Seq[(String, String)], inputSchema: StructType, setups: Seq[String] = Seq.empty) {
+  private val poolKey = PoolKey(expressions, inputSchema, setups)
+  private val cuPool = poolMap.getPool(poolKey)
   def performSql(values: Map[String, Any]): Seq[Map[String, Any]] =
     poolMap.performWithValue(poolKey, cuPool) { _.performSql(values) }
   def outputChrononSchema: Array[(String, DataType)] =

--- a/online/src/main/scala/ai/chronon/online/GroupByServingInfoParsed.scala
+++ b/online/src/main/scala/ai/chronon/online/GroupByServingInfoParsed.scala
@@ -71,18 +71,22 @@ class GroupByServingInfoParsed(val groupByServingInfo: GroupByServingInfo)
   @transient lazy val keyTransformFunc: Map[String, Any] => Map[String, AnyRef] = {
     val transforms = groupBy.keyTransformsScala
     if (transforms.isEmpty) { keys =>
-      keys.map { case (key, value) => key -> value.asInstanceOf[AnyRef] }
+      Option(keys).map(_.map { case (key, value) => key -> value.asInstanceOf[AnyRef] }).orNull
     } else {
       val expressions = keyChrononSchema.fields.map { field =>
         field.name -> transforms.getOrElse(field.name, field.name)
       }
       val catalystUtil = new PooledCatalystUtil(expressions, keyChrononSchema, groupBy.allSetups)
       keys =>
-        catalystUtil
-          .performSql(keys)
-          .headOption
-          .getOrElse(Map.empty[String, Any])
-          .map { case (key, value) => key -> value.asInstanceOf[AnyRef] }
+        Option(keys)
+          .map { keyMap =>
+            catalystUtil
+              .performSql(keyMap)
+              .headOption
+              .getOrElse(Map.empty[String, Any])
+              .map { case (key, value) => key -> value.asInstanceOf[AnyRef] }
+          }
+          .orNull
     }
   }
 

--- a/online/src/main/scala/ai/chronon/online/GroupByServingInfoParsed.scala
+++ b/online/src/main/scala/ai/chronon/online/GroupByServingInfoParsed.scala
@@ -68,6 +68,24 @@ class GroupByServingInfoParsed(val groupByServingInfo: GroupByServingInfo)
   @transient lazy val keyChrononSchema: StructType =
     AvroConversions.toChrononSchema(keyCodec.schema).asInstanceOf[StructType]
 
+  @transient lazy val keyTransformFunc: Map[String, Any] => Map[String, AnyRef] = {
+    val transforms = groupBy.keyTransformsScala
+    if (transforms.isEmpty) { keys =>
+      keys.map { case (key, value) => key -> value.asInstanceOf[AnyRef] }
+    } else {
+      val expressions = keyChrononSchema.fields.map { field =>
+        field.name -> transforms.getOrElse(field.name, field.name)
+      }
+      val catalystUtil = new PooledCatalystUtil(expressions, keyChrononSchema, groupBy.allSetups)
+      keys =>
+        catalystUtil
+          .performSql(keys)
+          .headOption
+          .getOrElse(Map.empty[String, Any])
+          .map { case (key, value) => key -> value.asInstanceOf[AnyRef] }
+    }
+  }
+
   lazy val valueChrononSchema: StructType = {
     val valueFields = groupBy.aggregationInputs
       .flatMap(inp => selectedChrononSchema.fields.find(_.name == inp))

--- a/online/src/main/scala/ai/chronon/online/fetcher/GroupByFetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/GroupByFetcher.scala
@@ -55,14 +55,15 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
 
       var batchKeyBytes: Array[Byte] = null
       var streamingKeyBytes: Array[Byte] = null
+      val transformedKeys = groupByServingInfo.keyTransformFunc(request.keys)
 
       try {
         // The formats of key bytes for batch requests and key bytes for streaming requests may differ based
         // on the KVStore implementation, so we encode each distinctly.
-        batchKeyBytes = fetchContext.kvStore.createKeyBytes(request.keys,
+        batchKeyBytes = fetchContext.kvStore.createKeyBytes(transformedKeys,
                                                             groupByServingInfo,
                                                             groupByServingInfo.groupByOps.batchDataset)
-        streamingKeyBytes = fetchContext.kvStore.createKeyBytes(request.keys,
+        streamingKeyBytes = fetchContext.kvStore.createKeyBytes(transformedKeys,
                                                                 groupByServingInfo,
                                                                 groupByServingInfo.groupByOps.streamingDataset)
 
@@ -71,7 +72,7 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
         // TODO: only gets hit in cli path - make this code path just use avro schema to decode keys directly in cli
         // TODO: Remove this code block
         case ex: Exception =>
-          val castedKeys = groupByServingInfo.keyChrononSchema.cast(request.keys)
+          val castedKeys = groupByServingInfo.keyChrononSchema.cast(transformedKeys)
 
           try {
             batchKeyBytes = fetchContext.kvStore.createKeyBytes(castedKeys,
@@ -120,7 +121,7 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
 
       }
 
-      val castedRequest = request.copy(keys = groupByServingInfo.keyChrononSchema.cast(request.keys))
+      val castedRequest = request.copy(keys = groupByServingInfo.keyChrononSchema.cast(transformedKeys))
       LambdaKvRequest(groupByServingInfo, castedRequest, batchRequest, streamingRequestOpt, request.atMillis, context)
 
     }

--- a/online/src/test/scala/ai/chronon/online/test/FetcherBaseTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/FetcherBaseTest.scala
@@ -17,7 +17,21 @@
 package ai.chronon.online.test
 
 import ai.chronon.aggregator.windowing.FinalBatchIr
-import ai.chronon.api.{MetaData, TimeUnit, Window}
+import ai.chronon.api.{
+  Accuracy,
+  Builders,
+  DoubleType,
+  GroupByServingInfo,
+  IntType,
+  LongType,
+  MetaData,
+  Operation,
+  StringType,
+  StructField,
+  StructType,
+  TimeUnit,
+  Window
+}
 import ai.chronon.api.Extensions.{GroupByOps, WindowOps}
 import ai.chronon.online.fetcher.Fetcher.ColumnSpec
 import ai.chronon.online.fetcher.Fetcher.Request
@@ -38,7 +52,9 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import ai.chronon.online.metrics.TTLCache
+import ai.chronon.online.serde.AvroConversions
 
+import scala.collection.mutable
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -70,6 +86,68 @@ class FetcherBaseTest extends AnyFlatSpec with MockitoSugar with Matchers with M
     metadataStore = spy[fetcher.MetadataStore](new MetadataStore(fetchContext))
     joinPartFetcher = spy[fetcher.JoinPartFetcher](new fetcher.JoinPartFetcher(fetchContext, metadataStore))
     groupByFetcher = spy[fetcher.GroupByFetcher](new GroupByFetcher(fetchContext, metadataStore))
+  }
+
+  private def makeKeyTransformServingInfo(): GroupByServingInfoParsed = {
+    val groupBy = Builders.GroupBy(
+      sources = Seq(
+        Builders.Source.events(
+          table = "events.my_stream_raw",
+          topic = "events.my_stream",
+          query = Builders.Query(
+            selects = Map(
+              "id" -> "id",
+              "int_val" -> "int_val",
+              "double_val" -> "double_val"
+            ),
+            wheres = Seq.empty,
+            timeColumn = "ts",
+            startPartition = "20231106"
+          )
+        )
+      ),
+      keyColumns = Seq("id"),
+      keyTransforms = Map("id" -> "lower(id)"),
+      aggregations = Seq(
+        Builders.Aggregation(
+          operation = Operation.SUM,
+          inputColumn = "double_val",
+          windows = Seq(new Window(1, TimeUnit.DAYS))
+        )
+      ),
+      metaData = Builders.MetaData(name = "key_transform_test_group_by"),
+      accuracy = Accuracy.SNAPSHOT
+    )
+    val groupByServingInfo = new GroupByServingInfo()
+    groupByServingInfo.setGroupBy(groupBy)
+
+    val inputSchema = StructType(
+      "Input",
+      Array(
+        StructField("id", StringType),
+        StructField("int_val", IntType),
+        StructField("double_val", DoubleType),
+        StructField("ts", LongType)
+      )
+    )
+    groupByServingInfo.setInputAvroSchema(AvroConversions.fromChrononSchema(inputSchema).toString(true))
+
+    val keySchema = StructType("Key", Array(StructField("id", StringType)))
+    groupByServingInfo.setKeyAvroSchema(AvroConversions.fromChrononSchema(keySchema).toString(true))
+
+    val selectedSchema = StructType(
+      "Selected",
+      Array(
+        StructField("id", StringType),
+        StructField("int_val", IntType),
+        StructField("double_val", DoubleType)
+      )
+    )
+    groupByServingInfo.setSelectedAvroSchema(AvroConversions.fromChrononSchema(selectedSchema).toString(true))
+
+    groupByServingInfo.setBatchEndDate("2023-11-06")
+    groupByServingInfo.setDateFormat("yyyy-MM-dd")
+    new GroupByServingInfoParsed(groupByServingInfo)
   }
 
   it should "fetch columns single query" in {
@@ -158,6 +236,43 @@ class FetcherBaseTest extends AnyFlatSpec with MockitoSugar with Matchers with M
     actualRequest shouldNot be(None)
     actualRequest.get.name shouldBe query.groupByName + "." + query.columnName
     actualRequest.get.keys shouldBe query.keyMapping.get
+  }
+
+  it should "transform groupBy keys before encoding kv requests" in {
+    val servingInfo = makeKeyTransformServingInfo()
+    val ttlCache = mock[TTLCache[String, Try[GroupByServingInfoParsed]]]
+    val encodedKeys = mutable.ArrayBuffer.empty[Map[String, AnyRef]]
+
+    doReturn(ttlCache).when(metadataStore).getGroupByServingInfo
+    doReturn(Success(servingInfo)).when(ttlCache).apply("key_transform_test_group_by")
+
+    doAnswer(new Answer[Array[Byte]] {
+      def answer(invocation: InvocationOnMock): Array[Byte] = {
+        val keys = invocation.getArgument(0).asInstanceOf[Map[String, AnyRef]]
+        val dataset = invocation.getArgument(2).asInstanceOf[String]
+        encodedKeys.append(keys)
+        s"$dataset:${keys("id")}".getBytes
+      }
+    }).when(kvStore).createKeyBytes(any(), any(), any())
+
+    doAnswer(new Answer[Future[Seq[KVStore.GetResponse]]] {
+      def answer(invocation: InvocationOnMock): Future[Seq[KVStore.GetResponse]] = {
+        val requests = invocation.getArgument(0).asInstanceOf[Seq[KVStore.GetRequest]]
+        Future.successful(requests.map(request => KVStore.GetResponse(request, Success(Seq.empty))))
+      }
+    }).when(kvStore).multiGet(any())
+
+    val request = Request(
+      name = "key_transform_test_group_by",
+      keys = Map("id" -> "TEST_USER_123"),
+      atMillis = None,
+      context = None
+    )
+
+    Await.result(groupByFetcher.fetchGroupBys(Seq(request)), 1.second)
+
+    encodedKeys should not be empty
+    encodedKeys.foreach(_ shouldEqual Map("id" -> "test_user_123"))
   }
 
   // updateServingInfo() is called when the batch response is from the KV store.

--- a/python/src/ai/chronon/group_by.py
+++ b/python/src/ai/chronon/group_by.py
@@ -17,7 +17,7 @@ import json
 import logging
 from collections.abc import Sequence
 from copy import deepcopy
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Mapping, Optional, Tuple, Union
 
 import ai.chronon.utils as utils
 import ai.chronon.windows as window_utils
@@ -479,10 +479,11 @@ def get_output_col_names(aggregation):
 
 def GroupBy(
     sources: Union[Sequence[utils.ANY_SOURCE_TYPE], utils.ANY_SOURCE_TYPE],
-    keys: List[str],
+    keys: Union[List[str], Mapping[str, Optional[str]]],
     aggregations: Optional[List[ttypes.Aggregation]],
     version: Optional[int] = None,
     derivations: List[ttypes.Derivation] = None,
+    setups: List[str] = None,
     accuracy: ttypes.Accuracy = None,
     output_namespace: str = None,
     table_properties: Dict[str, str] = None,
@@ -529,8 +530,9 @@ def GroupBy(
     :type sources: List of sources or a single source
     :param keys:
         List of primary keys that defines the data that needs to be collected in the result table. Similar to the
-        GroupBy in the SQL context.
-    :type keys: List[String]
+        GroupBy in the SQL context. Can also be a dict of output key name to SQL expression for canonicalizing the
+        stored/lookup key. Dict values of None or the same key name are treated as identity transforms.
+    :type keys: Union[List[String], Dict[String, Optional[String]]]
     :param aggregations:
         List of aggregations that needs to be computed for the data following the grouping defined by the keys::
 
@@ -610,6 +612,10 @@ def GroupBy(
         Derivation allows arbitrary SQL select clauses to be computed using columns from the output of group by backfill
         output schema. It is supported for offline computations for now.
     :type derivations: List[gen_thrift.api.ttypes.Drivation]
+    :param setups:
+        SQL setup statements colocated with the GroupBy. These are available to key transforms and other GroupBy SQL
+        expressions.
+    :type setups: List[str]
     :param kwargs:
         Additional properties that would be passed to run.py if specified under additional_args property.
         And provides an option to pass custom values to the processing logic.
@@ -642,6 +648,28 @@ def GroupBy(
     assert version is None or isinstance(version, int), (
         f"Version must be an integer or None, but found {type(version).__name__}"
     )
+
+    # Normalize the user-facing keys API into the engine-facing representation.
+    #
+    # The Python API allows:
+    #   keys=["user_id", "query"]
+    #   keys={"user_id": None, "query": "stem(lower(query))"}
+    #
+    # The engine still needs keyColumns to remain an ordered list for compatibility
+    # across thrift/Scala/Java/serving code. Transform expressions are therefore
+    # stored separately as a sparse map keyed by the same output key names. Missing
+    # entries, None values, and identity expressions all mean "use the key as-is".
+    key_transforms = None
+    if isinstance(keys, Mapping):
+        key_items = list(keys.items())
+        key_transforms = {
+            key: expr
+            for key, expr in key_items
+            if expr is not None and expr != key
+        }
+        keys = [key for key, _ in key_items]
+    else:
+        keys = list(keys)
 
     agg_inputs = []
     if aggregations is not None:
@@ -731,6 +759,8 @@ def GroupBy(
         metaData=metadata,
         accuracy=accuracy,
         derivations=derivations,
+        keyTransforms=key_transforms if key_transforms else None,
+        setups=setups,
     )
     validate_group_by(group_by)
 

--- a/python/src/ai/chronon/group_by.py
+++ b/python/src/ai/chronon/group_by.py
@@ -374,7 +374,7 @@ Mismatched columns among sources [1, {i + 2}], Difference: {column_diff}
 """
 
     # all keys should be present in the selected columns
-    unselected_keys = set(keys) - first_source_columns
+    unselected_keys = set(keys) - set(group_by.keyTransforms or {}) - first_source_columns
     assert not unselected_keys, f"""
 Keys {unselected_keys}, are unselected in source
 """
@@ -675,7 +675,8 @@ def GroupBy(
     if aggregations is not None:
         agg_inputs = [agg.inputColumn for agg in aggregations]
 
-    required_columns = keys + agg_inputs
+    transformed_keys = set(key_transforms or {})
+    required_columns = [key for key in keys if key not in transformed_keys] + agg_inputs
 
     def _sanitize_columns(src: ttypes.Source):
         source = deepcopy(src)

--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -144,7 +144,7 @@ class Analyzer(tableUtils: TableUtils,
                      prefix: String = "",
                      includeOutputTableName: Boolean = false,
                      skewDetection: Boolean = false): (Array[AggregationMetadata], Map[String, DataType]) = {
-    Option(groupByConf.setups).foreach(_.foreach(tableUtils.sql))
+    groupByConf.allSetups.foreach(tableUtils.sql)
     val groupBy = GroupBy.from(groupByConf, range, tableUtils, computeDependency = skewDetection, finalize = true)
     val name = "group_by/" + prefix + groupByConf.metaData.name
     logger.info(s"""Running GroupBy analysis for $name ...""".stripMargin)

--- a/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
@@ -637,9 +637,11 @@ object GroupBy {
         "Please note that for the entities case, \"ts\" needs to be explicitly specified in the selects."
     )
 
+    val transformedInputDf = JoinUtils.applyKeyTransforms(inputDf, groupByConf)
+
     // at-least one of the keys should be present in the row.
     val nullFilterClause = groupByConf.keyColumns.toScala.map(key => s"($key IS NOT NULL)").mkString(" OR ")
-    inputDf.filter(nullFilterClause)
+    transformedInputDf.filter(nullFilterClause)
   }
 
   def from(groupByConfOld: api.GroupBy,
@@ -687,7 +689,8 @@ object GroupBy {
       }
       .getOrElse(inputDf)
 
-    val processedInputDf = bloomMapOpt.map { skewFilteredDf.filterBloom }.getOrElse { skewFilteredDf }
+    val transformedInputDf = JoinUtils.applyKeyTransforms(skewFilteredDf, groupByConf)
+    val processedInputDf = bloomMapOpt.map { transformedInputDf.filterBloom }.getOrElse { transformedInputDf }
 
     // at-least one of the keys should be present in the row.
     val nullFilterClause = groupByConf.keyColumns.toScala.map(key => s"($key IS NOT NULL)").mkString(" OR ")
@@ -719,8 +722,9 @@ object GroupBy {
             val columns1 = df1.schema.fields.map(_.name)
             df1.union(df2.selectExpr(columns1: _*))
           }
-          .selectExpr(mutationsColumnOrder: _*)
-        bloomMapOpt.map { mutationDf.filterBloom }.getOrElse { mutationDf }
+        val transformedMutationDf = JoinUtils.applyKeyTransforms(mutationDf, groupByConf)
+        val mutationDfWithColumns = transformedMutationDf.selectExpr(mutationsColumnOrder: _*)
+        bloomMapOpt.map { mutationDfWithColumns.filterBloom }.getOrElse { mutationDfWithColumns }
       } else null
 
       if (showDf && df != null) {
@@ -873,7 +877,7 @@ object GroupBy {
                       tableUtils: TableUtils,
                       stepDays: Option[Int] = None,
                       skipFirstHole: Boolean = true): Unit = {
-    Option(groupByConf.setups).foreach(_.foreach(tableUtils.sql))
+    groupByConf.allSetups.foreach(tableUtils.sql)
     val outputTable = groupByConf.metaData.outputTable
     val tableProps = Option(groupByConf.metaData.tableProperties)
       .map(_.toScala)

--- a/spark/src/main/scala/ai/chronon/spark/GroupByUpload.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupByUpload.scala
@@ -393,7 +393,7 @@ object GroupByUpload {
                                 jsonPercent: Int = 1,
                                 maybeContext: Option[Metrics.Context] = None): UploadResult = {
     implicit val partitionSpec: PartitionSpec = tableUtils.partitionSpec
-    Option(groupByConf.setups).foreach(_.foreach(tableUtils.sql))
+    groupByConf.allSetups.foreach(tableUtils.sql)
     // add 1 day to the batch end time to reflect data [ds 00:00:00.000, ds + 1 00:00:00.000)
     val batchEndDate = partitionSpec.after(endDs)
     // for snapshot accuracy - we don't need to scan mutations

--- a/spark/src/main/scala/ai/chronon/spark/Join.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Join.scala
@@ -312,7 +312,7 @@ class Join(joinConf: api.Join,
           // So partTable needs to be defined BEFORE the runSmallMode logic below
           val partTable = planner.RelevantLeftForJoinPart.partTableName(joinConfCloned, joinPart)
 
-          val bloomFilterOpt = if (runSmallMode) {
+          val bloomFilterOpt = if (runSmallMode && !joinPart.groupBy.hasKeyTransforms) {
             // If left DF is small, hardcode the key filter into the joinPart's GroupBy's where clause.
             injectKeyFilter(leftDf, joinPart)
             None
@@ -321,7 +321,10 @@ class Join(joinConf: api.Join,
           }
 
           val runContext =
-            JoinPartJobContext(unfilledLeftDf, bloomFilterOpt, tableProps, runSmallMode)
+            JoinPartJobContext(unfilledLeftDf,
+                               bloomFilterOpt,
+                               tableProps,
+                               runSmallMode && !joinPart.groupBy.hasKeyTransforms)
 
           val skewKeys: Option[Map[String, Seq[String]]] = Option(joinConfCloned.skewKeys).map { jmap =>
             val scalaMap = jmap.toScala

--- a/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
@@ -116,7 +116,7 @@ abstract class JoinBase(val joinConfCloned: api.Join,
                |${leftDf.schema.pretty}
                |Right Schema:
                |${joinableRightDf.schema.pretty}""".stripMargin)
-    val joinedDf = coalescedJoin(leftDf, joinableRightDf, keys)
+    val joinedDf = JoinUtils.coalescedJoinWithKeyTransforms(leftDf, joinableRightDf, keys, joinPart)
     logger.info(s"""Final Schema:
                |${joinedDf.schema.pretty}
                |""".stripMargin)

--- a/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
@@ -27,7 +27,7 @@ import ai.chronon.spark.catalog.TableUtils
 import com.google.gson.Gson
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.expressions.UserDefinedFunction
-import org.apache.spark.sql.functions.{coalesce, col, udf}
+import org.apache.spark.sql.functions.{coalesce, col, expr, udf}
 import org.apache.spark.util.sketch.BloomFilter
 import org.slf4j.{Logger, LoggerFactory}
 
@@ -106,6 +106,57 @@ object JoinUtils {
     }
 
     Some(result.translatePartitionSpec(effectiveLeftSpec, tableUtils.partitionSpec))
+  }
+
+  def applyKeyTransforms(df: DataFrame, groupBy: api.GroupBy): DataFrame = {
+    val transforms = groupBy.keyTransformsScala
+    if (transforms.isEmpty) {
+      df
+    } else {
+      val projections = df.columns.map { column =>
+        transforms.get(column) match {
+          case Some(transform) => expr(transform).as(column)
+          case None            => col(column)
+        }
+      }
+      df.select(projections: _*)
+    }
+  }
+
+  def transformedJoinBloomMap(leftDfWithRightKeys: DataFrame,
+                              joinPart: api.JoinPart,
+                              totalCount: Long,
+                              leftTable: String,
+                              partitionRange: PartitionRange): Option[util.Map[String, BloomFilter]] = {
+    if (!joinPart.groupBy.hasKeyTransforms) {
+      None
+    } else {
+      val transformedLeft = applyKeyTransforms(leftDfWithRightKeys, joinPart.groupBy)
+      Some(
+        joinPart.groupBy.keyColumns.toScala
+          .map { key =>
+            key -> transformedLeft.generateBloomFilter(key, totalCount, leftTable, partitionRange)
+          }
+          .toMap
+          .asJava
+      )
+    }
+  }
+
+  def coalescedJoinWithKeyTransforms(leftDf: DataFrame,
+                                     rightDf: DataFrame,
+                                     keys: Seq[String],
+                                     joinPart: api.JoinPart,
+                                     joinType: String = "left"): DataFrame = {
+    val transformedKeyJoin = new TransformedKeyJoin(joinPart, leftDf.columns.toSet)
+    if (transformedKeyJoin.isEmpty) coalescedJoin(leftDf, rightDf, keys, joinType)
+    else {
+      coalescedJoin(transformedKeyJoin.prepareLeft(leftDf),
+                    transformedKeyJoin.prepareRight(rightDf),
+                    transformedKeyJoin.joinKeys(keys),
+                    joinType)
+        .drop(transformedKeyJoin.columnsToDropAfterJoin: _*)
+    }
   }
 
   /** *

--- a/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
@@ -148,7 +148,7 @@ object JoinUtils {
                                      keys: Seq[String],
                                      joinPart: api.JoinPart,
                                      joinType: String = "left"): DataFrame = {
-    val transformedKeyJoin = new TransformedKeyJoin(joinPart, leftDf.columns.toSet)
+    val transformedKeyJoin = new TransformedKeyJoin(joinPart, leftDf.columns.toSet ++ rightDf.columns.toSet)
     if (transformedKeyJoin.isEmpty) coalescedJoin(leftDf, rightDf, keys, joinType)
     else {
       coalescedJoin(transformedKeyJoin.prepareLeft(leftDf),

--- a/spark/src/main/scala/ai/chronon/spark/TransformedKeyJoin.scala
+++ b/spark/src/main/scala/ai/chronon/spark/TransformedKeyJoin.scala
@@ -1,0 +1,91 @@
+package ai.chronon.spark
+
+import ai.chronon.api.Extensions._
+import ai.chronon.api.JoinPart
+import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
+import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.functions.{col, expr}
+
+// Handles joins where a GroupBy key is stored under a canonical transformed value, for example
+// `keys = {"query": "stem(query)"}`. The right side already contains the transformed/canonical key
+// because GroupBy applies key transforms before aggregation. The left side still contains the raw
+// join key from the query, so the join must compute the same canonical value before joining.
+//
+// Key mappings make this subtle. If a join maps `leftKey -> rightKey`, transform expressions are
+// authored against the GroupBy/right key name, while the left dataframe stores the raw value under
+// `leftKey`. Rather than overwrite `rightKey` on the left dataframe, which can collide with an
+// unrelated user column, we create an internal input alias for `leftKey` and rewrite the parsed
+// Catalyst expression so references to `rightKey` point at that internal alias. Function calls and
+// UDFs remain unchanged because only unresolved attribute nodes are rewritten. The actual join uses
+// internal temp columns, and those internal columns are dropped after the coalesced join finishes.
+private[spark] case class TransformedJoinKey(leftKey: String,
+                                             rightKey: String,
+                                             tempKey: String,
+                                             inputKey: String,
+                                             leftTransform: String)
+
+private[spark] class TransformedKeyJoin(joinPart: JoinPart, occupiedColumns: Set[String]) {
+
+  private val transforms = joinPart.groupBy.keyTransformsScala
+
+  val keys: Seq[TransformedJoinKey] = {
+    val (result, _) = joinPart.leftToRight.toSeq.foldLeft((Seq.empty[TransformedJoinKey], occupiedColumns)) {
+      case ((acc, usedColumns), (leftKey, rightKey)) if transforms.contains(rightKey) =>
+        val tempKey = internalColumn("key", leftKey, usedColumns)
+        val inputKey = internalColumn("input", rightKey, usedColumns + tempKey)
+        val leftTransform = rewriteTransform(transforms(rightKey), rightKey, inputKey)
+        (acc :+ TransformedJoinKey(leftKey, rightKey, tempKey, inputKey, leftTransform),
+         usedColumns ++ Seq(tempKey, inputKey))
+
+      case ((acc, usedColumns), _) => (acc, usedColumns)
+    }
+    result
+  }
+
+  private def internalColumn(prefix: String, key: String, usedColumns: Set[String]): String = {
+    val base = s"${prefix}_$key"
+    Iterator
+      .iterate(0)(_ + 1)
+      .map {
+        case 0 => base
+        case i => s"${base}_$i"
+      }
+      .dropWhile(usedColumns.contains)
+      .next()
+  }
+
+  private def rewriteTransform(transform: String, from: String, to: String): String =
+    CatalystSqlParser
+      .parseExpression(transform)
+      .transform {
+        case attr: UnresolvedAttribute if attr.nameParts.headOption.contains(from) =>
+          UnresolvedAttribute(to +: attr.nameParts.tail)
+      }
+      .sql
+
+  def isEmpty: Boolean = keys.isEmpty
+
+  def prepareLeft(leftDf: DataFrame): DataFrame = {
+    val withInputKeys = keys.foldLeft(leftDf) { case (df, key) =>
+      df.withColumn(key.inputKey, col(key.leftKey))
+    }
+
+    keys.foldLeft(withInputKeys) { case (df, key) =>
+      df.withColumn(key.tempKey, expr(key.leftTransform))
+    }
+  }
+
+  def prepareRight(rightDf: DataFrame): DataFrame =
+    keys.foldLeft(rightDf) { case (df, key) =>
+      df.withColumn(key.tempKey, col(key.leftKey))
+    }
+
+  def joinKeys(baseKeys: Seq[String]): Seq[String] = {
+    val leftToTempKey = keys.map(key => key.leftKey -> key.tempKey).toMap
+    baseKeys.map(key => leftToTempKey.getOrElse(key, key))
+  }
+
+  def columnsToDropAfterJoin: Seq[String] =
+    keys.flatMap(key => Seq(key.tempKey, key.inputKey))
+}

--- a/spark/src/main/scala/ai/chronon/spark/batch/Eval.scala
+++ b/spark/src/main/scala/ai/chronon/spark/batch/Eval.scala
@@ -172,7 +172,7 @@ class Eval(implicit tableUtils: TableUtils) {
     // If the source expression is invalid, set the failure and return early
     val groupBy =
       try {
-        groupByConf.setups.foreach(tableUtils.sql)
+        groupByConf.allSetups.foreach(tableUtils.sql)
         GroupBy.from(groupByConf, effectiveRange, tableUtils, computeDependency = false, finalize = true)
       } catch {
         case e: Throwable =>

--- a/spark/src/main/scala/ai/chronon/spark/batch/JoinPartJob.scala
+++ b/spark/src/main/scala/ai/chronon/spark/batch/JoinPartJob.scala
@@ -63,12 +63,13 @@ class JoinPartJob(node: JoinPartNode,
           return None
         }
 
-        val runSmallMode = JoinUtils.runSmallMode(tableUtils, cachedLeftDf)
+        val runSmallMode = JoinUtils.runSmallMode(tableUtils, cachedLeftDf) && !joinPart.groupBy.hasKeyTransforms
 
         val leftWithStats = cachedLeftDf.withStats
 
         val joinLevelBloomMapOpt =
-          JoinUtils.genBloomFilterIfNeeded(joinPart, node.leftDataModel, dateRange, None)
+          if (joinPart.groupBy.hasKeyTransforms) None
+          else JoinUtils.genBloomFilterIfNeeded(joinPart, node.leftDataModel, dateRange, None)
 
         JoinPartJobContext(Option(leftWithStats),
                            joinLevelBloomMapOpt,
@@ -144,26 +145,6 @@ class JoinPartJob(node: JoinPartNode,
     val statsDf = leftDfWithStats.get
 
     logger.info(s"\nBackfill is required for ${joinPart.groupBy.metaData.name}")
-    val rightBloomMap = if (skipBloom) {
-      None
-    } else {
-      JoinUtils.genBloomFilterIfNeeded(joinPart, node.leftDataModel, dateRange, joinLevelBloomMapOpt)
-    }
-
-    val rightSkewFilter = JoinUtils.partSkewFilter(joinPart, skewKeys)
-
-    def genGroupBy(partitionRange: PartitionRange) =
-      GroupBy.from(joinPart.groupBy,
-                   partitionRange,
-                   tableUtils,
-                   computeDependency = true,
-                   rightBloomMap,
-                   rightSkewFilter,
-                   showDf = showDf)
-
-    // all lazy vals - so evaluated only when needed by each case.
-    lazy val partitionRangeGroupBy = genGroupBy(dateRange)
-
     lazy val unfilledPartitionRange = if (tableUtils.checkLeftTimeRange) {
       val timeRange = statsDf.timeRange
       logger.info(s"left unfilled time range checked to be: $timeRange")
@@ -214,6 +195,30 @@ class JoinPartJob(node: JoinPartNode,
       case c => renamedLeftRawDf.col(c)
     }.toList: _*)
 
+    lazy val transformedLeftDf = JoinUtils.applyKeyTransforms(renamedLeftDf, joinPart.groupBy)
+    lazy val rightBloomMap =
+      if (skipBloom) None
+      else if (joinPart.groupBy.hasKeyTransforms)
+        JoinUtils.transformedJoinBloomMap(renamedLeftDf,
+                                          joinPart,
+                                          statsDf.partitionCounts.values.sum,
+                                          leftTable,
+                                          unfilledPartitionRange)
+      else JoinUtils.genBloomFilterIfNeeded(joinPart, node.leftDataModel, dateRange, joinLevelBloomMapOpt)
+
+    val rightSkewFilter = JoinUtils.partSkewFilter(joinPart, skewKeys)
+
+    def genGroupBy(partitionRange: PartitionRange) =
+      GroupBy.from(joinPart.groupBy,
+                   partitionRange,
+                   tableUtils,
+                   computeDependency = true,
+                   rightBloomMap,
+                   rightSkewFilter,
+                   showDf = showDf)
+
+    lazy val partitionRangeGroupBy = genGroupBy(dateRange)
+
     val rightDf = (node.leftDataModel, joinPart.groupBy.dataModel, joinPart.groupBy.inferredAccuracy) match {
       case (ENTITIES, EVENTS, _)   => partitionRangeGroupBy.snapshotEvents(dateRange)
       case (ENTITIES, ENTITIES, _) => partitionRangeGroupBy.snapshotEntities
@@ -229,21 +234,22 @@ class JoinPartJob(node: JoinPartNode,
           val joinPartWithoutMapping = joinPart.deepCopy()
           joinPartWithoutMapping.unsetKeyMapping()
 
-          UnionJoin.computeJoinPart(renamedLeftDf,
+          UnionJoin.computeJoinPart(transformedLeftDf,
                                     joinPartWithoutMapping,
                                     unfilledPartitionRange,
                                     produceFinalJoinOutput = false)
 
         } else {
           // Use traditional temporalEvents approach
-          genGroupBy(unfilledPartitionRange).temporalEvents(renamedLeftDf, Some(toTimeRange(unfilledPartitionRange)))
+          genGroupBy(unfilledPartitionRange).temporalEvents(transformedLeftDf,
+                                                            Some(toTimeRange(unfilledPartitionRange)))
         }
 
       case (EVENTS, ENTITIES, Accuracy.SNAPSHOT) => genGroupBy(shiftedPartitionRange).snapshotEntities
 
       case (EVENTS, ENTITIES, Accuracy.TEMPORAL) =>
         // Snapshots and mutations are partitioned with ds holding data between <ds 00:00> and ds <23:59>.
-        genGroupBy(unfilledPartitionRange.shift(-1)).temporalEntities(renamedLeftDf)
+        genGroupBy(unfilledPartitionRange.shift(-1)).temporalEntities(transformedLeftDf)
     }
 
     val rightDfWithDerivations = if (joinPart.groupBy.hasDerivations) {

--- a/spark/src/main/scala/ai/chronon/spark/batch/MergeJob.scala
+++ b/spark/src/main/scala/ai/chronon/spark/batch/MergeJob.scala
@@ -219,7 +219,7 @@ class MergeJob(node: JoinMergeNode, metaData: MetaData, range: DateRange, joinPa
                    |${leftDf.schema.pretty}
                    |Right Schema:
                    |${joinableRightDf.schema.pretty}""".stripMargin)
-    val joinedDf = coalescedJoin(leftDf, joinableRightDf, keys)
+    val joinedDf = JoinUtils.coalescedJoinWithKeyTransforms(leftDf, joinableRightDf, keys, joinPart)
     logger.info(s"""Final Schema:
                    |${joinedDf.schema.pretty}
                    |""".stripMargin)

--- a/spark/src/main/scala/ai/chronon/spark/streaming/GroupBy.scala
+++ b/spark/src/main/scala/ai/chronon/spark/streaming/GroupBy.scala
@@ -24,6 +24,7 @@ import ai.chronon.online.Extensions.ChrononStructTypeOps
 import ai.chronon.online._
 import ai.chronon.online.serde._
 import ai.chronon.spark.GenericRowHandler
+import ai.chronon.spark.JoinUtils
 import com.google.gson.Gson
 import org.apache.spark.sql._
 import org.apache.spark.sql.streaming.DataStreamWriter
@@ -142,8 +143,9 @@ class GroupBy(inputStream: DataFrame,
 
     des.createOrReplaceTempView(streamingTable)
 
-    Option(groupByConf.setups).foreach(_.foreach(session.sql))
-    val selectedDf = session.sql(streamingQuery)
+    groupByConf.allSetups.foreach(session.sql)
+    val selectedRawDf = session.sql(streamingQuery)
+    val selectedDf = JoinUtils.applyKeyTransforms(selectedRawDf, groupByConf)
     assert(selectedDf.schema.fieldNames.contains(Constants.TimeColumn),
            s"time column ${Constants.TimeColumn} must be included in the selects")
     if (groupByConf.dataModel == api.DataModel.ENTITIES) {

--- a/spark/src/test/scala/ai/chronon/spark/groupby/GroupByTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/groupby/GroupByTest.scala
@@ -40,6 +40,69 @@ class GroupByTest extends SparkTestBase {
   val tableUtils: TableUtils = TableUtils(spark)
   implicit val partitionSpec: PartitionSpec = tableUtils.partitionSpec
 
+  it should "aggregate over transformed key expressions" in {
+    import spark.implicits._
+
+    val df = Seq(
+      ("Alice", 10L, "2024-01-01", 1),
+      ("alice", 20L, "2024-01-01", 1),
+      ("Bob", 30L, "2024-01-01", 1)
+    ).toDF("user", Constants.TimeColumn, tableUtils.partitionColumn, "event_count")
+
+    val keyColumns = Seq("user")
+    val aggregations = Seq(Builders.Aggregation(Operation.SUM, "event_count", Seq(WindowUtils.Unbounded)))
+    val groupByConf = Builders.GroupBy(
+      keyColumns = keyColumns,
+      keyTransforms = Map("user" -> "lower(user)"),
+      aggregations = aggregations,
+      metaData = Builders.MetaData(name = "unit_test.transformed_key_group_by", team = "chronon")
+    )
+
+    val transformedGroupBy = new GroupBy(aggregations, keyColumns, JoinUtils.applyKeyTransforms(df, groupByConf))
+    val results = transformedGroupBy.snapshotEntities
+      .select("user", "event_count_sum")
+      .collect()
+      .map(row => row.getAs[String]("user") -> row.getAs[Long]("event_count_sum"))
+      .toMap
+
+    assertEquals(2, results.size)
+    assertEquals(2L, results("alice"))
+    assertEquals(1L, results("bob"))
+  }
+
+  it should "aggregate over transformed key expressions using group by setups" in {
+    import spark.implicits._
+
+    val df = Seq(
+      ("Alice", 10L, "2024-01-01", 1),
+      ("alice", 20L, "2024-01-01", 1),
+      ("Bob", 30L, "2024-01-01", 1)
+    ).toDF("user", Constants.TimeColumn, tableUtils.partitionColumn, "event_count")
+
+    val keyColumns = Seq("user")
+    val aggregations = Seq(Builders.Aggregation(Operation.SUM, "event_count", Seq(WindowUtils.Unbounded)))
+    val groupByConf = Builders.GroupBy(
+      keyColumns = keyColumns,
+      keyTransforms = Map("user" -> "temp_replace_group_by_key(user, 'A', 'a')"),
+      setups =
+        Seq("create temporary function temp_replace_group_by_key as 'org.apache.hadoop.hive.ql.udf.UDFRegExpReplace'"),
+      aggregations = aggregations,
+      metaData = Builders.MetaData(name = "unit_test.transformed_key_group_by_setup", team = "chronon")
+    )
+
+    groupByConf.allSetups.foreach(tableUtils.sql)
+    val transformedGroupBy = new GroupBy(aggregations, keyColumns, JoinUtils.applyKeyTransforms(df, groupByConf))
+    val results = transformedGroupBy.snapshotEntities
+      .select("user", "event_count_sum")
+      .collect()
+      .map(row => row.getAs[String]("user") -> row.getAs[Long]("event_count_sum"))
+      .toMap
+
+    assertEquals(2, results.size)
+    assertEquals(2L, results("alice"))
+    assertEquals(1L, results("Bob"))
+  }
+
   it should "snapshot entities" in {
     val schema = List(
       Column("user", StringType, 10),

--- a/spark/src/test/scala/ai/chronon/spark/join/KeyMappingOverlappingFieldsTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/join/KeyMappingOverlappingFieldsTest.scala
@@ -26,6 +26,27 @@ import org.junit.Assert._
 
 class KeyMappingOverlappingFieldsTest extends BaseJoinTest {
 
+  it should "evaluate transformed mapped keys against the mapped left key when right key name exists on left" in {
+    import spark.implicits._
+
+    val groupBy = Builders.GroupBy(
+      keyColumns = Seq("user"),
+      keyTransforms = Map("user" -> "lower(user)"),
+      metaData = Builders.MetaData(name = "unit_test.key_overlap.transformed_user_names", team = "chronon")
+    )
+    val joinPart = Builders.JoinPart(groupBy = groupBy, keyMapping = Map("user_id" -> "user"))
+
+    val leftDf = Seq(("Alice", "unrelated_user_column")).toDF("user_id", "user")
+    val rightDf = Seq(("alice", "matched")).toDF("user_id", "value")
+
+    val joinedDf = JoinUtils.coalescedJoinWithKeyTransforms(leftDf, rightDf, Seq("user_id"), joinPart)
+    val row = joinedDf.select("user_id", "user", "value").collect().head
+
+    assertEquals("Alice", row.getAs[String]("user_id"))
+    assertEquals("unrelated_user_column", row.getAs[String]("user"))
+    assertEquals("matched", row.getAs[String]("value"))
+  }
+
   it should "testKeyMappingOverlappingFields" in {
     // test the scenario when a key_mapping is a -> b, (right key b is mapped to left key a) and
     // a happens to be another field in the same group by
@@ -70,6 +91,59 @@ class KeyMappingOverlappingFieldsTest extends BaseJoinTest {
                           ))),
       metaData =
         Builders.MetaData(name = "unit_test.key_overlap.user_features", namespace = namespace, team = "chronon")
+    )
+
+    val runner = new ai.chronon.spark.Join(joinConf = joinConf, endPartition = end, tableUtils = tableUtils)
+    val computed = runner.computeJoin(Some(7))
+    assertFalse(computed.isEmpty)
+  }
+
+  it should "test keyMapping overlapping fields with transformed group by keys" in {
+    // Covers the full offline Join path when the left key is renamed to the GroupBy key and then transformed.
+
+    val namesSchema = List(
+      Column("user", api.StringType, 10),
+      Column("attribute", api.StringType, 10)
+    )
+    val namesTable = s"$namespace.key_overlap_transformed_names"
+    DataFrameGen.entities(spark, namesSchema, 100, partitions = 400).save(namesTable)
+
+    val namesSource = Builders.Source.entities(
+      query =
+        Builders.Query(selects =
+                         Builders.Selects.exprs("user" -> "user", "user_id" -> "user", "attribute" -> "attribute"),
+                       startPartition = yearAgo,
+                       endPartition = dayAndMonthBefore),
+      snapshotTable = namesTable
+    )
+
+    val namesGroupBy = Builders.GroupBy(
+      sources = Seq(namesSource),
+      keyColumns = Seq("user"),
+      keyTransforms = Map("user" -> "lower(user)"),
+      aggregations = null,
+      metaData = Builders.MetaData(name = "unit_test.key_overlap.transformed_user_names", team = "chronon")
+    )
+
+    val userSchema = List(Column("user_id", api.StringType, 10), Column("user", api.StringType, 10))
+    val usersTable = s"$namespace.key_overlap_transformed_users"
+    DataFrameGen.events(spark, userSchema, 100, partitions = 400).dropDuplicates().save(usersTable)
+
+    val start = tableUtils.partitionSpec.minus(today, new Window(60, TimeUnit.DAYS))
+    val end = tableUtils.partitionSpec.minus(today, new Window(15, TimeUnit.DAYS))
+    val joinConf = Builders.Join(
+      left = Builders.Source.entities(
+        Builders.Query(selects = Map("user_id" -> "user_id", "user" -> "user"), startPartition = start),
+        snapshotTable = usersTable),
+      joinParts = Seq(
+        Builders.JoinPart(groupBy = namesGroupBy,
+                          keyMapping = Map(
+                            "user_id" -> "user"
+                          ))),
+      metaData =
+        Builders.MetaData(name = "unit_test.key_overlap.transformed_user_features",
+                          namespace = namespace,
+                          team = "chronon")
     )
 
     val runner = new ai.chronon.spark.Join(joinConf = joinConf, endPartition = end, tableUtils = tableUtils)

--- a/spark/src/test/scala/ai/chronon/spark/join/KeyMappingOverlappingFieldsTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/join/KeyMappingOverlappingFieldsTest.scala
@@ -47,6 +47,29 @@ class KeyMappingOverlappingFieldsTest extends BaseJoinTest {
     assertEquals("matched", row.getAs[String]("value"))
   }
 
+  it should "preserve right columns that conflict with transformed key internals" in {
+    import spark.implicits._
+
+    val groupBy = Builders.GroupBy(
+      keyColumns = Seq("user"),
+      keyTransforms = Map("user" -> "lower(user)"),
+      metaData = Builders.MetaData(name = "unit_test.key_overlap.transformed_user_names", team = "chronon")
+    )
+    val joinPart = Builders.JoinPart(groupBy = groupBy, keyMapping = Map("user_id" -> "user"))
+
+    val leftDf = Seq("Alice").toDF("user_id")
+    val rightDf = Seq(("alice", "right_key_user_id", "right_input_user", "matched"))
+      .toDF("user_id", "key_user_id", "input_user", "value")
+
+    val joinedDf = JoinUtils.coalescedJoinWithKeyTransforms(leftDf, rightDf, Seq("user_id"), joinPart)
+    val row = joinedDf.select("user_id", "key_user_id", "input_user", "value").collect().head
+
+    assertEquals("Alice", row.getAs[String]("user_id"))
+    assertEquals("right_key_user_id", row.getAs[String]("key_user_id"))
+    assertEquals("right_input_user", row.getAs[String]("input_user"))
+    assertEquals("matched", row.getAs[String]("value"))
+  }
+
   it should "testKeyMappingOverlappingFields" in {
     // test the scenario when a key_mapping is a -> b, (right key b is mapped to left key a) and
     // a happens to be another field in the same group by

--- a/spark/src/test/scala/ai/chronon/spark/streaming/StreamingTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/streaming/StreamingTest.scala
@@ -20,22 +20,26 @@ import ai.chronon.aggregator.test.Column
 import ai.chronon.api
 import ai.chronon.api.Constants.MetadataDataset
 import ai.chronon.api._
+import ai.chronon.online.fetcher.Fetcher
 import ai.chronon.online.fetcher.{FetchContext, MetadataStore}
 import ai.chronon.spark.Extensions._
 import ai.chronon.spark.catalog.TableUtils
 import ai.chronon.online.InMemoryKvStore
-import ai.chronon.spark.utils.{DataFrameGen, OnlineUtils, SparkTestBase}
+import ai.chronon.spark.utils.{DataFrameGen, MockApi, OnlineUtils, SparkTestBase}
 import ai.chronon.spark.{Join => _, _}
+import org.junit.Assert.assertEquals
 
 import java.util.TimeZone
 import scala.collection.JavaConverters.asScalaBufferConverter
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
 
 object StreamingTest {
-  def buildInMemoryKvStore(): InMemoryKvStore = {
-    InMemoryKvStore.build("StreamingTest",
+  def buildInMemoryKvStore(name: String = "StreamingTest"): InMemoryKvStore = {
+    InMemoryKvStore.build(name,
                           { () =>
                             import ai.chronon.spark.submission
-                            submission.SparkSessionBuilder.build("StreamingTest", local = true)
+                            submission.SparkSessionBuilder.build(name, local = true)
                           })
   }
 }
@@ -48,6 +52,63 @@ class StreamingTest extends SparkTestBase {
   private val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
   tableUtils.partitionSpec.before(today)
   private val yearAgo = tableUtils.partitionSpec.minus(today, new Window(365, TimeUnit.DAYS))
+
+  it should "apply key transforms before streaming key encoding" in {
+    import spark.implicits._
+
+    createDatabase(namespace)
+    val storeName = s"StreamingKeyTransformTest_${System.nanoTime()}"
+    def kvStoreFunc(): InMemoryKvStore =
+      StreamingTest.buildInMemoryKvStore(storeName)
+    val inMemoryKvStore = kvStoreFunc()
+    inMemoryKvStore.create(MetadataDataset)
+
+    val eventsTable = s"$namespace.streaming_key_transform_events"
+    val eventTs = tableUtils.partitionSpec.epochMillis(today) + 1000L
+    Seq(
+      ("Alice", 1, eventTs, today),
+      ("alice", 2, eventTs + 1000L, today)
+    ).toDF("user", "event_count", "ts", "ds").save(eventsTable)
+
+    val source = Builders.Source.events(
+      table = eventsTable,
+      topic = "streaming_key_transform_topic",
+      query = Builders.Query(
+        selects = Map("user" -> "user", "event_count" -> "event_count"),
+        timeColumn = "ts",
+        startPartition = yearAgo
+      )
+    )
+
+    val groupBy = Builders.GroupBy(
+      sources = Seq(source),
+      keyColumns = Seq("user"),
+      keyTransforms = Map("user" -> "lower(user)"),
+      aggregations = Seq(
+        Builders.Aggregation(
+          operation = Operation.SUM,
+          inputColumn = "event_count",
+          windows = Seq(new Window(1, TimeUnit.DAYS))
+        )
+      ),
+      metaData = Builders.MetaData(name = "streaming_key_transform_user_counts", namespace = namespace, team = "chronon"),
+      accuracy = Accuracy.TEMPORAL
+    )
+
+    OnlineUtils.serve(tableUtils, inMemoryKvStore, kvStoreFunc, namespace, today, groupBy)
+
+    val fetcher = new MockApi(kvStoreFunc, namespace).buildFetcher()
+    val response = Await
+      .result(
+        fetcher.fetchGroupBys(
+          Seq(Fetcher.Request(groupBy.metaData.name, Map("user" -> "ALICE"), Some(eventTs + 2000L)))
+        ),
+        10.seconds
+      )
+      .head
+
+    assertEquals(3L, response.values.get("event_count_sum_1d"))
+  }
 
   it should "struct in streaming" in {
     createDatabase(namespace)
@@ -111,6 +172,6 @@ class StreamingTest extends SparkTestBase {
     inMemoryKvStore.create(MetadataDataset)
     metadataStore.putJoinConf(joinConf)
     joinConf.joinParts.asScala.foreach(jp =>
-      OnlineUtils.serve(tableUtils, inMemoryKvStore, StreamingTest.buildInMemoryKvStore, namespace, today, jp.groupBy))
+      OnlineUtils.serve(tableUtils, inMemoryKvStore, () => StreamingTest.buildInMemoryKvStore(), namespace, today, jp.groupBy))
   }
 }

--- a/thrift/api.thrift
+++ b/thrift/api.thrift
@@ -377,6 +377,11 @@ struct GroupBy {
     5: optional Accuracy accuracy
     // support for offline only for now
     7: optional list<Derivation> derivations
+    // SQL expressions for canonicalizing key columns before storing or looking up GroupBy rows.
+    // Keys not present in this map are treated as identity transforms.
+    8: optional map<string, string> keyTransforms
+    // SQL setup statements needed by keyTransforms/derivations, colocated with the GroupBy.
+    9: optional list<string> setups
 }
 
 struct JoinPart {


### PR DESCRIPTION
## Summary

The motivation behind this PR is that we'd like to usually apply some transform over a query key for aggregations, and then re-apply that transformation at inference time to fetch the feature value. We have two options (I think), either materialize the transform applied to each source in a StagingQuery, and then re-apply the transform externally from the caller of the fetcher service (obvious source of inconsistency) or push the transform onto the GroupBy itself and resolve where the transform should occur. 

Given an arbitrary transform of a key on a GroupBy though we must:

- Require that the GroupBy aggregation happens over that key transform
- Require that the streaming GroupBy aggregation happens over that key transform
- Require that the fetcher knows for a given GroupBy the key must be transformed prior to fetching the result
- Require that when running a Join, the raw key value must be transformed to match the existing pre-transformed value in the GroupBy. 

Off the primary motivation being how do you transform strings, we'd want NLP support which mostly comes from UDFs so we also need to include setups support within the GroupBy. 

The implementation of a transform would then look something like:

```py
query_item_views = GroupBy(
    sources=[search_queries],
    # Transform query to the lowercase query. Apply this transform offline and online
    keys={"query": "lower(query)"},
    aggregations=[
        Aggregation(
            input_column="item_id",
            operation=Operation.COUNT,
            windows=["7d"],
        )
    ]
)
```

## Checklist
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Group-by operations now support key transformations before aggregation
  * Join operations improved to handle key mapping with derived expressions

* **Bug Fixes**
  * Enhanced consistency in setup SQL execution across group-by and join workflows
  * Improved join request key derivation for complex join scenarios

* **Tests**
  * Added comprehensive test coverage for key transformation workflows
  * New test suite validating join operations with overlapping field mappings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->