### PR TITLE
Merge into fails on on delta tables with deletion vectors

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
@@ -20,12 +20,10 @@ import ai.chronon.api.{Constants, PartitionRange, PartitionSpec, Query, QueryUti
 import ai.chronon.api.ColorPrinter.ColorString
 import ai.chronon.api.Extensions._
 import ai.chronon.api.ScalaJavaConversions._
-import org.apache.spark.sql.{AnalysisException, DataFrame, Dataset, Row, SaveMode, SparkSession}
+import org.apache.spark.sql.{AnalysisException, DataFrame, SaveMode, SparkSession}
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException
-import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, Project}
 import org.apache.spark.sql.catalyst.util.QuotingUtils
-import org.apache.spark.sql.delta.stats.PrepareDeltaScan
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 import org.slf4j.{Logger, LoggerFactory}
@@ -335,12 +333,11 @@ class TableUtils(@transient val sparkSession: SparkSession) extends Serializable
       // semantics are meaningless; IN-lists stay correct for those. It is slightly over-broad
       // for multi-column keys (matches cartesian product of distinct values) but safe here —
       // we only delete rows the upstream job intends to rewrite.
-      val mergeSourceDf = prepareDeltaScansForMerge(finalizedDf)
       val tempView = s"__chronon_insert_${tableName.replace('.', '_')}_${System.nanoTime()}"
-      mergeSourceDf.createOrReplaceTempView(tempView)
+      finalizedDf.createOrReplaceTempView(tempView)
       val deleteCondition = partitionColumns
         .map { pc =>
-          val values = mergeSourceDf.select(col(pc)).distinct().collect().map(row => lit(row.get(0)).expr.sql)
+          val values = finalizedDf.select(col(pc)).distinct().collect().map(row => lit(row.get(0)).expr.sql)
           s"target.`$pc` IN (${values.mkString(", ")})"
         }
         .mkString(" AND ")
@@ -350,38 +347,14 @@ class TableUtils(@transient val sparkSession: SparkSession) extends Serializable
            |ON FALSE
            |WHEN NOT MATCHED BY SOURCE AND $deleteCondition THEN DELETE
            |WHEN NOT MATCHED THEN INSERT *""".stripMargin
-      try {
-        sparkSession.sql(mergeSQL)
-      } finally {
-        sparkSession.catalog.dropTempView(tempView)
-      }
+      sparkSession.sql(mergeSQL)
+      sparkSession.catalog.dropTempView(tempView)
     } else {
       finalizedDf.write
         .mode(SaveMode.Overwrite)
         .insertInto(tableName)
     }
     logger.info(s"Finished writing to $tableName")
-  }
-
-  private def prepareDeltaScansForMerge(df: DataFrame): DataFrame = {
-    // Iceberg MERGE sources can carry Delta scans through a temp view. Delta tables with
-    // deletion vectors require those scans to be planned against a pinned snapshot.
-    //
-    // PrepareDeltaScan returns the original plan when Delta stats skipping is disabled, which
-    // leaves a non-pinned TahoeLogFileIndex in the MERGE source. Temporarily enabling it here
-    // makes Delta replace those scans with PreparedDeltaFileIndex instances.
-    val deltaStatsSkippingConf = "spark.databricks.delta.stats.skipping"
-    val previousDeltaStatsSkipping = sparkSession.conf.getOption(deltaStatsSkippingConf)
-    sparkSession.conf.set(deltaStatsSkippingConf, "true")
-    try {
-      val preparedPlan = new PrepareDeltaScan(sparkSession).apply(df.queryExecution.analyzed)
-      new Dataset[Row](sparkSession, preparedPlan, ExpressionEncoder(preparedPlan.schema))
-    } finally {
-      previousDeltaStatsSkipping match {
-        case Some(value) => sparkSession.conf.set(deltaStatsSkippingConf, value)
-        case None        => sparkSession.conf.unset(deltaStatsSkippingConf)
-      }
-    }
   }
 
   // retains only the invocations from chronon code.

--- a/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
@@ -20,10 +20,12 @@ import ai.chronon.api.{Constants, PartitionRange, PartitionSpec, Query, QueryUti
 import ai.chronon.api.ColorPrinter.ColorString
 import ai.chronon.api.Extensions._
 import ai.chronon.api.ScalaJavaConversions._
-import org.apache.spark.sql.{AnalysisException, DataFrame, SaveMode, SparkSession}
+import org.apache.spark.sql.{AnalysisException, DataFrame, Dataset, Row, SaveMode, SparkSession}
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, Project}
 import org.apache.spark.sql.catalyst.util.QuotingUtils
+import org.apache.spark.sql.delta.stats.PrepareDeltaScan
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 import org.slf4j.{Logger, LoggerFactory}
@@ -333,11 +335,12 @@ class TableUtils(@transient val sparkSession: SparkSession) extends Serializable
       // semantics are meaningless; IN-lists stay correct for those. It is slightly over-broad
       // for multi-column keys (matches cartesian product of distinct values) but safe here —
       // we only delete rows the upstream job intends to rewrite.
+      val mergeSourceDf = prepareDeltaScansForMerge(finalizedDf)
       val tempView = s"__chronon_insert_${tableName.replace('.', '_')}_${System.nanoTime()}"
-      finalizedDf.createOrReplaceTempView(tempView)
+      mergeSourceDf.createOrReplaceTempView(tempView)
       val deleteCondition = partitionColumns
         .map { pc =>
-          val values = finalizedDf.select(col(pc)).distinct().collect().map(row => lit(row.get(0)).expr.sql)
+          val values = mergeSourceDf.select(col(pc)).distinct().collect().map(row => lit(row.get(0)).expr.sql)
           s"target.`$pc` IN (${values.mkString(", ")})"
         }
         .mkString(" AND ")
@@ -347,14 +350,38 @@ class TableUtils(@transient val sparkSession: SparkSession) extends Serializable
            |ON FALSE
            |WHEN NOT MATCHED BY SOURCE AND $deleteCondition THEN DELETE
            |WHEN NOT MATCHED THEN INSERT *""".stripMargin
