### PR TITLE
Make schedule-all schedule all confs and not just the diffs

### DIFF
--- a/python/src/ai/chronon/repo/hub_runner.py
+++ b/python/src/ai/chronon/repo/hub_runner.py
@@ -372,7 +372,7 @@ def redeploy_streaming(repo, confs, hub_url=None, use_auth=True, format: Format 
 def submit_schedule_all(
     repo, cloud, customer_id, hub_url=None, use_auth=True, format: Format = Format.TEXT
 ):
-    """Deploy schedules for all changed confs that have schedules defined."""
+    """Deploy schedules for all confs that have schedules defined."""
     zipline_hub = _get_zipline_hub(
         hub_url,
         get_hub_conf_from_metadata_conf(
@@ -391,18 +391,19 @@ def submit_schedule_all(
     branch = get_current_branch()
 
     with status_spinner("Syncing confs with Hub...", format=format):
-        diff_confs = hub_uploader.compute_and_upload_diffs(
+        # Upload any changed confs to Hub
+        hub_uploader.compute_and_upload_diffs(
             branch,
             zipline_hub=zipline_hub,
             local_repo_confs=conf_name_to_obj_dict,
             format=format,
         )
 
-    # Collect confs with schedules
+    # Collect confs with schedules (from ALL confs, not just changed ones)
     confs_with_schedules = []
     skipped_confs = []
 
-    for name, conf in diff_confs.items():
+    for name, conf in conf_name_to_obj_dict.items():
         try:
             schedule_modes = get_schedule_modes(conf.localPath)
 
@@ -433,8 +434,8 @@ def submit_schedule_all(
 
     if not confs_with_schedules:
         print_info(
-            f"No changed confs with schedules found. "
-            f"{len(skipped_confs)} conf(s) changed but have no schedules defined.",
+            f"No confs with schedules found. "
+            f"{len(skipped_confs)} conf(s) have no schedules defined.",
             format=format,
         )
         return

--- a/python/test/test_hub_runner.py
+++ b/python/test/test_hub_runner.py
@@ -523,17 +523,19 @@ class TestHubRunner:
         from gen_thrift.api.ttypes import Conf
 
         mock_get_current_branch.return_value = "test-branch"
-        mock_build_hashmap.return_value = {}
 
-        # Mock compute_and_upload_diffs to return a conf without schedules
+        # Mock build_local_repo_hashmap to return a conf without schedules
         conf_without_schedules = Conf(
             name="test_team.join_without_schedules",
             localPath="/path/to/conf",
             hash="hash1",
         )
-        mock_compute_diffs.return_value = {
+        mock_build_hashmap.return_value = {
             "test_team.join_without_schedules": conf_without_schedules,
         }
+
+        # Mock compute_and_upload_diffs (still called to upload any changes)
+        mock_compute_diffs.return_value = {}
 
         # Mock get_schedule_modes to return SCHEDULE_NONE_STR for both schedules
         mock_get_schedule_modes.return_value = ScheduleModes(


### PR DESCRIPTION
## Summary

Previously schedule-all would perform a diff b/n the local state of the repo and the hub and upload the confs that changed AND only schedule those confs. 

But this doesn't work when diff_and_upload might have already been called previously because then schedule-all would call the same diff_and_upload which would return empty since the different confs would have already been uploaded; no confs would be scheduled then in schedule-all

Changing the implementation to just schedule-all all local confs. The request to schedule-all API size should be manageable as we are basically creating a dictionary per conf that has this shape:

```
{

"conf_name": name,

"conf_hash": conf.hash,

"branch": branch,

"modes": modes,

}
```

1000 of these dictionaries would be ~200-600 KB.

## Checklist
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Schedule deployment now processes all configurations that have defined schedules (not just recently changed ones).
  * Deployment messaging clarified to report which configurations were skipped because they lack schedules.

* **Tests**
  * Updated and added tests to verify scheduling submits both changed and unchanged configurations when schedules are present, and skips configs with no schedules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zipline-ai/chronon/pull/1831)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->