### PR TITLE
[megatile 2.0] Add cumulated batch IR cache

### DIFF
--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/CumulatedBatchIr.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/CumulatedBatchIr.scala
@@ -1,0 +1,37 @@
+/*
+ *    Copyright (C) 2023 The Chronon Authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package ai.chronon.aggregator.windowing
+
+case class CumulatedBatchIr(columns: Array[CumulatedBatchColumn],
+                            collapsed: Array[Any],
+                            suffixColumnIndices: Array[Int])
+
+sealed trait CumulatedBatchColumn
+case class StaticBatchColumn(value: Any) extends CumulatedBatchColumn
+case class SuffixBatchColumn(timestamps: Array[Long], values: Array[Any], collapsed: Any) extends CumulatedBatchColumn
+
+case class CumulatedBatchOptions(skipSmallWindowBatchTails: Boolean)
+
+object CumulatedBatchOptions {
+  // Standard sawtooth serving only reads streaming data after batchEnd, so small windows
+  // still need their batch-side tail suffixes when they cross batchEnd.
+  val SawtoothServing: CumulatedBatchOptions = CumulatedBatchOptions(skipSmallWindowBatchTails = false)
+
+  // MegaTile serving keeps small windows fully in streaming megatiles; batch tails
+  // must be skipped there or they will be counted twice.
+  val MegaTileServing: CumulatedBatchOptions = CumulatedBatchOptions(skipSmallWindowBatchTails = true)
+}

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileAggregator.scala
@@ -11,6 +11,12 @@ class MegaTileAggregator(aggregations: Seq[Aggregation],
                          override val tailBufferMillis: Long = new Window(2, TimeUnit.DAYS).millis)
     extends SawtoothMutationAggregator(aggregations, inputSchema, resolution, tailBufferMillis) {
 
+  override def cumulateBatchIr(
+      batchIr: FinalBatchIr,
+      batchEndTs: Long,
+      options: CumulatedBatchOptions = CumulatedBatchOptions.MegaTileServing): CumulatedBatchIr =
+    super.cumulateBatchIr(batchIr, batchEndTs, options)
+
   // Per-column hop size: maps windowed column index → hop size in millis
   val columnHopSize: Array[Long] = windowMappings.map { mapping =>
     Option(mapping.aggregationPart.window) match {

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileMerger.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileMerger.scala
@@ -75,6 +75,39 @@ class MegaTileMerger(megaTileAgg: MegaTileAggregator) {
     val resultIr =
       if (batchIr != null) windowedAggregator.clone(batchIr.collapsed)
       else windowedAggregator.init
+
+    mergeDailyTileIrs(resultIr, dailyTileIrs, queryTs, batchEnd)
+
+    // Tail hops for large windowed columns (skips small + unwindowed)
+    if (batchIr != null) {
+      megaTileAgg.mergeTailHopsForBatchColumns(resultIr, queryTs, batchEnd, batchIr)
+    }
+
+    windowedAggregator.finalize(resultIr)
+  }
+
+  /** Merge a pre-cumulated batch tail IR + N daily streaming entries into a finalized result.
+    *
+    * This is equivalent to merge(FinalBatchIr, ...) except the selected batch tail hops
+    * have already been precomputed into one suffix per possible tail cutoff.
+    */
+  def mergeCumulatedBatch(cumulatedBatchIr: CumulatedBatchIr,
+                          dailyTileIrs: Seq[(Long, Array[Any])],
+                          queryTs: Long,
+                          batchEnd: Long): Array[Any] = {
+    val resultIr =
+      if (cumulatedBatchIr != null) megaTileAgg.selectCumulatedBatchCollapsedIr(cumulatedBatchIr)
+      else windowedAggregator.init
+
+    mergeDailyTileIrs(resultIr, dailyTileIrs, queryTs, batchEnd)
+    megaTileAgg.mergeCumulatedTailHops(resultIr, cumulatedBatchIr, queryTs)
+    windowedAggregator.finalize(resultIr)
+  }
+
+  private def mergeDailyTileIrs(ir: Array[Any],
+                                dailyTileIrs: Seq[(Long, Array[Any])],
+                                queryTs: Long,
+                                batchEnd: Long): Unit = {
     val oldestNoBatchDayStart = TsUtils.round(queryTs, DayMillis) - DayMillis
     val batchDayStart = TsUtils.round(batchEnd, DayMillis)
     val nonNullDailyTileIrs = dailyTileIrs.filter(_._2 != null).sortBy(_._1).reverse
@@ -88,24 +121,17 @@ class MegaTileMerger(megaTileAgg: MegaTileAggregator) {
         val newestAvailableIr = nonNullDailyTileIrs.collectFirst {
           case (dayStart, dayIr) if dayStart >= oldestNoBatchDayStart => dayIr
         }.orNull
-        resultIr(col) = if (newestAvailableIr != null) newestAvailableIr(col) else null
+        ir(col) = if (newestAvailableIr != null) newestAvailableIr(col) else null
       } else {
         // Large window / unwindowed: batch collapsed + streaming daily aggregates
-        // resultIr(col) already has batchIr.collapsed(col) from clone
+        // ir(col) already has either batchIr.collapsed(col) or the pre-cumulated batch tail.
         nonNullDailyTileIrs.reverseIterator.foreach { case (dayStart, dayIr) =>
           if (dayStart >= batchDayStart && dayIr(col) != null) {
-            resultIr(col) = windowedAggregator.columnAggregators(col).merge(resultIr(col), dayIr(col))
+            ir(col) = windowedAggregator.columnAggregators(col).merge(ir(col), dayIr(col))
           }
         }
       }
       col += 1
     }