-      sparkSession.sql(mergeSQL)
-      sparkSession.catalog.dropTempView(tempView)
+      try {
+        sparkSession.sql(mergeSQL)
+      } finally {
+        sparkSession.catalog.dropTempView(tempView)
+      }
     } else {
       finalizedDf.write
         .mode(SaveMode.Overwrite)
         .insertInto(tableName)
     }
     logger.info(s"Finished writing to $tableName")
+  }
+
+  private def prepareDeltaScansForMerge(df: DataFrame): DataFrame = {
+    // Iceberg MERGE sources can carry Delta scans through a temp view. Delta tables with
+    // deletion vectors require those scans to be planned against a pinned snapshot.
+    //
+    // PrepareDeltaScan returns the original plan when Delta stats skipping is disabled, which
+    // leaves a non-pinned TahoeLogFileIndex in the MERGE source. Temporarily enabling it here
+    // makes Delta replace those scans with PreparedDeltaFileIndex instances.
+    val deltaStatsSkippingConf = "spark.databricks.delta.stats.skipping"
+    val previousDeltaStatsSkipping = sparkSession.conf.getOption(deltaStatsSkippingConf)
+    sparkSession.conf.set(deltaStatsSkippingConf, "true")
+    try {
+      val preparedPlan = new PrepareDeltaScan(sparkSession).apply(df.queryExecution.analyzed)
+      new Dataset[Row](sparkSession, preparedPlan, ExpressionEncoder(preparedPlan.schema))
+    } finally {
+      previousDeltaStatsSkipping match {
+        case Some(value) => sparkSession.conf.set(deltaStatsSkippingConf, value)
+        case None        => sparkSession.conf.unset(deltaStatsSkippingConf)
+      }
+    }
   }
 
   // retains only the invocations from chronon code.

