### PR TITLE
fix: vertx metrics to otlp and resource attributes

### DIFF
--- a/service_commons/src/main/java/ai/chronon/service/ChrononServiceLauncher.java
+++ b/service_commons/src/main/java/ai/chronon/service/ChrononServiceLauncher.java
@@ -64,6 +64,7 @@ public class ChrononServiceLauncher extends Launcher {
     private void configureOtlpHttpMetrics(String serviceName, VertxOptions options) {
         String exporterUrl = OtelMetricsReporter.getExporterUrl() + "/v1/metrics";
         String exportInterval = OtelMetricsReporter.getMetricsExporterInterval();
+        String resourceAttributes = buildOtlpResourceAttributes(serviceName);
 
         // Configure OTLP using Micrometer's built-in registry
         OtlpConfig otlpConfig = key -> {
@@ -73,7 +74,7 @@ public class ChrononServiceLauncher extends Launcher {
                 case "otlp.step":
                     return exportInterval;
                 case "otlp.resourceAttributes":
-                    return "service.name=" + serviceName;
+                    return resourceAttributes;
                 // Emit exponential histograms so backends can compute server-side percentiles
                 case "otlp.histogramFlavor":
                     return "BASE2_EXPONENTIAL";
@@ -124,6 +125,37 @@ public class ChrononServiceLauncher extends Launcher {
                 .addLabels(Label.HTTP_METHOD, Label.HTTP_CODE, Label.HTTP_PATH);
 
         options.setMetricsOptions(metricsOptions);
+    }
+
+    /**
+     * Build the comma-separated resource attributes string for the Vert.x/Micrometer OTLP registry.
+     *
+     * Unlike the OTel SDK, Micrometer's OtlpMeterRegistry does not auto-read OTEL_SERVICE_NAME or
+     * OTEL_RESOURCE_ATTRIBUTES, so we mirror that behavior here. We also honor the Chronon-specific
+     * system property used by OtelMetricsReporter so both metrics pipelines accept the same config.
+     *
+     * Precedence (later entries override earlier ones, since Micrometer parses into a LinkedHashMap
+     * where the last value for a given key wins):
+     *   1. service.name=&lt;default&gt;
+     *   2. OTEL_RESOURCE_ATTRIBUTES env var
+     *   3. ai.chronon.metrics.exporter.resources system property
+     *   4. OTEL_SERVICE_NAME env var (overrides service.name)
+     */
+    static String buildOtlpResourceAttributes(String defaultServiceName) {
+        StringBuilder sb = new StringBuilder("service.name=").append(defaultServiceName);
+        String envResourceAttrs = System.getenv("OTEL_RESOURCE_ATTRIBUTES");
+        if (envResourceAttrs != null && !envResourceAttrs.trim().isEmpty()) {
+            sb.append(',').append(envResourceAttrs.trim());
+        }
+        String chrononResourceAttrs = System.getProperty(OtelMetricsReporter.MetricsExporterResourceKey(), "");
+        if (!chrononResourceAttrs.trim().isEmpty()) {
+            sb.append(',').append(chrononResourceAttrs.trim());
+        }
+        String envServiceName = System.getenv("OTEL_SERVICE_NAME");
+        if (envServiceName != null && !envServiceName.trim().isEmpty()) {
+            sb.append(',').append("service.name=").append(envServiceName.trim());
+        }
+        return sb.toString();
     }
 
     public static void main(String[] args) {

--- a/service_commons/src/main/java/ai/chronon/service/ChrononServiceLauncher.java
+++ b/service_commons/src/main/java/ai/chronon/service/ChrononServiceLauncher.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Optional;
+import java.util.function.Function;
 
 /**
  * Custom launcher to help configure the Chronon vertx feature service
@@ -142,8 +143,13 @@ public class ChrononServiceLauncher extends Launcher {
      *   4. OTEL_SERVICE_NAME env var (overrides service.name)
      */
     static String buildOtlpResourceAttributes(String defaultServiceName) {
+        return buildOtlpResourceAttributes(defaultServiceName, System::getenv);
+    }
+
+    // Overload that takes an env lookup function for testability — System.getenv is immutable in-process.
+    static String buildOtlpResourceAttributes(String defaultServiceName, Function<String, String> envLookup) {
         StringBuilder sb = new StringBuilder("service.name=").append(defaultServiceName);
-        String envResourceAttrs = System.getenv("OTEL_RESOURCE_ATTRIBUTES");
+        String envResourceAttrs = envLookup.apply("OTEL_RESOURCE_ATTRIBUTES");
         if (envResourceAttrs != null && !envResourceAttrs.trim().isEmpty()) {
             sb.append(',').append(envResourceAttrs.trim());
         }
@@ -151,7 +157,7 @@ public class ChrononServiceLauncher extends Launcher {
         if (!chrononResourceAttrs.trim().isEmpty()) {
             sb.append(',').append(chrononResourceAttrs.trim());
         }
-        String envServiceName = System.getenv("OTEL_SERVICE_NAME");
+        String envServiceName = envLookup.apply("OTEL_SERVICE_NAME");
         if (envServiceName != null && !envServiceName.trim().isEmpty()) {
             sb.append(',').append("service.name=").append(envServiceName.trim());
         }

--- a/service_commons/src/main/java/ai/chronon/service/ChrononServiceLauncher.java
+++ b/service_commons/src/main/java/ai/chronon/service/ChrononServiceLauncher.java
@@ -4,6 +4,8 @@ import ai.chronon.online.metrics.Metrics;
 import ai.chronon.online.metrics.OtelMetricsReporter;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.config.MeterFilter;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.micrometer.registry.otlp.OtlpConfig;
@@ -72,13 +74,27 @@ public class ChrononServiceLauncher extends Launcher {
                     return exportInterval;
                 case "otlp.resourceAttributes":
                     return "service.name=" + serviceName;
+                // Emit exponential histograms so backends can compute server-side percentiles
+                case "otlp.histogramFlavor":
+                    return "BASE2_EXPONENTIAL";
                 default:
                     return null;
             }
         };
 
-        MeterRegistry registry = new OtlpMeterRegistry(otlpConfig, Clock.SYSTEM);
-        MicrometerMetricsFactory metricsFactory = new MicrometerMetricsFactory(registry);
+        OtlpMeterRegistry registry = new OtlpMeterRegistry(otlpConfig, Clock.SYSTEM);
+        // histogramFlavor only takes effect when publishPercentileHistogram is enabled on the meter
+        registry.config().meterFilter(new MeterFilter() {
+            @Override
+            public DistributionStatisticConfig configure(io.micrometer.core.instrument.Meter.Id id,
+                                                        DistributionStatisticConfig config) {
+                return DistributionStatisticConfig.builder()
+                        .percentilesHistogram(true)
+                        .build()
+                        .merge(config);
+            }
+        });
+        MicrometerMetricsFactory metricsFactory = new MicrometerMetricsFactory((MeterRegistry) registry);
 
         MicrometerMetricsOptions metricsOptions = new MicrometerMetricsOptions()
                 .setEnabled(true)

--- a/service_commons/src/test/java/ai/chronon/service/ChrononServiceLauncherTest.java
+++ b/service_commons/src/test/java/ai/chronon/service/ChrononServiceLauncherTest.java
@@ -1,0 +1,94 @@
+package ai.chronon.service;
+
+import ai.chronon.online.metrics.OtelMetricsReporter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ChrononServiceLauncherTest {
+
+    private static final String CHRONON_RESOURCES_PROP = OtelMetricsReporter.MetricsExporterResourceKey();
+
+    private String savedChrononProp;
+
+    @BeforeEach
+    void saveSysProps() {
+        savedChrononProp = System.getProperty(CHRONON_RESOURCES_PROP);
+        System.clearProperty(CHRONON_RESOURCES_PROP);
+    }
+
+    @AfterEach
+    void restoreSysProps() {
+        if (savedChrononProp == null) {
+            System.clearProperty(CHRONON_RESOURCES_PROP);
+        } else {
+            System.setProperty(CHRONON_RESOURCES_PROP, savedChrononProp);
+        }
+    }
+
+    private Function<String, String> envOf(Map<String, String> env) {
+        return env::get;
+    }
+
+    // Mirrors how Micrometer's OtlpConfig parses the resourceAttributes string into a LinkedHashMap
+    // where the last value for a duplicate key wins. Asserting against this parsed view keeps the
+    // precedence checks meaningful even if the raw string layout changes.
+    private Map<String, String> parseAsMicrometerWould(String resourceAttributes) {
+        Map<String, String> parsed = new LinkedHashMap<>();
+        for (String entry : resourceAttributes.split(",")) {
+            String[] kv = entry.split("=", 2);
+            if (kv.length == 2) {
+                parsed.put(kv[0].trim(), kv[1].trim());
+            }
+        }
+        return parsed;
+    }
+
+    @Test
+    void onlyDefaultServiceNameWhenNothingElseConfigured() {
+        String result = ChrononServiceLauncher.buildOtlpResourceAttributes(
+                "ai.chronon", envOf(new HashMap<>()));
+
+        assertEquals("service.name=ai.chronon", result);
+    }
+
+    @Test
+    void allFourSourcesCombineWithCorrectPrecedence() {
+        // Both OTEL_RESOURCE_ATTRIBUTES and the chronon sysprop set deployment.environment.name —
+        // the sysprop is appended later so it must win. OTEL_SERVICE_NAME is appended last and
+        // must beat the default service.name.
+        Map<String, String> env = new HashMap<>();
+        env.put("OTEL_RESOURCE_ATTRIBUTES", "deployment.environment.name=staging,team=ml");
+        env.put("OTEL_SERVICE_NAME", "feature-service-prod");
+        System.setProperty(CHRONON_RESOURCES_PROP, "deployment.environment.name=prod,region=us-east-1");
+
+        Map<String, String> parsed = parseAsMicrometerWould(
+                ChrononServiceLauncher.buildOtlpResourceAttributes("ai.chronon", envOf(env)));
+
+        assertEquals("feature-service-prod", parsed.get("service.name"));
+        assertEquals("prod", parsed.get("deployment.environment.name"));
+        assertEquals("ml", parsed.get("team"));
+        assertEquals("us-east-1", parsed.get("region"));
+    }
+
+    @Test
+    void blankInputsAreIgnoredWithoutTrailingDelimiters() {
+        // Guards against producing strings like "service.name=ai.chronon,," that would parse
+        // into spurious empty entries on the receiving side.
+        Map<String, String> env = new HashMap<>();
+        env.put("OTEL_RESOURCE_ATTRIBUTES", "   ");
+        env.put("OTEL_SERVICE_NAME", "");
+        System.setProperty(CHRONON_RESOURCES_PROP, "");
+
+        String result = ChrononServiceLauncher.buildOtlpResourceAttributes("ai.chronon", envOf(env));
+
+        assertEquals("service.name=ai.chronon", result);
+    }
+}


### PR DESCRIPTION
## Summary
used cursor to fix issues i noticed in ck fetcher deployment

* Let Vert.x(io.micrometer), `jvm.*` OTLP metrics inherit standard OTel resource attribute config (`OTEL_SERVICE_NAME`, `OTEL_RESOURCE_ATTRIBUTES`, and the existing `ai.chronon.metrics.exporter.resources` sysprop) so env/region/etc. tags can be set without code changes. 
* switches the OTLP histogram flavor to `BASE2_EXPONENTIAL` with `publishPercentileHistogram` enabled, so backends like New Relic compute accurate p50/p95/p99 server-side instead of average(we see counts and sums only right now).


```
FROM Metric SELECT * 
WHERE newrelic.source = 'api.metrics.otlp' and service.name = 'ai.chronon' 
AND metricName = 'vertx.http.server.response.time'
```

<img width="618" height="693" alt="Screenshot 2026-05-05 at 9 37 30 AM" src="https://github.com/user-attachments/assets/92c9d83b-3add-4419-b995-58ef50a57577" />


## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced OTLP metrics configuration to compute customizable resource attributes (supports defaults, environment overrides, and service-name override) for clearer service identification.
  * Micrometer OTLP setup preserves histogram percentile behavior to maintain detailed metrics distribution reporting.

* **Tests**
  * Added tests validating resource-attribute construction, precedence rules, and handling of blank inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->