### PR TITLE
feat(stats): stats for staging query outputs

### DIFF
--- a/api/src/main/scala/ai/chronon/api/Constants.scala
+++ b/api/src/main/scala/ai/chronon/api/Constants.scala
@@ -65,6 +65,13 @@ object Constants {
 
   val EnhancedStatsDataset: String = "ENHANCED_STATS"
 
+  // KV-name prefixes that disambiguate which producer type owns a stats lookup name
+  // (so a Join and a StagingQuery with the same conf name don't collide). The Join
+  // prefix is intentionally empty for backward compatibility with stats already
+  // written without any prefix.
+  val EnhancedStatsNodeTypeJoin: String = "join"
+  val EnhancedStatsNodeTypeStagingQuery: String = "staging_query"
+
   val DefaultDriftTileSize: Window = new Window(30, TimeUnit.MINUTES)
 
   val FetchTimeout: Duration = Duration(10, concurrent.TimeUnit.MINUTES)

--- a/api/src/main/scala/ai/chronon/api/planner/StagingQueryPlanner.scala
+++ b/api/src/main/scala/ai/chronon/api/planner/StagingQueryPlanner.scala
@@ -1,8 +1,9 @@
 package ai.chronon.api.planner
 
 import ai.chronon.api.Extensions._
-import ai.chronon.api.{PartitionSpec, StagingQuery}
-import ai.chronon.planner.{ConfPlan, StagingQueryNode}
+import ai.chronon.api.{PartitionSpec, StagingQuery, TableDependency, TableInfo}
+import ai.chronon.planner
+import ai.chronon.planner.{ConfPlan, Node, StagingQueryNode, StagingQueryStatsComputeNode}
 
 import scala.collection.JavaConverters._
 
@@ -15,7 +16,7 @@ case class StagingQueryPlanner(stagingQuery: StagingQuery)(implicit outputPartit
     semanticStagingQuery
   }
 
-  override def buildPlan: ConfPlan = {
+  private def stagingNode: Node = {
     val tableDependencies = TableDependencies.fromStagingQuery(stagingQuery)
 
     val metaData = MetaDataUtils.layer(
@@ -27,18 +28,62 @@ case class StagingQueryPlanner(stagingQuery: StagingQuery)(implicit outputPartit
     )
 
     val node = new StagingQueryNode().setStagingQuery(stagingQuery)
-    val finalNode = toNode(metaData, _.setStagingQuery(node), semanticStagingQuery(stagingQuery))
+    toNode(metaData, _.setStagingQuery(node), semanticStagingQuery(stagingQuery))
+  }
+
+  // Stats compute depends on the staging query output table — same shape as MonolithJoinPlanner.statsComputeNode.
+  private def statsComputeNode(stagingNodeOutputTable: String): Node = {
+    val defaultStepDays = 1
+    val effectiveStepDays = Option(stagingQuery.metaData.executionInfo)
+      .filter(_.isSetStepDays)
+      .map(_.stepDays)
+      .getOrElse(defaultStepDays)
+
+    val tableDep = new TableDependency()
+      .setTableInfo(
+        new TableInfo()
+          .setTable(stagingNodeOutputTable)
+          .setPartitionColumn(outputPartitionSpec.column)
+          .setPartitionFormat(outputPartitionSpec.format)
+          .setPartitionInterval(WindowUtils.hours(outputPartitionSpec.spanMillis))
+      )
+      .setStartOffset(WindowUtils.zero())
+      .setEndOffset(WindowUtils.zero())
+
+    val metaData =
+      MetaDataUtils.layer(stagingQuery.metaData,
+                          "stats_compute",
+                          stagingQuery.metaData.name + "__stats_compute",
+                          Seq(tableDep),
+                          Some(effectiveStepDays))
+
+    val node = new StagingQueryStatsComputeNode().setStagingQuery(stagingQuery)
+    toNode(metaData, _.setStagingQueryStatsCompute(node), semanticStagingQuery(stagingQuery))
+  }
+
+  override def buildPlan: ConfPlan = {
+    val backfill = stagingNode
+
+    val enableStatsCompute = Option(stagingQuery.metaData.executionInfo)
+      .flatMap(ei => Option(ei.enableStatsCompute))
+      .exists(_.booleanValue())
+
     val externalSensorNodes = ExternalSourceSensorUtil
-      .sensorNodes(finalNode.metaData)
+      .sensorNodes(backfill.metaData)
       .map((es) =>
         toNode(es.metaData, _.setExternalSourceSensor(es), ExternalSourceSensorUtil.semanticExternalSourceSensor(es)))
 
-    val terminalNodeNames = Map(
-      ai.chronon.planner.Mode.BACKFILL -> finalNode.metaData.name
-    )
+    val (allNodes, terminalNodeNames) = if (enableStatsCompute) {
+      val statsCompute = statsComputeNode(backfill.metaData.outputTable)
+      val terminals = Map(planner.Mode.BACKFILL -> statsCompute.metaData.name)
+      (Seq(backfill, statsCompute) ++ externalSensorNodes, terminals)
+    } else {
+      val terminals = Map(planner.Mode.BACKFILL -> backfill.metaData.name)
+      (Seq(backfill) ++ externalSensorNodes, terminals)
+    }
 
     new ConfPlan()
-      .setNodes((Seq(finalNode) ++ externalSensorNodes).asJava)
+      .setNodes(allNodes.asJava)
       .setTerminalNodeNames(terminalNodeNames.asJava)
   }
 }

--- a/api/src/test/scala/ai/chronon/api/test/planner/StagingQueryPlannerTest.scala
+++ b/api/src/test/scala/ai/chronon/api/test/planner/StagingQueryPlannerTest.scala
@@ -218,6 +218,64 @@ class StagingQueryPlannerTest extends AnyFlatSpec with Matchers {
     firstSemanticHashes should equal(secondSemanticHashes)
   }
 
+  it should "staging query planner should add a stats compute node when enableStatsCompute is true" in {
+    val stagingQuery = StagingQuery(
+      query = "SELECT * FROM test_table",
+      metaData = MetaData(
+        name = "testStatsStagingQuery",
+        executionInfo = new ExecutionInfo().setEnableStatsCompute(true)
+      ),
+      engineType = EngineType.SPARK
+    )
+
+    val planner = new StagingQueryPlanner(stagingQuery)
+    val plan = planner.buildPlan
+
+    plan.nodes.asScala should have size 2
+
+    val statsNodeName = "testStatsStagingQuery__stats_compute"
+    val stagingNodeName = "testStatsStagingQuery__staging"
+    val nodeNames = plan.nodes.asScala.map(_.metaData.name).toSet
+    nodeNames should contain(stagingNodeName)
+    nodeNames should contain(statsNodeName)
+
+    plan.terminalNodeNames.asScala(ai.chronon.planner.Mode.BACKFILL) should equal(statsNodeName)
+
+    val statsNode = plan.nodes.asScala.find(_.metaData.name == statsNodeName).get
+    statsNode.content.getStagingQueryStatsCompute should not be null
+    statsNode.content.getStagingQueryStatsCompute.stagingQuery should not be null
+
+    // The stats node should depend on the upstream staging output table
+    val stagingNode = plan.nodes.asScala.find(_.metaData.name == stagingNodeName).get
+    val expectedTable = stagingNode.metaData.executionInfo.outputTableInfo.table
+    val deps = statsNode.metaData.executionInfo.getTableDependencies.asScala
+    deps should have size 1
+    deps.head.getTableInfo.table should equal(expectedTable)
+  }
+
+  it should "staging query planner should omit stats compute node when enableStatsCompute is false or unset" in {
+    val sqUnset = StagingQuery(
+      query = "SELECT * FROM test_table",
+      metaData = MetaData(name = "unsetSq"),
+      engineType = EngineType.SPARK
+    )
+    val sqFalse = StagingQuery(
+      query = "SELECT * FROM test_table",
+      metaData = MetaData(
+        name = "falseSq",
+        executionInfo = new ExecutionInfo().setEnableStatsCompute(false)
+      ),
+      engineType = EngineType.SPARK
+    )
+
+    Seq(sqUnset, sqFalse).foreach { sq =>
+      val plan = new StagingQueryPlanner(sq).buildPlan
+      plan.nodes.asScala should have size 1
+      plan.terminalNodeNames.asScala(ai.chronon.planner.Mode.BACKFILL) should equal(
+        sq.metaData.name + "__staging")
+    }
+  }
+
   it should "staging query planner should produce exactly one node wrapping a StagingQuery for canary confs" in {
     val stagingQueryRootDir = Paths.get(getClass.getClassLoader.getResource("canary/compiled/staging_queries").getPath)
 

--- a/online/src/main/scala/ai/chronon/online/JavaStatsService.scala
+++ b/online/src/main/scala/ai/chronon/online/JavaStatsService.scala
@@ -106,6 +106,18 @@ class JavaStatsService(api: Api,
     }
   }
 
+  /** Translates a (tableName, nodeType) pair into the disambiguated lookup name used as the
+    * stats KV key prefix. "join" (or null/empty) keeps the legacy un-prefixed shape so existing
+    * data and callers remain compatible; other types (e.g. "staging_query") get a `<type>/` prefix.
+    */
+  private def lookupNameFor(tableName: String, nodeType: String): String = {
+    Option(nodeType).map(_.trim).filter(_.nonEmpty) match {
+      case Some(t) if t.equalsIgnoreCase(Constants.EnhancedStatsNodeTypeJoin) => tableName
+      case Some(t)                                                            => s"$t/$tableName"
+      case None                                                               => tableName
+    }
+  }
+
   /** Fetch and merge statistics for a given table and time range.
     *
     * @param tableName The name of the table (used as key in KV store)
@@ -113,13 +125,17 @@ class JavaStatsService(api: Api,
     * @param endTimeMillis End of time range (inclusive)
     * @param semanticHash If set, reads from the shard written by the job with this config hash.
     *                     Pass null (Java) or None (Scala) to read un-sharded legacy data.
+    * @param nodeType Optional producer type ("staging_query" for StagingQuery-produced stats,
+    *                 null/"join" for Join-produced stats — joins remain un-prefixed for backward compat).
     * @return CompletableFuture of JavaStatsResponse with statistics or error
     */
   def fetchStats(tableName: String,
                  startTimeMillis: Long,
                  endTimeMillis: Long,
-                 semanticHash: String): CompletableFuture[JavaStatsResponse] = {
+                 semanticHash: String,
+                 nodeType: String): CompletableFuture[JavaStatsResponse] = {
 
+    val lookupName = lookupNameFor(tableName, nodeType)
     val requestedHash = Option(semanticHash)
     // When the flag is off, drop any hash the caller passed and read un-sharded data.
     // Log a warning so the frontend knows the hash was ignored rather than silently failing.
@@ -137,8 +153,8 @@ class JavaStatsService(api: Api,
     val scalaFuture: Future[JavaStatsResponse] = Future {
       Try {
         // Retrieve schemas from KV Store in a single batch call
-        val keySchemaKey = s"$tableName${Constants.TimedKvRDDKeySchemaKey}"
-        val valueSchemaKey = s"$tableName${Constants.TimedKvRDDValueSchemaKey}"
+        val keySchemaKey = s"$lookupName${Constants.TimedKvRDDKeySchemaKey}"
+        val valueSchemaKey = s"$lookupName${Constants.TimedKvRDDValueSchemaKey}"
 
         val (keyCodecOpt, valueCodecOpt) = getSchemasFromKVStore(keySchemaKey, valueSchemaKey, maybeHash)
 
@@ -149,14 +165,15 @@ class JavaStatsService(api: Api,
             case None =>
               " (no semanticHash — reading un-sharded data)"
           }
-          throw new RuntimeException(s"Failed to retrieve schemas for $tableName$hashHint. Has it been uploaded?")
+          throw new RuntimeException(s"Failed to retrieve schemas for $lookupName$hashHint. Has it been uploaded?")
         }
 
         val keyCodec = keyCodecOpt.get
         val valueCodec = valueCodecOpt.get
 
-        // Encode key using the stored key codec
-        val chrononRow = Array[Any](tableName)
+        // Encode key using the stored key codec — must use the (potentially prefixed) lookupName
+        // because that is what the producer wrote as the JoinPath column value.
+        val chrononRow = Array[Any](lookupName)
         val record = AvroConversions
           .fromChrononRow(chrononRow, keyCodec.chrononSchema, keyCodec.schema)
           .asInstanceOf[generic.GenericData.Record]
@@ -184,8 +201,8 @@ class JavaStatsService(api: Api,
               logger.info(s"Fetched ${timedValues.size} tiles for $tableName")
 
               // Fetch schemas (these are static metadata)
-              val selectedSchemaOpt = getMetadataValue(s"$tableName/selectedSchema", None, maybeHash)
-              val noKeysSchemaOpt = getMetadataValue(s"$tableName/noKeysSchema", None, maybeHash)
+              val selectedSchemaOpt = getMetadataValue(s"$lookupName/selectedSchema", None, maybeHash)
+              val noKeysSchemaOpt = getMetadataValue(s"$lookupName/noKeysSchema", None, maybeHash)
 
               if (selectedSchemaOpt.isEmpty || noKeysSchemaOpt.isEmpty) {
                 throw new RuntimeException(s"Failed to retrieve schemas for $tableName. Metadata may be missing.")
@@ -198,7 +215,7 @@ class JavaStatsService(api: Api,
               val noKeysSchema = noKeysSchemaCodec.chrononSchema.asInstanceOf[StructType]
 
               // Fallback: try to get from metadata row (backward compatibility)
-              val cardinalityMapOpt = getMetadataValue(s"$tableName/cardinalityMap", Some(endTimeMillis), maybeHash)
+              val cardinalityMapOpt = getMetadataValue(s"$lookupName/cardinalityMap", Some(endTimeMillis), maybeHash)
               val mergedCardinalityMap = if (cardinalityMapOpt.isDefined) {
                 val cardinalityJson = cardinalityMapOpt.get
                 cardinalityJson
@@ -318,13 +335,15 @@ class JavaStatsService(api: Api,
                  comparisonStartTimeMillis: Long,
                  comparisonEndTimeMillis: Long,
                  metricName: String,
-                 semanticHash: String): CompletableFuture[JavaStatsDriftResponse] = {
+                 semanticHash: String,
+                 nodeType: String): CompletableFuture[JavaStatsDriftResponse] = {
 
+    val lookupName = lookupNameFor(tableName, nodeType)
     val scalaFuture: Future[JavaStatsDriftResponse] = Future {
       Try {
         val requestedHash = Option(semanticHash).filter(_.nonEmpty)
         val maybeHash = effectiveSemanticHash(tableName, requestedHash)
-        val drift = computeDrift(tableName,
+        val drift = computeDrift(lookupName,
                                  referenceStartTimeMillis,
                                  referenceEndTimeMillis,
                                  comparisonStartTimeMillis,
@@ -372,7 +391,9 @@ class JavaStatsService(api: Api,
                          windowDays: Int,
                          metricName: String,
                          distanceName: String,
-                         semanticHash: String): CompletableFuture[JavaStatsTrailingDriftResponse] = {
+                         semanticHash: String,
+                         nodeType: String): CompletableFuture[JavaStatsTrailingDriftResponse] = {
+    val lookupName = lookupNameFor(tableName, nodeType)
     val scalaFuture: Future[JavaStatsTrailingDriftResponse] = Future {
       Try {
         if (windowDays <= 0) {
@@ -394,7 +415,7 @@ class JavaStatsService(api: Api,
         val lastAnchorMillis = end.atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli
         val fetchStartMillis = firstAnchorMillis - (2L * windowMillis)
         val fetchEndMillis = lastAnchorMillis - 1L
-        val cached = fetchDecodedIrRange(tableName, fetchStartMillis, fetchEndMillis, maybeHash, "trailing")
+        val cached = fetchDecodedIrRange(lookupName, fetchStartMillis, fetchEndMillis, maybeHash, "trailing")
 
         var date = start
         while (!date.isAfter(end)) {
@@ -913,7 +934,14 @@ class JavaStatsService(api: Api,
 
   /** Overload for callers that don't use semantic-hash sharding (reads un-sharded legacy data). */
   def fetchStats(tableName: String, startTimeMillis: Long, endTimeMillis: Long): CompletableFuture[JavaStatsResponse] =
-    fetchStats(tableName, startTimeMillis, endTimeMillis, null)
+    fetchStats(tableName, startTimeMillis, endTimeMillis, null, null)
+
+  /** Overload for callers that pass semanticHash but not a nodeType (defaults to Join shape). */
+  def fetchStats(tableName: String,
+                 startTimeMillis: Long,
+                 endTimeMillis: Long,
+                 semanticHash: String): CompletableFuture[JavaStatsResponse] =
+    fetchStats(tableName, startTimeMillis, endTimeMillis, semanticHash, null)
 
   def fetchDrift(tableName: String,
                  referenceStartTimeMillis: Long,
@@ -927,6 +955,23 @@ class JavaStatsService(api: Api,
                comparisonStartTimeMillis,
                comparisonEndTimeMillis,
                metricName,
+               null,
+               null)
+
+  def fetchDrift(tableName: String,
+                 referenceStartTimeMillis: Long,
+                 referenceEndTimeMillis: Long,
+                 comparisonStartTimeMillis: Long,
+                 comparisonEndTimeMillis: Long,
+                 metricName: String,
+                 semanticHash: String): CompletableFuture[JavaStatsDriftResponse] =
+    fetchDrift(tableName,
+               referenceStartTimeMillis,
+               referenceEndTimeMillis,
+               comparisonStartTimeMillis,
+               comparisonEndTimeMillis,
+               metricName,
+               semanticHash,
                null)
 
   def fetchTrailingDrift(tableName: String,
@@ -935,7 +980,16 @@ class JavaStatsService(api: Api,
                          windowDays: Int,
                          metricName: String,
                          distanceName: String): CompletableFuture[JavaStatsTrailingDriftResponse] =
-    fetchTrailingDrift(tableName, startDate, endDate, windowDays, metricName, distanceName, null)
+    fetchTrailingDrift(tableName, startDate, endDate, windowDays, metricName, distanceName, null, null)
+
+  def fetchTrailingDrift(tableName: String,
+                         startDate: String,
+                         endDate: String,
+                         windowDays: Int,
+                         metricName: String,
+                         distanceName: String,
+                         semanticHash: String): CompletableFuture[JavaStatsTrailingDriftResponse] =
+    fetchTrailingDrift(tableName, startDate, endDate, windowDays, metricName, distanceName, semanticHash, null)
 
   /** Add derived features to the statistics map.
     * Computes additional metrics based on existing statistics:

--- a/python/src/ai/chronon/staging_query.py
+++ b/python/src/ai/chronon/staging_query.py
@@ -179,6 +179,7 @@ def StagingQuery(
     env_vars: Optional[common.EnvironmentVariables] = None,
     cluster_conf: common.ClusterConfigProperties = None,
     step_days: Optional[int] = None,
+    enable_stats_compute: Optional[bool] = None,
     recompute_days: Optional[int] = None,
     additional_partitions: List[str] = None,
 ) -> ttypes.StagingQuery:
@@ -227,6 +228,13 @@ def StagingQuery(
     :param step_days:
         The maximum number of days to process at once
     :type step_days: int
+    :param enable_stats_compute:
+        Whether to enable enhanced statistics computation and upload for this staging query.
+        When True, a stats compute node will be added to the workflow that computes
+        cardinality-aware statistics on the staging query output and uploads them to the
+        KV store. Stats are written under a `staging_query/<name>` lookup so they do not
+        collide with same-named joins; readers must pass `?type=staging_query` to fetch them.
+    :type enable_stats_compute: bool
     :param dependencies:
         List of dependencies for the StagingQuery. Each dependency can be either a TableDependency object
         or a dictionary with 'name' and 'spec' keys.
@@ -277,6 +285,7 @@ def StagingQuery(
         env=env_vars,
         stepDays=step_days,
         clusterConf=cluster_conf,
+        enableStatsCompute=enable_stats_compute,
     )
 
     airflow_dependencies = []

--- a/service/src/main/java/ai/chronon/service/handlers/StatsDriftHandler.java
+++ b/service/src/main/java/ai/chronon/service/handlers/StatsDriftHandler.java
@@ -30,6 +30,7 @@ import scala.concurrent.ExecutionContext$;
  *   - metric: Approx percentile metric name, or source column name (required when table has multiple percentile metrics)
  *   - dataset: Dataset name (optional, defaults to ENHANCED_STATS)
  *   - semanticHash: Config hash to read from a specific shard (optional)
+ *   - type: Producer type ("staging_query" for StagingQuery-produced stats; omit for Join).
  */
 public class StatsDriftHandler implements Handler<RoutingContext> {
 
@@ -60,6 +61,7 @@ public class StatsDriftHandler implements Handler<RoutingContext> {
         String metric = ctx.request().getParam("metric");
         String datasetName = ctx.request().getParam("dataset");
         String semanticHash = ctx.request().getParam("semanticHash");
+        String nodeType = ctx.request().getParam("type");
 
         if (referenceStartTimeStr == null || referenceEndTimeStr == null ||
                 comparisonStartTimeStr == null || comparisonEndTimeStr == null) {
@@ -91,15 +93,16 @@ public class StatsDriftHandler implements Handler<RoutingContext> {
             datasetName = Constants.EnhancedStatsDataset();
         }
 
-        logger.info("Computing stats drift for table: {}, metric: {}, referenceRange: [{}, {}], comparisonRange: [{}, {}], dataset: {}, semanticHash: {}",
+        logger.info("Computing stats drift for table: {}, metric: {}, referenceRange: [{}, {}], comparisonRange: [{}, {}], dataset: {}, semanticHash: {}, type: {}",
                 tableName, metric, referenceStartTimeMillis, referenceEndTimeMillis,
                 comparisonStartTimeMillis, comparisonEndTimeMillis, datasetName,
-                semanticHash != null ? semanticHash : "(none)");
+                semanticHash != null ? semanticHash : "(none)",
+                nodeType != null ? nodeType : "(none)");
 
         JavaStatsService statsService = new JavaStatsService(api, "ENHANCED_STATS", datasetName, ec);
         CompletableFuture<JavaStatsDriftResponse> driftResponseFuture =
                 statsService.fetchDrift(tableName, referenceStartTimeMillis, referenceEndTimeMillis,
-                        comparisonStartTimeMillis, comparisonEndTimeMillis, metric, semanticHash);
+                        comparisonStartTimeMillis, comparisonEndTimeMillis, metric, semanticHash, nodeType);
 
         Future<JavaStatsDriftResponse> vertxFuture = Future.fromCompletionStage(driftResponseFuture);
 

--- a/service/src/main/java/ai/chronon/service/handlers/StatsHandler.java
+++ b/service/src/main/java/ai/chronon/service/handlers/StatsHandler.java
@@ -27,6 +27,9 @@ import scala.concurrent.ExecutionContext$;
  *   - endTime: End time in milliseconds (required)
  *   - dataset: Dataset name (optional, defaults to ENHANCED_STATS)
  *   - semanticHash: Config hash to read from a specific shard (optional, omit for legacy un-sharded data)
+ *   - type: Producer type for the stats lookup name. Use "staging_query" for StagingQuery-produced
+ *           stats. Omit (or "join") for Join-produced stats, which remain un-prefixed for
+ *           backward compatibility.
  */
 public class StatsHandler implements Handler<RoutingContext> {
 
@@ -52,6 +55,7 @@ public class StatsHandler implements Handler<RoutingContext> {
         String endTimeStr = ctx.request().getParam("endTime");
         String datasetName = ctx.request().getParam("dataset");
         String semanticHash = ctx.request().getParam("semanticHash");
+        String nodeType = ctx.request().getParam("type");
 
         // Validate required parameters
         if (startTimeStr == null || endTimeStr == null) {
@@ -80,14 +84,16 @@ public class StatsHandler implements Handler<RoutingContext> {
             datasetName = Constants.EnhancedStatsDataset();
         }
 
-        logger.info("Fetching stats for table: {}, timeRange: [{}, {}], dataset: {}, semanticHash: {}",
-                tableName, startTimeMillis, endTimeMillis, datasetName, semanticHash != null ? semanticHash : "(none)");
+        logger.info("Fetching stats for table: {}, timeRange: [{}, {}], dataset: {}, semanticHash: {}, type: {}",
+                tableName, startTimeMillis, endTimeMillis, datasetName,
+                semanticHash != null ? semanticHash : "(none)",
+                nodeType != null ? nodeType : "(none)");
 
         // Create stats service and fetch stats
         // Use default table name "ENHANCED_STATS" for BigTable storage
         JavaStatsService statsService = new JavaStatsService(api, "ENHANCED_STATS", datasetName, ec);
         CompletableFuture<JavaStatsResponse> statsResponseFuture =
-                statsService.fetchStats(tableName, startTimeMillis, endTimeMillis, semanticHash);
+                statsService.fetchStats(tableName, startTimeMillis, endTimeMillis, semanticHash, nodeType);
 
         // Convert Java future to Vert.x Future
         Future<JavaStatsResponse> vertxFuture = Future.fromCompletionStage(statsResponseFuture);

--- a/service/src/main/java/ai/chronon/service/handlers/StatsTrailingDriftHandler.java
+++ b/service/src/main/java/ai/chronon/service/handlers/StatsTrailingDriftHandler.java
@@ -34,6 +34,7 @@ import scala.concurrent.ExecutionContext$;
  *   - distance: Distance to return as y: linf, l2, or l1 (optional, defaults to linf)
  *   - dataset: Dataset name (optional, defaults to ENHANCED_STATS)
  *   - semanticHash: Config hash to read from a specific shard (optional)
+ *   - type: Producer type ("staging_query" for StagingQuery-produced stats; omit for Join).
  */
 public class StatsTrailingDriftHandler implements Handler<RoutingContext> {
 
@@ -64,6 +65,7 @@ public class StatsTrailingDriftHandler implements Handler<RoutingContext> {
         String distance = ctx.request().getParam("distance");
         String datasetName = ctx.request().getParam("dataset");
         String semanticHash = ctx.request().getParam("semanticHash");
+        String nodeType = ctx.request().getParam("type");
 
         if (startDate == null || endDate == null || windowDaysStr == null) {
             sendError(ctx, 400, "Missing required query parameters: startDate, endDate, windowDays");
@@ -99,13 +101,14 @@ public class StatsTrailingDriftHandler implements Handler<RoutingContext> {
             datasetName = Constants.EnhancedStatsDataset();
         }
 
-        logger.info("Computing trailing stats drift for table: {}, metric: {}, distance: {}, dateRange: [{}, {}], windowDays: {}, dataset: {}, semanticHash: {}",
+        logger.info("Computing trailing stats drift for table: {}, metric: {}, distance: {}, dateRange: [{}, {}], windowDays: {}, dataset: {}, semanticHash: {}, type: {}",
                 tableName, metric, distance, startDate, endDate, windowDays, datasetName,
-                semanticHash != null ? semanticHash : "(none)");
+                semanticHash != null ? semanticHash : "(none)",
+                nodeType != null ? nodeType : "(none)");
 
         JavaStatsService statsService = new JavaStatsService(api, "ENHANCED_STATS", datasetName, ec);
         CompletableFuture<JavaStatsTrailingDriftResponse> driftResponseFuture =
-                statsService.fetchTrailingDrift(tableName, startDate, endDate, windowDays, metric, distance, semanticHash);
+                statsService.fetchTrailingDrift(tableName, startDate, endDate, windowDays, metric, distance, semanticHash, nodeType);
 
         Future<JavaStatsTrailingDriftResponse> vertxFuture = Future.fromCompletionStage(driftResponseFuture);
 

--- a/spark/src/main/scala/ai/chronon/spark/batch/BatchNodeRunner.scala
+++ b/spark/src/main/scala/ai/chronon/spark/batch/BatchNodeRunner.scala
@@ -229,57 +229,68 @@ class BatchNodeRunner(node: Node, tableUtils: TableUtils, api: Api) extends Node
                                   range: PartitionRange): Unit = {
     require(joinStatsCompute.isSetJoin, "JoinStatsComputeNode must have a join set")
     val joinConf = joinStatsCompute.join
-    val joinName = metadata.name
+    // keyColumns can NPE when join parts are null; tolerate that and fall back to all-columns.
+    val keys = scala.util.Try(joinConf.keyColumns).toOption.map(_.toSeq).getOrElse(Seq.empty)
+    runEnhancedStatsCompute(metadata, statsName = joinConf.metaData.name, keys = keys, range = range)
+  }
 
+  private def runStagingQueryStatsCompute(metadata: MetaData,
+                                          stagingQueryStatsCompute: StagingQueryStatsComputeNode,
+                                          range: PartitionRange): Unit = {
+    require(stagingQueryStatsCompute.isSetStagingQuery, "StagingQueryStatsComputeNode must have a stagingQuery set")
+    val sqConf = stagingQueryStatsCompute.stagingQuery
+    // Prefix the stats lookup name with the node-type segment so it can't collide with a
+    // same-named Join. Join stats are intentionally written un-prefixed for backward compatibility.
+    val prefixedName = s"${Constants.EnhancedStatsNodeTypeStagingQuery}/${sqConf.metaData.name}"
+    runEnhancedStatsCompute(metadata, statsName = prefixedName, keys = Seq.empty, range = range)
+  }
+
+  // Shared compute+upload path for Join and StagingQuery enhanced stats. Reads the upstream output
+  // table from the node's first table dependency, runs EnhancedStatsCompute, then writes both to the
+  // configured output table and the KV store (with optional semanticHash sharding).
+  private def runEnhancedStatsCompute(metadata: MetaData,
+                                      statsName: String,
+                                      keys: Seq[String],
+                                      range: PartitionRange): Unit = {
     // step-days slicing is handled by the orchestrator via DependencyResolver.getMissingSteps;
     // each invocation receives exactly one step-sized range.
-    logger.info(s"Running stats compute for join '$joinName' for range: [${range.start}, ${range.end}]")
+    logger.info(s"Running enhanced stats compute for '$statsName' for range: [${range.start}, ${range.end}]")
 
-    // Import the necessary stats classes
-    import ai.chronon.spark.stats.EnhancedStatsCompute
+    import ai.chronon.spark.stats.{EnhancedStatsCompute, EnhancedStatsStore}
 
-    // Get the join output table from dependencies - the first table dependency should be the join output
-    val joinOutputTable = Option(metadata.executionInfo)
+    val inputTable = Option(metadata.executionInfo)
       .flatMap(ei => Option(ei.getTableDependencies))
       .map(_.asScala.head.getTableInfo.table)
-      .getOrElse(
-        throw new IllegalStateException(s"Could not determine join output table for stats compute node: $joinName"))
+      .getOrElse(throw new IllegalStateException(s"Could not determine input table for stats compute node: $statsName"))
 
-    logger.info(s"Reading join output from table: $joinOutputTable")
+    logger.info(s"Reading stats input from table: $inputTable")
 
-    // Read the join output for the specified partition range
-    val joinOutputDf = tableUtils.sql(
-      s"SELECT * FROM $joinOutputTable WHERE ${tableUtils.partitionColumn} >= '${range.start}' AND ${tableUtils.partitionColumn} <= '${range.end}'"
+    val inputDf = tableUtils.sql(
+      s"SELECT * FROM $inputTable WHERE ${tableUtils.partitionColumn} >= '${range.start}' AND ${tableUtils.partitionColumn} <= '${range.end}'"
     )
 
-    if (joinOutputDf.isEmpty) {
-      logger.info(s"No rows found for join '$joinName' in range [${range.start}, ${range.end}], skipping stats compute")
+    if (inputDf.isEmpty) {
+      logger.info(s"No rows found for '$statsName' in range [${range.start}, ${range.end}], skipping stats compute")
       return
     }
 
-    // Extract key columns from the join configuration
-    // Use Try to handle potential NPE from keyColumns method when join parts are null
-    val keys = scala.util.Try(joinConf.keyColumns).toOption.map(_.toSeq).getOrElse(Seq.empty)
     if (keys.nonEmpty) {
       logger.info(s"Computing enhanced statistics with keys: ${keys.mkString(", ")}")
     } else {
       logger.info(s"Computing enhanced statistics without key exclusions (all columns will be analyzed)")
     }
 
-    // Create EnhancedStatsCompute instance
     val enhancedStats = new EnhancedStatsCompute(
-      inputDf = joinOutputDf,
+      inputDf = inputDf,
       keys = keys,
-      name = joinConf.metaData.name
+      name = statsName
     )
 
-    // Compute daily summary statistics
     val (flatDf, statsMetadata) = enhancedStats.enhancedDailySummary(
       sample = 1.0,
       timeBucketMinutes = 0 // Daily tiles
     )
 
-    // Convert to Avro DataFrame format (with key_bytes, value_bytes, ts columns)
     implicit val sparkSession = tableUtils.sparkSession
     val keyColumns = Seq("JoinPath")
     val valueColumns = flatDf.columns.filterNot(c => c == "JoinPath" || c == Constants.TimeColumn).toSeq
@@ -287,30 +298,26 @@ class BatchNodeRunner(node: Node, tableUtils: TableUtils, api: Api) extends Node
       flatDf,
       keyColumns,
       valueColumns,
-      storeSchemasPrefix = Some(joinConf.metaData.name),
+      storeSchemasPrefix = Some(statsName),
       metadata = Some(statsMetadata)
     )
     val outputTable = metadata.outputTable
     avroDf.show()
 
-    // Add partition column (ds) derived from timestamp for partitioning
     val avroDfWithPartition = avroDf.withTimeBasedColumn(tableUtils.partitionColumn).drop("key_json").drop("value_json")
 
     val recordCount = avroDfWithPartition.count()
     logger.info(s"Saving $recordCount stats records to table: $outputTable")
 
-    // Write the stats in Avro format to the output table, partitioned by day
     tableUtils.insertPartitions(
       df = avroDfWithPartition,
       tableName = outputTable,
       semanticHash = Option(node.semanticHash).filter(_.nonEmpty)
     )
 
-    // Upload to KV store using the proper EnhancedStatsStore method.
     // Sharding is gated by CHRONON_SHARD_ENHANCED_STATS — must be enabled on both write and read sides
     // before activating, otherwise the service won't find the sharded data.
     logger.info(s"Uploading $recordCount stats records to KV store")
-    import ai.chronon.spark.stats.EnhancedStatsStore
     val shardingEnabled = sys.env.getOrElse("CHRONON_SHARD_ENHANCED_STATS", "false").equalsIgnoreCase("true")
     val statsSemanticHash = if (shardingEnabled) Option(node.semanticHash).filter(_.nonEmpty) else None
     logger.info(
@@ -320,7 +327,7 @@ class BatchNodeRunner(node: Node, tableUtils: TableUtils, api: Api) extends Node
       tableUtils)
     statsStore.upload(avroDf, putsPerRequest = 100)
 
-    logger.info(s"Successfully computed and saved stats for join '$joinName'")
+    logger.info(s"Successfully computed and saved stats for '$statsName'")
   }
 
   private[batch] def extractAndPersistPartitionStats(metricsKvStore: KVStore, outputTable: String, confName: String)(
@@ -470,6 +477,14 @@ class BatchNodeRunner(node: Node, tableUtils: TableUtils, api: Api) extends Node
         require(conf.getJoinStatsCompute.isSetJoin, "JoinStatsComputeNode must have a join set")
         runJoinStatsCompute(metadata, conf.getJoinStatsCompute, range)
         logger.info(s"Successfully completed join stats compute for '${metadata.name}'")
+
+      case NodeContent._Fields.STAGING_QUERY_STATS_COMPUTE =>
+        logger.info(
+          s"Running staging query stats compute for '${metadata.name}' for range: [${range.start}, ${range.end}]")
+        require(conf.getStagingQueryStatsCompute.isSetStagingQuery,
+                "StagingQueryStatsComputeNode must have a stagingQuery set")
+        runStagingQueryStatsCompute(metadata, conf.getStagingQueryStatsCompute, range)
+        logger.info(s"Successfully completed staging query stats compute for '${metadata.name}'")
 
       case _ =>
         throw new UnsupportedOperationException(s"Unsupported NodeContent type: ${conf.getSetField}")

--- a/spark/src/test/scala/ai/chronon/spark/batch/BatchNodeRunnerTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/batch/BatchNodeRunnerTest.scala
@@ -21,7 +21,7 @@ import ai.chronon.api._
 import ai.chronon.api.planner.{MetaDataUtils, TableDependencies}
 import ai.chronon.observability.{TileSummaryKey, TileSummary}
 import ai.chronon.online.KVStore.PutRequest
-import ai.chronon.planner.{ExternalSourceSensorNode, GroupByBackfillNode, JoinStatsComputeNode, MonolithJoinNode, Node, NodeContent, StagingQueryNode}
+import ai.chronon.planner.{ExternalSourceSensorNode, GroupByBackfillNode, JoinStatsComputeNode, MonolithJoinNode, Node, NodeContent, StagingQueryNode, StagingQueryStatsComputeNode}
 import ai.chronon.spark.other.MockKVStore
 import ai.chronon.spark.utils.{MockApi, SparkTestBase}
 import ai.chronon.spark.catalog.TableUtils
@@ -1255,6 +1255,49 @@ class BatchNodeRunnerTest extends SparkTestBase with Matchers with BeforeAndAfte
       tableDependencies = Seq(tableDep),
       stepDays = Some(1),
       outputTableOverride = Some("test_db.empty_stats_join__stats_output")
+    )
+
+    val node = new Node().setMetaData(metadata).setContent(nodeContent)
+    val runner = new BatchNodeRunner(node, tableUtils, mockApi)
+    val range = PartitionRange(twoDaysAgo, yesterday)(tableUtils.partitionSpec)
+
+    noException should be thrownBy runner.run(metadata, nodeContent, Option(range))
+  }
+
+  "BatchNodeRunner.run with StagingQueryStatsComputeNode" should "skip gracefully when staging query output table has no rows" in {
+    val sqOutputTable = "test_db.empty_sq_output"
+    spark.sql(s"DROP TABLE IF EXISTS $sqOutputTable")
+    spark.sql(
+      s"""CREATE TABLE $sqOutputTable (
+         |  user_id INT,
+         |  amount DOUBLE,
+         |  ds STRING
+         |)
+         |PARTITIONED BY (ds)""".stripMargin
+    )
+
+    val sqConf = Builders.StagingQuery(
+      metaData = Builders.MetaData(namespace = "test_db", name = "empty_stats_sq"),
+      query = s"SELECT * FROM $sqOutputTable"
+    )
+
+    val sqStatsNode = new StagingQueryStatsComputeNode().setStagingQuery(sqConf)
+    val nodeContent = new NodeContent()
+    nodeContent.setStagingQueryStatsCompute(sqStatsNode)
+
+    val tableDep = TableDependencies.fromTable(
+      sqOutputTable,
+      new Query().setPartitionColumn("ds").setPartitionFormat("yyyy-MM-dd")
+    )
+
+    implicit val partitionSpec: PartitionSpec = tableUtils.partitionSpec
+    val metadata = MetaDataUtils.layer(
+      baseMetadata = new MetaData().setOutputNamespace("test_db").setTeam("test_team"),
+      modeName = "backfill",
+      nodeName = "test_db__empty_stats_sq__stats_compute",
+      tableDependencies = Seq(tableDep),
+      stepDays = Some(1),
+      outputTableOverride = Some("test_db.empty_stats_sq__stats_output")
     )
 
     val node = new Node().setMetaData(metadata).setContent(nodeContent)

--- a/thrift/planner.thrift
+++ b/thrift/planner.thrift
@@ -101,6 +101,10 @@ struct JoinStatsUploadToKVNode {
     1: optional api.Join join
 }
 
+struct StagingQueryStatsComputeNode {
+    1: optional api.StagingQuery stagingQuery
+}
+
 union NodeContent {
     // join nodes
     1: SourceWithFilterNode sourceWithFilter
@@ -122,6 +126,7 @@ union NodeContent {
 
     // Stats Node
     20: JoinStatsComputeNode joinStatsCompute
+    21: StagingQueryStatsComputeNode stagingQueryStatsCompute
 
     // groupBy nodes
     100: GroupByBackfillNode groupByBackfill


### PR DESCRIPTION
## Summary

  Extends the Enhanced Statistics pipeline (originally Join-only) to also run on StagingQuery outputs. When a StagingQuery sets enable_stats_compute=True, the planner emits a StagingQueryStatsComputeNode that runs after the staging node,
  computes cardinality-aware stats on the SQ output, and uploads mergeable IRs to the KV store — surfacing them through the existing /v1/stats/:tableName REST endpoint.

  To avoid collisions between same-named Joins and StagingQueries, SQ stats are written under a staging_query/<name> lookup prefix. The REST endpoints accept an optional ?type= query param that selects which producer's stats to read; omitting it preserves today's Join behavior.

##  Changes

  **Thrift**
  - thrift/planner.thrift — new StagingQueryStatsComputeNode and corresponding NodeContent union entry.
  - api/Constants.scala — added EnhancedStatsNodeTypeJoin / EnhancedStatsNodeTypeStagingQuery constants for symmetric producer/consumer naming.

  **Planner**
  - StagingQueryPlanner.scala — adds a statsComputeNode (mirrors MonolithJoinPlanner.statsComputeNode), gated by the existing ExecutionInfo.enableStatsCompute flag; when on, re-points the BACKFILL terminal to the stats node.

  **Spark runner**
  - BatchNodeRunner.scala — extracted a shared runEnhancedStatsCompute(metadata, statsName, keys, range) helper from the existing join path; runJoinStatsCompute and the new runStagingQueryStatsCompute both delegate to it. SQ path passes
  statsName = "staging_query/<sq.metaData.name>" and empty keys. New dispatch case NodeContent._Fields.STAGING_QUERY_STATS_COMPUTE.

  **Service**
  - JavaStatsService.scala — fetchStats / fetchDrift / fetchTrailingDrift each take a trailing nodeType: String arg. A private lookupNameFor(tableName, nodeType) derives the disambiguated KV lookup name ("join" / null / empty → un-prefixed,
  legacy-compatible; other types → <type>/<tableName>). Backward-compat overloads preserve every prior signature.
  - StatsHandler.java, StatsDriftHandler.java, StatsTrailingDriftHandler.java — read ?type= and forward.

  **Python API**
  - python/src/ai/chronon/staging_query.py — new enable_stats_compute: Optional[bool] = None kwarg on StagingQuery(...), threaded into ExecutionInfo.enableStatsCompute (matches the same flag on Join).

##  Backward compatibility

  - Joins: zero change. Stats continue to be written/read un-prefixed; existing /v1/stats/:tableName calls keep working with no ?type= param.
  - StagingQueries: opt-in via enable_stats_compute=True. New data is written under staging_query/<name>; the UI must pass ?type=staging_query to read it.
  - API: all existing JavaStatsService / handler signatures preserved via overloads.

##  Tests

  - StagingQueryPlannerTest.scala — new cases for enableStatsCompute=true|false|unset (stats node presence, terminal node, dependency table).
  - BatchNodeRunnerTest.scala — new empty-table regression test for StagingQueryStatsComputeNode mirroring the existing join one. Log output confirms the staging_query/<name> prefix is applied.
  - Existing join stats regression test (runJoinStatsCompute) still passes after the shared-helper extraction.
  - ./mill api.compile, online.compile, spark.compile, service.compile all clean.

##  Test plan

  - ./mill api.test.testOnly "ai.chronon.api.test.planner.StagingQueryPlannerTest"
  - ./mill spark.test.testOnly "ai.chronon.spark.batch.BatchNodeRunnerTest" -- -z "StagingQueryStatsComputeNode"
  - ./mill spark.test.testOnly "ai.chronon.spark.batch.BatchNodeRunnerTest" -- -z "JoinStatsComputeNode" (regression)
  - ./mill spark.test.testOnly "ai.chronon.spark.other.StatsComputeTest"
  - End-to-end on a canary SQ: set enable_stats_compute=True, run the batch, then curl "http://<host>:9000/v1/stats/<sq.metaData.name>?type=staging_query&startTime=...&endTime=..." and confirm non-zero tilesCount and populated statistics.
  - Confirm a Join stats call without ?type= still returns its existing data (no regression).

##  Rollout

  1. Land + deploy.
  2. Existing Join stats are untouched — no data migration.
  3. To enable stats for a specific StagingQuery: set enable_stats_compute=True in the Python conf and re-deploy that SQ.
  4. UI changes to call /v1/stats/<sq_name>?type=staging_query for any SQ-backed dashboards.

## Checklist
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Staging queries now compute and publish enhanced statistics for monitoring
  * Stats service endpoints support optional producer type parameter to disambiguate metrics from different sources (joins vs staging queries)
  * Python `StagingQuery` class now accepts `enable_stats_compute` parameter to enable statistics computation

* **Improvements**
  * Enhanced error handling for empty staging query outputs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zipline-ai/chronon/pull/1851)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->