--- a/spark/src/main/scala/ai/chronon/spark/extensions/ChrononDeltaFixExtension.scala
+++ b/spark/src/main/scala/ai/chronon/spark/extensions/ChrononDeltaFixExtension.scala
@@ -5,14 +5,15 @@ import org.apache.spark.sql.SparkSessionExtensions
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, MergeIntoTable, V2WriteCommand}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.delta.stats.PrepareDeltaScan
+import org.apache.spark.sql.execution.command.DataWritingCommand
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 
 /** Workaround for delta-io/delta#5804 on EMR where Delta's PrepareDeltaScan incorrectly
-  * skips ALL V2WriteCommand plans (including Iceberg writes reading from Delta sources with DVs).
+  * skips write-command plans (including Iceberg/Hive writes reading from Delta sources with DVs).
   *
   * Registered AFTER DeltaSparkSessionExtension in spark.sql.extensions so this rule runs
-  * after Delta's PrepareDeltaScan. For V2 writes without V1 fallback (e.g. Iceberg), and
-  * for MERGE source plans, we apply PrepareDeltaScan to the source table scans that Delta's
+  * after Delta's PrepareDeltaScan. For V2 writes without V1 fallback, V1 data-writing commands,
+  * and MERGE source plans, we apply PrepareDeltaScan to the source table scans that Delta's
   * rule skipped.
   */
 class ChrononDeltaFixExtension extends (SparkSessionExtensions => Unit) {
@@ -40,6 +41,8 @@ private[extensions] class DeltaScanFixRule(session: SparkSession) extends Rule[L
         } else {
           plan.mapChildren(delegate.apply)
         }
+      case _: DataWritingCommand =>
+        plan.mapChildren(delegate.apply)
       case merge: MergeIntoTable =>
         merge.copy(sourceTable = delegate.apply(merge.sourceTable))
       case _ => plan

--- a/spark/src/main/scala/ai/chronon/spark/extensions/ChrononDeltaFixExtension.scala
+++ b/spark/src/main/scala/ai/chronon/spark/extensions/ChrononDeltaFixExtension.scala
@@ -2,7 +2,7 @@ package ai.chronon.spark.extensions
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.SparkSessionExtensions
-import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, V2WriteCommand}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, MergeIntoTable, V2WriteCommand}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.delta.stats.PrepareDeltaScan
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
@@ -11,11 +11,13 @@ import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
   * skips ALL V2WriteCommand plans (including Iceberg writes reading from Delta sources with DVs).
   *
   * Registered AFTER DeltaSparkSessionExtension in spark.sql.extensions so this rule runs
-  * after Delta's PrepareDeltaScan. For V2 writes without V1 fallback (e.g. Iceberg), we
-  * apply PrepareDeltaScan to the children (source table scans) that Delta's rule skipped.
+  * after Delta's PrepareDeltaScan. For V2 writes without V1 fallback (e.g. Iceberg), and
+  * for MERGE source plans, we apply PrepareDeltaScan to the source table scans that Delta's
+  * rule skipped.
   */
 class ChrononDeltaFixExtension extends (SparkSessionExtensions => Unit) {
   override def apply(extensions: SparkSessionExtensions): Unit = {
+    extensions.injectPostHocResolutionRule(session => new DeltaScanFixRule(session))
     extensions.injectPreCBORule(session => new DeltaScanFixRule(session))
   }
 }
@@ -26,14 +28,21 @@ private[extensions] class DeltaScanFixRule(session: SparkSession) extends Rule[L
   private def hasV1Fallback(table: Any): Boolean =
     table.getClass.getInterfaces.exists(_.getSimpleName == "V2TableWithV1Fallback")
 
-  override def apply(plan: LogicalPlan): LogicalPlan = plan match {
-    case v2: V2WriteCommand =>
-      val targetHasV1Fallback = v2.table match {
-        case r: DataSourceV2Relation => hasV1Fallback(r.table)
-        case _                       => false
-      }
-      if (targetHasV1Fallback) plan
-      else plan.mapChildren(delegate.apply)
-    case _ => plan
+  override def apply(plan: LogicalPlan): LogicalPlan = {
+    plan match {
+      case v2: V2WriteCommand =>
+        val targetHasV1Fallback = v2.table match {
+          case r: DataSourceV2Relation => hasV1Fallback(r.table)
+          case _                       => false
+        }
+        if (targetHasV1Fallback) {
+          plan
+        } else {
+          plan.mapChildren(delegate.apply)
+        }
+      case merge: MergeIntoTable =>
+        merge.copy(sourceTable = delegate.apply(merge.sourceTable))
+      case _ => plan
+    }
   }
 }

--- a/spark/src/test/scala/ai/chronon/spark/catalog/IcebergDeltaMergeSourceTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/catalog/IcebergDeltaMergeSourceTest.scala
@@ -12,10 +12,10 @@ class IcebergDeltaMergeSourceTest extends SparkTestBase with Matchers {
     "spark.serializer" -> "org.apache.spark.serializer.JavaSerializer",
     "spark.sql.extensions" -> (
       "io.delta.sql.DeltaSparkSessionExtension," +
+      "ai.chronon.spark.extensions.ChrononDeltaFixExtension," +
       "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions," +
       "ai.chronon.spark.extensions.ChrononMergeExtension"
-    ),
-    "spark.databricks.delta.stats.skipping" -> "false"
+    )
   )
 
   "insertPartitions on an unpartitioned Iceberg table" should