-
-    // Tail hops for large windowed columns (skips small + unwindowed)
-    if (batchIr != null) {
-      megaTileAgg.mergeTailHopsForBatchColumns(resultIr, queryTs, batchEnd, batchIr)
-    }
-
-    windowedAggregator.finalize(resultIr)
   }
 }

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/SawtoothMutationAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/SawtoothMutationAggregator.scala
@@ -49,6 +49,26 @@ class SawtoothMutationAggregator(aggregations: Seq[Aggregation],
 
   val hopsAggregator = new HopsAggregatorBase(aggregations, inputSchema, resolution)
 
+  private[this] val emptyHopIrs = Array.empty[Array[Any]]
+  private[this] val cumulatedWindowMillis: Array[Long] =
+    windowMappings.map { mapping =>
+      val window = mapping.aggregationPart.window
+      if (window == null) 0L else window.millis
+    }
+  private[this] val cumulatedHopSizes: Array[Long] =
+    tailHopIndices.map(hopSizes)
+  private[this] val cumulatedSuffixReusable: Array[Boolean] =
+    windowMappings.map { mapping =>
+      mapping.aggregationPart.operation match {
+        case Operation.AVERAGE | Operation.VARIANCE | Operation.SKEW | Operation.KURTOSIS |
+            Operation.APPROX_UNIQUE_COUNT | Operation.APPROX_PERCENTILE | Operation.APPROX_FREQUENT_K |
+            Operation.APPROX_HEAVY_HITTERS_K | Operation.UNIQUE_TOP_K |
+            Operation.LAST_K | Operation.FIRST_K | Operation.TOP_K | Operation.BOTTOM_K =>
+          false
+        case _ => true
+      }
+    }
+
   def batchIrSchema: Array[(String, DataType)] = {
     val collapsedSchema = windowedAggregator.irSchema
 
@@ -125,6 +145,143 @@ class SawtoothMutationAggregator(aggregations: Seq[Aggregation],
   // Ready the snapshot aggregated data to be merged with mutations data.
   def finalizeSnapshot(batchIr: BatchIr): FinalBatchIr =
     FinalBatchIr(batchIr.collapsed, Option(batchIr.tailHops).map(hopsAggregator.toTimeSortedArray).orNull)
+
+  def cumulateBatchIr(batchIr: FinalBatchIr,
+                      batchEndTs: Long,
+                      options: CumulatedBatchOptions = CumulatedBatchOptions.SawtoothServing): CumulatedBatchIr = {
+    if (batchIr == null) return null
+
+    val columns = new Array[CumulatedBatchColumn](windowedAggregator.length)
+    val collapsedValues = new Array[Any](windowedAggregator.length)
+    val suffixColumnIndices = new Array[Int](windowedAggregator.length)
+    var suffixColumnCount = 0
+    var col = 0
+    while (col < windowedAggregator.length) {
+      val columnAggregator = windowedAggregator(col)
+      val window = windowMappings(col).aggregationPart.window
+      if (window == null) {
+        val collapsed = columnAggregator.clone(batchIr.collapsed(col))
+        collapsedValues(col) = collapsed
+        columns(col) = StaticBatchColumn(collapsed)
+      } else if (options.skipSmallWindowBatchTails && window.millis <= tailBufferMillis) {
+        collapsedValues(col) = null
+        columns(col) = StaticBatchColumn(null)
+      } else {
+        val tailHops = batchIr.tailHops
+        val hopIrs = if (tailHops == null) emptyHopIrs else tailHops(tailHopIndices(col))
+        val alignedCollapsed = alignedCollapsedBoundary(batchEndTs - window.millis, col)
+        val eligibleCount = firstHopGreaterOrEqual(hopIrs, alignedCollapsed)
+        val collapsed = columnAggregator.clone(batchIr.collapsed(col))
+        collapsedValues(col) = collapsed
+
+        if (eligibleCount == 0) {
+          columns(col) = StaticBatchColumn(collapsed)
+        } else {
+          val timestamps = new Array[Long](eligibleCount)
+          val values = new Array[Any](eligibleCount)
+          val baseIrIndex = baseIrIndices(col)
+          if (cumulatedSuffixReusable(col)) {
+            var tailSuffix: Any = null
+            var idx = eligibleCount - 1
+            while (idx >= 0) {
+              val hopIr = hopIrs(idx)
+              timestamps(idx) = hopTimestamp(hopIr)
+              val hopValue = columnAggregator.clone(hopIr(baseIrIndex))
+              tailSuffix = columnAggregator.merge(hopValue, tailSuffix)
+              values(idx) = columnAggregator.clone(tailSuffix)
+              idx -= 1
+            }
+          } else {
+            var startIdx = 0
+            while (startIdx < eligibleCount) {
+              timestamps(startIdx) = hopTimestamp(hopIrs(startIdx))
+              val suffixIrs = new Iterator[Any] {
+                private var idx = startIdx
+
+                override def hasNext: Boolean = idx < eligibleCount
+
+                override def next(): Any = {
+                  if (idx >= eligibleCount) throw new NoSuchElementException("next on empty iterator")
+                  val hopValue = hopIrs(idx)(baseIrIndex)
+                  idx += 1
+                  columnAggregator.clone(hopValue)
+                }
+              }
+              values(startIdx) = columnAggregator.bulkMerge(suffixIrs)
+              startIdx += 1
+            }
+          }
+
+          columns(col) = SuffixBatchColumn(timestamps, values, collapsed)
+          suffixColumnIndices(suffixColumnCount) = col
+          suffixColumnCount += 1
+        }
+      }
+      col += 1
+    }
+
+    CumulatedBatchIr(columns, collapsedValues, util.Arrays.copyOf(suffixColumnIndices, suffixColumnCount))
+  }
+
+  def selectCumulatedBatchIr(cumulatedBatchIr: CumulatedBatchIr, queryTs: Long): Array[Any] = {
+    val result = selectCumulatedBatchCollapsedIr(cumulatedBatchIr)
+    mergeCumulatedTailHops(result, cumulatedBatchIr, queryTs)
+    result
+  }
+
+  def selectCumulatedBatchCollapsedIr(cumulatedBatchIr: CumulatedBatchIr): Array[Any] = {
+    if (cumulatedBatchIr == null) return windowedAggregator.init
+
+    val result = new Array[Any](windowedAggregator.length)
+    var col = 0
+    while (col < windowedAggregator.length) {
+      result(col) = windowedAggregator(col).clone(cumulatedBatchIr.collapsed(col))
+      col += 1
+    }
+    result
+  }
+
+  def mergeCumulatedTailHops(ir: Array[Any], cumulatedBatchIr: CumulatedBatchIr, queryTs: Long): Array[Any] = {
+    if (ir == null || cumulatedBatchIr == null) return ir
+
+    val suffixColumnIndices = cumulatedBatchIr.suffixColumnIndices
+    var suffixIdx = 0
+    while (suffixIdx < suffixColumnIndices.length) {
+      val col = suffixColumnIndices(suffixIdx)
+      val suffixColumn = cumulatedBatchIr.columns(col).asInstanceOf[SuffixBatchColumn]
+      val timestamps = suffixColumn.timestamps
+      val queryTail = TsUtils.round(queryTs - cumulatedWindowMillis(col), cumulatedHopSizes(col))
+      val idx = firstGreaterOrEqual(timestamps, queryTail)
+      if (idx < timestamps.length) {
+        ir(col) = windowedAggregator(col).merge(ir(col), suffixColumn.values(idx))
+      }
+      suffixIdx += 1
+    }
+    ir
+  }
+
+  protected final def hopTimestamp(hopIr: Array[Any]): Long =
+    hopIr(hopIr.length - 1).asInstanceOf[Long]
+
+  private def firstHopGreaterOrEqual(hopIrs: Array[Array[Any]], target: Long): Int = {
+    var low = 0
+    var high = hopIrs.length
+    while (low < high) {
+      val mid = (low + high) >>> 1
+      if (hopTimestamp(hopIrs(mid)) < target) low = mid + 1 else high = mid
+    }
+    low
+  }
+
+  private def firstGreaterOrEqual(values: Array[Long], target: Long): Int = {
+    var low = 0
+    var high = values.length
+    while (low < high) {
+      val mid = (low + high) >>> 1
+      if (values(mid) < target) low = mid + 1 else high = mid
+    }
+    low
+  }
 
   /** Go through the aggregators and update or delete the intermediate with the information of the row if relevant.
     * Useful for both online and mutations

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/SawtoothOnlineAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/SawtoothOnlineAggregator.scala
@@ -125,6 +125,44 @@ class SawtoothOnlineAggregator(val batchEndTs: Long,
     resultIr
   }
 
+  def lambdaAggregateIrFromCumulatedBatch(cumulatedBatchIr: CumulatedBatchIr,
+                                          streamingRows: Iterator[Row],
+                                          queryTs: Long,
+                                          hasReversal: Boolean = false): Array[Any] = {
+    if (cumulatedBatchIr == null && streamingRows == null) return null
+    val headRows = Option(streamingRows).getOrElse(Array.empty[Row].iterator)
+
+    if (batchEndTs > queryTs) {
+      throw new IllegalArgumentException(s"Request time of $queryTs is less than batch time $batchEndTs")
+    }
+
+    val resultIr =
+      if (cumulatedBatchIr == null) windowedAggregator.init
+      else selectCumulatedBatchCollapsedIr(cumulatedBatchIr)
+
+    while (headRows.hasNext) {
+      val row = headRows.next()
+      val rowTs = row.ts
+
+      val shouldSelect = if (hasReversal) {
+        val mutationTs = row.mutationTs
+        val rowBeforeQuery = queryTs > rowTs && queryTs > mutationTs
+        val rowAfterBatchEnd = mutationTs >= batchEndTs
+        rowBeforeQuery && rowAfterBatchEnd
+      } else {
+        val rowBeforeQuery = queryTs > rowTs
+        val rowAfterBatchEnd = rowTs >= batchEndTs
+        rowBeforeQuery && rowAfterBatchEnd
+      }
+
+      if (shouldSelect) {
+        updateIr(resultIr, row, queryTs, hasReversal)
+      }
+    }
+    mergeCumulatedTailHops(resultIr, cumulatedBatchIr, queryTs)
+    resultIr
+  }
+
   def lambdaAggregateIrTiled(finalBatchIr: FinalBatchIr,
                              streamingTiledIrs: Iterator[TiledIr],
                              queryTs: Long): Array[Any] = {
@@ -152,6 +190,32 @@ class SawtoothOnlineAggregator(val batchEndTs: Long,
     resultIr
   }
 
+  def lambdaAggregateIrTiledFromCumulatedBatch(cumulatedBatchIr: CumulatedBatchIr,
+                                               streamingTiledIrs: Iterator[TiledIr],
+                                               queryTs: Long): Array[Any] = {
+    // null handling
+    if (cumulatedBatchIr == null && streamingTiledIrs == null) return null
+    val tiledIrs = Option(streamingTiledIrs).getOrElse(Array.empty[TiledIr].iterator)
+
+    if (batchEndTs > queryTs) {
+      throw new IllegalArgumentException(s"Request time of $queryTs is less than batch time $batchEndTs")
+    }
+
+    val resultIr =
+      if (cumulatedBatchIr == null) windowedAggregator.init
+      else selectCumulatedBatchCollapsedIr(cumulatedBatchIr)
+
+    while (tiledIrs.hasNext) {
+      val tiledIr = tiledIrs.next()
+      val tiledIrTs = tiledIr.ts
+      if (queryTs > tiledIrTs && tiledIrTs >= batchEndTs) {
+        updateIrTiled(resultIr, tiledIr, queryTs)
+      }
+    }
+    mergeCumulatedTailHops(resultIr, cumulatedBatchIr, queryTs)
+    resultIr
+  }
+
   def lambdaAggregateFinalized(finalBatchIr: FinalBatchIr,
                                streamingRows: Iterator[Row],
                                ts: Long,
@@ -159,11 +223,26 @@ class SawtoothOnlineAggregator(val batchEndTs: Long,
     windowedAggregator.finalize(lambdaAggregateIr(finalBatchIr, streamingRows, ts, hasReversal = hasReversal))
   }
 
+  def lambdaAggregateFinalizedFromCumulatedBatch(cumulatedBatchIr: CumulatedBatchIr,
+                                                 streamingRows: Iterator[Row],
+                                                 ts: Long,
+                                                 hasReversal: Boolean = false): Array[Any] = {
+    windowedAggregator.finalize(
+      lambdaAggregateIrFromCumulatedBatch(cumulatedBatchIr, streamingRows, ts, hasReversal))
+  }
+
   def lambdaAggregateFinalizedTiled(finalBatchIr: FinalBatchIr,
                                     streamingTiledIrs: Iterator[TiledIr],
                                     ts: Long): Array[Any] = {
     // TODO: Add support for mutations / hasReversal to the tiled implementation
     windowedAggregator.finalize(lambdaAggregateIrTiled(finalBatchIr, streamingTiledIrs, ts))
+  }
+
+  def lambdaAggregateFinalizedTiledFromCumulatedBatch(cumulatedBatchIr: CumulatedBatchIr,
+                                                      streamingTiledIrs: Iterator[TiledIr],
+                                                      ts: Long): Array[Any] = {
+    // TODO: Add support for mutations / hasReversal to the tiled implementation
+    windowedAggregator.finalize(lambdaAggregateIrTiledFromCumulatedBatch(cumulatedBatchIr, streamingTiledIrs, ts))
   }
 
   // example: window size = 30d

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/MegaTileMergerTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/MegaTileMergerTest.scala
@@ -126,6 +126,20 @@ class MegaTileMergerTest extends AnyFlatSpec {
 
     assertNull(merged(0))
     assertEquals(5L, merged(1))
+
+    val cumulatedBatchIr = megaTileAgg.cumulateBatchIr(finalBatchIr, batchEnd, CumulatedBatchOptions.MegaTileServing)
+    val cumulatedMerged = merger.mergeCumulatedBatch(
+      cumulatedBatchIr,
+      Seq(
+        TsUtils.round(queryTs, DayMillis) -> null,
+        (TsUtils.round(queryTs, DayMillis) - DayMillis) -> null
+      ),
+      queryTs,
+      batchEnd
+    )
+
+    assertNull(cumulatedMerged(0))
+    assertEquals(5L, cumulatedMerged(1))
   }
 
   def naiveAggregate(allEvents: Array[TestRow],
@@ -158,7 +172,8 @@ class MegaTileMergerTest extends AnyFlatSpec {
                               queryTimes: Array[Long],
                               aggregations: Seq[Aggregation],
                               schema: Seq[(String, DataType)],
-                              batchEnd: Long): Array[Array[Any]] = {
+                              batchEnd: Long,
+                              useCumulatedBatchIr: Boolean = false): Array[Array[Any]] = {
 
     val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
     val merger = new MegaTileMerger(megaTileAgg)
@@ -170,6 +185,10 @@ class MegaTileMergerTest extends AnyFlatSpec {
     var batchIr = onlineAgg.init
     batchEvents.foreach(row => batchIr = onlineAgg.update(batchIr, row))
     val finalBatchIr = onlineAgg.finalizeSnapshot(batchIr)
+    val cumulatedBatchIr =
+      if (useCumulatedBatchIr)
+        megaTileAgg.cumulateBatchIr(finalBatchIr, batchEnd, CumulatedBatchOptions.MegaTileServing)
+      else null
 
     // 2. Simulate Flink: bucket ALL events into small tiles per tier
     val tiles: Map[Long, mutable.Map[Long, Array[Any]]] =
@@ -206,11 +225,53 @@ class MegaTileMergerTest extends AnyFlatSpec {
       val yesterdayIr = megaTileAgg.buildMegaTileIr(tiles, now = todayStart, batchEnd = yesterdayStart)
 
       // Merge using the fetcher logic
-      resultsByQueryTs(queryTs) = merger.merge(finalBatchIr, todayIr, yesterdayIr, todayStart, queryTs, batchEnd)
+      resultsByQueryTs(queryTs) =
+        if (useCumulatedBatchIr)
+          merger.mergeCumulatedBatch(cumulatedBatchIr,
+                                     Seq(todayStart -> todayIr, yesterdayStart -> yesterdayIr),
+                                     queryTs,
+                                     batchEnd)
+        else merger.merge(finalBatchIr, todayIr, yesterdayIr, todayStart, queryTs, batchEnd)
     }
 
     // Return results in original query order
     queryTimes.map(resultsByQueryTs)
+  }
+
+  it should "match raw batch tail merging with cumulated batch tails" in {
+    val (events, schema) = generateEvents(10, 10000)
+    val maxTs = events.map(_.ts).max
+    val batchEnd = TsUtils.round(maxTs - DayMillis, DayMillis)
+
+    val aggregations: Seq[Aggregation] = Seq(
+      Builders.Aggregation(Operation.SUM, "num", AllWindows),
+      Builders.Aggregation(Operation.COUNT, "num", AllWindows),
+      Builders.Aggregation(Operation.AVERAGE, "amount", AllWindows),
+      Builders.Aggregation(Operation.VARIANCE, "amount", AllWindows),
+      Builders.Aggregation(Operation.SKEW, "amount", AllWindows),
+      Builders.Aggregation(Operation.KURTOSIS, "amount", AllWindows),
+      Builders.Aggregation(Operation.MIN, "num", AllWindows),
+      Builders.Aggregation(Operation.MAX, "num", AllWindows),
+      Builders.Aggregation(Operation.UNIQUE_COUNT, "num", AllWindows),
+      Builders.Aggregation(Operation.APPROX_UNIQUE_COUNT, "num", AllWindows),
+      Builders.Aggregation(Operation.TOP_K, "num", AllWindows, argMap = Map("k" -> "3")),
+      Builders.Aggregation(Operation.BOTTOM_K, "num", AllWindows, argMap = Map("k" -> "3")),
+      Builders.Aggregation(Operation.LAST, "num", AllWindows),
+      Builders.Aggregation(Operation.FIRST, "num", AllWindows),
+      Builders.Aggregation(Operation.LAST_K, "num", AllWindows, argMap = Map("k" -> "3")),
+      Builders.Aggregation(Operation.FIRST_K, "num", AllWindows, argMap = Map("k" -> "3"))
+    )
+
+    val queryTimes = Array(
+      batchEnd + 6 * 3600 * 1000L,
+      batchEnd + 14 * 3600 * 1000L,
+      batchEnd + 23 * 3600 * 1000L
+    ).filter(_ <= maxTs)
+
+    val rawResults = megaTileMergerAggregate(events, queryTimes, aggregations, schema, batchEnd)
+    val cumulatedResults =
+      megaTileMergerAggregate(events, queryTimes, aggregations, schema, batchEnd, useCumulatedBatchIr = true)
+    compareResults(cumulatedResults, rawResults, queryTimes, "cumulated_batch_tail")
   }
 
   it should "match naive aggregation with batch fresh" in {

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/SawtoothOnlineAggregatorTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/SawtoothOnlineAggregatorTest.scala
@@ -17,7 +17,13 @@
 package ai.chronon.aggregator.test
 
 import ai.chronon.aggregator.test.SawtoothAggregatorTest.sawtoothAggregate
-import ai.chronon.aggregator.windowing.{FinalBatchIr, FiveMinuteResolution, SawtoothOnlineAggregator}
+import ai.chronon.aggregator.windowing.{
+  CumulatedBatchOptions,
+  FinalBatchIr,
+  FiveMinuteResolution,
+  SawtoothOnlineAggregator,
+  TiledIr
+}
 import ai.chronon.api.Extensions.{WindowOps, WindowUtils}
 import ai.chronon.api._
 import com.google.gson.Gson
@@ -127,6 +133,19 @@ class SawtoothOnlineAggregatorTest extends AnyFlatSpec {
 
     val sawtoothIrs = sawtoothAggregate(events, queries, aggregations, schema)
     val onlineAggregator = new SawtoothOnlineAggregator(batchEndTs, aggregations, schema, FiveMinuteResolution)
+    val mergeTreeSensitiveOperations = Set(
+      Operation.AVERAGE,
+      Operation.APPROX_UNIQUE_COUNT,
+      Operation.VARIANCE,
+      Operation.SKEW,
+      Operation.KURTOSIS,
+      Operation.APPROX_PERCENTILE,
+      Operation.APPROX_FREQUENT_K,
+      Operation.APPROX_HEAVY_HITTERS_K,
+      Operation.UNIQUE_TOP_K
+    )
+    val cumulatedCacheSafeAggregations =
+      aggregations.filterNot(aggregation => mergeTreeSensitiveOperations.contains(aggregation.operation))
     val (events1, events2) = events.splitAt(eventCount / 2)
     val batchIr1 = events1.foldLeft(onlineAggregator.init)(onlineAggregator.update)
     val batchIr2 = events2.foldLeft(onlineAggregator.init)(onlineAggregator.update)
@@ -136,10 +155,74 @@ class SawtoothOnlineAggregatorTest extends AnyFlatSpec {
     val onlineIrs = queries.map(onlineAggregator.lambdaAggregateIr(denormBatchIr, windowHeadEvents.iterator, _))
 
     val gson = new Gson()
+    def assertJsonEquals(label: String,
+                         expected: Array[Any],
+                         actual: Array[Any],
+                         aggregator: SawtoothOnlineAggregator): Unit = {
+      val expectedStr = gson.toJson(expected)
+      val actualStr = gson.toJson(actual)
+      if (expectedStr != actualStr) {
+        val mismatch = expected.indices
+          .find { idx =>
+            gson.toJson(expected(idx)) != gson.toJson(actual(idx))
+          }
+          .getOrElse(-1)
+        val columnName =
+          if (mismatch >= 0) aggregator.windowedAggregator.outputSchema(mismatch)._1 else "unknown"
+        assertEquals(s"$label mismatch at column $mismatch ($columnName)", expectedStr, actualStr)
+      }
+    }
+
     for (i <- queries.indices) {
-      val onlineStr = gson.toJson(onlineAggregator.windowedAggregator.finalize(onlineIrs(i)))
-      val sawtoothStr = gson.toJson(onlineAggregator.windowedAggregator.finalize(sawtoothIrs(i)))
-      assertEquals(sawtoothStr, onlineStr)
+      val onlineFinal = onlineAggregator.windowedAggregator.finalize(onlineIrs(i))
+      val sawtoothFinal = onlineAggregator.windowedAggregator.finalize(sawtoothIrs(i))
+      assertJsonEquals(s"raw online at query ${queries(i)}", sawtoothFinal, onlineFinal, onlineAggregator)
+    }
+
+    val cumulatedAggregator =
+      new SawtoothOnlineAggregator(batchEndTs, cumulatedCacheSafeAggregations, schema, FiveMinuteResolution)
+    val safeBatchIr1 = events1.foldLeft(cumulatedAggregator.init)(cumulatedAggregator.update)
+    val safeBatchIr2 = events2.foldLeft(cumulatedAggregator.init)(cumulatedAggregator.update)
+    val safeBatchIr = cumulatedAggregator.normalizeBatchIr(cumulatedAggregator.merge(safeBatchIr1, safeBatchIr2))
+    val safeDenormBatchIr = cumulatedAggregator.denormalizeBatchIr(safeBatchIr)
+    val cumulatedBatchIr =
+      cumulatedAggregator.cumulateBatchIr(safeDenormBatchIr, batchEndTs, CumulatedBatchOptions.SawtoothServing)
+    val safeOnlineIrs =
+      queries.map(cumulatedAggregator.lambdaAggregateIr(safeDenormBatchIr, windowHeadEvents.iterator, _))
+    val cumulatedOnlineIrs =
+      queries.map(
+        cumulatedAggregator.lambdaAggregateIrFromCumulatedBatch(cumulatedBatchIr, windowHeadEvents.iterator, _))
+
+    for (i <- queries.indices) {
+      val onlineFinal = cumulatedAggregator.windowedAggregator.finalize(safeOnlineIrs(i))
+      val cumulatedOnlineFinal = cumulatedAggregator.windowedAggregator.finalize(cumulatedOnlineIrs(i))
+      assertJsonEquals(s"cumulated row at query ${queries(i)}", onlineFinal, cumulatedOnlineFinal, cumulatedAggregator)
+    }
+
+    def streamingTiles(queryTs: Long): Seq[TiledIr] =
+      windowHeadEvents
+        .filter(row => row.ts < queryTs)
+        .groupBy(row => TsUtils.round(row.ts, WindowUtils.Hour.millis))
+        .map {
+          case (tileStart, rows) =>
+            val ir = cumulatedAggregator.windowedAggregator.init
+            rows.foreach(cumulatedAggregator.windowedAggregator.update(ir, _))
+            TiledIr(tileStart, ir)
+        }
+        .toSeq
+
+    def cloneTiles(tiles: Seq[TiledIr]): Iterator[TiledIr] =
+      tiles.map(tile => TiledIr(tile.ts, cumulatedAggregator.windowedAggregator.clone(tile.ir))).iterator
+
+    queries.take(20).foreach { queryTs =>
+      val tiles = streamingTiles(queryTs)
+      val rawTiled =
+        cumulatedAggregator.lambdaAggregateFinalizedTiled(safeDenormBatchIr, cloneTiles(tiles), queryTs)
+      val cumulatedTiled =
+        cumulatedAggregator.lambdaAggregateFinalizedTiledFromCumulatedBatch(cumulatedBatchIr,
+                                                                            cloneTiles(tiles),
+                                                                            queryTs)
+      assertJsonEquals(s"cumulated tiled at query $queryTs", rawTiled, cumulatedTiled, cumulatedAggregator)
     }
   }
 

--- a/online/src/main/scala/ai/chronon/online/GroupByServingInfoParsed.scala
+++ b/online/src/main/scala/ai/chronon/online/GroupByServingInfoParsed.scala
@@ -16,7 +16,15 @@
 
 package ai.chronon.online
 
-import ai.chronon.aggregator.windowing.{MegaTileAggregator, MegaTileMerger, ResolutionUtils, SawtoothOnlineAggregator}
+import ai.chronon.aggregator.windowing.{
+  CumulatedBatchIr,
+  CumulatedBatchOptions,
+  FinalBatchIr,
+  MegaTileAggregator,
+  MegaTileMerger,
+  ResolutionUtils,
+  SawtoothOnlineAggregator
+}
 import ai.chronon.api.Constants.{ReversalField, TimeField}
 import ai.chronon.api.Extensions.{GroupByOps, MetadataOps, WindowOps, WindowUtils}
 import ai.chronon.api.ScalaJavaConversions.ListOps
@@ -48,6 +56,9 @@ class GroupByServingInfoParsed(val groupByServingInfo: GroupByServingInfo)
 
   // caching groupBy helper to avoid re-computing batchDataSet,streamingDataset & inferred accuracy
   lazy val groupByOps = new GroupByOps(groupByServingInfo.groupBy)
+
+  lazy val isCumulatedBatchIrCacheSafe: Boolean =
+    GroupByServingInfoParsed.isCumulatedBatchIrCacheSafe(groupBy)
 
   lazy val irChrononSchema: StructType =
     StructType.from(s"${groupBy.metaData.cleanName}_IR", aggregator.batchIrSchema)
@@ -106,6 +117,12 @@ class GroupByServingInfoParsed(val groupByServingInfo: GroupByServingInfo)
 
   lazy val megaTileCodec: MegaTileCodec = new MegaTileCodec(groupBy, valueInputSchema)
 
+  def cumulateBatchIrForServing(finalBatchIr: FinalBatchIr): CumulatedBatchIr =
+    if (groupByOps.isMegaTilingEnabled)
+      megaTileAggregator.cumulateBatchIr(finalBatchIr, batchEndTsMillis, CumulatedBatchOptions.MegaTileServing)
+    else
+      aggregator.cumulateBatchIr(finalBatchIr, batchEndTsMillis, CumulatedBatchOptions.SawtoothServing)
+
   // End mega tiling specific variables
 
   def outputChrononSchema: StructType =
@@ -155,4 +172,19 @@ class GroupByServingInfoParsed(val groupByServingInfo: GroupByServingInfo)
       case DataModel.ENTITIES => mutationChrononSchema
     }
   }
+}
+
+object GroupByServingInfoParsed {
+  private[online] def isCumulatedBatchIrCacheSafe(groupBy: GroupBy): Boolean =
+    Option(groupBy)
+      .flatMap(groupBy => Option(groupBy.aggregations))
+      .forall(_.toScala.forall { aggregation =>
+        aggregation.operation match {
+          case Operation.AVERAGE | Operation.VARIANCE | Operation.SKEW | Operation.KURTOSIS |
+              Operation.APPROX_UNIQUE_COUNT | Operation.APPROX_PERCENTILE | Operation.APPROX_FREQUENT_K |
+              Operation.APPROX_HEAVY_HITTERS_K | Operation.UNIQUE_TOP_K =>
+            false
+          case _ => true
+        }
+      })
 }

--- a/online/src/main/scala/ai/chronon/online/fetcher/FetcherCache.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/FetcherCache.scala
@@ -1,15 +1,18 @@
 package ai.chronon.online.fetcher
 
-import ai.chronon.aggregator.windowing.FinalBatchIr
+import ai.chronon.aggregator.windowing.{CumulatedBatchIr, FinalBatchIr}
 import ai.chronon.api.GroupBy
 import ai.chronon.online.KVStore.{GetRequest, TimedValue}
 import ai.chronon.online.fetcher.FetcherCache._
 import ai.chronon.online.GroupByServingInfoParsed
-import ai.chronon.online.metrics.Metrics
+import ai.chronon.online.metrics.{FlexibleExecutionContext, Metrics}
 import com.github.benmanes.caffeine.cache.{Cache => CaffeineCache}
 import org.slf4j.{Logger, LoggerFactory}
 
-import scala.util.{Success, Try}
+import java.util.concurrent.ConcurrentHashMap
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.control.NonFatal
+import scala.util.{Failure, Success, Try}
 
 /*
  * FetcherCache is an extension to FetcherBase that provides caching functionality. It caches KV store
@@ -26,6 +29,7 @@ trait FetcherCache {
   @transient private lazy val logger: Logger = LoggerFactory.getLogger(getClass)
 
   val batchIrCacheName = "batch_cache"
+  val cumulatedBatchIrCacheName = "cumulated_batch_cache"
   val defaultBatchIrCacheSize = "10000"
 
   val configuredBatchIrCacheSize: Option[Int] =
@@ -37,12 +41,26 @@ trait FetcherCache {
   val maybeBatchIrCache: Option[BatchIrCache] =
     configuredBatchIrCacheSize
       .map(size => new BatchIrCache(batchIrCacheName, size))
+  val maybeCumulatedBatchIrCache: Option[CumulatedBatchIrCache] =
+    configuredBatchIrCacheSize
+      .map(size => new CumulatedBatchIrCache(cumulatedBatchIrCacheName, size))
+  @transient private lazy val inFlightCumulatedBatchIrBuilds =
+    new ConcurrentHashMap[BatchIrCache.Key, java.lang.Boolean]()
 
   // Caching needs to be configured globally with a cache size > 0
   def isCacheSizeConfigured: Boolean = maybeBatchIrCache.isDefined
 
   // Caching needs to be enabled for the specific groupBy
   def isCachingEnabled(groupBy: GroupBy): Boolean = false
+
+  protected def cumulatedBatchIrBuildExecutionContext: ExecutionContext =
+    FetcherCache.cumulatedBatchIrBuildExecutionContext
+
+  protected lazy val cumulatedBatchIrMetricsContext: Metrics.Context =
+    caffeineMetricsContext.withSuffix(cumulatedBatchIrCacheName)
+
+  def isCumulatedBatchIrCachingEnabled(groupBy: GroupBy): Boolean =
+    isCachingEnabled(groupBy) && GroupByServingInfoParsed.isCumulatedBatchIrCacheSafe(groupBy)
 
   protected val caffeineMetricsContext: Metrics.Context = Metrics.Context(Metrics.Environment.JoinFetching)
 
@@ -111,7 +129,69 @@ trait FetcherCache {
         cachedResponse match {
           case CachedFinalIrBatchResponse(finalBatchIr: FinalBatchIr) => finalBatchIr
           case CachedMapBatchResponse(_: Map[String, AnyRef])         => decodingFunction(batchBytes, servingInfo)
+      }
+    }
+  }
+
+  private[online] def getCumulatedBatchIrFromBatchIr(finalBatchIr: FinalBatchIr,
+                                                     servingInfo: GroupByServingInfoParsed,
+                                                     keys: Map[String, Any]): Option[CumulatedBatchIr] = {
+    if (finalBatchIr == null || !isCachingEnabled(servingInfo.groupBy) || !servingInfo.isCumulatedBatchIrCacheSafe) {
+      return None
+    }
+
+    val batchRequestCacheKey =
+      BatchIrCache.Key(servingInfo.groupByOps.batchDataset, keys, servingInfo.batchEndTsMillis)
+    maybeCumulatedBatchIrCache match {
+      case None => None
+      case Some(cache) =>
+        val cumulatedBatchIr = cache.cache.getIfPresent(batchRequestCacheKey)
+        if (cumulatedBatchIr != null) {
+          cumulatedBatchIrMetricsContext.increment("hits")
+          Some(cumulatedBatchIr)
+        } else {
+          cumulatedBatchIrMetricsContext.increment("misses")
+          scheduleCumulatedBatchIrBuild(batchRequestCacheKey,
+                                        finalBatchIr,
+                                        servingInfo,
+                                        cache,
+                                        cumulatedBatchIrMetricsContext)
+          None
         }
+    }
+  }
+
+  private def scheduleCumulatedBatchIrBuild(batchRequestCacheKey: BatchIrCache.Key,
+                                            finalBatchIr: FinalBatchIr,
+                                            servingInfo: GroupByServingInfoParsed,
+                                            cache: CumulatedBatchIrCache,
+                                            metricsContext: Metrics.Context): Unit = {
+    if (inFlightCumulatedBatchIrBuilds.putIfAbsent(batchRequestCacheKey, java.lang.Boolean.TRUE) != null) {
+      metricsContext.increment("async_build_in_flight")
+      return
+    }
+
+    metricsContext.increment("async_build_scheduled")
+    try {
+      Future {
+        val buildStartTime = System.currentTimeMillis()
+        val cumulatedBatchIr = servingInfo.cumulateBatchIrForServing(finalBatchIr)
+        cache.cache.put(batchRequestCacheKey, cumulatedBatchIr)
+        metricsContext.distribution("async_build.latency.millis", System.currentTimeMillis() - buildStartTime)
+      }(cumulatedBatchIrBuildExecutionContext).andThen {
+        case Success(_) =>
+          metricsContext.increment("async_build_successes")
+          inFlightCumulatedBatchIrBuilds.remove(batchRequestCacheKey)
+        case Failure(ex) =>
+          metricsContext.increment("async_build_failures")
+          metricsContext.incrementException(ex)(logger)
+          inFlightCumulatedBatchIrBuilds.remove(batchRequestCacheKey)
+      }(cumulatedBatchIrBuildExecutionContext)
+    } catch {
+      case NonFatal(ex) =>
+        metricsContext.increment("async_build_failures")
+        metricsContext.incrementException(ex)(logger)
+        inFlightCumulatedBatchIrBuilds.remove(batchRequestCacheKey)
     }
   }
 
@@ -146,6 +226,10 @@ trait FetcherCache {
               metricsContext.increment(s"${batchIrCacheName}_gb_hits")
               Map(batchRequest -> cachedIr)
 
+            case _ =>
+              metricsContext.increment(s"${batchIrCacheName}_gb_misses")
+              empty
+
           }
 
         case _ => empty
@@ -156,11 +240,21 @@ trait FetcherCache {
 }
 
 object FetcherCache {
+  private[online] lazy val cumulatedBatchIrBuildExecutionContext: ExecutionContext =
+    FlexibleExecutionContext.buildExecutionContext
+
   private[online] class BatchIrCache(val cacheName: String, val maximumSize: Int = 10000) {
     import BatchIrCache._
 
     val cache: CaffeineCache[Key, Value] =
       LRUCache[Key, Value](cacheName = cacheName, maximumSize = maximumSize)
+  }
+
+  private[online] class CumulatedBatchIrCache(val cacheName: String, val maximumSize: Int = 10000) {
+    import BatchIrCache._
+
+    val cache: CaffeineCache[Key, CumulatedBatchIr] =
+      LRUCache[Key, CumulatedBatchIr](cacheName = cacheName, maximumSize = maximumSize)
   }
 
   private[online] object BatchIrCache {

--- a/online/src/main/scala/ai/chronon/online/fetcher/GroupByFetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/GroupByFetcher.scala
@@ -189,6 +189,8 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
     // Collect cache metrics once per fetchGroupBys call; Caffeine metrics aren't tagged by groupBy
     maybeBatchIrCache.foreach(cache =>
       LRUCache.collectCaffeineCacheMetrics(caffeineMetricsContext, cache.cache, cache.cacheName))
+    maybeCumulatedBatchIrCache.foreach(cache =>
+      LRUCache.collectCaffeineCacheMetrics(caffeineMetricsContext, cache.cache, cache.cacheName))
 
     val allRequestsToFetch: Seq[GetRequest] = groupByRequestToKvRequest.flatMap {
       case (_,

--- a/online/src/main/scala/ai/chronon/online/fetcher/GroupByResponseHandler.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/GroupByResponseHandler.scala
@@ -148,7 +148,8 @@ class GroupByResponseHandler(fetchContext: FetchContext, metadataStore: Metadata
                                   streamingResponses,
                                   mutations,
                                   aggregator,
-                                  batchIr)
+                                  batchIr,
+                                  requestContext.keys)
     }
   }
 
@@ -157,7 +158,8 @@ class GroupByResponseHandler(fetchContext: FetchContext, metadataStore: Metadata
                                           streamingResponses: Seq[TimedValue],
                                           mutations: Boolean,
                                           aggregator: SawtoothOnlineAggregator,
-                                          batchIr: FinalBatchIr): Array[Any] = {
+                                          batchIr: FinalBatchIr,
+                                          keys: Map[String, Any]): Array[Any] = {
 
     val selectedCodec = servingInfo.groupByOps.dataModel match {
       case DataModel.EVENTS   => servingInfo.valueAvroCodec
@@ -200,7 +202,15 @@ class GroupByResponseHandler(fetchContext: FetchContext, metadataStore: Metadata
                      |""".stripMargin)
     }
 
-    aggregator.lambdaAggregateFinalized(batchIr, streamingRows.iterator, queryTimeMs, mutations)
+    val cumulatedBatchIr = getCumulatedBatchIrFromBatchIr(batchIr, servingInfo, keys).orNull
+    if (cumulatedBatchIr != null) {
+      aggregator.lambdaAggregateFinalizedFromCumulatedBatch(cumulatedBatchIr,
+                                                            streamingRows.iterator,
+                                                            queryTimeMs,
+                                                            mutations)
+    } else {
+      aggregator.lambdaAggregateFinalized(batchIr, streamingRows.iterator, queryTimeMs, mutations)
+    }
   }
 
   private def mergeTiledIrsFromStreaming(requestContext: RequestContext,
@@ -258,7 +268,15 @@ class GroupByResponseHandler(fetchContext: FetchContext, metadataStore: Metadata
     }
 
     val aggregatorStartTime = System.currentTimeMillis()
-    val result = aggregator.lambdaAggregateFinalizedTiled(batchIr, streamingIrs, requestContext.queryTimeMs)
+    val cumulatedBatchIr = getCumulatedBatchIrFromBatchIr(batchIr, servingInfo, requestContext.keys).orNull
+    val result =
+      if (cumulatedBatchIr != null) {
+        aggregator.lambdaAggregateFinalizedTiledFromCumulatedBatch(cumulatedBatchIr,
+                                                                   streamingIrs,
+                                                                   requestContext.queryTimeMs)
+      } else {
+        aggregator.lambdaAggregateFinalizedTiled(batchIr, streamingIrs, requestContext.queryTimeMs)
+      }
     requestContext.metricsContext.distribution("group_by.aggregator.latency.millis",
                                                System.currentTimeMillis() - aggregatorStartTime)
     result
@@ -317,8 +335,15 @@ class GroupByResponseHandler(fetchContext: FetchContext, metadataStore: Metadata
     }
 
     val aggregatorStartTime = System.currentTimeMillis()
+    val cumulatedBatchIr = getCumulatedBatchIrFromBatchIr(batchIr, servingInfo, requestContext.keys).orNull
     val result =
-      servingInfo.megaTileMerger.merge(batchIr, dailyTileIrs, requestContext.queryTimeMs, servingInfo.batchEndTsMillis)
+      if (cumulatedBatchIr != null) {
+        servingInfo.megaTileMerger
+          .mergeCumulatedBatch(cumulatedBatchIr, dailyTileIrs, requestContext.queryTimeMs, servingInfo.batchEndTsMillis)
+      } else {
+        servingInfo.megaTileMerger
+          .merge(batchIr, dailyTileIrs, requestContext.queryTimeMs, servingInfo.batchEndTsMillis)
+      }
     requestContext.metricsContext.distribution("group_by.aggregator.latency.millis",
                                                System.currentTimeMillis() - aggregatorStartTime)
     result

--- a/online/src/test/scala/ai/chronon/online/test/FetcherCacheTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/FetcherCacheTest.scala
@@ -1,18 +1,26 @@
 package ai.chronon.online
 
-import ai.chronon.aggregator.windowing.FinalBatchIr
-import ai.chronon.api.Extensions.GroupByOps
-import ai.chronon.api.GroupBy
+import ai.chronon.aggregator.windowing.{
+  CumulatedBatchOptions,
+  FinalBatchIr,
+  MegaTileAggregator,
+  SawtoothOnlineAggregator
+}
+import ai.chronon.api.Extensions.{GroupByOps, WindowOps}
+import ai.chronon.api.{Builders, GroupBy, GroupByServingInfo, LongType, OnlineStrategy, Operation, TimeUnit, Window}
 import ai.chronon.online.fetcher.Fetcher.Request
 import ai.chronon.online.fetcher.FetcherCache.BatchIrCache
 import ai.chronon.online.fetcher.FetcherCache.BatchResponses
 import ai.chronon.online.fetcher.FetcherCache.CachedMapBatchResponse
+import ai.chronon.online.fetcher.FetcherCache.CumulatedBatchIrCache
 import ai.chronon.online.KVStore.TimedValue
 import ai.chronon.online.metrics.Metrics.Context
 import ai.chronon.online.fetcher.LambdaKvRequest
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito
 import org.mockito.Mockito._
@@ -20,6 +28,7 @@ import org.mockito.stubbing.Stubber
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.mockito.MockitoSugar
 
+import scala.concurrent.ExecutionContext
 import scala.collection.JavaConverters._
 import scala.util.Failure
 import scala.util.Success
@@ -34,10 +43,136 @@ trait MockitoHelper extends MockitoSugar {
 }
 
 class FetcherCacheTest extends AnyFlatSpec with MockitoHelper {
-  class TestableFetcherCache(cache: Option[BatchIrCache]) extends fetcher.FetcherCache {
+  private val directExecutionContext: ExecutionContext =
+    ExecutionContext.fromExecutor(new java.util.concurrent.Executor {
+      override def execute(command: Runnable): Unit = command.run()
+    })
+
+  class TestableFetcherCache(cache: Option[BatchIrCache], cumulatedCache: Option[CumulatedBatchIrCache] = None)
+      extends fetcher.FetcherCache {
     override val maybeBatchIrCache: Option[BatchIrCache] = cache
+    override val maybeCumulatedBatchIrCache: Option[CumulatedBatchIrCache] = cumulatedCache
+    override protected def cumulatedBatchIrBuildExecutionContext: ExecutionContext = directExecutionContext
   }
   val batchIrCacheMaximumSize = 50
+
+  it should "cumulated batch ir caching supports order-sensitive limit aggregations" in {
+    val fetcherCache = new TestableFetcherCache(None) {
+      override def isCachingEnabled(groupBy: GroupBy) = true
+    }
+    val windows = Seq(new Window(7, TimeUnit.DAYS))
+
+    val sumGroupBy = Builders.GroupBy(
+      aggregations = Seq(Builders.Aggregation(Operation.SUM, "value", windows))
+    )
+    val lastKGroupBy = Builders.GroupBy(
+      aggregations = Seq(Builders.Aggregation(Operation.LAST_K, "value", windows, argMap = Map("k" -> "2")))
+    )
+    val firstKGroupBy = Builders.GroupBy(
+      aggregations = Seq(Builders.Aggregation(Operation.FIRST_K, "value", windows, argMap = Map("k" -> "2")))
+    )
+    val approxUniqueCountGroupBy = Builders.GroupBy(
+      aggregations = Seq(Builders.Aggregation(Operation.APPROX_UNIQUE_COUNT, "value", windows))
+    )
+    val averageGroupBy = Builders.GroupBy(
+      aggregations = Seq(Builders.Aggregation(Operation.AVERAGE, "value", windows))
+    )
+
+    assertTrue(fetcherCache.isCumulatedBatchIrCachingEnabled(sumGroupBy))
+    assertTrue(fetcherCache.isCumulatedBatchIrCachingEnabled(lastKGroupBy))
+    assertTrue(fetcherCache.isCumulatedBatchIrCachingEnabled(firstKGroupBy))
+    assertFalse(fetcherCache.isCumulatedBatchIrCachingEnabled(approxUniqueCountGroupBy))
+    assertFalse(fetcherCache.isCumulatedBatchIrCachingEnabled(averageGroupBy))
+  }
+
+  it should "cumulated batch ir cache miss builds asynchronously and falls back" in {
+    val cumulatedCache = new CumulatedBatchIrCache("test_cumulated", batchIrCacheMaximumSize)
+    val fetcherCache = new TestableFetcherCache(None, Some(cumulatedCache)) {
+      override def isCachingEnabled(groupBy: GroupBy) = true
+    }
+
+    val windows = Seq(new Window(7, TimeUnit.DAYS))
+    val aggregations = Seq(Builders.Aggregation(Operation.SUM, "value", windows))
+    val groupBy = Builders.GroupBy(metaData = Builders.MetaData(name = "test_group_by"), aggregations = aggregations)
+    val batchEndMillis = new Window(10, TimeUnit.DAYS).millis
+    val testMegaTileAggregator = new MegaTileAggregator(aggregations, Seq("value" -> LongType))
+    val groupByServingInfo = new GroupByServingInfo()
+    groupByServingInfo.setGroupBy(groupBy)
+    val servingInfo = new GroupByServingInfoParsed(groupByServingInfo) {
+      override lazy val batchEndTsMillis: Long = batchEndMillis
+      override lazy val groupByOps: GroupByOps = new GroupByOps(groupBy)
+      override lazy val megaTileAggregator: MegaTileAggregator = testMegaTileAggregator
+      override def cumulateBatchIrForServing(finalBatchIr: FinalBatchIr) =
+        testMegaTileAggregator.cumulateBatchIr(finalBatchIr, batchEndMillis, CumulatedBatchOptions.MegaTileServing)
+    }
+
+    val tailHops = Array(Array.empty[Array[Any]], Array.empty[Array[Any]], Array.empty[Array[Any]])
+    val finalBatchIr = FinalBatchIr(Array[Any](1L), tailHops)
+    val keys = Map("key" -> "value")
+
+    assertFalse(fetcherCache.getCumulatedBatchIrFromBatchIr(finalBatchIr, servingInfo, keys).isDefined)
+
+    val cachedCumulatedBatchIr = fetcherCache.getCumulatedBatchIrFromBatchIr(finalBatchIr, servingInfo, keys)
+    assertTrue(cachedCumulatedBatchIr.isDefined)
+    assertEquals(1L, testMegaTileAggregator.selectCumulatedBatchIr(cachedCumulatedBatchIr.get, batchEndMillis).head)
+  }
+
+  it should "cumulated batch ir cache build uses serving mode for small windows" in {
+    val windows = Seq(new Window(1, TimeUnit.HOURS))
+    val aggregations = Seq(Builders.Aggregation(Operation.SUM, "value", windows))
+    val schema = Seq("value" -> LongType)
+    val batchEndMillis = new Window(10, TimeUnit.DAYS).millis
+    val queryTs = batchEndMillis
+    val keys = Map("key" -> "value")
+
+    def smallWindowBatchIr: FinalBatchIr = {
+      val fiveMinuteHops = Array(
+        Array[Any](7L, batchEndMillis - 30 * 60 * 1000L),
+        Array[Any](11L, batchEndMillis - 20 * 60 * 1000L)
+      )
+      FinalBatchIr(Array[Any](null), Array(Array.empty[Array[Any]], Array.empty[Array[Any]], fiveMinuteHops))
+    }
+
+    def servingInfo(groupBy: GroupBy,
+                    testAggregator: SawtoothOnlineAggregator,
+                    testMegaTileAggregator: MegaTileAggregator): GroupByServingInfoParsed = {
+      val groupByServingInfo = new GroupByServingInfo()
+      groupByServingInfo.setGroupBy(groupBy)
+      new GroupByServingInfoParsed(groupByServingInfo) {
+        override lazy val batchEndTsMillis: Long = batchEndMillis
+        override lazy val groupByOps: GroupByOps = new GroupByOps(groupBy)
+        override lazy val aggregator: SawtoothOnlineAggregator = testAggregator
+        override lazy val megaTileAggregator: MegaTileAggregator = testMegaTileAggregator
+      }
+    }
+
+    def cachedFor(groupBy: GroupBy): Option[FinalBatchIr] = {
+      val cache = new CumulatedBatchIrCache("test_cumulated", batchIrCacheMaximumSize)
+      val fetcherCache = new TestableFetcherCache(None, Some(cache)) {
+        override def isCachingEnabled(groupBy: GroupBy) = true
+      }
+      val onlineAggregator = new SawtoothOnlineAggregator(batchEndMillis, aggregations, schema)
+      val megaTileAggregator = new MegaTileAggregator(aggregations, schema)
+      val info = servingInfo(groupBy, onlineAggregator, megaTileAggregator)
+      val finalBatchIr = smallWindowBatchIr
+
+      assertFalse(fetcherCache.getCumulatedBatchIrFromBatchIr(finalBatchIr, info, keys).isDefined)
+      fetcherCache.getCumulatedBatchIrFromBatchIr(finalBatchIr, info, keys).map { cumulated =>
+        FinalBatchIr(info.aggregator.selectCumulatedBatchIr(cumulated, queryTs), null)
+      }
+    }
+
+    val sawtoothGroupBy =
+      Builders.GroupBy(metaData = Builders.MetaData(name = "test_sawtooth_group_by"), aggregations = aggregations)
+    val sawtoothSelected = cachedFor(sawtoothGroupBy).get
+    assertEquals(18L, sawtoothSelected.collapsed.head)
+
+    val megaTileGroupBy =
+      Builders.GroupBy(metaData = Builders.MetaData(name = "test_megatile_group_by"), aggregations = aggregations)
+    megaTileGroupBy.setOnlineStrategy(OnlineStrategy.STREAMING_MEGATILES)
+    val megaTileSelected = cachedFor(megaTileGroupBy).get
+    assertNull(megaTileSelected.collapsed.head)
+  }
 
   it should "batch ir cache correctly caches batch irs" in {
     val cacheName = "test"


### PR DESCRIPTION
## Summary

- Ports the cumulative batch IR cache work from openai/chronon-private#91 onto the Zipline MegaTile branch from #1627.
- all credits to https://github.com/zipline-ai/chronon/issues/1377

## Changes

- Adds `CumulatedBatchIr` and helpers to precompute selectable batch tail suffixes.
- Wires standard, tiled, and MegaTile serving paths to use cached cumulated batch IRs when available, while falling back and asynchronously warming the cache on misses.
- Adds focused equivalence coverage for raw-vs-cumulated batch merging and cache warmup behavior.

## Validation

- `./mill aggregator.compile`
- `./mill online.compile`
- `./mill aggregator.test.testOnly "ai.chronon.aggregator.test.MegaTileMergerTest"`
- `JAVA_HOME=/Users/mickjermsurawong/Library/Java/JavaVirtualMachines/temurin-17.0.18/Contents/Home ./mill aggregator.test.testOnly "ai.chronon.aggregator.test.SawtoothOnlineAggregatorTest"`
- `JAVA_HOME=/Users/mickjermsurawong/Library/Java/JavaVirtualMachines/temurin-17.0.18/Contents/Home ./mill online.test.testOnly "ai.chronon.online.FetcherCacheTest"`

Note: the Sawtooth/online focused tests were run under JDK 17 because DataSketches rejects the default JDK 25 runtime.