### PR TITLE
Skip System.exit in cluster deploy mode to fix YARN status reporting 

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -1350,7 +1350,11 @@ object Driver {
         }
       case None => logger.info("specify a subcommand please")
     }
-    if (shouldExit && !skipExit) {
+    // In cluster deploy mode, avoid System.exit(0) so the YARN ApplicationMaster can
+    // report final status before the JVM shuts down. Without this, YARN sees
+    // "Shutdown hook called before final status was reported" and marks the app as FAILED.
+    val isClusterMode = sys.props.get("spark.submit.deployMode").contains("cluster")
+    if (shouldExit && !skipExit && !isClusterMode) {
       System.exit(0)
     }
   }

--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -1184,10 +1184,8 @@ object Driver {
       }
       if (isAllPartitionsPresent) {
         logger.info(s"All partitions ${partitionNames} are present.")
-        sys.exit(0)
       } else {
-        logger.info(s"Not all partitions ${partitionNames} are present.")
-        sys.exit(1)
+        throw new RuntimeException(s"Not all partitions ${partitionNames} are present.")
       }
 
     }


### PR DESCRIPTION
## Summary
- Skip `System.exit(0)` when `spark.submit.deployMode` is `cluster`, so the YARN ApplicationMaster can report final status before the JVM shuts down                                                                                                                                                                  
- Without this, cluster-mode jobs (e.g. on Dataproc) succeed but YARN marks them  as FAILED with "Shutdown hook called before final status was reported"         

## Test plan                                                                                                                                                                                                                           
- Verified on GCP Dataproc with `spark.submit.deployMode=cluster` upload and upload jobs now complete with correct YARN/Dataproc status                                                                                                                                                          
                                                                            
## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Jobs now fail with a clear error when requested partitions are missing, improving visibility and diagnostics.
  * Prevented premature JVM shutdown in cluster deployments so the application master can report final job status reliably, improving job completion reporting and stability for distributed runs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zipline-ai/chronon/pull/1844)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->