--- a/spark/src/test/scala/ai/chronon/spark/catalog/IcebergDeltaMergeSourceTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/catalog/IcebergDeltaMergeSourceTest.scala
@@ -2,6 +2,7 @@ package ai.chronon.spark.catalog
 
 import ai.chronon.spark.utils.SparkTestBase
 import io.delta.tables.DeltaTable
+import org.apache.commons.io.FileUtils
 import org.scalatest.matchers.should.Matchers
 
 import java.nio.file.Files
@@ -21,7 +22,8 @@ class IcebergDeltaMergeSourceTest extends SparkTestBase with Matchers {
   "insertPartitions on an unpartitioned Iceberg table" should
     "prepare Delta source scans before MERGE" in {
       val tableName = "default.iceberg_delta_merge_source_test"
-      val deltaPath = Files.createTempDirectory("chronon-delta-dv-source").toString
+      val deltaDir = Files.createTempDirectory("chronon-delta-dv-source")
+      val deltaPath = deltaDir.toString
       val tableUtils = TableUtils(spark)
       import spark.implicits._
 
@@ -68,13 +70,15 @@ class IcebergDeltaMergeSourceTest extends SparkTestBase with Matchers {
           "keep")
       } finally {
         spark.sql(s"DROP TABLE IF EXISTS $tableName")
+        FileUtils.deleteDirectory(deltaDir.toFile)
       }
     }
 
   "insertPartitions on a V1 table" should
     "prepare Delta source scans before insertInto" in {
       val tableName = "default.v1_delta_dv_insert_source_test"
-      val deltaPath = Files.createTempDirectory("chronon-delta-dv-v1-source").toString
+      val deltaDir = Files.createTempDirectory("chronon-delta-dv-v1-source")
+      val deltaPath = deltaDir.toString
       val tableUtils = TableUtils(spark)
       import spark.implicits._
 
@@ -116,6 +120,7 @@ class IcebergDeltaMergeSourceTest extends SparkTestBase with Matchers {
           "keep")
       } finally {
         spark.sql(s"DROP TABLE IF EXISTS $tableName")
+        FileUtils.deleteDirectory(deltaDir.toFile)
       }
     }
 }

--- a/spark/src/test/scala/ai/chronon/spark/catalog/IcebergDeltaMergeSourceTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/catalog/IcebergDeltaMergeSourceTest.scala
@@ -70,4 +70,52 @@ class IcebergDeltaMergeSourceTest extends SparkTestBase with Matchers {
         spark.sql(s"DROP TABLE IF EXISTS $tableName")
       }
     }
+
+  "insertPartitions on a V1 table" should
+    "prepare Delta source scans before insertInto" in {
+      val tableName = "default.v1_delta_dv_insert_source_test"
+      val deltaPath = Files.createTempDirectory("chronon-delta-dv-v1-source").toString
+      val tableUtils = TableUtils(spark)
+      import spark.implicits._
+
+      try {
+        spark.sql(s"DROP TABLE IF EXISTS $tableName")
+        Seq(
+          (1, "first_1", "2026-04-01"),
+          (2, "deleted", "2026-04-01"),
+          (3, "first_2", "2026-04-02")
+        ).toDF("id", "value", "ds")
+          .write
+          .format("delta")
+          .option("delta.enableDeletionVectors", "true")
+          .mode("overwrite")
+          .save(deltaPath)
+        DeltaTable.forPath(spark, deltaPath).delete("id = 2")
+
+        spark.sql(s"""
+          CREATE TABLE $tableName (
+            id INT,
+            value STRING
+          ) USING parquet
+          PARTITIONED BY (ds STRING)
+        """)
+        spark.sql(s"""
+          INSERT INTO $tableName VALUES
+          (99, 'stale', '2026-04-01'),
+          (100, 'keep', '2026-04-03')
+        """)
+
+        val sourceDf = spark.read.format("delta").load(deltaPath)
+        tableUtils.insertPartitions(sourceDf, tableName)
+
+        val result = spark.table(tableName).orderBy("ds", "id").collect()
+        result.map(_.getAs[Int]("id")) should contain theSameElementsInOrderAs Seq(1, 3, 100)
+        result.map(_.getAs[String]("value")) should contain theSameElementsInOrderAs Seq(
+          "first_1",
+          "first_2",
+          "keep")
+      } finally {
+        spark.sql(s"DROP TABLE IF EXISTS $tableName")
+      }
+    }
 }

