### PR TITLE
Include KV key in missing metadata error messages

### DIFF
--- a/online/src/main/scala/ai/chronon/online/Api.scala
+++ b/online/src/main/scala/ai/chronon/online/Api.scala
@@ -45,8 +45,10 @@ object KVStore {
   case class TimedValue(bytes: Array[Byte], millis: Long)
   case class GetResponse(request: GetRequest, values: Try[Seq[TimedValue]]) {
     def latest: Try[TimedValue] = values.flatMap { vals =>
-      if (vals.isEmpty) Failure(new NoSuchElementException(s"No values found for key in dataset ${request.dataset}"))
-      else Success(vals.maxBy(_.millis))
+      if (vals.isEmpty) {
+        val key = new String(request.keyBytes, Constants.UTF8)
+        Failure(new NoSuchElementException(s"No values found for key '$key' in dataset ${request.dataset}"))
+      } else Success(vals.maxBy(_.millis))
     }
   }
   case class PutRequest(keyBytes: Array[Byte], valueBytes: Array[Byte], dataset: String, tsMillis: Option[Long] = None)

--- a/online/src/test/scala/ai/chronon/online/test/KVStoreTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/KVStoreTest.scala
@@ -1,0 +1,20 @@
+package ai.chronon.online.test
+
+import ai.chronon.api.Constants
+import ai.chronon.online.KVStore
+import org.scalatest.flatspec.AnyFlatSpec
+
+import scala.util.Success
+
+class KVStoreTest extends AnyFlatSpec {
+
+  it should "include the key and dataset when no latest value exists" in {
+    val request =
+      KVStore.GetRequest("pricing.price_prediction.v1__1".getBytes(Constants.UTF8), "CHRONON_METADATA")
+    val response = KVStore.GetResponse(request, Success(Seq.empty))
+
+    val exception = response.latest.failed.get
+
+    assert(exception.getMessage == "No values found for key 'pricing.price_prediction.v1__1' in dataset CHRONON_METADATA")
+  }
+}


### PR DESCRIPTION
## Summary

Include the requested KV key in missing metadata errors so Fetcher failures identify the missing CHRONON_METADATA record.
Tests: Added KVStoreTest

- [x] Added Unit Tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for missing data: empty lookups now include the specific missing key (decoded as UTF-8) and dataset to aid troubleshooting.

* **Tests**
  * Added a unit test that verifies empty lookup results produce the expected failure message reporting the absent key and dataset.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zipline-ai/chronon/pull/1850)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->