### PR TITLE
Use delta log/snapshot explicitly to pull partition off stats if available

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/batch/iceberg/IcebergPartitionStatsExtractor.scala
+++ b/spark/src/main/scala/ai/chronon/spark/batch/iceberg/IcebergPartitionStatsExtractor.scala
@@ -352,7 +352,7 @@ class IcebergPartitionStatsExtractor(spark: SparkSession) {
     columnStatsMap.toMap
   }
 
-  private[iceberg] def convertBoundValue(bound: java.nio.ByteBuffer, fieldType: org.apache.iceberg.types.Type): Any = {
+  private[spark] def convertBoundValue(bound: java.nio.ByteBuffer, fieldType: org.apache.iceberg.types.Type): Any = {
     require(bound != null, "bound cannot be null")
     require(fieldType != null, "fieldType cannot be null")
     org.apache.iceberg.types.Conversions.fromByteBuffer(fieldType, bound)

--- a/spark/src/main/scala/ai/chronon/spark/batch/iceberg/IcebergPartitionStatsExtractor.scala
+++ b/spark/src/main/scala/ai/chronon/spark/batch/iceberg/IcebergPartitionStatsExtractor.scala
@@ -352,7 +352,7 @@ class IcebergPartitionStatsExtractor(spark: SparkSession) {
     columnStatsMap.toMap
   }
 
-  private[spark] def convertBoundValue(bound: java.nio.ByteBuffer, fieldType: org.apache.iceberg.types.Type): Any = {
+  def convertBoundValue(bound: java.nio.ByteBuffer, fieldType: org.apache.iceberg.types.Type): Any = {
     require(bound != null, "bound cannot be null")
     require(fieldType != null, "fieldType cannot be null")
     org.apache.iceberg.types.Conversions.fromByteBuffer(fieldType, bound)

--- a/spark/src/main/scala/ai/chronon/spark/batch/iceberg/IcebergPartitionStatsExtractor.scala
+++ b/spark/src/main/scala/ai/chronon/spark/batch/iceberg/IcebergPartitionStatsExtractor.scala
@@ -352,7 +352,7 @@ class IcebergPartitionStatsExtractor(spark: SparkSession) {
     columnStatsMap.toMap
   }
 
-  def convertBoundValue(bound: java.nio.ByteBuffer, fieldType: org.apache.iceberg.types.Type): Any = {
+  private[spark] def convertBoundValue(bound: java.nio.ByteBuffer, fieldType: org.apache.iceberg.types.Type): Any = {
     require(bound != null, "bound cannot be null")
     require(fieldType != null, "fieldType cannot be null")
     org.apache.iceberg.types.Conversions.fromByteBuffer(fieldType, bound)

--- a/spark/src/main/scala/ai/chronon/spark/catalog/DeltaLake.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/DeltaLake.scala
@@ -34,8 +34,7 @@ case object DeltaLake extends Format {
 
     def firstAvailablePartition: String = start
 
-    def lastAvailablePartition(partitionSpec: PartitionSpec, isStringColumn: Boolean): String =
-      if (isStringColumn) end else partitionSpec.before(end)
+    def lastAvailablePartition: String = end
   }
 
   override def tableTypeString: String = "delta"
@@ -61,6 +60,7 @@ case object DeltaLake extends Format {
 
     val partitions = snapshotPartitionsDf.collect().map(r => r.getAs[Map[String, String]](0))
     partitions.toList
+      .distinct
 
   }
 
@@ -84,11 +84,8 @@ case object DeltaLake extends Format {
     metadataLastAvailablePartition(tableName, partitionColumn)
       .orElse(
         statsDateRange(tableName, partitionColumn, partitionSpec)
-          .map(_.lastAvailablePartition(partitionSpec, isStringColumn(tableName, partitionColumn))))
+          .map(_.lastAvailablePartition))
       .orElse(scanLastAvailablePartition(tableName, partitionColumn, partitionSpec))
-
-  private def isStringColumn(tableName: String, columnName: String)(implicit sparkSession: SparkSession): Boolean =
-    Try(sparkSession.read.table(tableName).schema(columnName).dataType == StringType).getOrElse(false)
 
   private[catalog] def statsDateRange(tableName: String, columnName: String, partitionSpec: PartitionSpec)(implicit
       sparkSession: SparkSession): Option[StatsDateRange] = {

--- a/spark/src/main/scala/ai/chronon/spark/catalog/DeltaLake.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/DeltaLake.scala
@@ -1,10 +1,23 @@
 package ai.chronon.spark.catalog
 
 import ai.chronon.api.PartitionSpec
+import org.apache.spark.sql.Column
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.delta.DeltaLog
-import org.apache.spark.sql.functions.{col, count, date_format, from_json, lit, min, max, when}
-import org.apache.spark.sql.types.{MapType, StringType, StructField, StructType}
+import org.apache.spark.sql.functions.{
+  coalesce,
+  col,
+  count,
+  date_format,
+  from_json,
+  lit,
+  min,
+  max,
+  to_date,
+  to_timestamp,
+  when
+}
+import org.apache.spark.sql.types.{DataType, DateType, MapType, StringType, StructField, StructType}
 
 import scala.util.{Failure, Success, Try}
 
@@ -12,6 +25,8 @@ import scala.util.{Failure, Success, Try}
 // across Delta versions (e.g. 2 params in 3.2, 3 params in 3.3), so compiling against an older
 // version will cause NoSuchMethodError at runtime if the EMR-bundled Delta jar has a newer signature.
 case object DeltaLake extends Format {
+
+  private val DayMillis = 24L * 60L * 60L * 1000L
 
   private[catalog] case class StatsDateRange(start: String, end: String) {
     def virtualPartitions(partitionSpec: PartitionSpec): List[String] =
@@ -51,23 +66,26 @@ case object DeltaLake extends Format {
 
   override def virtualPartitions(tableName: String, timestampColumn: String, partitionSpec: PartitionSpec)(implicit
       sparkSession: SparkSession): List[String] = {
-    statsDateRange(tableName, timestampColumn, partitionSpec) match {
-      case Some(range) => range.virtualPartitions(partitionSpec)
-      case None        => super.virtualPartitions(tableName, timestampColumn, partitionSpec)
-    }
+    metadataPartitions(tableName, timestampColumn)
+      .filter(_.nonEmpty)
+      .orElse(statsDateRange(tableName, timestampColumn, partitionSpec)
+        .map(_.virtualPartitions(partitionSpec)))
+      .getOrElse(super.virtualPartitions(tableName, timestampColumn, partitionSpec))
   }
 
   override def firstAvailablePartition(tableName: String, partitionColumn: String, partitionSpec: PartitionSpec)(
       implicit sparkSession: SparkSession): Option[String] =
-    statsDateRange(tableName, partitionColumn, partitionSpec)
-      .map(_.firstAvailablePartition)
-      .orElse(super.firstAvailablePartition(tableName, partitionColumn, partitionSpec))
+    metadataFirstAvailablePartition(tableName, partitionColumn)
+      .orElse(statsDateRange(tableName, partitionColumn, partitionSpec).map(_.firstAvailablePartition))
+      .orElse(scanFirstAvailablePartition(tableName, partitionColumn, partitionSpec))
 
   override def lastAvailablePartition(tableName: String, partitionColumn: String, partitionSpec: PartitionSpec)(implicit
       sparkSession: SparkSession): Option[String] =
-    statsDateRange(tableName, partitionColumn, partitionSpec)
-      .map(_.lastAvailablePartition(partitionSpec, isStringColumn(tableName, partitionColumn)))
-      .orElse(super.lastAvailablePartition(tableName, partitionColumn, partitionSpec))
+    metadataLastAvailablePartition(tableName, partitionColumn)
+      .orElse(
+        statsDateRange(tableName, partitionColumn, partitionSpec)
+          .map(_.lastAvailablePartition(partitionSpec, isStringColumn(tableName, partitionColumn))))
+      .orElse(scanLastAvailablePartition(tableName, partitionColumn, partitionSpec))
 
   private def isStringColumn(tableName: String, columnName: String)(implicit sparkSession: SparkSession): Boolean =
     Try(sparkSession.read.table(tableName).schema(columnName).dataType == StringType).getOrElse(false)
@@ -80,6 +98,7 @@ case object DeltaLake extends Format {
       val describeResult = sparkSession.sql(s"DESCRIBE DETAIL $tableName")
       val tablePath = describeResult.select("location").head().getString(0)
       val activeFiles = DeltaLog.forTable(sparkSession, tablePath).update().allFiles.toDF()
+      val columnType = sparkSession.read.table(tableName).schema(columnName).dataType
 
       val statsSchema = StructType(
         Seq(
@@ -98,8 +117,8 @@ case object DeltaLake extends Format {
         .agg(
           count(lit(1)).as("fileCount"),
           count(when(col("min_value").isNull || col("max_value").isNull, lit(1))).as("missingCount"),
-          date_format(min(col("min_value").cast("timestamp")), partitionSpec.format).as("start"),
-          date_format(max(col("max_value").cast("timestamp")), partitionSpec.format).as("end")
+          date_format(min(statsBoundary("min_value", columnType, partitionSpec)), partitionSpec.format).as("start"),
+          date_format(max(statsBoundary("max_value", columnType, partitionSpec)), partitionSpec.format).as("end")
         )
         .collect()
         .headOption
@@ -130,6 +149,18 @@ case object DeltaLake extends Format {
         None
     }
   }
+
+  private def statsBoundary(boundaryColumn: String, columnType: DataType, partitionSpec: PartitionSpec): Column =
+    columnType match {
+      case DateType =>
+        col(boundaryColumn).cast(DateType)
+      case StringType if partitionSpec.spanMillis >= DayMillis =>
+        coalesce(to_date(col(boundaryColumn), partitionSpec.format), col(boundaryColumn).cast(DateType))
+      case StringType =>
+        coalesce(to_timestamp(col(boundaryColumn), partitionSpec.format), col(boundaryColumn).cast("timestamp"))
+      case _ =>
+        col(boundaryColumn).cast("timestamp")
+    }
 
   override def supportSubPartitionsFilter: Boolean = true
 }

--- a/spark/src/main/scala/ai/chronon/spark/catalog/DeltaLake.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/DeltaLake.scala
@@ -17,7 +17,7 @@ import org.apache.spark.sql.functions.{
   to_timestamp,
   when
 }
-import org.apache.spark.sql.types.{DataType, DateType, MapType, StringType, StructField, StructType}
+import org.apache.spark.sql.types.{DataType, DateType, MapType, StringType, StructField, StructType, TimestampType}
 
 import scala.util.{Failure, Success, Try}
 
@@ -72,10 +72,17 @@ case object DeltaLake extends Format {
   override def lastAvailablePartition(tableName: String, partitionColumn: String, partitionSpec: PartitionSpec)(implicit
       sparkSession: SparkSession): Option[String] =
     metadataLastAvailablePartition(tableName, partitionColumn)
-      .orElse(
-        statsDateRange(tableName, partitionColumn, partitionSpec)
-          .map(_.lastAvailablePartition))
+      .orElse(statsLastAvailablePartition(tableName, partitionColumn, partitionSpec))
       .orElse(scanLastAvailablePartition(tableName, partitionColumn, partitionSpec))
+
+  private def statsLastAvailablePartition(tableName: String, columnName: String, partitionSpec: PartitionSpec)(implicit
+      sparkSession: SparkSession): Option[String] =
+    statsDateRange(tableName, columnName, partitionSpec).map { range =>
+      sparkSession.read.table(tableName).schema(columnName).dataType match {
+        case TimestampType => partitionSpec.before(range.lastAvailablePartition)
+        case _             => range.lastAvailablePartition
+      }
+    }
 
   private[catalog] def statsDateRange(tableName: String, columnName: String, partitionSpec: PartitionSpec)(implicit
       sparkSession: SparkSession): Option[StatsDateRange] = {

--- a/spark/src/main/scala/ai/chronon/spark/catalog/DeltaLake.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/DeltaLake.scala
@@ -1,12 +1,27 @@
 package ai.chronon.spark.catalog
 
+import ai.chronon.api.PartitionSpec
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.functions.{col, count, date_format, from_json, lit, min, max, when}
+import org.apache.spark.sql.types.{MapType, StringType, StructField, StructType}
+
+import scala.util.{Failure, Success, Try}
 
 // Compiled against delta-spark 3.3.2 to match EMR 7.12.0. DeltaLog.update() signature changes
 // across Delta versions (e.g. 2 params in 3.2, 3 params in 3.3), so compiling against an older
 // version will cause NoSuchMethodError at runtime if the EMR-bundled Delta jar has a newer signature.
 case object DeltaLake extends Format {
+
+  private[catalog] case class StatsDateRange(start: String, end: String) {
+    def virtualPartitions(partitionSpec: PartitionSpec): List[String] =
+      partitionSpec.expandRange(start, end)
+
+    def firstAvailablePartition: String = start
+
+    def lastAvailablePartition(partitionSpec: PartitionSpec, isStringColumn: Boolean): String =
+      if (isStringColumn) end else partitionSpec.before(end)
+  }
 
   override def tableTypeString: String = "delta"
 
@@ -32,6 +47,88 @@ case object DeltaLake extends Format {
     val partitions = snapshotPartitionsDf.collect().map(r => r.getAs[Map[String, String]](0))
     partitions.toList
 
+  }
+
+  override def virtualPartitions(tableName: String, timestampColumn: String, partitionSpec: PartitionSpec)(implicit
+      sparkSession: SparkSession): List[String] = {
+    statsDateRange(tableName, timestampColumn, partitionSpec) match {
+      case Some(range) => range.virtualPartitions(partitionSpec)
+      case None        => super.virtualPartitions(tableName, timestampColumn, partitionSpec)
+    }
+  }
+
+  override def firstAvailablePartition(tableName: String, partitionColumn: String, partitionSpec: PartitionSpec)(
+      implicit sparkSession: SparkSession): Option[String] =
+    statsDateRange(tableName, partitionColumn, partitionSpec)
+      .map(_.firstAvailablePartition)
+      .orElse(super.firstAvailablePartition(tableName, partitionColumn, partitionSpec))
+
+  override def lastAvailablePartition(tableName: String, partitionColumn: String, partitionSpec: PartitionSpec)(implicit
+      sparkSession: SparkSession): Option[String] =
+    statsDateRange(tableName, partitionColumn, partitionSpec)
+      .map(_.lastAvailablePartition(partitionSpec, isStringColumn(tableName, partitionColumn)))
+      .orElse(super.lastAvailablePartition(tableName, partitionColumn, partitionSpec))
+
+  private def isStringColumn(tableName: String, columnName: String)(implicit sparkSession: SparkSession): Boolean =
+    Try(sparkSession.read.table(tableName).schema(columnName).dataType == StringType).getOrElse(false)
+
+  private[catalog] def statsDateRange(tableName: String, columnName: String, partitionSpec: PartitionSpec)(implicit
+      sparkSession: SparkSession): Option[StatsDateRange] = {
+    import sparkSession.implicits._
+
+    Try {
+      val describeResult = sparkSession.sql(s"DESCRIBE DETAIL $tableName")
+      val tablePath = describeResult.select("location").head().getString(0)
+      val activeFiles = DeltaLog.forTable(sparkSession, tablePath).update().allFiles.toDF()
+
+      val statsSchema = StructType(
+        Seq(
+          StructField("minValues", MapType(StringType, StringType), nullable = true),
+          StructField("maxValues", MapType(StringType, StringType), nullable = true)
+        ))
+
+      val stats = activeFiles
+        .select(from_json(col("stats"), statsSchema).as("stats"))
+        .select(
+          col("stats.minValues").getItem(columnName).as("min_value"),
+          col("stats.maxValues").getItem(columnName).as("max_value")
+        )
+
+      val boundaries = stats
+        .agg(
+          count(lit(1)).as("fileCount"),
+          count(when(col("min_value").isNull || col("max_value").isNull, lit(1))).as("missingCount"),
+          date_format(min(col("min_value").cast("timestamp")), partitionSpec.format).as("start"),
+          date_format(max(col("max_value").cast("timestamp")), partitionSpec.format).as("end")
+        )
+        .collect()
+        .headOption
+
+      boundaries.flatMap { row =>
+        val fileCount = row.getAs[Long]("fileCount")
+        val missingCount = row.getAs[Long]("missingCount")
+        val start = row.getAs[String]("start")
+        val end = row.getAs[String]("end")
+
+        if (fileCount > 0 && missingCount == 0 && start != null && end != null) {
+          Some(StatsDateRange(start = start, end = end))
+        } else {
+          None
+        }
+      }
+    } match {
+      case Success(result) =>
+        if (result.isDefined) {
+          logger.info(s"Resolved Delta log stats boundaries for $tableName.$columnName: ${result.get}")
+        } else {
+          logger.info(s"Delta log stats were incomplete for $tableName.$columnName; falling back to table scan")
+        }
+        result
+      case Failure(e) =>
+        logger.warn(
+          s"Failed to resolve Delta log stats boundaries for $tableName.$columnName: ${Option(e.getMessage).getOrElse("(no message)")}")
+        None
+    }
   }
 
   override def supportSubPartitionsFilter: Boolean = true

--- a/spark/src/main/scala/ai/chronon/spark/catalog/DeltaLake.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/DeltaLake.scala
@@ -28,15 +28,6 @@ case object DeltaLake extends Format {
 
   private val DayMillis = 24L * 60L * 60L * 1000L
 
-  private[catalog] case class StatsDateRange(start: String, end: String) {
-    def virtualPartitions(partitionSpec: PartitionSpec): List[String] =
-      partitionSpec.expandRange(start, end)
-
-    def firstAvailablePartition: String = start
-
-    def lastAvailablePartition: String = end
-  }
-
   override def tableTypeString: String = "delta"
 
   override def primaryPartitions(tableName: String,

--- a/spark/src/main/scala/ai/chronon/spark/catalog/DeltaLake.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/DeltaLake.scala
@@ -50,8 +50,7 @@ case object DeltaLake extends Format {
     val snapshotPartitionsDf = snapshot.allFiles.toDF().select("partitionValues")
 
     val partitions = snapshotPartitionsDf.collect().map(r => r.getAs[Map[String, String]](0))
-    partitions.toList
-      .distinct
+    partitions.toList.distinct
 
   }
 

--- a/spark/src/main/scala/ai/chronon/spark/catalog/Format.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/Format.scala
@@ -5,7 +5,7 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException
 import org.apache.spark.sql.catalyst.util.QuotingUtils
 import org.apache.spark.sql.connector.catalog.Identifier
-import org.apache.spark.sql.functions.{col, date_format, date_sub, min, max}
+import org.apache.spark.sql.functions.{col, date_format, min, max}
 import org.apache.spark.sql.types.{DateType, StringType, StructType}
 import org.slf4j.{Logger, LoggerFactory}
 
@@ -154,8 +154,7 @@ trait Format {
             .headOption
             .flatMap(v => Option(v))
         case _ =>
-          df.select(date_format(date_sub(max(col(partitionColumn)).cast(DateType), 1), partitionSpec.format)
-            .as("last_partition"))
+          df.select(date_format(max(col(partitionColumn)).cast(DateType), partitionSpec.format).as("last_partition"))
             .as[String]
             .collect()
             .headOption
@@ -269,6 +268,15 @@ trait Format {
     }
   }
 
+}
+
+private[catalog] case class StatsDateRange(start: String, end: String) {
+  def virtualPartitions(partitionSpec: PartitionSpec): List[String] =
+    partitionSpec.expandRange(start, end)
+
+  def firstAvailablePartition: String = start
+
+  def lastAvailablePartition: String = end
 }
 
 case class ResolvedTableName(catalog: String, namespace: String, table: String) {

--- a/spark/src/main/scala/ai/chronon/spark/catalog/Format.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/Format.scala
@@ -125,7 +125,7 @@ trait Format {
       sparkSession: SparkSession): Option[List[String]] =
     Try(primaryPartitions(tableName, partitionColumn, "")(sparkSession)) match {
       case Success(metadata) =>
-        Some(Format.sanitizePartitionValues(metadata))
+        Some(Format.sanitizePartitionValues(metadata).distinct)
       case Failure(ex) =>
         logger.warn(
           s"[NonFatal] Failed to check primary partitions for ${tableName}, falling back to another boundary lookup: ${ex.getMessage}")

--- a/spark/src/main/scala/ai/chronon/spark/catalog/Format.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/Format.scala
@@ -121,23 +121,27 @@ trait Format {
   // Does this format support sub partitions filters
   def supportSubPartitionsFilter: Boolean
 
-  // Unified last available partition: handles both string partition columns and timestamp/date columns.
-  // For string columns that are catalog partitions (Hive/Iceberg/Delta), uses metadata-only lookup — no data scan.
-  // For timestamp/date columns, falls back to a scan: DATE(MAX(col)) - 1 day.
-  def lastAvailablePartition(tableName: String, partitionColumn: String, partitionSpec: PartitionSpec)(implicit
-      sparkSession: SparkSession): Option[String] = {
-    // Try metadata-based partition listing first (free for Hive/Iceberg/Delta)
-    val metadataResult = Try(primaryPartitions(tableName, partitionColumn, "")(sparkSession)) match {
+  protected def metadataPartitions(tableName: String, partitionColumn: String)(implicit
+      sparkSession: SparkSession): Option[List[String]] =
+    Try(primaryPartitions(tableName, partitionColumn, "")(sparkSession)) match {
       case Success(metadata) =>
-        Format.pickMaxPartition(metadata)
+        Some(Format.sanitizePartitionValues(metadata))
       case Failure(ex) =>
         logger.warn(
-          s"[NonFatal] Failed to check primary partitions for ${tableName}, falling back to data scan: ${ex.getMessage}");
+          s"[NonFatal] Failed to check primary partitions for ${tableName}, falling back to another boundary lookup: ${ex.getMessage}")
         None
     }
-    if (metadataResult.isDefined) return metadataResult
 
-    // Fall back to data scan for non-partitioned tables or timestamp/date columns
+  protected def metadataFirstAvailablePartition(tableName: String, partitionColumn: String)(implicit
+      sparkSession: SparkSession): Option[String] =
+    metadataPartitions(tableName, partitionColumn).flatMap(Format.pickMinPartition)
+
+  protected def metadataLastAvailablePartition(tableName: String, partitionColumn: String)(implicit
+      sparkSession: SparkSession): Option[String] =
+    metadataPartitions(tableName, partitionColumn).flatMap(Format.pickMaxPartition)
+
+  protected def scanLastAvailablePartition(tableName: String, partitionColumn: String, partitionSpec: PartitionSpec)(
+      implicit sparkSession: SparkSession): Option[String] = {
     import sparkSession.implicits._
     Try {
       val df = sparkSession.read.table(tableName)
@@ -169,18 +173,8 @@ trait Format {
     }
   }
 
-  // Unified first available partition: handles both string partition columns and timestamp/date columns.
-  // For string columns that are catalog partitions, uses metadata-only lookup.
-  // For timestamp/date columns, falls back to a scan.
-  def firstAvailablePartition(tableName: String, partitionColumn: String, partitionSpec: PartitionSpec)(implicit
-      sparkSession: SparkSession): Option[String] = {
-    val metadataResult = Try(primaryPartitions(tableName, partitionColumn, "")(sparkSession)) match {
-      case Success(metadata) =>
-        Format.pickMinPartition(metadata)
-      case _ => None
-    }
-    if (metadataResult.isDefined) return metadataResult
-
+  protected def scanFirstAvailablePartition(tableName: String, partitionColumn: String, partitionSpec: PartitionSpec)(
+      implicit sparkSession: SparkSession): Option[String] = {
     import sparkSession.implicits._
     Try {
       val df = sparkSession.read.table(tableName)
@@ -210,6 +204,22 @@ trait Format {
         None
     }
   }
+
+  // Unified last available partition: handles both string partition columns and timestamp/date columns.
+  // For string columns that are catalog partitions (Hive/Iceberg/Delta), uses metadata-only lookup.
+  // For timestamp/date columns, falls back to a scan: DATE(MAX(col)) - 1 day.
+  def lastAvailablePartition(tableName: String, partitionColumn: String, partitionSpec: PartitionSpec)(implicit
+      sparkSession: SparkSession): Option[String] =
+    metadataLastAvailablePartition(tableName, partitionColumn)
+      .orElse(scanLastAvailablePartition(tableName, partitionColumn, partitionSpec))
+
+  // Unified first available partition: handles both string partition columns and timestamp/date columns.
+  // For string columns that are catalog partitions, uses metadata-only lookup.
+  // For timestamp/date columns, falls back to a scan.
+  def firstAvailablePartition(tableName: String, partitionColumn: String, partitionSpec: PartitionSpec)(implicit
+      sparkSession: SparkSession): Option[String] =
+    metadataFirstAvailablePartition(tableName, partitionColumn)
+      .orElse(scanFirstAvailablePartition(tableName, partitionColumn, partitionSpec))
 
   @deprecated("Use lastAvailablePartition instead", "0.1.0")
   def maxTimestampDate(tableName: String, timestampColumn: String, partitionSpec: PartitionSpec)(implicit

--- a/spark/src/main/scala/ai/chronon/spark/catalog/Format.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/Format.scala
@@ -5,7 +5,7 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException
 import org.apache.spark.sql.catalyst.util.QuotingUtils
 import org.apache.spark.sql.connector.catalog.Identifier
-import org.apache.spark.sql.functions.{col, date_format, min, max}
+import org.apache.spark.sql.functions.{col, date_format, date_sub, min, max}
 import org.apache.spark.sql.types.{DateType, StringType, StructType}
 import org.slf4j.{Logger, LoggerFactory}
 
@@ -154,7 +154,8 @@ trait Format {
             .headOption
             .flatMap(v => Option(v))
         case _ =>
-          df.select(date_format(max(col(partitionColumn)).cast(DateType), partitionSpec.format).as("last_partition"))
+          df.select(date_format(date_sub(max(col(partitionColumn)).cast(DateType), 1), partitionSpec.format)
+            .as("last_partition"))
             .as[String]
             .collect()
             .headOption
@@ -206,7 +207,7 @@ trait Format {
 
   // Unified last available partition: handles both string partition columns and timestamp/date columns.
   // For string columns that are catalog partitions (Hive/Iceberg/Delta), uses metadata-only lookup.
-  // For timestamp/date columns, falls back to a scan: DATE(MAX(col)) - 1 day.
+  // For non-string columns, falls back to the historical scan behavior: DATE(MAX(col)) - 1 day.
   def lastAvailablePartition(tableName: String, partitionColumn: String, partitionSpec: PartitionSpec)(implicit
       sparkSession: SparkSession): Option[String] =
     metadataLastAvailablePartition(tableName, partitionColumn)

--- a/spark/src/main/scala/ai/chronon/spark/catalog/Iceberg.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/Iceberg.scala
@@ -23,8 +23,7 @@ case object Iceberg extends Format {
 
     def firstAvailablePartition: String = start
 
-    def lastAvailablePartition(partitionSpec: PartitionSpec, isStringColumn: Boolean): String =
-      if (isStringColumn) end else partitionSpec.before(end)
+    def lastAvailablePartition: String = end
   }
 
   override def tableTypeString: String = "iceberg"
@@ -113,12 +112,8 @@ case object Iceberg extends Format {
     metadataLastAvailablePartition(tableName, partitionColumn)
       .orElse(
         statsDateRange(tableName, partitionColumn, partitionSpec)
-          .map(_.lastAvailablePartition(partitionSpec, isStringColumn(tableName, partitionColumn))))
+          .map(_.lastAvailablePartition))
       .orElse(scanLastAvailablePartition(tableName, partitionColumn, partitionSpec))
-
-  private def isStringColumn(tableName: String, columnName: String)(implicit sparkSession: SparkSession): Boolean =
-    Try(sparkSession.read.table(tableName).schema(columnName).dataType == org.apache.spark.sql.types.StringType)
-      .getOrElse(false)
 
   private[catalog] def statsDateRange(tableName: String, columnName: String, partitionSpec: PartitionSpec)(implicit
       sparkSession: SparkSession): Option[StatsDateRange] =

--- a/spark/src/main/scala/ai/chronon/spark/catalog/Iceberg.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/Iceberg.scala
@@ -17,15 +17,6 @@ import scala.util.{Failure, Success, Try}
 
 case object Iceberg extends Format {
 
-  private[catalog] case class StatsDateRange(start: String, end: String) {
-    def virtualPartitions(partitionSpec: PartitionSpec): List[String] =
-      partitionSpec.expandRange(start, end)
-
-    def firstAvailablePartition: String = start
-
-    def lastAvailablePartition: String = end
-  }
-
   override def tableTypeString: String = "iceberg"
 
   override def tableProperties: Map[String, String] = {

--- a/spark/src/main/scala/ai/chronon/spark/catalog/Iceberg.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/Iceberg.scala
@@ -1,13 +1,31 @@
 package ai.chronon.spark.catalog
 
+import ai.chronon.api.PartitionSpec
+import ai.chronon.spark.batch.iceberg.IcebergPartitionStatsExtractor
+import org.apache.iceberg.{DataFile, ManifestFiles}
+import org.apache.iceberg.spark.source.SparkTable
+import org.apache.iceberg.types.Type
+import org.apache.spark.sql.connector.catalog.TableCatalog
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.util.QuotingUtils
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.StructType
 
+import java.time.{LocalDate, ZoneOffset}
+import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
 
 case object Iceberg extends Format {
+
+  private[catalog] case class StatsDateRange(start: String, end: String) {
+    def virtualPartitions(partitionSpec: PartitionSpec): List[String] =
+      partitionSpec.expandRange(start, end)
+
+    def firstAvailablePartition: String = start
+
+    def lastAvailablePartition(partitionSpec: PartitionSpec, isStringColumn: Boolean): String =
+      if (isStringColumn) end else partitionSpec.before(end)
+  }
 
   override def tableTypeString: String = "iceberg"
 
@@ -75,6 +93,130 @@ case object Iceberg extends Format {
     val index = partitionsDf.schema.fieldIndex("partition")
     partitionsDf.schema(index).dataType.asInstanceOf[StructType].fieldNames
   }
+
+  override def virtualPartitions(tableName: String, timestampColumn: String, partitionSpec: PartitionSpec)(implicit
+      sparkSession: SparkSession): List[String] =
+    metadataPartitions(tableName, timestampColumn)
+      .filter(_.nonEmpty)
+      .orElse(statsDateRange(tableName, timestampColumn, partitionSpec)
+        .map(_.virtualPartitions(partitionSpec)))
+      .getOrElse(super.virtualPartitions(tableName, timestampColumn, partitionSpec))
+
+  override def firstAvailablePartition(tableName: String, partitionColumn: String, partitionSpec: PartitionSpec)(
+      implicit sparkSession: SparkSession): Option[String] =
+    metadataFirstAvailablePartition(tableName, partitionColumn)
+      .orElse(statsDateRange(tableName, partitionColumn, partitionSpec).map(_.firstAvailablePartition))
+      .orElse(scanFirstAvailablePartition(tableName, partitionColumn, partitionSpec))
+
+  override def lastAvailablePartition(tableName: String, partitionColumn: String, partitionSpec: PartitionSpec)(implicit
+      sparkSession: SparkSession): Option[String] =
+    metadataLastAvailablePartition(tableName, partitionColumn)
+      .orElse(
+        statsDateRange(tableName, partitionColumn, partitionSpec)
+          .map(_.lastAvailablePartition(partitionSpec, isStringColumn(tableName, partitionColumn))))
+      .orElse(scanLastAvailablePartition(tableName, partitionColumn, partitionSpec))
+
+  private def isStringColumn(tableName: String, columnName: String)(implicit sparkSession: SparkSession): Boolean =
+    Try(sparkSession.read.table(tableName).schema(columnName).dataType == org.apache.spark.sql.types.StringType)
+      .getOrElse(false)
+
+  private[catalog] def statsDateRange(tableName: String, columnName: String, partitionSpec: PartitionSpec)(implicit
+      sparkSession: SparkSession): Option[StatsDateRange] =
+    Try {
+      val table = loadIcebergTable(tableName).getOrElse {
+        throw new IllegalStateException(s"Could not load Iceberg table: $tableName")
+      }
+      val field = Option(table.schema().findField(columnName)).getOrElse {
+        throw new IllegalArgumentException(s"Column $columnName not found in Iceberg schema for $tableName")
+      }
+      val fieldId = field.fieldId().asInstanceOf[java.lang.Integer]
+      val fieldType = field.`type`()
+      val extractor = new IcebergPartitionStatsExtractor(sparkSession)
+
+      val files = Option(table.currentSnapshot()).toSeq.flatMap { snapshot =>
+        snapshot.allManifests(table.io()).asScala.flatMap { manifest =>
+          val reader = ManifestFiles.read(manifest, table.io())
+          try {
+            reader.iterator().asScala.map(_.copy()).toList
+          } finally {
+            reader.close()
+          }
+        }
+      }
+
+      val fileRanges = files.map(file => fileDateRange(file, fieldId, fieldType, partitionSpec, extractor))
+
+      if (fileRanges.nonEmpty && fileRanges.forall(_.isDefined)) {
+        val ranges = fileRanges.flatten
+        Some(
+          StatsDateRange(
+            start = partitionSpec.at(ranges.map(_._1).min),
+            end = partitionSpec.at(ranges.map(_._2).max)
+          ))
+      } else {
+        None
+      }
+    } match {
+      case Success(result) =>
+        if (result.isDefined) {
+          logger.info(s"Resolved Iceberg file stats boundaries for $tableName.$columnName: ${result.get}")
+        } else {
+          logger.info(s"Iceberg file stats were incomplete for $tableName.$columnName; falling back to table scan")
+        }
+        result
+      case Failure(e) =>
+        logger.warn(
+          s"Failed to resolve Iceberg file stats boundaries for $tableName.$columnName: ${Option(e.getMessage).getOrElse("(no message)")}")
+        None
+    }
+
+  private def fileDateRange(file: DataFile,
+                            fieldId: java.lang.Integer,
+                            fieldType: org.apache.iceberg.types.Type,
+                            partitionSpec: PartitionSpec,
+                            extractor: IcebergPartitionStatsExtractor): Option[(Long, Long)] = {
+    val lower = Option(file.lowerBounds()).flatMap(bounds => Option(bounds.get(fieldId)))
+    val upper = Option(file.upperBounds()).flatMap(bounds => Option(bounds.get(fieldId)))
+
+    for {
+      lowerBound <- lower
+      upperBound <- upper
+    } yield {
+      val lowerMillis = boundMillis(extractor.convertBoundValue(lowerBound, fieldType), fieldType, partitionSpec)
+      val upperMillis = boundMillis(extractor.convertBoundValue(upperBound, fieldType), fieldType, partitionSpec)
+      lowerMillis -> upperMillis
+    }
+  }
+
+  private def boundMillis(value: Any, fieldType: Type, partitionSpec: PartitionSpec): Long =
+    fieldType.typeId() match {
+      case Type.TypeID.TIMESTAMP =>
+        value.asInstanceOf[java.lang.Long].longValue() / 1000L
+      case Type.TypeID.DATE =>
+        LocalDate
+          .ofEpochDay(value.asInstanceOf[java.lang.Integer].longValue())
+          .atStartOfDay()
+          .toInstant(ZoneOffset.UTC)
+          .toEpochMilli
+      case Type.TypeID.STRING =>
+        partitionSpec.epochMillis(value.toString)
+      case other =>
+        throw new IllegalArgumentException(s"Unsupported Iceberg bound type $other for value $value")
+    }
+
+  private def loadIcebergTable(tableName: String)(implicit
+      sparkSession: SparkSession): Option[org.apache.iceberg.Table] =
+    Try {
+      val resolved = Format.resolveTableName(tableName)
+      val catalog = sparkSession.sessionState.catalogManager
+        .catalog(resolved.catalog)
+        .asInstanceOf[TableCatalog]
+
+      catalog.loadTable(resolved.toIdentifier) match {
+        case sparkTable: SparkTable => sparkTable.table()
+        case other => throw new IllegalStateException(s"Not an Iceberg SparkTable: ${other.getClass.getName}")
+      }
+    }.toOption
 
   private def getIcebergPartitions(tableName: String, partitionColumn: String)(implicit
       sparkSession: SparkSession): List[String] = {

--- a/spark/src/main/scala/ai/chronon/spark/catalog/Iceberg.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/Iceberg.scala
@@ -9,7 +9,7 @@ import org.apache.spark.sql.connector.catalog.TableCatalog
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.util.QuotingUtils
 import org.apache.spark.sql.functions.col
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{StructType, TimestampType}
 
 import java.time.{LocalDate, ZoneOffset}
 import scala.collection.JavaConverters._
@@ -101,10 +101,17 @@ case object Iceberg extends Format {
   override def lastAvailablePartition(tableName: String, partitionColumn: String, partitionSpec: PartitionSpec)(implicit
       sparkSession: SparkSession): Option[String] =
     metadataLastAvailablePartition(tableName, partitionColumn)
-      .orElse(
-        statsDateRange(tableName, partitionColumn, partitionSpec)
-          .map(_.lastAvailablePartition))
+      .orElse(statsLastAvailablePartition(tableName, partitionColumn, partitionSpec))
       .orElse(scanLastAvailablePartition(tableName, partitionColumn, partitionSpec))
+
+  private def statsLastAvailablePartition(tableName: String, columnName: String, partitionSpec: PartitionSpec)(implicit
+      sparkSession: SparkSession): Option[String] =
+    statsDateRange(tableName, columnName, partitionSpec).map { range =>
+      sparkSession.read.table(tableName).schema(columnName).dataType match {
+        case TimestampType => partitionSpec.before(range.lastAvailablePartition)
+        case _             => range.lastAvailablePartition
+      }
+    }
 
   private[catalog] def statsDateRange(tableName: String, columnName: String, partitionSpec: PartitionSpec)(implicit
       sparkSession: SparkSession): Option[StatsDateRange] =

--- a/spark/src/main/scala/ai/chronon/spark/catalog/Iceberg.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/Iceberg.scala
@@ -119,20 +119,7 @@ case object Iceberg extends Format {
       val fieldType = field.`type`()
       val extractor = new IcebergPartitionStatsExtractor(sparkSession)
 
-      val files = currentDataFiles(table)
-
-      val fileRanges = files.map(file => fileDateRange(file, fieldId, fieldType, partitionSpec, extractor))
-
-      if (fileRanges.nonEmpty && fileRanges.forall(_.isDefined)) {
-        val ranges = fileRanges.flatten
-        Some(
-          StatsDateRange(
-            start = partitionSpec.at(ranges.map(_._1).min),
-            end = partitionSpec.at(ranges.map(_._2).max)
-          ))
-      } else {
-        None
-      }
+      currentDataFilesDateRange(table, fieldId, fieldType, partitionSpec, extractor)
     } match {
       case Success(result) =>
         if (result.isDefined) {
@@ -168,7 +155,7 @@ case object Iceberg extends Format {
   private def boundMillis(value: Any, fieldType: Type, partitionSpec: PartitionSpec): Long =
     fieldType.typeId() match {
       case Type.TypeID.TIMESTAMP =>
-        value.asInstanceOf[java.lang.Long].longValue() / 1000L
+        Math.floorDiv(value.asInstanceOf[java.lang.Long].longValue(), 1000L)
       case Type.TypeID.DATE =>
         LocalDate
           .ofEpochDay(value.asInstanceOf[java.lang.Integer].longValue())
@@ -181,11 +168,31 @@ case object Iceberg extends Format {
         throw new IllegalArgumentException(s"Unsupported Iceberg bound type $other for value $value")
     }
 
-  private def currentDataFiles(table: org.apache.iceberg.Table): List[DataFile] =
-    Option(table.currentSnapshot()).toList.flatMap { _ =>
+  private def currentDataFilesDateRange(table: org.apache.iceberg.Table,
+                                        fieldId: java.lang.Integer,
+                                        fieldType: org.apache.iceberg.types.Type,
+                                        partitionSpec: PartitionSpec,
+                                        extractor: IcebergPartitionStatsExtractor): Option[StatsDateRange] =
+    Option(table.currentSnapshot()).flatMap { _ =>
       val tasks = table.newScan().includeColumnStats().planFiles()
       try {
-        tasks.iterator().asScala.map(task => task.file().copy()).toList
+        val range = tasks.iterator().asScala.foldLeft(Some(None): Option[Option[(Long, Long)]]) {
+          case (None, _) => None
+          case (Some(acc), task) =>
+            fileDateRange(task.file(), fieldId, fieldType, partitionSpec, extractor).map {
+              case (lowerMillis, upperMillis) =>
+                Some(acc.fold(lowerMillis -> upperMillis) { case (minMillis, maxMillis) =>
+                  Math.min(minMillis, lowerMillis) -> Math.max(maxMillis, upperMillis)
+                })
+            }
+        }
+
+        range.flatten.map { case (minMillis, maxMillis) =>
+          StatsDateRange(
+            start = partitionSpec.at(minMillis),
+            end = partitionSpec.at(maxMillis)
+          )
+        }
       } finally {
         tasks.close()
       }

--- a/spark/src/main/scala/ai/chronon/spark/catalog/Iceberg.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/Iceberg.scala
@@ -2,7 +2,7 @@ package ai.chronon.spark.catalog
 
 import ai.chronon.api.PartitionSpec
 import ai.chronon.spark.batch.iceberg.IcebergPartitionStatsExtractor
-import org.apache.iceberg.{DataFile, ManifestFiles}
+import org.apache.iceberg.DataFile
 import org.apache.iceberg.spark.source.SparkTable
 import org.apache.iceberg.types.Type
 import org.apache.spark.sql.connector.catalog.TableCatalog
@@ -133,16 +133,7 @@ case object Iceberg extends Format {
       val fieldType = field.`type`()
       val extractor = new IcebergPartitionStatsExtractor(sparkSession)
 
-      val files = Option(table.currentSnapshot()).toSeq.flatMap { snapshot =>
-        snapshot.allManifests(table.io()).asScala.flatMap { manifest =>
-          val reader = ManifestFiles.read(manifest, table.io())
-          try {
-            reader.iterator().asScala.map(_.copy()).toList
-          } finally {
-            reader.close()
-          }
-        }
-      }
+      val files = currentDataFiles(table)
 
       val fileRanges = files.map(file => fileDateRange(file, fieldId, fieldType, partitionSpec, extractor))
 
@@ -202,6 +193,16 @@ case object Iceberg extends Format {
         partitionSpec.epochMillis(value.toString)
       case other =>
         throw new IllegalArgumentException(s"Unsupported Iceberg bound type $other for value $value")
+    }
+
+  private def currentDataFiles(table: org.apache.iceberg.Table): List[DataFile] =
+    Option(table.currentSnapshot()).toList.flatMap { _ =>
+      val tasks = table.newScan().includeColumnStats().planFiles()
+      try {
+        tasks.iterator().asScala.map(task => task.file().copy()).toList
+      } finally {
+        tasks.close()
+      }
     }
 
   private def loadIcebergTable(tableName: String)(implicit

--- a/spark/src/test/scala/ai/chronon/spark/catalog/DeltaLakeTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/catalog/DeltaLakeTest.scala
@@ -85,6 +85,65 @@ class DeltaLakeTest extends AnyFlatSpec with BeforeAndAfterAll {
     }
   }
 
+  it should "prefer actual partition metadata over Delta log stats" in {
+    val dbName = s"delta_partition_metadata_${System.nanoTime()}"
+    val tableName = s"$dbName.time_partitioned"
+    spark.sql(s"CREATE DATABASE IF NOT EXISTS $dbName")
+
+    try {
+      spark.sql(s"""
+        CREATE TABLE $tableName (
+          created_at TIMESTAMP,
+          user_id STRING,
+          ds STRING
+        ) USING DELTA
+        PARTITIONED BY (ds)
+      """)
+      spark.sql(s"""
+        INSERT INTO $tableName VALUES
+          (TIMESTAMP '2024-06-01 12:00:00', 'user1', '2024-06-01'),
+          (TIMESTAMP '2024-06-03 12:00:00', 'user2', '2024-06-03')
+      """)
+
+      DeltaLake.virtualPartitions(tableName, "ds", PartitionSpec.daily) should contain theSameElementsAs
+        List("2024-06-01", "2024-06-03")
+      DeltaLake.firstAvailablePartition(tableName, "ds", PartitionSpec.daily) shouldBe Some("2024-06-01")
+      DeltaLake.lastAvailablePartition(tableName, "ds", PartitionSpec.daily) shouldBe Some("2024-06-03")
+    } finally {
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+      spark.sql(s"DROP DATABASE IF EXISTS $dbName")
+    }
+  }
+
+  it should "derive Delta log stats boundaries for date and date string columns without timestamp casts" in {
+    val dbName = s"delta_date_stats_${System.nanoTime()}"
+    val tableName = s"$dbName.date_with_stats"
+    spark.sql(s"CREATE DATABASE IF NOT EXISTS $dbName")
+
+    try {
+      spark.sql(s"""
+        CREATE TABLE $tableName (
+          created_date DATE,
+          created_day STRING,
+          user_id STRING
+        ) USING DELTA
+      """)
+      spark.sql(s"""
+        INSERT INTO $tableName VALUES
+          (DATE '2024-07-01', '2024-07-01', 'user1'),
+          (DATE '2024-07-03', '2024-07-03', 'user2')
+      """)
+
+      DeltaLake.statsDateRange(tableName, "created_date", PartitionSpec.daily) shouldBe
+        Some(DeltaLake.StatsDateRange(start = "2024-07-01", end = "2024-07-03"))
+      DeltaLake.statsDateRange(tableName, "created_day", PartitionSpec.daily) shouldBe
+        Some(DeltaLake.StatsDateRange(start = "2024-07-01", end = "2024-07-03"))
+    } finally {
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+      spark.sql(s"DROP DATABASE IF EXISTS $dbName")
+    }
+  }
+
   it should "fall back to scanning when Delta log stats do not cover the timestamp column" in {
     val dbName = s"delta_stats_fallback_${System.nanoTime()}"
     val tableName = s"$dbName.time_missing_stats"

--- a/spark/src/test/scala/ai/chronon/spark/catalog/DeltaLakeTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/catalog/DeltaLakeTest.scala
@@ -49,7 +49,7 @@ class DeltaLakeTest extends AnyFlatSpec with BeforeAndAfterAll {
       DeltaLake.virtualPartitions(tableName, "created_at", PartitionSpec.daily) shouldBe
         List("2024-01-01", "2024-01-02", "2024-01-03")
       DeltaLake.firstAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-01-01")
-      DeltaLake.lastAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-01-02")
+      DeltaLake.lastAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-01-03")
     } finally {
       spark.sql(s"DROP TABLE IF EXISTS $tableName")
       spark.sql(s"DROP DATABASE IF EXISTS $dbName")
@@ -83,6 +83,14 @@ class DeltaLakeTest extends AnyFlatSpec with BeforeAndAfterAll {
       spark.sql(s"DROP TABLE IF EXISTS $tableName")
       spark.sql(s"DROP DATABASE IF EXISTS $dbName")
     }
+  }
+
+  it should "return the inclusive last partition from Delta log stats for a single-day timestamp range" in {
+    val range = DeltaLake.StatsDateRange(start = "2024-01-01", end = "2024-01-01")
+
+    range.virtualPartitions(PartitionSpec.daily) shouldBe List("2024-01-01")
+    range.firstAvailablePartition shouldBe "2024-01-01"
+    range.lastAvailablePartition shouldBe "2024-01-01"
   }
 
   it should "prefer actual partition metadata over Delta log stats" in {

--- a/spark/src/test/scala/ai/chronon/spark/catalog/DeltaLakeTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/catalog/DeltaLakeTest.scala
@@ -1,0 +1,118 @@
+package ai.chronon.spark.catalog
+
+import ai.chronon.api.PartitionSpec
+import ai.chronon.spark.submission.SparkSessionBuilder
+import org.apache.spark.sql.SparkSession
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers._
+
+class DeltaLakeTest extends AnyFlatSpec with BeforeAndAfterAll {
+
+  private implicit lazy val spark: SparkSession =
+    SparkSessionBuilder.build(
+      "DeltaLakeTest",
+      local = true,
+      additionalConfig = Some(
+        Map(
+          "spark.sql.extensions" -> "io.delta.sql.DeltaSparkSessionExtension",
+          "spark.sql.catalog.spark_catalog" -> "org.apache.spark.sql.delta.catalog.DeltaCatalog"
+        ))
+    )
+
+  override def afterAll(): Unit = {
+    if (spark != null) {
+      spark.stop()
+    }
+  }
+
+  it should "derive virtual partitions from Delta log stats for a timestamp column" in {
+    val dbName = s"delta_stats_${System.nanoTime()}"
+    val tableName = s"$dbName.time_with_stats"
+    spark.sql(s"CREATE DATABASE IF NOT EXISTS $dbName")
+
+    try {
+      spark.sql(s"""
+        CREATE TABLE $tableName (
+          created_at TIMESTAMP,
+          user_id STRING
+        ) USING DELTA
+      """)
+      spark.sql(s"""
+        INSERT INTO $tableName VALUES
+          (TIMESTAMP '2024-01-01 12:00:00', 'user1'),
+          (TIMESTAMP '2024-01-03 12:00:00', 'user2')
+      """)
+
+      DeltaLake.statsDateRange(tableName, "created_at", PartitionSpec.daily) shouldBe
+        Some(DeltaLake.StatsDateRange(start = "2024-01-01", end = "2024-01-03"))
+      DeltaLake.virtualPartitions(tableName, "created_at", PartitionSpec.daily) shouldBe
+        List("2024-01-01", "2024-01-02", "2024-01-03")
+      DeltaLake.firstAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-01-01")
+      DeltaLake.lastAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-01-02")
+    } finally {
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+      spark.sql(s"DROP DATABASE IF EXISTS $dbName")
+    }
+  }
+
+  it should "derive virtual partitions from Delta log stats for a clustered timestamp column" in {
+    val dbName = s"delta_clustered_stats_${System.nanoTime()}"
+    val tableName = s"$dbName.time_clustered_with_stats"
+    spark.sql(s"CREATE DATABASE IF NOT EXISTS $dbName")
+
+    try {
+      spark.sql(s"""
+        CREATE TABLE $tableName (
+          created_at TIMESTAMP,
+          user_id STRING
+        ) USING DELTA
+        CLUSTER BY (created_at)
+      """)
+      spark.sql(s"""
+        INSERT INTO $tableName VALUES
+          (TIMESTAMP '2024-03-01 12:00:00', 'user1'),
+          (TIMESTAMP '2024-03-03 12:00:00', 'user2')
+      """)
+
+      DeltaLake.statsDateRange(tableName, "created_at", PartitionSpec.daily) shouldBe
+        Some(DeltaLake.StatsDateRange(start = "2024-03-01", end = "2024-03-03"))
+      DeltaLake.virtualPartitions(tableName, "created_at", PartitionSpec.daily) shouldBe
+        List("2024-03-01", "2024-03-02", "2024-03-03")
+    } finally {
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+      spark.sql(s"DROP DATABASE IF EXISTS $dbName")
+    }
+  }
+
+  it should "fall back to scanning when Delta log stats do not cover the timestamp column" in {
+    val dbName = s"delta_stats_fallback_${System.nanoTime()}"
+    val tableName = s"$dbName.time_missing_stats"
+    spark.sql(s"CREATE DATABASE IF NOT EXISTS $dbName")
+
+    try {
+      spark.sql(s"""
+        CREATE TABLE $tableName (
+          indexed_id INT,
+          created_at TIMESTAMP,
+          user_id STRING
+        ) USING DELTA
+        TBLPROPERTIES ('delta.dataSkippingNumIndexedCols' = '1')
+      """)
+      spark.sql(s"""
+        INSERT INTO $tableName VALUES
+          (1, TIMESTAMP '2024-02-01 12:00:00', 'user1'),
+          (2, TIMESTAMP '2024-02-03 12:00:00', 'user2')
+      """)
+
+      DeltaLake.statsDateRange(tableName, "created_at", PartitionSpec.daily) shouldBe None
+      DeltaLake.virtualPartitions(tableName, "created_at", PartitionSpec.daily) shouldBe
+        List("2024-02-01", "2024-02-02", "2024-02-03")
+      DeltaLake.firstAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-02-01")
+      DeltaLake.lastAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-02-02")
+    } finally {
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+      spark.sql(s"DROP DATABASE IF EXISTS $dbName")
+    }
+  }
+}

--- a/spark/src/test/scala/ai/chronon/spark/catalog/DeltaLakeTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/catalog/DeltaLakeTest.scala
@@ -45,7 +45,7 @@ class DeltaLakeTest extends AnyFlatSpec with BeforeAndAfterAll {
       """)
 
       DeltaLake.statsDateRange(tableName, "created_at", PartitionSpec.daily) shouldBe
-        Some(DeltaLake.StatsDateRange(start = "2024-01-01", end = "2024-01-03"))
+        Some(StatsDateRange(start = "2024-01-01", end = "2024-01-03"))
       DeltaLake.virtualPartitions(tableName, "created_at", PartitionSpec.daily) shouldBe
         List("2024-01-01", "2024-01-02", "2024-01-03")
       DeltaLake.firstAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-01-01")
@@ -76,7 +76,7 @@ class DeltaLakeTest extends AnyFlatSpec with BeforeAndAfterAll {
       """)
 
       DeltaLake.statsDateRange(tableName, "created_at", PartitionSpec.daily) shouldBe
-        Some(DeltaLake.StatsDateRange(start = "2024-03-01", end = "2024-03-03"))
+        Some(StatsDateRange(start = "2024-03-01", end = "2024-03-03"))
       DeltaLake.virtualPartitions(tableName, "created_at", PartitionSpec.daily) shouldBe
         List("2024-03-01", "2024-03-02", "2024-03-03")
     } finally {
@@ -86,7 +86,7 @@ class DeltaLakeTest extends AnyFlatSpec with BeforeAndAfterAll {
   }
 
   it should "return the inclusive last partition from Delta log stats for a single-day timestamp range" in {
-    val range = DeltaLake.StatsDateRange(start = "2024-01-01", end = "2024-01-01")
+    val range = StatsDateRange(start = "2024-01-01", end = "2024-01-01")
 
     range.virtualPartitions(PartitionSpec.daily) shouldBe List("2024-01-01")
     range.firstAvailablePartition shouldBe "2024-01-01"
@@ -123,6 +123,30 @@ class DeltaLakeTest extends AnyFlatSpec with BeforeAndAfterAll {
     }
   }
 
+  it should "return distinct logical partitions from Delta file metadata" in {
+    val dbName = s"delta_duplicate_partition_metadata_${System.nanoTime()}"
+    val tableName = s"$dbName.duplicate_partition_files"
+    spark.sql(s"CREATE DATABASE IF NOT EXISTS $dbName")
+
+    try {
+      spark.sql(s"""
+        CREATE TABLE $tableName (
+          user_id STRING,
+          ds STRING
+        ) USING DELTA
+        PARTITIONED BY (ds)
+      """)
+      spark.sql(s"INSERT INTO $tableName VALUES ('user1', '2024-08-01')")
+      spark.sql(s"INSERT INTO $tableName VALUES ('user2', '2024-08-01')")
+
+      DeltaLake.partitions(tableName, "") shouldBe List(Map("ds" -> "2024-08-01"))
+      DeltaLake.virtualPartitions(tableName, "ds", PartitionSpec.daily) shouldBe List("2024-08-01")
+    } finally {
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+      spark.sql(s"DROP DATABASE IF EXISTS $dbName")
+    }
+  }
+
   it should "derive Delta log stats boundaries for date and date string columns without timestamp casts" in {
     val dbName = s"delta_date_stats_${System.nanoTime()}"
     val tableName = s"$dbName.date_with_stats"
@@ -143,9 +167,9 @@ class DeltaLakeTest extends AnyFlatSpec with BeforeAndAfterAll {
       """)
 
       DeltaLake.statsDateRange(tableName, "created_date", PartitionSpec.daily) shouldBe
-        Some(DeltaLake.StatsDateRange(start = "2024-07-01", end = "2024-07-03"))
+        Some(StatsDateRange(start = "2024-07-01", end = "2024-07-03"))
       DeltaLake.statsDateRange(tableName, "created_day", PartitionSpec.daily) shouldBe
-        Some(DeltaLake.StatsDateRange(start = "2024-07-01", end = "2024-07-03"))
+        Some(StatsDateRange(start = "2024-07-01", end = "2024-07-03"))
     } finally {
       spark.sql(s"DROP TABLE IF EXISTS $tableName")
       spark.sql(s"DROP DATABASE IF EXISTS $dbName")
@@ -176,7 +200,7 @@ class DeltaLakeTest extends AnyFlatSpec with BeforeAndAfterAll {
       DeltaLake.virtualPartitions(tableName, "created_at", PartitionSpec.daily) shouldBe
         List("2024-02-01", "2024-02-02", "2024-02-03")
       DeltaLake.firstAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-02-01")
-      DeltaLake.lastAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-02-02")
+      DeltaLake.lastAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-02-03")
     } finally {
       spark.sql(s"DROP TABLE IF EXISTS $tableName")
       spark.sql(s"DROP DATABASE IF EXISTS $dbName")

--- a/spark/src/test/scala/ai/chronon/spark/catalog/DeltaLakeTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/catalog/DeltaLakeTest.scala
@@ -49,7 +49,7 @@ class DeltaLakeTest extends AnyFlatSpec with BeforeAndAfterAll {
       DeltaLake.virtualPartitions(tableName, "created_at", PartitionSpec.daily) shouldBe
         List("2024-01-01", "2024-01-02", "2024-01-03")
       DeltaLake.firstAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-01-01")
-      DeltaLake.lastAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-01-03")
+      DeltaLake.lastAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-01-02")
     } finally {
       spark.sql(s"DROP TABLE IF EXISTS $tableName")
       spark.sql(s"DROP DATABASE IF EXISTS $dbName")
@@ -200,7 +200,7 @@ class DeltaLakeTest extends AnyFlatSpec with BeforeAndAfterAll {
       DeltaLake.virtualPartitions(tableName, "created_at", PartitionSpec.daily) shouldBe
         List("2024-02-01", "2024-02-02", "2024-02-03")
       DeltaLake.firstAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-02-01")
-      DeltaLake.lastAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-02-03")
+      DeltaLake.lastAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-02-02")
     } finally {
       spark.sql(s"DROP TABLE IF EXISTS $tableName")
       spark.sql(s"DROP DATABASE IF EXISTS $dbName")

--- a/spark/src/test/scala/ai/chronon/spark/catalog/FormatTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/catalog/FormatTest.scala
@@ -115,6 +115,47 @@ class FormatTest extends SparkTestBase {
     fmt.lastAvailablePartition(tableName, "ds", PartitionSpec.daily)(spark) shouldBe Some("2024-04-02")
   }
 
+  it should "deduplicate sanitized metadata partitions while preserving discovery order" in {
+    val fmt = new Format {
+      override def supportSubPartitionsFilter = false
+      override def partitions(tableName: String, partitionFilters: String)(implicit ss: SparkSession) = Nil
+      override def primaryPartitions(tableName: String,
+                                     partitionColumn: String,
+                                     partitionFilters: String,
+                                     subPartitionsFilter: Map[String, String])(implicit
+          ss: SparkSession) = List("2024-04-02", null, "2024-04-02", "2024-04-01")
+
+      def discoveredPartitions(tableName: String, partitionColumn: String)(implicit
+          ss: SparkSession): Option[List[String]] =
+        metadataPartitions(tableName, partitionColumn)(ss)
+    }
+
+    fmt.discoveredPartitions("db.table", "ds")(spark) shouldBe Some(List("2024-04-02", "2024-04-01"))
+  }
+
+  it should "return the inclusive last available partition when scanning a timestamp column" in {
+    val tableName = "format_timestamp_scan_last_available_test"
+    spark.sql(s"""
+      CREATE OR REPLACE TEMP VIEW $tableName AS
+      SELECT * FROM VALUES
+        (1, TIMESTAMP '2024-04-01 12:00:00'),
+        (2, TIMESTAMP '2024-04-03 12:00:00')
+      AS t(id, created_at)
+    """)
+
+    val fmt = new Format {
+      override def supportSubPartitionsFilter = false
+      override def partitions(tableName: String, partitionFilters: String)(implicit ss: SparkSession) = Nil
+      override def primaryPartitions(tableName: String,
+                                     partitionColumn: String,
+                                     partitionFilters: String,
+                                     subPartitionsFilter: Map[String, String])(implicit
+          ss: SparkSession) = Nil
+    }
+
+    fmt.lastAvailablePartition(tableName, "created_at", PartitionSpec.daily)(spark) shouldBe Some("2024-04-03")
+  }
+
   it should "resolve table names consistently with Spark SQL" in {
     spark.sql("CREATE DATABASE IF NOT EXISTS spark_non_default_catalog.custom_test_db")
     spark.sql(

--- a/spark/src/test/scala/ai/chronon/spark/catalog/FormatTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/catalog/FormatTest.scala
@@ -133,7 +133,7 @@ class FormatTest extends SparkTestBase {
     fmt.discoveredPartitions("db.table", "ds")(spark) shouldBe Some(List("2024-04-02", "2024-04-01"))
   }
 
-  it should "return the inclusive last available partition when scanning a timestamp column" in {
+  it should "return the last complete partition when scanning a timestamp column" in {
     val tableName = "format_timestamp_scan_last_available_test"
     spark.sql(s"""
       CREATE OR REPLACE TEMP VIEW $tableName AS
@@ -153,7 +153,7 @@ class FormatTest extends SparkTestBase {
           ss: SparkSession) = Nil
     }
 
-    fmt.lastAvailablePartition(tableName, "created_at", PartitionSpec.daily)(spark) shouldBe Some("2024-04-03")
+    fmt.lastAvailablePartition(tableName, "created_at", PartitionSpec.daily)(spark) shouldBe Some("2024-04-02")
   }
 
   it should "resolve table names consistently with Spark SQL" in {

--- a/spark/src/test/scala/ai/chronon/spark/catalog/IcebergTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/catalog/IcebergTest.scala
@@ -1,5 +1,6 @@
 package ai.chronon.spark.catalog
 
+import ai.chronon.api.PartitionSpec
 import ai.chronon.spark.utils.SparkTestBase
 import org.scalatest.matchers.should.Matchers
 
@@ -135,6 +136,96 @@ class IcebergTest extends SparkTestBase with Matchers {
 
     val parts = Iceberg.primaryPartitions(tableName, "ds", "")
     parts shouldBe List("2024-03-01")
+  }
+
+  it should "derive virtual partitions from Iceberg file stats for a clustered timestamp column" in {
+    val tableName = "default.iceberg_time_stats_test"
+    spark.sql(s"DROP TABLE IF EXISTS $tableName")
+
+    spark.sql(s"""
+      CREATE TABLE $tableName (
+        id INT,
+        created_at TIMESTAMP
+      ) USING iceberg
+      TBLPROPERTIES (
+        'write.metadata.metrics.default' = 'full',
+        'write.metadata.metrics.column.created_at' = 'full'
+      )
+    """)
+    spark.sql(s"ALTER TABLE $tableName WRITE ORDERED BY created_at")
+
+    spark.sql(s"""
+      INSERT INTO $tableName VALUES
+      (1, TIMESTAMP '2024-04-01 12:00:00'),
+      (2, TIMESTAMP '2024-04-03 12:00:00')
+    """)
+
+    Iceberg.statsDateRange(tableName, "created_at", PartitionSpec.daily) shouldBe
+      Some(Iceberg.StatsDateRange(start = "2024-04-01", end = "2024-04-03"))
+    Iceberg.virtualPartitions(tableName, "created_at", PartitionSpec.daily) shouldBe
+      List("2024-04-01", "2024-04-02", "2024-04-03")
+    Iceberg.firstAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-04-01")
+    Iceberg.lastAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-04-02")
+  }
+
+  it should "prefer actual partition metadata over Iceberg file stats" in {
+    val tableName = "default.iceberg_partition_metadata_test"
+    spark.sql(s"DROP TABLE IF EXISTS $tableName")
+
+    try {
+      spark.sql(s"""
+        CREATE TABLE $tableName (
+          id INT,
+          created_at TIMESTAMP,
+          ds STRING
+        ) USING iceberg
+        PARTITIONED BY (ds)
+        TBLPROPERTIES (
+          'write.metadata.metrics.default' = 'full',
+          'write.metadata.metrics.column.ds' = 'full'
+        )
+      """)
+
+      spark.sql(s"""
+        INSERT INTO $tableName VALUES
+        (1, TIMESTAMP '2024-06-01 12:00:00', '2024-06-01'),
+        (2, TIMESTAMP '2024-06-03 12:00:00', '2024-06-03')
+      """)
+
+      Iceberg.virtualPartitions(tableName, "ds", PartitionSpec.daily) should contain theSameElementsAs
+        List("2024-06-01", "2024-06-03")
+      Iceberg.firstAvailablePartition(tableName, "ds", PartitionSpec.daily) shouldBe Some("2024-06-01")
+      Iceberg.lastAvailablePartition(tableName, "ds", PartitionSpec.daily) shouldBe Some("2024-06-03")
+    } finally {
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+    }
+  }
+
+  it should "fall back to scanning when Iceberg file stats do not cover the timestamp column" in {
+    val tableName = "default.iceberg_time_missing_stats_test"
+    spark.sql(s"DROP TABLE IF EXISTS $tableName")
+
+    spark.sql(s"""
+      CREATE TABLE $tableName (
+        id INT,
+        created_at TIMESTAMP
+      ) USING iceberg
+      TBLPROPERTIES (
+        'write.metadata.metrics.default' = 'none'
+      )
+    """)
+
+    spark.sql(s"""
+      INSERT INTO $tableName VALUES
+      (1, TIMESTAMP '2024-05-01 12:00:00'),
+      (2, TIMESTAMP '2024-05-03 12:00:00')
+    """)
+
+    Iceberg.statsDateRange(tableName, "created_at", PartitionSpec.daily) shouldBe None
+    Iceberg.virtualPartitions(tableName, "created_at", PartitionSpec.daily) shouldBe
+      List("2024-05-01", "2024-05-02", "2024-05-03")
+    Iceberg.firstAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-05-01")
+    Iceberg.lastAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-05-02")
   }
 
   "insertPartitions on unpartitioned Iceberg table" should "overwrite only the subrange without duplicates" in {

--- a/spark/src/test/scala/ai/chronon/spark/catalog/IcebergTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/catalog/IcebergTest.scala
@@ -161,7 +161,7 @@ class IcebergTest extends SparkTestBase with Matchers {
     """)
 
     Iceberg.statsDateRange(tableName, "created_at", PartitionSpec.daily) shouldBe
-      Some(Iceberg.StatsDateRange(start = "2024-04-01", end = "2024-04-03"))
+      Some(StatsDateRange(start = "2024-04-01", end = "2024-04-03"))
     Iceberg.virtualPartitions(tableName, "created_at", PartitionSpec.daily) shouldBe
       List("2024-04-01", "2024-04-02", "2024-04-03")
     Iceberg.firstAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-04-01")
@@ -169,7 +169,7 @@ class IcebergTest extends SparkTestBase with Matchers {
   }
 
   it should "return the inclusive last partition from Iceberg file stats for a single-day timestamp range" in {
-    val range = Iceberg.StatsDateRange(start = "2024-04-01", end = "2024-04-01")
+    val range = StatsDateRange(start = "2024-04-01", end = "2024-04-01")
 
     range.virtualPartitions(PartitionSpec.daily) shouldBe List("2024-04-01")
     range.firstAvailablePartition shouldBe "2024-04-01"
@@ -233,7 +233,7 @@ class IcebergTest extends SparkTestBase with Matchers {
     Iceberg.virtualPartitions(tableName, "created_at", PartitionSpec.daily) shouldBe
       List("2024-05-01", "2024-05-02", "2024-05-03")
     Iceberg.firstAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-05-01")
-    Iceberg.lastAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-05-02")
+    Iceberg.lastAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-05-03")
   }
 
   "insertPartitions on unpartitioned Iceberg table" should "overwrite only the subrange without duplicates" in {

--- a/spark/src/test/scala/ai/chronon/spark/catalog/IcebergTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/catalog/IcebergTest.scala
@@ -165,7 +165,15 @@ class IcebergTest extends SparkTestBase with Matchers {
     Iceberg.virtualPartitions(tableName, "created_at", PartitionSpec.daily) shouldBe
       List("2024-04-01", "2024-04-02", "2024-04-03")
     Iceberg.firstAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-04-01")
-    Iceberg.lastAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-04-02")
+    Iceberg.lastAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-04-03")
+  }
+
+  it should "return the inclusive last partition from Iceberg file stats for a single-day timestamp range" in {
+    val range = Iceberg.StatsDateRange(start = "2024-04-01", end = "2024-04-01")
+
+    range.virtualPartitions(PartitionSpec.daily) shouldBe List("2024-04-01")
+    range.firstAvailablePartition shouldBe "2024-04-01"
+    range.lastAvailablePartition shouldBe "2024-04-01"
   }
 
   it should "prefer actual partition metadata over Iceberg file stats" in {

--- a/spark/src/test/scala/ai/chronon/spark/catalog/IcebergTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/catalog/IcebergTest.scala
@@ -165,7 +165,7 @@ class IcebergTest extends SparkTestBase with Matchers {
     Iceberg.virtualPartitions(tableName, "created_at", PartitionSpec.daily) shouldBe
       List("2024-04-01", "2024-04-02", "2024-04-03")
     Iceberg.firstAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-04-01")
-    Iceberg.lastAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-04-03")
+    Iceberg.lastAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-04-02")
   }
 
   it should "return the inclusive last partition from Iceberg file stats for a single-day timestamp range" in {
@@ -233,7 +233,7 @@ class IcebergTest extends SparkTestBase with Matchers {
     Iceberg.virtualPartitions(tableName, "created_at", PartitionSpec.daily) shouldBe
       List("2024-05-01", "2024-05-02", "2024-05-03")
     Iceberg.firstAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-05-01")
-    Iceberg.lastAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-05-03")
+    Iceberg.lastAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-05-02")
   }
 
   "insertPartitions on unpartitioned Iceberg table" should "overwrite only the subrange without duplicates" in {


### PR DESCRIPTION
## Summary

A `min`/`max` query does not necessarily (and appears to rarely) use the metadata available on the delta log or iceberg snapshot and instead almost always re-queries the table which then forces a scan over all files (admittedly only reading the footer of each file so not a full scan) but rather expensive when it doesn't need to be. 

## Checklist
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved partition boundary detection performance for Delta Lake and Iceberg tables by leveraging table statistics metadata before falling back to full scans.
  * Enhanced support for various partition column data types, including DATE and date-representing STRING columns.

* **Tests**
  * Added comprehensive test coverage for partition detection and date-range boundary behavior across table formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->