--- a/spark/src/test/scala/ai/chronon/spark/catalog/IcebergDeltaMergeSourceTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/catalog/IcebergDeltaMergeSourceTest.scala
@@ -1,0 +1,73 @@
+package ai.chronon.spark.catalog
+
+import ai.chronon.spark.utils.SparkTestBase
+import io.delta.tables.DeltaTable
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.file.Files
+
+class IcebergDeltaMergeSourceTest extends SparkTestBase with Matchers {
+
+  override def sparkConfs: Map[String, String] = Map(
+    "spark.serializer" -> "org.apache.spark.serializer.JavaSerializer",
+    "spark.sql.extensions" -> (
+      "io.delta.sql.DeltaSparkSessionExtension," +
+      "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions," +
+      "ai.chronon.spark.extensions.ChrononMergeExtension"
+    ),
+    "spark.databricks.delta.stats.skipping" -> "false"
+  )
+
+  "insertPartitions on an unpartitioned Iceberg table" should
+    "prepare Delta source scans before MERGE" in {
+      val tableName = "default.iceberg_delta_merge_source_test"
+      val deltaPath = Files.createTempDirectory("chronon-delta-dv-source").toString
+      val tableUtils = TableUtils(spark)
+      import spark.implicits._
+
+      try {
+        spark.sql(s"DROP TABLE IF EXISTS $tableName")
+        Seq(
+          (1, "first_1", "2026-04-01"),
+          (2, "deleted", "2026-04-01"),
+          (3, "first_2", "2026-04-02")
+        ).toDF("id", "value", "ds")
+          .write
+          .format("delta")
+          .option("delta.enableDeletionVectors", "true")
+          .mode("overwrite")
+          .save(deltaPath)
+        DeltaTable.forPath(spark, deltaPath).delete("id = 2")
+
+        spark.sql(s"""
+          CREATE TABLE $tableName (
+            id INT,
+            value STRING,
+            ds STRING
+          ) USING iceberg
+          TBLPROPERTIES (
+            'format-version' = '2',
+            'write.delete.mode' = 'merge-on-read',
+            'write.update.mode' = 'merge-on-read'
+          )
+        """)
+        spark.sql(s"""
+          INSERT INTO $tableName VALUES
+          (99, 'stale', '2026-04-01'),
+          (100, 'keep', '2026-04-03')
+        """)
+
+        val sourceDf = spark.read.format("delta").load(deltaPath)
+        tableUtils.insertPartitions(sourceDf, tableName)
+
+        val result = spark.table(tableName).orderBy("ds", "id").collect()
+        result.map(_.getAs[Int]("id")) should contain theSameElementsInOrderAs Seq(1, 3, 100)
+        result.map(_.getAs[String]("value")) should contain theSameElementsInOrderAs Seq(
+          "first_1",
+          "first_2",
+          "keep")
+      } finally {
+        spark.sql(s"DROP TABLE IF EXISTS $tableName")
+      }
+    }
+}


### PR DESCRIPTION
## Summary

When tables have deletion vectors (comes with liquid clsutering / new tables) the merge into carries through the delta table in the planner and fails with:

```
Cannot work with a non-pinned table snapshot of the TahoeFileIndex
```

By running `PrepareDeltaScan` before the merge into we can pin the table snapshot. This is a no-op on any non-delta or tables that do not have pinned versions. 

## Checklist
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Delta-to-Iceberg merge and write handling: enhanced preparation of Delta scans for various write and MERGE INTO workflows, better handling across table types and fallbacks.

* **Tests**
  * Added integration-style tests validating inserts from Delta sources (including deletion vectors) into Iceberg destinations, covering unpartitioned and partitioned targets.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zipline-ai/chronon/pull/1832)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->