### PR TITLE
Add canary support for compilation and Zipline hub

### DIFF
--- a/python/src/ai/chronon/airflow_helpers.py
+++ b/python/src/ai/chronon/airflow_helpers.py
@@ -170,6 +170,16 @@ def _get_airflow_deps_from_source(source, partition_column=None):
         # Unknown source type
         return []
 
+    # Without a partition column we can't construct a meaningful dependency
+    # spec — skip rather than fail. This happens in canary compile when a team
+    # has no canaryConf (executionInfo.conf is empty) and the source's query
+    # also doesn't specify a partition column. In prod compile this same path
+    # is reached only when the user genuinely forgot to set the partition
+    # column anywhere, but failing later (at runtime / scheduling) is preferred
+    # over an obscure assertion deep in compile-time dep generation.
+    if source_partition_column is None:
+        return []
+
     return [
         create_airflow_dependency(table, source_partition_column, additional_partitions)
         for table in tables

--- a/python/src/ai/chronon/cli/compile/compile_context.py
+++ b/python/src/ai/chronon/cli/compile/compile_context.py
@@ -6,6 +6,7 @@ import ai.chronon.cli.compile.parse_teams as teams
 from ai.chronon.cli.compile.conf_validator import ConfValidator
 from ai.chronon.cli.compile.display.compile_status import CompileStatus
 from ai.chronon.cli.compile.display.compiled_obj import CompiledObj
+from ai.chronon.cli.compile.parse_teams import CompileMode
 from ai.chronon.cli.compile.serializer import file2thrift
 from ai.chronon.cli.formatter import Format
 from ai.chronon.cli.logger import get_logger, require
@@ -64,13 +65,20 @@ CONFIG_INFOS: List[ConfigInfo] = [
 @dataclass
 class CompileContext:
     def __init__(
-        self, ignore_python_errors: bool = False, format: Format = Format.TEXT, force: bool = False
+        self,
+        ignore_python_errors: bool = False,
+        format: Format = Format.TEXT,
+        force: bool = False,
+        mode: CompileMode = CompileMode.PROD,
     ):
         self.chronon_root: str = os.getenv("CHRONON_ROOT", os.getcwd())
         self.teams_dict: Dict[str, Team] = teams.load_teams(
             self.chronon_root, print=format != Format.JSON
         )
-        self.compile_dir: str = "compiled"
+        self.mode: CompileMode = mode
+        # Mode picks the output folder. Each pass owns its own folder so the prod
+        # and canary outputs never trample each other.
+        self.compile_dir: str = "compiled" if mode == CompileMode.PROD else "canary_compiled"
         self.ignore_python_errors: bool = ignore_python_errors
         self.format: Format = format
         self.force: bool = force

--- a/python/src/ai/chronon/cli/compile/compiler.py
+++ b/python/src/ai/chronon/cli/compile/compiler.py
@@ -128,7 +128,11 @@ class Compiler:
                     shutil.rmtree(output_dir)
                 shutil.move(staging_dir, output_dir)
                 if self.compile_context.format != Format.JSON:
-                    console.print(f"Compilation successful. Compiled files saved to {output_dir}")
+                    mode_label = self.compile_context.mode.value.upper()
+                    console.print(
+                        f"[bold green]{mode_label} compilation successful.[/] "
+                        f"Compiled files saved to {output_dir}"
+                    )
             else:
                 if self.compile_context.format != Format.JSON:
                     console.print(
@@ -159,7 +163,7 @@ class Compiler:
         teams_dict = self.compile_context.teams_dict
         for team in teams_dict:
             m = MetaData()
-            merge_team_execution_info(m, teams_dict, team)
+            merge_team_execution_info(m, teams_dict, team, mode=self.compile_context.mode)
 
             tjson = serializer.thrift_simple_json(m)
             name = f"{team}.{team}_team_metadata"

--- a/python/src/ai/chronon/cli/compile/parse_configs.py
+++ b/python/src/ai/chronon/cli/compile/parse_configs.py
@@ -43,7 +43,9 @@ def from_folder(target_classes: List[type], input_dir: str, compile_context: Com
             # Process each type's results
             for target_cls, objects_dict in multi_type_results.items():
                 for name, obj in objects_dict.items():
-                    parse_teams.update_metadata(obj, compile_context.teams_dict)
+                    parse_teams.update_metadata(
+                        obj, compile_context.teams_dict, mode=compile_context.mode
+                    )
                     # Populate columnHashes field with semantic hashes
                     populate_column_hashes(obj)
 

--- a/python/src/ai/chronon/cli/compile/parse_teams.py
+++ b/python/src/ai/chronon/cli/compile/parse_teams.py
@@ -30,6 +30,21 @@ logger = get_logger()
 _DEFAULT_CONF_TEAM = "default"
 
 
+class CompileMode(str, Enum):
+    PROD = "prod"
+    CANARY = "canary"
+
+
+# Per-mode field tuples on Team. Strict isolation: prod compile reads only the
+# prod trio; canary compile reads only the canary trio. Adding a new mode means
+# extending this table — no other place in the compile pipeline reaches into
+# Team-level execution-info fields.
+_MODE_FIELD_NAMES = {
+    CompileMode.PROD: ("env", "conf", "clusterConf"),
+    CompileMode.CANARY: ("canaryEnv", "canaryConf", "canaryClusterConf"),
+}
+
+
 def import_module_from_file(file_path):
     # Get the module name from the file path (without .py extension)
     module_name = file_path.split("/")[-1].replace(".py", "")
@@ -106,7 +121,7 @@ def load_teams(conf_root: str, print: bool = True) -> Dict[str, Team]:
     return team_dict
 
 
-def update_metadata(obj: Any, team_dict: Dict[str, Team]):
+def update_metadata(obj: Any, team_dict: Dict[str, Team], mode: CompileMode = CompileMode.PROD):
     assert obj is not None, "Cannot update metadata None object"
 
     metadata = obj.metaData
@@ -137,7 +152,7 @@ def update_metadata(obj: Any, team_dict: Dict[str, Team]):
     # walker once — no chance of drift where (e.g.) propagate reaches
     # `Join.left.joinSource.join` but resolve doesn't.
     for node in _walk_nodes(obj):
-        _propagate_namespace_onto(node, team_dict, team, namespace)
+        _propagate_namespace_onto(node, team_dict, team, namespace, mode=mode)
     for node in _walk_nodes(obj):
         _require_output_namespace_on(node)
     for node in _walk_nodes(obj):
@@ -189,6 +204,7 @@ def _propagate_namespace_onto(
     team_dict: Dict[str, Team],
     default_team: str,
     default_namespace: Optional[str],
+    mode: CompileMode = CompileMode.PROD,
 ):
     """Populate `metaData.team` and `metaData.outputNamespace` on a node. Falls back
     to the top-level `default_team` / `default_namespace` only when the node has no
@@ -210,7 +226,7 @@ def _propagate_namespace_onto(
         raise ValueError(
             f"Team '{node.metaData.team}' referenced by '{node.metaData.name}' not found in teams.py"
         )
-    merge_team_execution_info(node.metaData, team_dict, node.metaData.team)
+    merge_team_execution_info(node.metaData, team_dict, node.metaData.team, mode=mode)
 
 
 def _require_output_namespace_on(node: Any):
@@ -290,28 +306,43 @@ def _substitute_source_tables(source: Any, namespace: str):
         source.entities.mutationTable = _substitute(source.entities.mutationTable, namespace)
 
 
-def merge_team_execution_info(metadata: MetaData, team_dict: Dict[str, Team], team_name: str):
+def merge_team_execution_info(
+    metadata: MetaData,
+    team_dict: Dict[str, Team],
+    team_name: str,
+    mode: CompileMode = CompileMode.PROD,
+):
+    """Merge Team-level env/conf/clusterConf onto `metadata.executionInfo`.
+
+    Strict mode isolation: `mode` selects between the prod trio (env/conf/clusterConf)
+    and the canary trio (canaryEnv/canaryConf/canaryClusterConf). Prod compile never
+    reads canary fields and canary compile never reads prod fields — that's the only
+    place this isolation lives, so `_MODE_FIELD_NAMES` is the single source of truth.
+    """
     default_team = team_dict.get(_DEFAULT_CONF_TEAM)
     if not metadata.executionInfo:
         metadata.executionInfo = ExecutionInfo()
 
+    env_attr, conf_attr, cluster_attr = _MODE_FIELD_NAMES[mode]
+    team = team_dict[team_name]
+
     metadata.executionInfo.env = _merge_mode_maps(
-        default_team.env if default_team else {},
-        team_dict[team_name].env,
+        getattr(default_team, env_attr) if default_team else None,
+        getattr(team, env_attr),
         metadata.executionInfo.env,
         env_or_config_attribute=EnvOrConfigAttribute.ENV,
     )
 
     metadata.executionInfo.conf = _merge_mode_maps(
-        default_team.conf if default_team else {},
-        team_dict[team_name].conf,
+        getattr(default_team, conf_attr) if default_team else None,
+        getattr(team, conf_attr),
         metadata.executionInfo.conf,
         env_or_config_attribute=EnvOrConfigAttribute.CONFIG,
     )
 
     metadata.executionInfo.clusterConf = _merge_mode_maps(
-        default_team.clusterConf if default_team else {},
-        team_dict[team_name].clusterConf,
+        getattr(default_team, cluster_attr) if default_team else None,
+        getattr(team, cluster_attr),
         metadata.executionInfo.clusterConf,
         env_or_config_attribute=EnvOrConfigAttribute.CLUSTER_CONFIG,
     )

--- a/python/src/ai/chronon/group_by.py
+++ b/python/src/ai/chronon/group_by.py
@@ -636,15 +636,16 @@ def GroupBy(
     :param step_days
         The maximum number of days to output at once
     :param environments:
-        List of environment names where this GroupBy should be deployed/available.
-        Defaults to ['prod']. Used to control which environments can access this GroupBy configuration.
+        List of environments where this GroupBy should be deployed/available.
+        Defaults to ['prod']. Valid values: 'prod', 'canary' (case-insensitive).
     :type environments: List[str]
     :return:
         A GroupBy object containing specified aggregations.
     """
-    # Initialize environments with default if not provided
+    # Initialize and validate environments
     if environments is None:
         environments = ['prod']
+    environments = utils.convert_environments_to_enum(environments)
 
     assert sources, "Sources are not specified"
 

--- a/python/src/ai/chronon/group_by.py
+++ b/python/src/ai/chronon/group_by.py
@@ -497,6 +497,7 @@ def GroupBy(
     cluster_conf: common.ClusterConfigProperties = None,
     step_days: int = None,
     disable_historical_backfill: bool = False,
+    environments: Optional[List[str]] = None,
 ) -> ttypes.GroupBy:
     """
 
@@ -634,9 +635,17 @@ def GroupBy(
         Cluster configuration properties for the join.
     :param step_days
         The maximum number of days to output at once
+    :param environments:
+        List of environment names where this GroupBy should be deployed/available.
+        Defaults to ['prod']. Used to control which environments can access this GroupBy configuration.
+    :type environments: List[str]
     :return:
         A GroupBy object containing specified aggregations.
     """
+    # Initialize environments with default if not provided
+    if environments is None:
+        environments = ['prod']
+
     assert sources, "Sources are not specified"
 
     assert version is None or isinstance(version, int), (
@@ -722,6 +731,7 @@ def GroupBy(
         tags=tags if tags else None,
         columnTags=column_tags if column_tags else None,
         version=str(version) if version is not None else None,
+        environments=environments,
     )
 
     group_by = ttypes.GroupBy(

--- a/python/src/ai/chronon/join.py
+++ b/python/src/ai/chronon/join.py
@@ -399,17 +399,18 @@ def Join(
         monolith planner (MonolithJoinPlanner).
     :type modular_execution: bool
     :param environments:
-        List of environment names where this join should be deployed/available.
-        Defaults to ['prod']. Used to control which environments can access this join configuration.
+        List of environments where this join should be deployed/available.
+        Defaults to ['prod']. Valid values: 'prod', 'canary' (case-insensitive).
     :type environments: List[str]
     """
     # Normalize row_ids
     if isinstance(row_ids, str):
         row_ids = [row_ids]
 
-    # Initialize environments with default if not provided
+    # Initialize and validate environments
     if environments is None:
         environments = ['prod']
+    environments = utils.convert_environments_to_enum(environments)
 
     assert version is None or isinstance(version, int), (
         f"Version must be an integer or None, but found {type(version).__name__}"

--- a/python/src/ai/chronon/join.py
+++ b/python/src/ai/chronon/join.py
@@ -290,6 +290,7 @@ def Join(
     step_days: int = None,
     enable_stats_compute: bool = None,
     modular_execution: bool = False,
+    environments: Optional[List[str]] = None,
 ) -> api.Join:
     """
     Construct a join object. A join can pull together data from various GroupBy's both offline and online. This is also
@@ -397,10 +398,18 @@ def Join(
         When True, uses modular join planning (JoinPlanner) instead of the default
         monolith planner (MonolithJoinPlanner).
     :type modular_execution: bool
+    :param environments:
+        List of environment names where this join should be deployed/available.
+        Defaults to ['prod']. Used to control which environments can access this join configuration.
+    :type environments: List[str]
     """
     # Normalize row_ids
     if isinstance(row_ids, str):
         row_ids = [row_ids]
+
+    # Initialize environments with default if not provided
+    if environments is None:
+        environments = ['prod']
 
     assert version is None or isinstance(version, int), (
         f"Version must be an integer or None, but found {type(version).__name__}"
@@ -486,6 +495,7 @@ def Join(
         consistencySamplePercent=consistency_sample_percent,
         executionInfo=exec_info,
         version=str(version) if version is not None else None,
+        environments=environments,
     )
 
     join = api.Join(

--- a/python/src/ai/chronon/model.py
+++ b/python/src/ai/chronon/model.py
@@ -161,6 +161,7 @@ def Model(
     output_namespace: Optional[str] = None,
     table_properties: Optional[Dict[str, str]] = None,
     tags: Optional[Dict[str, str]] = None,
+    environments: Optional[List[str]] = None,
 ) -> ttypes.Model:
     """
     Creates a Model object for ML model inference and orchestration.
@@ -200,9 +201,17 @@ def Model(
     :param tags:
         Additional metadata that does not directly affect computation, but is useful for management.
     :type tags: Dict[str, str]
+    :param environments:
+        List of environment names where this Model should be deployed/available.
+        Defaults to ['prod']. Used to control which environments can access this Model configuration.
+    :type environments: List[str]
     :return:
         A Model object
     """
+    # Initialize environments with default if not provided
+    if environments is None:
+        environments = ['prod']
+
     # Get caller's filename to assign team
     team = utils._get_team_from_caller()
 
@@ -215,6 +224,7 @@ def Model(
         tags=tags,
         tableProperties=table_properties,
         version=version,
+        environments=environments,
     )
 
     model = ttypes.Model(
@@ -249,6 +259,7 @@ def ModelTransforms(
     output_namespace: Optional[str] = None,
     table_properties: Optional[Dict[str, str]] = None,
     tags: Optional[Dict[str, str]] = None,
+    environments: Optional[List[str]] = None,
 ) -> ttypes.ModelTransforms:
     """
     ModelTransforms allows taking the output of existing sources (Event/Entity/Join) and
@@ -267,7 +278,13 @@ def ModelTransforms(
      - output_namespace: Namespace for the model output
      - table_properties: Additional table properties for the model output
      - tags: Additional metadata tags
+     - environments: List of environment names where this ModelTransforms should be deployed/available.
+        Defaults to ['prod']. Used to control which environments can access this ModelTransforms configuration.
     """
+    # Initialize environments with default if not provided
+    if environments is None:
+        environments = ['prod']
+
     # Get caller's filename to assign team
     team = utils._get_team_from_caller()
 
@@ -287,6 +304,7 @@ def ModelTransforms(
         tags=tags,
         tableProperties=table_properties,
         version=str(version),
+        environments=environments,
     )
 
     model_transforms = ttypes.ModelTransforms(

--- a/python/src/ai/chronon/model.py
+++ b/python/src/ai/chronon/model.py
@@ -202,15 +202,16 @@ def Model(
         Additional metadata that does not directly affect computation, but is useful for management.
     :type tags: Dict[str, str]
     :param environments:
-        List of environment names where this Model should be deployed/available.
-        Defaults to ['prod']. Used to control which environments can access this Model configuration.
+        List of environments where this Model should be deployed/available.
+        Defaults to ['prod']. Valid values: 'prod', 'canary' (case-insensitive).
     :type environments: List[str]
     :return:
         A Model object
     """
-    # Initialize environments with default if not provided
+    # Initialize and validate environments
     if environments is None:
         environments = ['prod']
+    environments = utils.convert_environments_to_enum(environments)
 
     # Get caller's filename to assign team
     team = utils._get_team_from_caller()
@@ -278,12 +279,13 @@ def ModelTransforms(
      - output_namespace: Namespace for the model output
      - table_properties: Additional table properties for the model output
      - tags: Additional metadata tags
-     - environments: List of environment names where this ModelTransforms should be deployed/available.
-        Defaults to ['prod']. Used to control which environments can access this ModelTransforms configuration.
+     - environments: List of environments where this ModelTransforms should be deployed/available.
+        Defaults to ['prod']. Valid values: 'prod', 'canary' (case-insensitive).
     """
-    # Initialize environments with default if not provided
+    # Initialize and validate environments
     if environments is None:
         environments = ['prod']
+    environments = utils.convert_environments_to_enum(environments)
 
     # Get caller's filename to assign team
     team = utils._get_team_from_caller()

--- a/python/src/ai/chronon/repo/compile.py
+++ b/python/src/ai/chronon/repo/compile.py
@@ -6,6 +6,7 @@ import click
 
 from ai.chronon.cli.compile.compile_context import CompileContext
 from ai.chronon.cli.compile.compiler import Compiler
+from ai.chronon.cli.compile.parse_teams import CompileMode
 from ai.chronon.cli.formatter import Format, jsonify_exceptions_if_json_format
 from ai.chronon.cli.theme import STYLE_INFO, console
 from gen_thrift.api.ttypes import ConfType
@@ -80,11 +81,39 @@ def __compile(
             )
         )
 
+    text_mode = format != Format.JSON
+
+    # Canary pass first: writes <root>/canary_compiled/ using Team.canaryEnv /
+    # canaryConf / canaryClusterConf. Reading happens before prod so a confirm-
+    # prompt in pending-changes doesn't get sandwiched between two prod outputs.
+    if text_mode:
+        console.rule("[bold cyan]🐤 BEGIN CANARY COMPILATION[/]")
+    canary_context = CompileContext(
+        ignore_python_errors=ignore_python_errors,
+        format=format,
+        force=force,
+        mode=CompileMode.CANARY,
+    )
+    canary_compiler = Compiler(canary_context)
+    canary_compiler.compile(dry_run, validate_all)
+    if text_mode:
+        console.rule("[bold cyan]🐤 END CANARY COMPILATION[/]")
+
+    # Prod pass: writes <root>/compiled/ as before. Results from this pass are
+    # what's returned and (in JSON mode) what's printed — keeping the external
+    # contract stable while canary output is recoverable from disk.
+    if text_mode:
+        console.rule("[bold magenta]🚀 BEGIN PROD COMPILATION[/]")
     compile_context = CompileContext(
-        ignore_python_errors=ignore_python_errors, format=format, force=force
+        ignore_python_errors=ignore_python_errors,
+        format=format,
+        force=force,
+        mode=CompileMode.PROD,
     )
     compiler = Compiler(compile_context)
     results = compiler.compile(dry_run, validate_all)
+    if text_mode:
+        console.rule("[bold magenta]🚀 END PROD COMPILATION[/]")
     if format == Format.JSON:
         print(
             json.dumps(
@@ -99,7 +128,7 @@ def __compile(
                 indent=4,
             )
         )
-    has_errors = compiler.has_compilation_errors()
+    has_errors = compiler.has_compilation_errors() or canary_compiler.has_compilation_errors()
 
     if has_errors and not ignore_python_errors:
         sys.exit(1)

--- a/python/src/ai/chronon/repo/hub_runner.py
+++ b/python/src/ai/chronon/repo/hub_runner.py
@@ -427,7 +427,7 @@ def submit_schedule_all(
     )
 
     with status_spinner("Computing local conf hashes...", format=format):
-        conf_name_to_obj_dict = hub_uploader.build_local_repo_hashmap(root_dir=repo)
+        conf_name_to_obj_dict = hub_uploader.build_local_repo_hashmap(root_dir=repo, env=env)
 
     branch = get_current_branch()
 

--- a/python/src/ai/chronon/repo/hub_runner.py
+++ b/python/src/ai/chronon/repo/hub_runner.py
@@ -30,10 +30,19 @@ from ai.chronon.repo.auth import get_user_email
 from ai.chronon.repo.constants import VALID_CLOUDS, RunMode
 from ai.chronon.repo.utils import print_possible_confs, upload_to_blob_store
 from ai.chronon.repo.zipline_hub import ZiplineHub
-from gen_thrift.api.ttypes import DataKind
+from gen_thrift.api.ttypes import DataKind, Environment
 from gen_thrift.planner.ttypes import Mode
 
 logger = logging.getLogger(__name__)
+
+
+def _env_string_to_enum(env_str: str) -> int:
+    """Convert environment string to enum value."""
+    env_map = {
+        'prod': Environment.PROD,
+        'canary': Environment.CANARY,
+    }
+    return env_map.get(env_str.lower(), Environment.PROD)
 
 
 def _validate_at_most_daily_schedule(schedule_expression: str) -> Optional[str]:
@@ -380,9 +389,9 @@ def redeploy_streaming(repo, confs, hub_url=None, use_auth=True, format: Format 
 
 
 def submit_schedule_all(
-    repo, cloud, customer_id, hub_url=None, use_auth=True, format: Format = Format.TEXT
+    repo, cloud, customer_id, env='prod', hub_url=None, use_auth=True, format: Format = Format.TEXT
 ):
-    """Deploy schedules for all changed confs that have schedules defined."""
+    """Deploy schedules for all changed confs that have schedules defined and match the specified environment."""
     zipline_hub = _get_zipline_hub(
         hub_url,
         get_hub_conf_from_metadata_conf(
@@ -411,9 +420,22 @@ def submit_schedule_all(
     # Collect confs with schedules
     confs_with_schedules = []
     skipped_confs = []
+    env_filtered_confs = []
+
+    # Convert env string to enum value for comparison
+    env_enum = _env_string_to_enum(env)
 
     for name, conf in diff_confs.items():
         try:
+            # Check if conf's environments field includes the specified env
+            metadata_map = get_metadata_map(conf.localPath)
+            conf_environments = metadata_map.get("environments", [Environment.PROD])
+
+            # Skip confs that don't match the specified environment
+            if env_enum not in conf_environments:
+                env_filtered_confs.append(name)
+                continue
+
             schedule_modes = get_schedule_modes(conf.localPath)
 
             # Skip confs without any schedules
@@ -442,11 +464,12 @@ def submit_schedule_all(
             skipped_confs.append(name)
 
     if not confs_with_schedules:
-        print_info(
-            f"No changed confs with schedules found. "
-            f"{len(skipped_confs)} conf(s) changed but have no schedules defined.",
-            format=format,
-        )
+        message_parts = [f"No changed confs with schedules found for environment '{env}'."]
+        if env_filtered_confs:
+            message_parts.append(f"{len(env_filtered_confs)} conf(s) filtered out due to environment mismatch.")
+        if skipped_confs:
+            message_parts.append(f"{len(skipped_confs)} conf(s) changed but have no schedules defined.")
+        print_info(" ".join(message_parts), format=format)
         return
 
     # Deploy schedules via batch API
@@ -504,13 +527,21 @@ def submit_schedule_all(
                     f"  ✓ {conf_name}", ", ".join(schedule_info), format=format
                 )
 
-    if skipped_confs:
-        print_info(
-            f"\n{len(skipped_confs)} conf(s) skipped (no schedules defined): "
-            f"{', '.join(skipped_confs[:5])}"
-            f"{'...' if len(skipped_confs) > 5 else ''}",
-            format=format,
+    info_parts = []
+    if env_filtered_confs:
+        info_parts.append(
+            f"{len(env_filtered_confs)} conf(s) skipped (environment mismatch): "
+            f"{', '.join(env_filtered_confs[:5])}"
+            f"{'...' if len(env_filtered_confs) > 5 else ''}"
         )
+    if skipped_confs:
+        info_parts.append(
+            f"{len(skipped_confs)} conf(s) skipped (no schedules defined): "
+            f"{', '.join(skipped_confs[:5])}"
+            f"{'...' if len(skipped_confs) > 5 else ''}"
+        )
+    if info_parts:
+        print_info("\n" + "\n".join(info_parts), format=format)
 
 
 def submit_workflow(
@@ -731,11 +762,19 @@ def schedule(
 @jsonify_exceptions_if_json_format
 @cloud_provider_option
 @customer_id_option
+@click.option(
+    "--env",
+    help="Environment to deploy schedules for (only schedules confs whose environments field includes this value)",
+    type=click.Choice(['prod', 'canary'], case_sensitive=False),
+    default='prod',
+    show_default=True,
+)
 @handle_dry_run_compile
 def schedule_all(
     repo,
     cloud,
     customer_id,
+    env,
     hub_url=None,
     use_auth=True,
     format: Format = Format.TEXT,
@@ -776,7 +815,7 @@ def schedule_all(
         print_success("No compilation changes detected.", format=format)
 
     submit_schedule_all(
-        repo, cloud, customer_id, hub_url=hub_url, use_auth=use_auth, format=format
+        repo, cloud, customer_id, env=env, hub_url=hub_url, use_auth=use_auth, format=format
     )
 
 

--- a/python/src/ai/chronon/repo/hub_runner.py
+++ b/python/src/ai/chronon/repo/hub_runner.py
@@ -17,6 +17,7 @@ from ai.chronon.cli.formatter import (
 )
 from ai.chronon.cli.git_utils import get_current_branch
 from ai.chronon.cli.theme import (
+    console,
     print_error,
     print_info,
     print_key_value,
@@ -104,7 +105,28 @@ def _resolve_data_type_kinds(obj):
     return obj
 
 
-DEFAULT_TEAM_METADATA_CONF = "compiled/teams_metadata/default/default_team_metadata"
+def team_metadata_conf(team: str = "default", env: str = 'prod') -> str:
+    """Path to a team's compiled metadata thriftjson, scoped to the compile
+    output folder selected by `env`. Mirrors the dual-folder layout produced
+    by `zipline compile`: `prod` → `compiled/`, `canary` → `canary_compiled/`.
+    Unknown values fall back to prod."""
+    folder = "canary_compiled" if env and env.lower() == "canary" else "compiled"
+    return f"{folder}/teams_metadata/{team}/{team}_team_metadata"
+
+
+def default_team_metadata_conf(env: str = 'prod') -> str:
+    return team_metadata_conf("default", env)
+
+
+def print_env_banner(env: str, format: Format = Format.TEXT) -> None:
+    """Loudly announce which compile environment a CLI command is targeting.
+    Suppressed in JSON mode so stdout stays machine-readable."""
+    if format == Format.JSON:
+        return
+    if env and env.lower() == "canary":
+        console.rule("[bold cyan]🐤 RUNNING AGAINST CANARY ENVIRONMENT[/]")
+    else:
+        console.rule("[bold magenta]🚀 RUNNING AGAINST PROD ENVIRONMENT[/]")
 
 
 @dataclass
@@ -395,7 +417,7 @@ def submit_schedule_all(
     zipline_hub = _get_zipline_hub(
         hub_url,
         get_hub_conf_from_metadata_conf(
-            DEFAULT_TEAM_METADATA_CONF,
+            default_team_metadata_conf(env),
             root_dir=repo,
             cloud_provider=cloud,
             customer_id=customer_id,
@@ -782,6 +804,8 @@ def schedule_all(
 ):
     """Deploy recurring schedules for all changed confs that have schedules defined."""
 
+    print_env_banner(env, format=format)
+
     if compile_pending_changes:
         # Check if there are any changes
         added = compile_pending_changes.get("added", [])
@@ -828,15 +852,23 @@ def schedule_all(
 @jsonify_exceptions_if_json_format
 @cloud_provider_option
 @customer_id_option
-def cancel(workflow_id, repo, hub_url, use_auth, format, cloud, customer_id):
+@click.option(
+    "--env",
+    help="Compile environment whose default team metadata supplies the hub config.",
+    type=click.Choice(['prod', 'canary'], case_sensitive=False),
+    default='prod',
+    show_default=True,
+)
+def cancel(workflow_id, repo, hub_url, use_auth, format, cloud, customer_id, env):
     """Cancel a running workflow.
 
     WORKFLOW_ID is the ID of the workflow to cancel.
     """
+    print_env_banner(env, format=format)
     zipline_hub = _get_zipline_hub(
         hub_url,
         get_hub_conf_from_metadata_conf(
-            DEFAULT_TEAM_METADATA_CONF,
+            default_team_metadata_conf(env),
             root_dir=repo,
             cloud_provider=cloud,
             customer_id=customer_id,
@@ -1173,14 +1205,22 @@ def eval(
     default="SPARK",
     show_default=True,
 )
+@click.option(
+    "--env",
+    help="Compile environment whose team/default metadata supplies the hub config.",
+    type=click.Choice(['prod', 'canary'], case_sensitive=False),
+    default='prod',
+    show_default=True,
+)
 @jsonify_exceptions_if_json_format
 def eval_table(
-    table, repo, conf, team, hub_url, use_auth, format, eval_url, engine_type
+    table, repo, conf, team, hub_url, use_auth, format, eval_url, engine_type, env
 ):
     """Validate a table's schema.
 
     TABLE is the table name for schema evaluation (e.g. data.loggable_response).
     """
+    print_env_banner(env, format=format)
     # Use conf for executionInfo if provided (highest priority)
     conf_execution_info, team_execution_info, default_execution_info = None, None, None
     team = team or os.environ.get("TEAM")
@@ -1189,13 +1229,12 @@ def eval_table(
         conf_execution_info = get_metadata_map(file_path).get("executionInfo")
     # Otherwise use team metadata if specified
     elif team:
-        team_metadata_path = f"compiled/teams_metadata/{team}/{team}_team_metadata"
-        file_path = os.path.join(repo, team_metadata_path)
+        file_path = os.path.join(repo, team_metadata_conf(team, env))
         with open(file_path, "r") as f:
             team_execution_info = json.load(f).get("executionInfo")
     # Otherwise use default team metadata
     else:
-        file_path = os.path.join(repo, DEFAULT_TEAM_METADATA_CONF)
+        file_path = os.path.join(repo, default_team_metadata_conf(env))
         with open(file_path, "r") as f:
             default_execution_info = json.load(f).get("executionInfo")
     execution_info = (
@@ -1273,21 +1312,28 @@ def eval_table(
     default="SPARK",
     show_default=True,
 )
+@click.option(
+    "--env",
+    help="Compile environment whose team/default metadata supplies the hub config.",
+    type=click.Choice(['prod', 'canary'], case_sensitive=False),
+    default='prod',
+    show_default=True,
+)
 @jsonify_exceptions_if_json_format
-def list_tables(schema_name, repo, team, hub_url, use_auth, format, eval_url, engine_type):
+def list_tables(schema_name, repo, team, hub_url, use_auth, format, eval_url, engine_type, env):
     """List tables in a schema.
 
     SCHEMA_NAME is the schema/database to list tables from (e.g. demo).
     """
+    print_env_banner(env, format=format)
     team_execution_info, default_execution_info = None, None
     team = team or os.environ.get("TEAM")
     if team:
-        team_metadata_path = f"compiled/teams_metadata/{team}/{team}_team_metadata"
-        file_path = os.path.join(repo, team_metadata_path)
+        file_path = os.path.join(repo, team_metadata_conf(team, env))
         with open(file_path, "r") as f:
             team_execution_info = json.load(f).get("executionInfo")
     else:
-        file_path = os.path.join(repo, DEFAULT_TEAM_METADATA_CONF)
+        file_path = os.path.join(repo, default_team_metadata_conf(env))
         with open(file_path, "r") as f:
             default_execution_info = json.load(f).get("executionInfo")
     execution_info = team_execution_info or default_execution_info

--- a/python/src/ai/chronon/repo/hub_runner.py
+++ b/python/src/ai/chronon/repo/hub_runner.py
@@ -118,6 +118,14 @@ def default_team_metadata_conf(env: str = 'prod') -> str:
     return team_metadata_conf("default", env)
 
 
+def _env_from_conf_path(conf: str) -> str:
+    """Infer the compile env from a conf path. A path that lives under
+    `canary_compiled/` targets canary; anything else targets prod. Lets
+    conf-path-taking commands stay env-aware without making the user pass an
+    explicit `--env` flag that has to agree with the path they typed."""
+    return "canary" if "canary_compiled" in os.path.normpath(conf).split(os.sep) else "prod"
+
+
 def print_env_banner(env: str, format: Format = Format.TEXT) -> None:
     """Loudly announce which compile environment a CLI command is targeting.
     Suppressed in JSON mode so stdout stays machine-readable."""
@@ -373,11 +381,25 @@ def redeploy_streaming(repo, confs, hub_url=None, use_auth=True, format: Format 
         raise ValueError(
             f"All confs must target the same Hub, but found multiple hub_url values:\n{mismatches}"
         )
+
+    # All confs in a single redeploy must come from the same compile env
+    # (mixing prod and canary in one call would hash against the wrong folder
+    # for half of them).
+    conf_envs = [_env_from_conf_path(c) for c in confs]
+    if len(set(conf_envs)) > 1:
+        mismatches = "\n".join(
+            f"  {conf}: {env}" for conf, env in zip(confs, conf_envs, strict=True)
+        )
+        raise ValueError(
+            f"All confs must come from the same compile environment, but found a mix of prod and canary:\n{mismatches}"
+        )
+    env = conf_envs[0] if conf_envs else "prod"
+
     hub_conf = hub_confs[0]
     zipline_hub = _get_zipline_hub(hub_url, hub_conf, use_auth, format)
 
     with status_spinner("Computing local conf hashes...", format=format):
-        conf_name_to_hash_dict = hub_uploader.build_local_repo_hashmap(root_dir=repo)
+        conf_name_to_hash_dict = hub_uploader.build_local_repo_hashmap(root_dir=repo, env=env)
     branch = get_current_branch()
     with status_spinner("Syncing confs with Hub...", format=format):
         hub_uploader.compute_and_upload_diffs(
@@ -581,7 +603,9 @@ def submit_workflow(
     zipline_hub = _get_zipline_hub(hub_url, hub_conf, use_auth, format)
 
     with status_spinner("Computing local conf hashes...", format=format):
-        conf_name_to_hash_dict = hub_uploader.build_local_repo_hashmap(root_dir=repo)
+        conf_name_to_hash_dict = hub_uploader.build_local_repo_hashmap(
+            root_dir=repo, env=_env_from_conf_path(conf)
+        )
     branch = get_current_branch()
 
     with status_spinner("Syncing confs with Hub...", format=format):
@@ -635,7 +659,9 @@ def submit_schedule(
     zipline_hub = _get_zipline_hub(hub_url, hub_conf, use_auth, format)
 
     with status_spinner("Computing local conf hashes...", format=format):
-        conf_name_to_obj_dict = hub_uploader.build_local_repo_hashmap(root_dir=repo)
+        conf_name_to_obj_dict = hub_uploader.build_local_repo_hashmap(
+            root_dir=repo, env=_env_from_conf_path(conf)
+        )
     branch = get_current_branch()
 
     with status_spinner("Syncing confs with Hub...", format=format):
@@ -1131,7 +1157,9 @@ def eval(
         format=format,
         auth_url=hub_conf.frontend_url,
     )
-    conf_name_to_hash_dict = hub_uploader.build_local_repo_hashmap(root_dir=repo)
+    conf_name_to_hash_dict = hub_uploader.build_local_repo_hashmap(
+        root_dir=repo, env=_env_from_conf_path(conf)
+    )
     branch = get_current_branch()
     if test_data_path:
         # Upload the test data skeleton to the bucket.

--- a/python/src/ai/chronon/repo/hub_uploader.py
+++ b/python/src/ai/chronon/repo/hub_uploader.py
@@ -13,8 +13,12 @@ from ai.chronon.repo.zipline_hub import ZiplineHub
 from gen_thrift.api.ttypes import Conf
 
 
-def build_local_repo_hashmap(root_dir: str):
-    compiled_dir = os.path.join(root_dir, "compiled")
+def build_local_repo_hashmap(root_dir: str, env: str = 'prod'):
+    # `env` picks the compile output folder. Mirrors the dual-folder layout
+    # produced by `zipline compile`: 'prod' → compiled/, 'canary' →
+    # canary_compiled/. Unknown values fall back to prod.
+    folder = "canary_compiled" if env and env.lower() == "canary" else "compiled"
+    compiled_dir = os.path.join(root_dir, folder)
     # Returns a map of name -> (tbinary, file_hash)
     results = {}
 

--- a/python/src/ai/chronon/staging_query.py
+++ b/python/src/ai/chronon/staging_query.py
@@ -239,15 +239,16 @@ def StagingQuery(
         day 1, and refresh it for the next 6 days)
     :type recompute_days: int
     :param environments:
-        List of environment names where this StagingQuery should be deployed/available.
-        Defaults to ['prod']. Used to control which environments can access this StagingQuery configuration.
+        List of environments where this StagingQuery should be deployed/available.
+        Defaults to ['prod']. Valid values: 'prod', 'canary' (case-insensitive).
     :type environments: List[str]
     :return:
         A StagingQuery object
     """
-    # Initialize environments with default if not provided
+    # Initialize and validate environments
     if environments is None:
         environments = ['prod']
+    environments = utils.convert_environments_to_enum(environments)
 
     # Get caller's filename to assign team
     team = utils._get_team_from_caller()

--- a/python/src/ai/chronon/staging_query.py
+++ b/python/src/ai/chronon/staging_query.py
@@ -181,6 +181,7 @@ def StagingQuery(
     step_days: Optional[int] = None,
     recompute_days: Optional[int] = None,
     additional_partitions: List[str] = None,
+    environments: Optional[List[str]] = None,
 ) -> ttypes.StagingQuery:
     """
     Creates a StagingQuery object for executing arbitrary SQL queries with templated date parameters.
@@ -237,9 +238,17 @@ def StagingQuery(
         X days later) or when you want partially mature aggregations (i.e. a 7 day window, but start computing it from
         day 1, and refresh it for the next 6 days)
     :type recompute_days: int
+    :param environments:
+        List of environment names where this StagingQuery should be deployed/available.
+        Defaults to ['prod']. Used to control which environments can access this StagingQuery configuration.
+    :type environments: List[str]
     :return:
         A StagingQuery object
     """
+    # Initialize environments with default if not provided
+    if environments is None:
+        environments = ['prod']
+
     # Get caller's filename to assign team
     team = utils._get_team_from_caller()
 
@@ -317,6 +326,7 @@ def StagingQuery(
         tableProperties=table_properties,
         version=str(version) if version is not None else None,
         additionalOutputPartitionColumns=additional_partitions,
+        environments=environments,
     )
 
     thrift_deps = []

--- a/python/src/ai/chronon/utils.py
+++ b/python/src/ai/chronon/utils.py
@@ -34,6 +34,33 @@ ANY_SOURCE_TYPE = Union[
 chronon_root_path = ""  # passed from compile.py
 
 
+def convert_environments_to_enum(environments: List[str]) -> List[int]:
+    """Convert environment strings to enum values with validation.
+
+    Args:
+        environments: List of environment strings ('prod', 'canary', case-insensitive)
+
+    Returns:
+        List of Environment enum integer values
+
+    Raises:
+        ValueError: If any environment string is not 'prod' or 'canary'
+    """
+    env_map = {
+        'prod': api.Environment.PROD,
+        'canary': api.Environment.CANARY,
+    }
+    result = []
+    for env in environments:
+        env_lower = env.lower()
+        if env_lower not in env_map:
+            raise ValueError(
+                f"Invalid environment '{env}'. Must be one of: {list(env_map.keys())}"
+            )
+        result.append(env_map[env_lower])
+    return result
+
+
 def normalize_source(source: ANY_SOURCE_TYPE, output_namespace: str = None) -> api.Source:
     """Convert any source type to a properly wrapped api.Source"""
     if isinstance(source, api.EventSource):

--- a/python/test/canary/canary_compiled/group_bys/aws/dim_listings.v1__0
+++ b/python/test/canary/canary_compiled/group_bys/aws/dim_listings.v1__0
@@ -1,0 +1,155 @@
+{
+  "keyColumns": [
+    "listing_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "brief_description": "c02f5fdfa63b63dc6a593a20cbab7d66",
+      "currency": "27d3da8403941e88f04007211468833e",
+      "headline": "961d1b3f1536af92638c63b2085fa728",
+      "inventory_count": "f3f379de8d3f9e74b60600f0356327d4",
+      "is_active": "b73c53f1089d15c7549d1be9e45bc05a",
+      "is_expensive": "dfe960db190729abde16b0eba360dfc4",
+      "is_in_stock": "6f24425755fd59b8a5a93de6912b111c",
+      "listing_id": "76323e9628393438a3d9bd1e0a0dcf40",
+      "long_description": "0588c5abbb679b56d18028e929d62124",
+      "main_image_path": "e670b87ebe0042f36d6dcb0379ce12da",
+      "merchant_id": "14059af75922b7fe7d8993867667f4af",
+      "price_cents": "33f80b9b819b9b68c65fc31652d4cc26",
+      "primary_category": "76c07f8cf4d4c3465843d890b89f8bb0",
+      "secondary_image_paths": "2d21e3616fce29041df8387677ef5193",
+      "tags": "b02298b5dc181fd94c357eef9f0623ca",
+      "weight_grams": "8b5ac3514f1c8f0db67748e07de128f4"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_exports_dim_listings__0_with_offset_0\", \"spec\": \"data.aws_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily",
+      "stepDays": 10
+    },
+    "name": "aws.dim_listings.v1__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/aws/dim_listings.py",
+    "team": "aws",
+    "version": "0"
+  },
+  "sources": [
+    {
+      "entities": {
+        "query": {
+          "selects": {
+            "brief_description": "brief_description",
+            "currency": "currency",
+            "headline": "headline",
+            "inventory_count": "inventory_count",
+            "is_active": "is_active",
+            "is_expensive": "IF(price_cents > 10000, 1, 0)",
+            "is_in_stock": "IF(inventory_count > 0, 1, 0)",
+            "listing_id": "listing_id",
+            "long_description": "long_description",
+            "main_image_path": "main_image_path",
+            "merchant_id": "merchant_id",
+            "price_cents": "price_cents",
+            "primary_category": "primary_category",
+            "secondary_image_paths": "secondary_image_paths",
+            "tags": "tags",
+            "weight_grams": "weight_grams"
+          },
+          "startPartition": "2025-01-01"
+        },
+        "snapshotTable": "data.aws_exports_dim_listings__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/aws/dim_merchants.v1__0
+++ b/python/test/canary/canary_compiled/group_bys/aws/dim_merchants.v1__0
@@ -1,0 +1,127 @@
+{
+  "keyColumns": [
+    "listing_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "listing_id": "d06b93d848d96f30e2870c8317667b51",
+      "primary_category": "7b4dbbd91897982b4f6672bb24202751"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_exports_dim_merchants__0_with_offset_0\", \"spec\": \"data.aws_exports_dim_merchants__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily",
+      "stepDays": 10
+    },
+    "name": "aws.dim_merchants.v1__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/aws/dim_merchants.py",
+    "team": "aws",
+    "version": "0"
+  },
+  "sources": [
+    {
+      "entities": {
+        "query": {
+          "selects": {
+            "listing_id": "merchant_id",
+            "primary_category": "primary_category"
+          },
+          "startPartition": "2025-01-01"
+        },
+        "snapshotTable": "data.aws_exports_dim_merchants__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/aws/item_event_canary.actions_v1__0
+++ b/python/test/canary/canary_compiled/group_bys/aws/item_event_canary.actions_v1__0
@@ -1,0 +1,182 @@
+{
+  "aggregations": [
+    {
+      "argMap": {},
+      "inputColumn": "add_cart",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "view",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "favorite",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        }
+      ]
+    }
+  ],
+  "keyColumns": [
+    "listing_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "add_cart_sum_1d": "1c84943e7da62cf176256a84020804bd",
+      "favorite_sum_1d": "c713f3f34dbb05d29f7f4a8379eee695",
+      "listing_id": "609094d15d01b15cd3c2f7b39a399409",
+      "purchase_sum_1d": "fb8cfc84fca71682f8d758092259323f",
+      "view_sum_1d": "cc58ae369bab825653562d7cd27aa09c"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_item_events_parquet_compat_partitioned_with_offset_0\", \"spec\": \"data.item_events_parquet_compat_partitioned/_DATE={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "_DATE",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "_DATE",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": "-Ztasks=4",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": "-Ztasks=4",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily"
+    },
+    "name": "aws.item_event_canary.actions_v1__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/aws/item_event_canary.py",
+    "team": "aws",
+    "version": "0"
+  },
+  "sources": [
+    {
+      "events": {
+        "query": {
+          "selects": {
+            "add_cart": "IF(event_type = 'backend_add_to_cart', 1, 0)",
+            "favorite": "IF(event_type = 'backend_favorite_item2', 1, 0)",
+            "listing_id": "EXPLODE(TRANSFORM(SPLIT(COALESCE(attributes['sold_listing_ids'], attributes['listing_id']), ','), e -> CAST(e AS LONG)))",
+            "purchase": "IF(event_type = 'backend_cart_payment', 1, 0)",
+            "view": "IF(event_type = 'view_listing', 1, 0)"
+          },
+          "timeColumn": "timestamp",
+          "wheres": [
+            "event_type in ('backend_add_to_cart', 'view_listing', 'backend_cart_payment', 'backend_favorite_item2')"
+          ]
+        },
+        "table": "data.item_events_parquet_compat_partitioned",
+        "topic": "kafka://test-item-event-data/serde=custom/provider_class=ai.chronon.flink.deser.MockCustomSchemaProvider/schema_name=item_event"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/aws/logging_schema.v1__2
+++ b/python/test/canary/canary_compiled/group_bys/aws/logging_schema.v1__2
@@ -1,0 +1,137 @@
+{
+  "accuracy": 1,
+  "aggregations": [
+    {
+      "argMap": {},
+      "inputColumn": "schema_value",
+      "operation": 3
+    }
+  ],
+  "keyColumns": [
+    "schema_hash"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "schema_hash": "dcf8cf2cef848c61a7120c4db9d241e5",
+      "schema_value_last": "2533f3b6588575d6884c6375f2b28e8d"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_partitioned_logging_v0__2_with_offset_0\", \"spec\": \"data.aws_partitioned_logging_v0__2/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "historicalBackfill": 0
+    },
+    "name": "aws.logging_schema.v1__2",
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/aws/logging_schema.py",
+    "team": "aws",
+    "version": "2"
+  },
+  "sources": [
+    {
+      "events": {
+        "query": {
+          "partitionColumn": "ds",
+          "selects": {
+            "schema_hash": "CAST(keyBytes AS STRING)",
+            "schema_value": "CAST(valueBytes AS STRING)"
+          },
+          "startPartition": "2025-09-23",
+          "timeColumn": "ts_millis",
+          "wheres": [
+            "name='SCHEMA_PUBLISH_EVENT'"
+          ]
+        },
+        "table": "data.aws_partitioned_logging_v0__2"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/aws/purchases.v1_dev__0
+++ b/python/test/canary/canary_compiled/group_bys/aws/purchases.v1_dev__0
@@ -1,0 +1,202 @@
+{
+  "aggregations": [
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 6,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {
+        "k": "10"
+      },
+      "inputColumn": "purchase_price",
+      "operation": 13
+    }
+  ],
+  "keyColumns": [
+    "user_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "purchase_price_average_1d": "bd4c481c4e592608ace5a2930f61d45a",
+      "purchase_price_average_3d": "bd4c481c4e592608ace5a2930f61d45a",
+      "purchase_price_average_7d": "bd4c481c4e592608ace5a2930f61d45a",
+      "purchase_price_count_1d": "bd4c481c4e592608ace5a2930f61d45a",
+      "purchase_price_count_3d": "bd4c481c4e592608ace5a2930f61d45a",
+      "purchase_price_count_7d": "bd4c481c4e592608ace5a2930f61d45a",
+      "purchase_price_last10": "bd4c481c4e592608ace5a2930f61d45a",
+      "purchase_price_sum_1d": "bd4c481c4e592608ace5a2930f61d45a",
+      "purchase_price_sum_3d": "bd4c481c4e592608ace5a2930f61d45a",
+      "purchase_price_sum_7d": "bd4c481c4e592608ace5a2930f61d45a",
+      "user_id": "677635fb8fabe631108435c5cffe73ce"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily"
+    },
+    "name": "aws.purchases.v1_dev__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/aws/purchases.py",
+    "team": "aws",
+    "version": "0"
+  },
+  "sources": [
+    {
+      "events": {
+        "query": {
+          "selects": {
+            "purchase_price": "purchase_price",
+            "user_id": "user_id"
+          },
+          "startPartition": "2023-11-01",
+          "timeColumn": "ts"
+        },
+        "table": "data.purchases"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/aws/purchases.v1_test__0
+++ b/python/test/canary/canary_compiled/group_bys/aws/purchases.v1_test__0
@@ -1,0 +1,202 @@
+{
+  "aggregations": [
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 6,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {
+        "k": "10"
+      },
+      "inputColumn": "purchase_price",
+      "operation": 13
+    }
+  ],
+  "keyColumns": [
+    "user_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "purchase_price_average_1d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+      "purchase_price_average_3d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+      "purchase_price_average_7d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+      "purchase_price_count_1d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+      "purchase_price_count_3d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+      "purchase_price_count_7d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+      "purchase_price_last10": "5814df4e6a1e2eb06b9fab89e70ea97d",
+      "purchase_price_sum_1d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+      "purchase_price_sum_3d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+      "purchase_price_sum_7d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+      "user_id": "dec6601a613992b4b6cdc50ac8014a29"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily"
+    },
+    "name": "aws.purchases.v1_test__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/aws/purchases.py",
+    "team": "aws",
+    "version": "0"
+  },
+  "sources": [
+    {
+      "events": {
+        "query": {
+          "selects": {
+            "purchase_price": "purchase_price",
+            "user_id": "user_id"
+          },
+          "startPartition": "2023-11-01",
+          "timeColumn": "ts"
+        },
+        "table": "data.purchases"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/aws/user_activities.kafka_iam_v1__1
+++ b/python/test/canary/canary_compiled/group_bys/aws/user_activities.kafka_iam_v1__1
@@ -1,0 +1,518 @@
+{
+  "aggregations": [
+    {
+      "argMap": {},
+      "inputColumn": "view_event",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "click_event",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_event",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "favorite_event",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "add_to_cart_event",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "view_event",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "click_event",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_event",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "favorite_event",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "add_to_cart_event",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "is_mobile",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "is_desktop",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "is_tablet",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {
+        "k": "128"
+      },
+      "inputColumn": "user_event_struct",
+      "operation": 13,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    }
+  ],
+  "keyColumns": [
+    "user_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "add_to_cart_event_average_14d": "05abc2cd4a5ebb162d4796294b526640",
+      "add_to_cart_event_average_1d": "05abc2cd4a5ebb162d4796294b526640",
+      "add_to_cart_event_average_30d": "05abc2cd4a5ebb162d4796294b526640",
+      "add_to_cart_event_average_7d": "05abc2cd4a5ebb162d4796294b526640",
+      "add_to_cart_event_sum_14d": "05abc2cd4a5ebb162d4796294b526640",
+      "add_to_cart_event_sum_1d": "05abc2cd4a5ebb162d4796294b526640",
+      "add_to_cart_event_sum_30d": "05abc2cd4a5ebb162d4796294b526640",
+      "add_to_cart_event_sum_7d": "05abc2cd4a5ebb162d4796294b526640",
+      "click_event_average_14d": "2108647d1229080fc2f053c3c08f89dc",
+      "click_event_average_1d": "2108647d1229080fc2f053c3c08f89dc",
+      "click_event_average_30d": "2108647d1229080fc2f053c3c08f89dc",
+      "click_event_average_7d": "2108647d1229080fc2f053c3c08f89dc",
+      "click_event_sum_14d": "2108647d1229080fc2f053c3c08f89dc",
+      "click_event_sum_1d": "2108647d1229080fc2f053c3c08f89dc",
+      "click_event_sum_30d": "2108647d1229080fc2f053c3c08f89dc",
+      "click_event_sum_7d": "2108647d1229080fc2f053c3c08f89dc",
+      "favorite_event_average_14d": "f65f3f8e07a5574f18115a5b36049fcd",
+      "favorite_event_average_1d": "f65f3f8e07a5574f18115a5b36049fcd",
+      "favorite_event_average_30d": "f65f3f8e07a5574f18115a5b36049fcd",
+      "favorite_event_average_7d": "f65f3f8e07a5574f18115a5b36049fcd",
+      "favorite_event_sum_14d": "f65f3f8e07a5574f18115a5b36049fcd",
+      "favorite_event_sum_1d": "f65f3f8e07a5574f18115a5b36049fcd",
+      "favorite_event_sum_30d": "f65f3f8e07a5574f18115a5b36049fcd",
+      "favorite_event_sum_7d": "f65f3f8e07a5574f18115a5b36049fcd",
+      "is_desktop_sum_14d": "a893d2077e3ba09589c19a605ad8b95e",
+      "is_desktop_sum_1d": "a893d2077e3ba09589c19a605ad8b95e",
+      "is_desktop_sum_30d": "a893d2077e3ba09589c19a605ad8b95e",
+      "is_desktop_sum_7d": "a893d2077e3ba09589c19a605ad8b95e",
+      "is_mobile_sum_14d": "32ad9d852b3a6d169232c9601eb94e7d",
+      "is_mobile_sum_1d": "32ad9d852b3a6d169232c9601eb94e7d",
+      "is_mobile_sum_30d": "32ad9d852b3a6d169232c9601eb94e7d",
+      "is_mobile_sum_7d": "32ad9d852b3a6d169232c9601eb94e7d",
+      "is_tablet_sum_14d": "40f8ccf6508b76bcc7b36d661d3b3f62",
+      "is_tablet_sum_1d": "40f8ccf6508b76bcc7b36d661d3b3f62",
+      "is_tablet_sum_30d": "40f8ccf6508b76bcc7b36d661d3b3f62",
+      "is_tablet_sum_7d": "40f8ccf6508b76bcc7b36d661d3b3f62",
+      "purchase_event_average_14d": "5555435c08468d56d98f57162a2651d1",
+      "purchase_event_average_1d": "5555435c08468d56d98f57162a2651d1",
+      "purchase_event_average_30d": "5555435c08468d56d98f57162a2651d1",
+      "purchase_event_average_7d": "5555435c08468d56d98f57162a2651d1",
+      "purchase_event_sum_14d": "5555435c08468d56d98f57162a2651d1",
+      "purchase_event_sum_1d": "5555435c08468d56d98f57162a2651d1",
+      "purchase_event_sum_30d": "5555435c08468d56d98f57162a2651d1",
+      "purchase_event_sum_7d": "5555435c08468d56d98f57162a2651d1",
+      "user_event_struct_last128_14d": "fefd18eaf8d2d3715d4844e54e18047c",
+      "user_event_struct_last128_1d": "fefd18eaf8d2d3715d4844e54e18047c",
+      "user_event_struct_last128_30d": "fefd18eaf8d2d3715d4844e54e18047c",
+      "user_event_struct_last128_7d": "fefd18eaf8d2d3715d4844e54e18047c",
+      "user_id": "e2499040cffcdfb2497443c48699bab0",
+      "view_event_average_14d": "85e2a9f708b8278a695c01f60e8c1396",
+      "view_event_average_1d": "85e2a9f708b8278a695c01f60e8c1396",
+      "view_event_average_30d": "85e2a9f708b8278a695c01f60e8c1396",
+      "view_event_average_7d": "85e2a9f708b8278a695c01f60e8c1396",
+      "view_event_sum_14d": "85e2a9f708b8278a695c01f60e8c1396",
+      "view_event_sum_1d": "85e2a9f708b8278a695c01f60e8c1396",
+      "view_event_sum_30d": "85e2a9f708b8278a695c01f60e8c1396",
+      "view_event_sum_7d": "85e2a9f708b8278a695c01f60e8c1396"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo_user_activities_raw_with_offset_0\", \"spec\": \"demo.user_activities_raw/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": "-Ztasks=1 -Zbootstrap=b-1.ziplinecanarykafka.hak90r.c4.kafka.us-west-2.amazonaws.com:9098",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": "-Ztasks=1 -Zbootstrap=b-1.ziplinecanarykafka.hak90r.c4.kafka.us-west-2.amazonaws.com:9098",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily",
+      "stepDays": 10
+    },
+    "name": "aws.user_activities.kafka_iam_v1__1",
+    "online": 1,
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/aws/user_activities.py",
+    "team": "aws",
+    "version": "1"
+  },
+  "sources": [
+    {
+      "events": {
+        "query": {
+          "selects": {
+            "add_to_cart_event": "IF(event_type = 'add_to_cart', 1, 0)",
+            "click_event": "IF(event_type = 'click', 1, 0)",
+            "favorite_event": "IF(event_type = 'favorite', 1, 0)",
+            "is_desktop": "IF(device_type = 'desktop', 1, 0)",
+            "is_mobile": "IF(device_type = 'mobile', 1, 0)",
+            "is_tablet": "IF(device_type = 'tablet', 1, 0)",
+            "listing_id": "listing_id",
+            "purchase_event": "IF(event_type = 'purchase', 1, 0)",
+            "user_event_struct": "STRUCT(event_type, listing_id, unix_millis(TIMESTAMP(event_time_ms)) as timestamp)",
+            "user_id": "user_id",
+            "view_event": "IF(event_type = 'view', 1, 0)"
+          },
+          "timeColumn": "unix_millis(TIMESTAMP(event_time_ms))"
+        },
+        "table": "demo.user_activities_raw",
+        "topic": "kafka://user-activities-js/serde=glue_registry/registry_name=zipline-canary/schema_name=user-activities-js/security.protocol=SASL_SSL/sasl.mechanism=AWS_MSK_IAM/sasl.jaas.config=software.amazon.msk.auth.iam.IAMLoginModule required;/sasl.client.callback.handler.class=software.amazon.msk.auth.iam.IAMClientCallbackHandler"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/aws/user_activities.kafka_v1__1
+++ b/python/test/canary/canary_compiled/group_bys/aws/user_activities.kafka_v1__1
@@ -1,0 +1,518 @@
+{
+  "aggregations": [
+    {
+      "argMap": {},
+      "inputColumn": "view_event",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "click_event",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_event",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "favorite_event",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "add_to_cart_event",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "view_event",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "click_event",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_event",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "favorite_event",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "add_to_cart_event",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "is_mobile",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "is_desktop",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "is_tablet",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {
+        "k": "128"
+      },
+      "inputColumn": "user_event_struct",
+      "operation": 13,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    }
+  ],
+  "keyColumns": [
+    "user_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "add_to_cart_event_average_14d": "9973d222146fbf6d1f8b5f443a5042a0",
+      "add_to_cart_event_average_1d": "9973d222146fbf6d1f8b5f443a5042a0",
+      "add_to_cart_event_average_30d": "9973d222146fbf6d1f8b5f443a5042a0",
+      "add_to_cart_event_average_7d": "9973d222146fbf6d1f8b5f443a5042a0",
+      "add_to_cart_event_sum_14d": "9973d222146fbf6d1f8b5f443a5042a0",
+      "add_to_cart_event_sum_1d": "9973d222146fbf6d1f8b5f443a5042a0",
+      "add_to_cart_event_sum_30d": "9973d222146fbf6d1f8b5f443a5042a0",
+      "add_to_cart_event_sum_7d": "9973d222146fbf6d1f8b5f443a5042a0",
+      "click_event_average_14d": "f3d7659895121b4a1ef83ab34e22703c",
+      "click_event_average_1d": "f3d7659895121b4a1ef83ab34e22703c",
+      "click_event_average_30d": "f3d7659895121b4a1ef83ab34e22703c",
+      "click_event_average_7d": "f3d7659895121b4a1ef83ab34e22703c",
+      "click_event_sum_14d": "f3d7659895121b4a1ef83ab34e22703c",
+      "click_event_sum_1d": "f3d7659895121b4a1ef83ab34e22703c",
+      "click_event_sum_30d": "f3d7659895121b4a1ef83ab34e22703c",
+      "click_event_sum_7d": "f3d7659895121b4a1ef83ab34e22703c",
+      "favorite_event_average_14d": "c048562dd6748348dc246050dff3cd15",
+      "favorite_event_average_1d": "c048562dd6748348dc246050dff3cd15",
+      "favorite_event_average_30d": "c048562dd6748348dc246050dff3cd15",
+      "favorite_event_average_7d": "c048562dd6748348dc246050dff3cd15",
+      "favorite_event_sum_14d": "c048562dd6748348dc246050dff3cd15",
+      "favorite_event_sum_1d": "c048562dd6748348dc246050dff3cd15",
+      "favorite_event_sum_30d": "c048562dd6748348dc246050dff3cd15",
+      "favorite_event_sum_7d": "c048562dd6748348dc246050dff3cd15",
+      "is_desktop_sum_14d": "7b1f52b7ee489011fc5daca587b42d1c",
+      "is_desktop_sum_1d": "7b1f52b7ee489011fc5daca587b42d1c",
+      "is_desktop_sum_30d": "7b1f52b7ee489011fc5daca587b42d1c",
+      "is_desktop_sum_7d": "7b1f52b7ee489011fc5daca587b42d1c",
+      "is_mobile_sum_14d": "3f81171b897cd66983648bce6115d756",
+      "is_mobile_sum_1d": "3f81171b897cd66983648bce6115d756",
+      "is_mobile_sum_30d": "3f81171b897cd66983648bce6115d756",
+      "is_mobile_sum_7d": "3f81171b897cd66983648bce6115d756",
+      "is_tablet_sum_14d": "32f530f5327d8a6592c06887bf374404",
+      "is_tablet_sum_1d": "32f530f5327d8a6592c06887bf374404",
+      "is_tablet_sum_30d": "32f530f5327d8a6592c06887bf374404",
+      "is_tablet_sum_7d": "32f530f5327d8a6592c06887bf374404",
+      "purchase_event_average_14d": "8a1b6978b0d685a442fac4193a005512",
+      "purchase_event_average_1d": "8a1b6978b0d685a442fac4193a005512",
+      "purchase_event_average_30d": "8a1b6978b0d685a442fac4193a005512",
+      "purchase_event_average_7d": "8a1b6978b0d685a442fac4193a005512",
+      "purchase_event_sum_14d": "8a1b6978b0d685a442fac4193a005512",
+      "purchase_event_sum_1d": "8a1b6978b0d685a442fac4193a005512",
+      "purchase_event_sum_30d": "8a1b6978b0d685a442fac4193a005512",
+      "purchase_event_sum_7d": "8a1b6978b0d685a442fac4193a005512",
+      "user_event_struct_last128_14d": "2811ec1735dc28e2d6d6631c6df0c09c",
+      "user_event_struct_last128_1d": "2811ec1735dc28e2d6d6631c6df0c09c",
+      "user_event_struct_last128_30d": "2811ec1735dc28e2d6d6631c6df0c09c",
+      "user_event_struct_last128_7d": "2811ec1735dc28e2d6d6631c6df0c09c",
+      "user_id": "2f8b602cd758224a9bb5cd74e6da851f",
+      "view_event_average_14d": "839e077acdbd8775ed00c561b685a207",
+      "view_event_average_1d": "839e077acdbd8775ed00c561b685a207",
+      "view_event_average_30d": "839e077acdbd8775ed00c561b685a207",
+      "view_event_average_7d": "839e077acdbd8775ed00c561b685a207",
+      "view_event_sum_14d": "839e077acdbd8775ed00c561b685a207",
+      "view_event_sum_1d": "839e077acdbd8775ed00c561b685a207",
+      "view_event_sum_30d": "839e077acdbd8775ed00c561b685a207",
+      "view_event_sum_7d": "839e077acdbd8775ed00c561b685a207"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo_user_activities_raw_with_offset_0\", \"spec\": \"demo.user_activities_raw/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": "-Ztasks=1 -Zbootstrap=b-1.ziplinecanarykafka.hak90r.c4.kafka.us-west-2.amazonaws.com:9092",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": "-Ztasks=1 -Zbootstrap=b-1.ziplinecanarykafka.hak90r.c4.kafka.us-west-2.amazonaws.com:9092",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily",
+      "stepDays": 10
+    },
+    "name": "aws.user_activities.kafka_v1__1",
+    "online": 1,
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/aws/user_activities.py",
+    "team": "aws",
+    "version": "1"
+  },
+  "sources": [
+    {
+      "events": {
+        "query": {
+          "selects": {
+            "add_to_cart_event": "IF(event_type = 'add_to_cart', 1, 0)",
+            "click_event": "IF(event_type = 'click', 1, 0)",
+            "favorite_event": "IF(event_type = 'favorite', 1, 0)",
+            "is_desktop": "IF(device_type = 'desktop', 1, 0)",
+            "is_mobile": "IF(device_type = 'mobile', 1, 0)",
+            "is_tablet": "IF(device_type = 'tablet', 1, 0)",
+            "listing_id": "listing_id",
+            "purchase_event": "IF(event_type = 'purchase', 1, 0)",
+            "user_event_struct": "STRUCT(event_type, listing_id, unix_millis(TIMESTAMP(event_time_ms)) as timestamp)",
+            "user_id": "user_id",
+            "view_event": "IF(event_type = 'view', 1, 0)"
+          },
+          "timeColumn": "unix_millis(TIMESTAMP(event_time_ms))"
+        },
+        "table": "demo.user_activities_raw",
+        "topic": "kafka://user-activities-js/serde=glue_registry/registry_name=zipline-canary/schema_name=user-activities-js"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/aws/user_activities.v1__1
+++ b/python/test/canary/canary_compiled/group_bys/aws/user_activities.v1__1
@@ -1,0 +1,518 @@
+{
+  "aggregations": [
+    {
+      "argMap": {},
+      "inputColumn": "view_event",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "click_event",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_event",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "favorite_event",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "add_to_cart_event",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "view_event",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "click_event",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_event",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "favorite_event",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "add_to_cart_event",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "is_mobile",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "is_desktop",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "is_tablet",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {
+        "k": "128"
+      },
+      "inputColumn": "user_event_struct",
+      "operation": 13,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    }
+  ],
+  "keyColumns": [
+    "user_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "add_to_cart_event_average_14d": "881d7a0a7d626d6c949db88d26cca669",
+      "add_to_cart_event_average_1d": "881d7a0a7d626d6c949db88d26cca669",
+      "add_to_cart_event_average_30d": "881d7a0a7d626d6c949db88d26cca669",
+      "add_to_cart_event_average_7d": "881d7a0a7d626d6c949db88d26cca669",
+      "add_to_cart_event_sum_14d": "881d7a0a7d626d6c949db88d26cca669",
+      "add_to_cart_event_sum_1d": "881d7a0a7d626d6c949db88d26cca669",
+      "add_to_cart_event_sum_30d": "881d7a0a7d626d6c949db88d26cca669",
+      "add_to_cart_event_sum_7d": "881d7a0a7d626d6c949db88d26cca669",
+      "click_event_average_14d": "e76cb96f6bdd94e36ac8be957089e0c7",
+      "click_event_average_1d": "e76cb96f6bdd94e36ac8be957089e0c7",
+      "click_event_average_30d": "e76cb96f6bdd94e36ac8be957089e0c7",
+      "click_event_average_7d": "e76cb96f6bdd94e36ac8be957089e0c7",
+      "click_event_sum_14d": "e76cb96f6bdd94e36ac8be957089e0c7",
+      "click_event_sum_1d": "e76cb96f6bdd94e36ac8be957089e0c7",
+      "click_event_sum_30d": "e76cb96f6bdd94e36ac8be957089e0c7",
+      "click_event_sum_7d": "e76cb96f6bdd94e36ac8be957089e0c7",
+      "favorite_event_average_14d": "e1a70c7033ed72888f782bb64b55b83b",
+      "favorite_event_average_1d": "e1a70c7033ed72888f782bb64b55b83b",
+      "favorite_event_average_30d": "e1a70c7033ed72888f782bb64b55b83b",
+      "favorite_event_average_7d": "e1a70c7033ed72888f782bb64b55b83b",
+      "favorite_event_sum_14d": "e1a70c7033ed72888f782bb64b55b83b",
+      "favorite_event_sum_1d": "e1a70c7033ed72888f782bb64b55b83b",
+      "favorite_event_sum_30d": "e1a70c7033ed72888f782bb64b55b83b",
+      "favorite_event_sum_7d": "e1a70c7033ed72888f782bb64b55b83b",
+      "is_desktop_sum_14d": "7a31d2cccd4268f15e72a3937ccdb132",
+      "is_desktop_sum_1d": "7a31d2cccd4268f15e72a3937ccdb132",
+      "is_desktop_sum_30d": "7a31d2cccd4268f15e72a3937ccdb132",
+      "is_desktop_sum_7d": "7a31d2cccd4268f15e72a3937ccdb132",
+      "is_mobile_sum_14d": "7c8d7f0fd04e17bfc46d3302b7962940",
+      "is_mobile_sum_1d": "7c8d7f0fd04e17bfc46d3302b7962940",
+      "is_mobile_sum_30d": "7c8d7f0fd04e17bfc46d3302b7962940",
+      "is_mobile_sum_7d": "7c8d7f0fd04e17bfc46d3302b7962940",
+      "is_tablet_sum_14d": "df94715e84196a8c29a674fad4c5517d",
+      "is_tablet_sum_1d": "df94715e84196a8c29a674fad4c5517d",
+      "is_tablet_sum_30d": "df94715e84196a8c29a674fad4c5517d",
+      "is_tablet_sum_7d": "df94715e84196a8c29a674fad4c5517d",
+      "purchase_event_average_14d": "f12000e102555d8a10eb745375fd5473",
+      "purchase_event_average_1d": "f12000e102555d8a10eb745375fd5473",
+      "purchase_event_average_30d": "f12000e102555d8a10eb745375fd5473",
+      "purchase_event_average_7d": "f12000e102555d8a10eb745375fd5473",
+      "purchase_event_sum_14d": "f12000e102555d8a10eb745375fd5473",
+      "purchase_event_sum_1d": "f12000e102555d8a10eb745375fd5473",
+      "purchase_event_sum_30d": "f12000e102555d8a10eb745375fd5473",
+      "purchase_event_sum_7d": "f12000e102555d8a10eb745375fd5473",
+      "user_event_struct_last128_14d": "ea8aea62e71ac12cd4ffc67b8b75a708",
+      "user_event_struct_last128_1d": "ea8aea62e71ac12cd4ffc67b8b75a708",
+      "user_event_struct_last128_30d": "ea8aea62e71ac12cd4ffc67b8b75a708",
+      "user_event_struct_last128_7d": "ea8aea62e71ac12cd4ffc67b8b75a708",
+      "user_id": "2426812b8e21edb4ab790123c864c598",
+      "view_event_average_14d": "c96e2586b4fbcb1b88553f770a5868e8",
+      "view_event_average_1d": "c96e2586b4fbcb1b88553f770a5868e8",
+      "view_event_average_30d": "c96e2586b4fbcb1b88553f770a5868e8",
+      "view_event_average_7d": "c96e2586b4fbcb1b88553f770a5868e8",
+      "view_event_sum_14d": "c96e2586b4fbcb1b88553f770a5868e8",
+      "view_event_sum_1d": "c96e2586b4fbcb1b88553f770a5868e8",
+      "view_event_sum_30d": "c96e2586b4fbcb1b88553f770a5868e8",
+      "view_event_sum_7d": "c96e2586b4fbcb1b88553f770a5868e8"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo_user_activities_raw_with_offset_0\", \"spec\": \"demo.user_activities_raw/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily",
+      "stepDays": 10
+    },
+    "name": "aws.user_activities.v1__1",
+    "online": 1,
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/aws/user_activities.py",
+    "team": "aws",
+    "version": "1"
+  },
+  "sources": [
+    {
+      "events": {
+        "query": {
+          "selects": {
+            "add_to_cart_event": "IF(event_type = 'add_to_cart', 1, 0)",
+            "click_event": "IF(event_type = 'click', 1, 0)",
+            "favorite_event": "IF(event_type = 'favorite', 1, 0)",
+            "is_desktop": "IF(device_type = 'desktop', 1, 0)",
+            "is_mobile": "IF(device_type = 'mobile', 1, 0)",
+            "is_tablet": "IF(device_type = 'tablet', 1, 0)",
+            "listing_id": "listing_id",
+            "purchase_event": "IF(event_type = 'purchase', 1, 0)",
+            "user_event_struct": "STRUCT(event_type, listing_id, unix_millis(TIMESTAMP(event_time_ms)) as timestamp)",
+            "user_id": "user_id",
+            "view_event": "IF(event_type = 'view', 1, 0)"
+          },
+          "timeColumn": "unix_millis(TIMESTAMP(event_time_ms))"
+        },
+        "table": "demo.user_activities_raw",
+        "topic": "kinesis://user-activities/serde=glue_registry/registry_name=zipline-canary/schema_name=user-activities"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/aws/user_activities_chained.chained_user_gb__0
+++ b/python/test/canary/canary_compiled/group_bys/aws/user_activities_chained.chained_user_gb__0
@@ -1,0 +1,405 @@
+{
+  "aggregations": [
+    {
+      "argMap": {
+        "k": "100"
+      },
+      "inputColumn": "price_cents",
+      "operation": 13,
+      "windows": [
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    }
+  ],
+  "keyColumns": [
+    "user_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "price_cents_last100_7d": "5377edbf5107cc02a5f74238b3c3696e",
+      "user_id": "96df20bb89ae17fa8229552a8afe4f3f"
+    },
+    "customJson": "{\"airflowDependencies\": []}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily"
+    },
+    "name": "aws.user_activities_chained.chained_user_gb__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/aws/user_activities_chained.py",
+    "team": "aws",
+    "version": "0"
+  },
+  "sources": [
+    {
+      "joinSource": {
+        "join": {
+          "joinParts": [
+            {
+              "groupBy": {
+                "keyColumns": [
+                  "listing_id"
+                ],
+                "metaData": {
+                  "environments": [
+                    0
+                  ],
+                  "executionInfo": {
+                    "clusterConf": {
+                      "common": {
+                        "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+                      }
+                    },
+                    "conf": {
+                      "common": {
+                        "spark.chronon.coalesce.factor": "10",
+                        "spark.chronon.partition.column": "ds",
+                        "spark.chronon.partition.format": "yyyy-MM-dd",
+                        "spark.chronon.table_write.format": "iceberg",
+                        "spark.chronon.table_write.upload.format": "ion",
+                        "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                        "spark.default.parallelism": "10",
+                        "spark.driver.cores": "1",
+                        "spark.driver.memory": "1g",
+                        "spark.executor.cores": "1",
+                        "spark.executor.memory": "1g",
+                        "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                        "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                        "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                        "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                        "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                        "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                        "spark.sql.shuffle.partitions": "10",
+                        "taskmanager.memory.process.size": "4G"
+                      },
+                      "modeConfigs": {
+                        "backfill": {
+                          "spark.chronon.coalesce.factor": "10",
+                          "spark.chronon.partition.column": "ds",
+                          "spark.chronon.partition.format": "yyyy-MM-dd",
+                          "spark.chronon.table_write.format": "iceberg",
+                          "spark.chronon.table_write.upload.format": "ion",
+                          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                          "spark.default.parallelism": "10",
+                          "spark.driver.cores": "1",
+                          "spark.driver.memory": "1g",
+                          "spark.executor.cores": "1",
+                          "spark.executor.memory": "1g",
+                          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                          "spark.sql.shuffle.partitions": "10",
+                          "taskmanager.memory.process.size": "4G"
+                        }
+                      }
+                    },
+                    "env": {
+                      "common": {
+                        "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                        "AWS_REGION": "us-west-2",
+                        "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                        "CLOUD_PROVIDER": "aws",
+                        "CUSTOMER_ID": "canary",
+                        "ENABLE_KINESIS": "true",
+                        "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                        "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                        "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                        "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                        "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                        "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                        "VERSION": "latest",
+                        "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                      },
+                      "modeEnvironments": {
+                        "upload": {
+                          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                          "AWS_REGION": "us-west-2",
+                          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                          "CLOUD_PROVIDER": "aws",
+                          "CUSTOMER_ID": "canary",
+                          "ENABLE_KINESIS": "true",
+                          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                          "VERSION": "latest",
+                          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                        }
+                      }
+                    },
+                    "historicalBackfill": 0,
+                    "onlineSchedule": "@daily",
+                    "stepDays": 10
+                  },
+                  "name": "aws.dim_listings.v1__0",
+                  "online": 1,
+                  "outputNamespace": "data",
+                  "team": "aws",
+                  "version": "0"
+                },
+                "sources": [
+                  {
+                    "entities": {
+                      "query": {
+                        "selects": {
+                          "brief_description": "brief_description",
+                          "currency": "currency",
+                          "headline": "headline",
+                          "inventory_count": "inventory_count",
+                          "is_active": "is_active",
+                          "is_expensive": "IF(price_cents > 10000, 1, 0)",
+                          "is_in_stock": "IF(inventory_count > 0, 1, 0)",
+                          "listing_id": "listing_id",
+                          "long_description": "long_description",
+                          "main_image_path": "main_image_path",
+                          "merchant_id": "merchant_id",
+                          "price_cents": "price_cents",
+                          "primary_category": "primary_category",
+                          "secondary_image_paths": "secondary_image_paths",
+                          "tags": "tags",
+                          "weight_grams": "weight_grams"
+                        },
+                        "startPartition": "2025-01-01"
+                      },
+                      "snapshotTable": "data.aws_exports_dim_listings__0"
+                    }
+                  }
+                ]
+              },
+              "useLongNames": 0
+            }
+          ],
+          "left": {
+            "events": {
+              "query": {
+                "selects": {
+                  "listing_id": "listing_id",
+                  "row_id": "event_id",
+                  "ts": "unix_millis(TIMESTAMP(event_time_ms))",
+                  "user_id": "user_id"
+                },
+                "timeColumn": "unix_millis(TIMESTAMP(event_time_ms))"
+              },
+              "table": "data.aws_exports_user_activities__0",
+              "topic": "kafka://user-activities-v2/serde=custom/provider_class=ai.chronon.flink.deser.MockCustomSchemaProvider/schema_name=user-activities"
+            }
+          },
+          "metaData": {
+            "environments": [
+              0
+            ],
+            "executionInfo": {
+              "clusterConf": {
+                "common": {
+                  "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+                }
+              },
+              "conf": {
+                "common": {
+                  "spark.chronon.coalesce.factor": "10",
+                  "spark.chronon.partition.column": "ds",
+                  "spark.chronon.partition.format": "yyyy-MM-dd",
+                  "spark.chronon.table_write.format": "iceberg",
+                  "spark.chronon.table_write.upload.format": "ion",
+                  "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                  "spark.default.parallelism": "10",
+                  "spark.driver.cores": "1",
+                  "spark.driver.memory": "1g",
+                  "spark.executor.cores": "1",
+                  "spark.executor.memory": "1g",
+                  "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                  "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                  "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                  "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                  "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                  "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                  "spark.sql.shuffle.partitions": "10",
+                  "taskmanager.memory.process.size": "4G"
+                },
+                "modeConfigs": {
+                  "backfill": {
+                    "spark.chronon.coalesce.factor": "10",
+                    "spark.chronon.partition.column": "ds",
+                    "spark.chronon.partition.format": "yyyy-MM-dd",
+                    "spark.chronon.table_write.format": "iceberg",
+                    "spark.chronon.table_write.upload.format": "ion",
+                    "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                    "spark.default.parallelism": "10",
+                    "spark.driver.cores": "1",
+                    "spark.driver.memory": "1g",
+                    "spark.executor.cores": "1",
+                    "spark.executor.memory": "1g",
+                    "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                    "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                    "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                    "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                    "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                    "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                    "spark.sql.shuffle.partitions": "10",
+                    "taskmanager.memory.process.size": "4G"
+                  }
+                }
+              },
+              "env": {
+                "common": {
+                  "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                  "AWS_REGION": "us-west-2",
+                  "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                  "CLOUD_PROVIDER": "aws",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_KINESIS": "true",
+                  "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                  "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                  "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                  "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                  "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                },
+                "modeEnvironments": {
+                  "upload": {
+                    "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                    "AWS_REGION": "us-west-2",
+                    "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                    "CLOUD_PROVIDER": "aws",
+                    "CUSTOMER_ID": "canary",
+                    "ENABLE_KINESIS": "true",
+                    "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                    "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                    "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                    "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                    "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                    "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                    "VERSION": "latest",
+                    "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                  }
+                }
+              },
+              "offlineSchedule": "@daily",
+              "onlineSchedule": "@daily"
+            },
+            "name": "aws.demo_parent.parent_join__0",
+            "online": 1,
+            "outputNamespace": "data",
+            "production": 0,
+            "samplePercent": 100.0,
+            "team": "aws",
+            "version": "0"
+          },
+          "rowIds": [
+            "event_id"
+          ],
+          "useLongNames": 0
+        },
+        "query": {
+          "selects": {
+            "listing_id": "listing_id",
+            "price_cents": "listing_id_price_cents",
+            "user_id": "user_id"
+          },
+          "timeColumn": "ts"
+        }
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/azure/crucible_stress.user_purchase_features__0
+++ b/python/test/canary/canary_compiled/group_bys/azure/crucible_stress.user_purchase_features__0
@@ -1,0 +1,169 @@
+{
+  "aggregations": [
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 6,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {
+        "k": "10"
+      },
+      "inputColumn": "purchase_price",
+      "operation": 13
+    }
+  ],
+  "keyColumns": [
+    "user_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "purchase_price_average_1d": "8c780fb5b00f55c0545cc6e48ef21c92",
+      "purchase_price_average_3d": "8c780fb5b00f55c0545cc6e48ef21c92",
+      "purchase_price_average_7d": "8c780fb5b00f55c0545cc6e48ef21c92",
+      "purchase_price_count_1d": "8c780fb5b00f55c0545cc6e48ef21c92",
+      "purchase_price_count_3d": "8c780fb5b00f55c0545cc6e48ef21c92",
+      "purchase_price_count_7d": "8c780fb5b00f55c0545cc6e48ef21c92",
+      "purchase_price_last10": "8c780fb5b00f55c0545cc6e48ef21c92",
+      "purchase_price_sum_1d": "8c780fb5b00f55c0545cc6e48ef21c92",
+      "purchase_price_sum_3d": "8c780fb5b00f55c0545cc6e48ef21c92",
+      "purchase_price_sum_7d": "8c780fb5b00f55c0545cc6e48ef21c92",
+      "user_id": "43dbce4df14238a2622226be130fb913"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_claims_demo_azure_crucible_stress_sources_purchases__0_with_offset_0\", \"spec\": \"claims_demo.azure_crucible_stress_sources_purchases__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_azure.AzureFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dlog4j.configurationFile=/opt/chronon/log4j2.properties",
+          "spark.driver.memory": "4g",
+          "spark.driver.memoryOverhead": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.extraJavaOptions": "-Dlog4j.configurationFile=/opt/chronon/log4j2.properties",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkCatalog",
+          "spark.sql.catalog.spark_catalog.credential": "",
+          "spark.sql.catalog.spark_catalog.header.X-Iceberg-Access-Delegation": "",
+          "spark.sql.catalog.spark_catalog.jdbc.password": "{POSTGRES_PASSWORD}",
+          "spark.sql.catalog.spark_catalog.jdbc.user": "chronon",
+          "spark.sql.catalog.spark_catalog.scope": "",
+          "spark.sql.catalog.spark_catalog.type": "jdbc",
+          "spark.sql.catalog.spark_catalog.uri": "jdbc:postgresql://{POSTGRES_HOST}:5432/iceberg_catalog?sslmode=require",
+          "spark.sql.catalog.spark_catalog.warehouse": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/warehouse",
+          "spark.sql.defaultCatalog": "spark_catalog",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/artifacts",
+          "CLOUD_PROVIDER": "azure",
+          "CUSTOMER_ID": "claims-demo",
+          "EVAL_URL": "http://hub.claims-demo-hub.svc.cluster.local:3903",
+          "FLINK_STATE_URI": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/flink-state",
+          "FRONTEND_URL": "http://hub.claims-demo-hub.svc.cluster.local:3903",
+          "HUB_URL": "http://hub.claims-demo-hub.svc.cluster.local:3903",
+          "K8S_NAMESPACE": "claims-demo-hub",
+          "OC_CREDENTIAL_VAULT_URI": "",
+          "POSTGRES_HOST": "crucible-claims-pg-westus.postgres.database.azure.com",
+          "POSTGRES_PASSWORD_VAULT_URI": "https://crucible-azure-kv.vault.azure.net/secrets/postgres-password",
+          "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=CLAIMS_DEMO&warehouse=demo_wh",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SPARK_CLUSTER_NAME": "http://crucible.crucible-system.svc.cluster.local:8080",
+          "SPARK_EVENT_LOG_DIR": "abfss://crucible@ziplineai2.dfs.core.windows.net/spark-events",
+          "SPARK_EVENT_LOG_ENABLED": "true",
+          "SPARK_HISTORY_SERVER_URL": "http://spark-history-server.crucible-system.svc.cluster.local:18080",
+          "SPARK_IMAGE": "ziplinecanary.azurecr.io/chronon-spark-azure:latest",
+          "SPARK_SERVICE_ACCOUNT": "spark",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/warehouse"
+        }
+      },
+      "historicalBackfill": 0,
+      "stepDays": 1
+    },
+    "name": "azure.crucible_stress.user_purchase_features__0",
+    "online": 0,
+    "outputNamespace": "claims_demo",
+    "sourceFile": "group_bys/azure/crucible_stress.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "sources": [
+    {
+      "events": {
+        "query": {
+          "selects": {
+            "purchase_price": "purchase_price",
+            "user_id": "user_id"
+          },
+          "startPartition": "2026-05-01",
+          "timeColumn": "ts"
+        },
+        "table": "claims_demo.azure_crucible_stress_sources_purchases__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/azure/dim_listings.pc_v3
+++ b/python/test/canary/canary_compiled/group_bys/azure/dim_listings.pc_v3
@@ -1,0 +1,78 @@
+{
+  "keyColumns": [
+    "listing_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "brief_description": "d8f700f63471993b54a19d71122ec11b",
+      "currency": "ca2881e80e9a9b877c2824d1072d337d",
+      "headline": "3336296614f6be325954fd9ba86eb0cf",
+      "inventory_count": "31547342ddbeb4a831724186b289ea87",
+      "is_active": "faf50877bb5bd0b8f8d920fa0105bd1d",
+      "is_expensive": "e637a3ddd3c42a1edf54251b574b481f",
+      "is_in_stock": "c5fc4a74834fb45b6d5af196310c0f31",
+      "listing_id": "e486882fe8630828862beed3908c72f6",
+      "long_description": "639ab6183464bef6ec2c16118a2cde83",
+      "main_image_path": "647aece2b7dd9c084a447f06db6c9078",
+      "merchant_id": "f00635e9f0582cc0a4504e90e7bc469f",
+      "price_cents": "89610b09ce4e5c7cdba038c3d9ded2ef",
+      "primary_category": "f7e610e63a0809f8b26f9d196b40d35e",
+      "secondary_image_paths": "f9194618378f2ea3855aa792c0bd9317",
+      "tags": "318519d7ab1453a331685dc7f165bb85",
+      "weight_grams": "f8f34e81434169852c03e62a335c20aa"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_azure_exports_dim_listings_pc__1_with_offset_0\", \"spec\": \"data.azure_exports_dim_listings_pc__1/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "historicalBackfill": 0
+    },
+    "name": "azure.dim_listings.pc_v3",
+    "online": 0,
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/azure/dim_listings.py",
+    "team": "azure"
+  },
+  "sources": [
+    {
+      "entities": {
+        "query": {
+          "selects": {
+            "brief_description": "brief_description",
+            "currency": "currency",
+            "headline": "headline",
+            "inventory_count": "inventory_count",
+            "is_active": "is_active",
+            "is_expensive": "IF(price_cents > 10000, 1, 0)",
+            "is_in_stock": "IF(inventory_count > 0, 1, 0)",
+            "listing_id": "CAST(listing_id AS INT)",
+            "long_description": "long_description",
+            "main_image_path": "main_image_path",
+            "merchant_id": "merchant_id",
+            "price_cents": "price_cents",
+            "primary_category": "primary_category",
+            "secondary_image_paths": "secondary_image_paths",
+            "tags": "tags",
+            "weight_grams": "weight_grams"
+          },
+          "startPartition": "2025-01-01"
+        },
+        "snapshotTable": "data.azure_exports_dim_listings_pc__1"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/azure/dim_listings.v3
+++ b/python/test/canary/canary_compiled/group_bys/azure/dim_listings.v3
@@ -1,0 +1,79 @@
+{
+  "keyColumns": [
+    "listing_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "brief_description": "3c179cccf0a9f57fda2fdfe3085a239f",
+      "currency": "8477ea4ad6b46f96255ce0905dfed26d",
+      "headline": "6bf685e11e97f4863d36fa953b964800",
+      "inventory_count": "9d63ce6eddf70502ad498603ec8b18b3",
+      "is_active": "9c9adf7999f230fc316c491f829b12d0",
+      "is_expensive": "255e0f554c8337c87a2a7f0b799c8d4b",
+      "is_in_stock": "80d7c029ebb919cfa22a82600ae3a3e1",
+      "listing_id": "e1d191582f23aad87ee1f5422600051f",
+      "long_description": "f3f74af9625f16c5d935e96d96e08698",
+      "main_image_path": "3ff96284663e8d05ad728b37f6acf122",
+      "merchant_id": "56b9c531a57e6d3f5320b72df8d63521",
+      "price_cents": "7be4ba1e811c96c5a4e5023ce1e05c38",
+      "primary_category": "d6beb0afb36cada1f65a9b1acdb5b995",
+      "secondary_image_paths": "de717ca6563464c24d63f8473a75ef85",
+      "tags": "f9ead5f03020ff66ff14e98fec19a774",
+      "weight_grams": "ac84b5b0b11dca76306214d5d2f12fa9"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_azure_exports_dim_listings__0_with_offset_0\", \"spec\": \"data.azure_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily"
+    },
+    "name": "azure.dim_listings.v3",
+    "online": 1,
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/azure/dim_listings.py",
+    "team": "azure"
+  },
+  "sources": [
+    {
+      "entities": {
+        "query": {
+          "selects": {
+            "brief_description": "brief_description",
+            "currency": "currency",
+            "headline": "headline",
+            "inventory_count": "inventory_count",
+            "is_active": "is_active",
+            "is_expensive": "IF(price_cents > 10000, 1, 0)",
+            "is_in_stock": "IF(inventory_count > 0, 1, 0)",
+            "listing_id": "CAST(listing_id AS INT)",
+            "long_description": "long_description",
+            "main_image_path": "main_image_path",
+            "merchant_id": "merchant_id",
+            "price_cents": "price_cents",
+            "primary_category": "primary_category",
+            "secondary_image_paths": "secondary_image_paths",
+            "tags": "tags",
+            "weight_grams": "weight_grams"
+          },
+          "startPartition": "2025-01-01"
+        },
+        "snapshotTable": "data.azure_exports_dim_listings__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/azure/dim_merchants.v2
+++ b/python/test/canary/canary_compiled/group_bys/azure/dim_merchants.v2
@@ -1,0 +1,51 @@
+{
+  "keyColumns": [
+    "listing_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "listing_id": "ef0459db5af8e98e7b54b6dbec987680",
+      "primary_category": "41f7c36859f55e0908a0e2ee1cea4fb3"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_azure_exports_dim_merchants__0_with_offset_0\", \"spec\": \"data.azure_exports_dim_merchants__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily"
+    },
+    "name": "azure.dim_merchants.v2",
+    "online": 1,
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/azure/dim_merchants.py",
+    "team": "azure"
+  },
+  "sources": [
+    {
+      "entities": {
+        "query": {
+          "selects": {
+            "listing_id": "CAST(merchant_id AS INT)",
+            "primary_category": "primary_category"
+          },
+          "startPartition": "2025-01-01"
+        },
+        "snapshotTable": "data.azure_exports_dim_merchants__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/azure/item_event_canary.actions_pubsub_v2__0
+++ b/python/test/canary/canary_compiled/group_bys/azure/item_event_canary.actions_pubsub_v2__0
@@ -1,0 +1,109 @@
+{
+  "aggregations": [
+    {
+      "argMap": {},
+      "inputColumn": "add_cart",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "view",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "favorite",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        }
+      ]
+    }
+  ],
+  "keyColumns": [
+    "listing_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "add_cart_sum_1d": "fd09e7f474cf0e3cd35100a8e393001e",
+      "favorite_sum_1d": "ec11648e296c67967b03bf92b4718e96",
+      "listing_id": "2b415bfb2391528543f06ac089fbee82",
+      "purchase_sum_1d": "ae525baa20eea731a1270dd356ec611a",
+      "view_sum_1d": "10afd70aaef55fd280157c808724d63a"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_item_events_parquet_compat_partitioned_with_offset_0\", \"spec\": \"data.item_events_parquet_compat_partitioned/_DATE={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "_DATE"
+        }
+      },
+      "env": {
+        "common": {
+          "CHRONON_ONLINE_ARGS": "-Ztasks=4 -Zbootstrap=bootstrap.zipline-kafka-cluster.us-central1.managedkafka.canary-443022.cloud.goog:9092",
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily"
+    },
+    "name": "azure.item_event_canary.actions_pubsub_v2__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/azure/item_event_canary.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "sources": [
+    {
+      "events": {
+        "query": {
+          "selects": {
+            "add_cart": "IF(event_type = 'backend_add_to_cart', 1, 0)",
+            "favorite": "IF(event_type = 'backend_favorite_item2', 1, 0)",
+            "listing_id": "EXPLODE(TRANSFORM(SPLIT(COALESCE(attributes['sold_listing_ids'], attributes['listing_id']), ','), e -> CAST(e AS LONG)))",
+            "purchase": "IF(event_type = 'backend_cart_payment', 1, 0)",
+            "view": "IF(event_type = 'view_listing', 1, 0)"
+          },
+          "timeColumn": "timestamp",
+          "wheres": [
+            "event_type in ('backend_add_to_cart', 'view_listing', 'backend_cart_payment', 'backend_favorite_item2')"
+          ]
+        },
+        "table": "data.item_events_parquet_compat_partitioned",
+        "topic": "pubsub://test-item-event-data/serde=pubsub_schema/project=canary-443022/schemaId=item-event/tasks=4/subscription=test-item-event-data-sub"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/azure/item_event_canary.actions_v1__0
+++ b/python/test/canary/canary_compiled/group_bys/azure/item_event_canary.actions_v1__0
@@ -1,0 +1,109 @@
+{
+  "aggregations": [
+    {
+      "argMap": {},
+      "inputColumn": "add_cart",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "view",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "favorite",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        }
+      ]
+    }
+  ],
+  "keyColumns": [
+    "listing_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "add_cart_sum_1d": "eec202d0ac106e0a8bc1657478954fcb",
+      "favorite_sum_1d": "c05a21cd1801578bb3f7d7c6cf580f3c",
+      "listing_id": "cb824d0b93bc534fbfbd0454b8667e58",
+      "purchase_sum_1d": "c6c0c4f2cc8ff4746513c9e8b7f4dbc8",
+      "view_sum_1d": "ace9014ad7611148a04bd9f08f557021"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_item_events_parquet_compat_partitioned_with_offset_0\", \"spec\": \"data.item_events_parquet_compat_partitioned/_DATE={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "_DATE"
+        }
+      },
+      "env": {
+        "common": {
+          "CHRONON_ONLINE_ARGS": "-Ztasks=4 -Zbootstrap=bootstrap.zipline-kafka-cluster.us-central1.managedkafka.canary-443022.cloud.goog:9092",
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily"
+    },
+    "name": "azure.item_event_canary.actions_v1__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/azure/item_event_canary.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "sources": [
+    {
+      "events": {
+        "query": {
+          "selects": {
+            "add_cart": "IF(event_type = 'backend_add_to_cart', 1, 0)",
+            "favorite": "IF(event_type = 'backend_favorite_item2', 1, 0)",
+            "listing_id": "EXPLODE(TRANSFORM(SPLIT(COALESCE(attributes['sold_listing_ids'], attributes['listing_id']), ','), e -> CAST(e AS LONG)))",
+            "purchase": "IF(event_type = 'backend_cart_payment', 1, 0)",
+            "view": "IF(event_type = 'view_listing', 1, 0)"
+          },
+          "timeColumn": "timestamp",
+          "wheres": [
+            "event_type in ('backend_add_to_cart', 'view_listing', 'backend_cart_payment', 'backend_favorite_item2')"
+          ]
+        },
+        "table": "data.item_events_parquet_compat_partitioned",
+        "topic": "kafka://test-item-event-data/serde=custom/provider_class=ai.chronon.flink.deser.MockCustomSchemaProvider/schema_name=item_event/security.protocol=SASL_SSL/sasl.mechanism=OAUTHBEARER/sasl.login.callback.handler.class=com.google.cloud.hosted.kafka.auth.GcpLoginCallbackHandler/sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/azure/logging_schema.v1__2
+++ b/python/test/canary/canary_compiled/group_bys/azure/logging_schema.v1__2
@@ -1,0 +1,63 @@
+{
+  "accuracy": 1,
+  "aggregations": [
+    {
+      "argMap": {},
+      "inputColumn": "schema_value",
+      "operation": 3
+    }
+  ],
+  "keyColumns": [
+    "schema_hash"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "schema_hash": "4e0ece42c39268b595edaa85fabd83b4",
+      "schema_value_last": "6cddbbee834e60b87d7464daa04aceb9"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_azure_partitioned_logging_v0__2_with_offset_0\", \"spec\": \"data.azure_partitioned_logging_v0__2/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "historicalBackfill": 0
+    },
+    "name": "azure.logging_schema.v1__2",
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/azure/logging_schema.py",
+    "team": "azure",
+    "version": "2"
+  },
+  "sources": [
+    {
+      "events": {
+        "query": {
+          "partitionColumn": "ds",
+          "selects": {
+            "schema_hash": "CAST(keyBytes AS STRING)",
+            "schema_value": "CAST(valueBytes AS STRING)"
+          },
+          "startPartition": "2025-09-23",
+          "timeColumn": "ts_millis",
+          "wheres": [
+            "name='SCHEMA_PUBLISH_EVENT'"
+          ]
+        },
+        "table": "data.azure_partitioned_logging_v0__2"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/azure/purchases.v1_dev__0
+++ b/python/test/canary/canary_compiled/group_bys/azure/purchases.v1_dev__0
@@ -1,0 +1,128 @@
+{
+  "aggregations": [
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 6,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {
+        "k": "10"
+      },
+      "inputColumn": "purchase_price",
+      "operation": 13
+    }
+  ],
+  "keyColumns": [
+    "user_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "purchase_price_average_1d": "3ee572f0e355659fc086d52ec43333f6",
+      "purchase_price_average_3d": "3ee572f0e355659fc086d52ec43333f6",
+      "purchase_price_average_7d": "3ee572f0e355659fc086d52ec43333f6",
+      "purchase_price_count_1d": "3ee572f0e355659fc086d52ec43333f6",
+      "purchase_price_count_3d": "3ee572f0e355659fc086d52ec43333f6",
+      "purchase_price_count_7d": "3ee572f0e355659fc086d52ec43333f6",
+      "purchase_price_last10": "3ee572f0e355659fc086d52ec43333f6",
+      "purchase_price_sum_1d": "3ee572f0e355659fc086d52ec43333f6",
+      "purchase_price_sum_3d": "3ee572f0e355659fc086d52ec43333f6",
+      "purchase_price_sum_7d": "3ee572f0e355659fc086d52ec43333f6",
+      "user_id": "e0009a36a0838b4549d689008bac5afd"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily"
+    },
+    "name": "azure.purchases.v1_dev__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/azure/purchases.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "sources": [
+    {
+      "events": {
+        "query": {
+          "selects": {
+            "purchase_price": "purchase_price",
+            "user_id": "user_id"
+          },
+          "startPartition": "2023-11-01",
+          "timeColumn": "ts"
+        },
+        "table": "data.purchases"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/azure/purchases.v1_dev_notds__0
+++ b/python/test/canary/canary_compiled/group_bys/azure/purchases.v1_dev_notds__0
@@ -1,0 +1,129 @@
+{
+  "aggregations": [
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 6,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {
+        "k": "10"
+      },
+      "inputColumn": "purchase_price",
+      "operation": 13
+    }
+  ],
+  "keyColumns": [
+    "user_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "purchase_price_average_1d": "7a943d6f94aa1c892adff82c36cc0d8a",
+      "purchase_price_average_3d": "7a943d6f94aa1c892adff82c36cc0d8a",
+      "purchase_price_average_7d": "7a943d6f94aa1c892adff82c36cc0d8a",
+      "purchase_price_count_1d": "7a943d6f94aa1c892adff82c36cc0d8a",
+      "purchase_price_count_3d": "7a943d6f94aa1c892adff82c36cc0d8a",
+      "purchase_price_count_7d": "7a943d6f94aa1c892adff82c36cc0d8a",
+      "purchase_price_last10": "7a943d6f94aa1c892adff82c36cc0d8a",
+      "purchase_price_sum_1d": "7a943d6f94aa1c892adff82c36cc0d8a",
+      "purchase_price_sum_3d": "7a943d6f94aa1c892adff82c36cc0d8a",
+      "purchase_price_sum_7d": "7a943d6f94aa1c892adff82c36cc0d8a",
+      "user_id": "5039d7bfb147f14cea3f30f7379e9d6f"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_purchases_notds_with_offset_0\", \"spec\": \"data.purchases_notds/notds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily"
+    },
+    "name": "azure.purchases.v1_dev_notds__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/azure/purchases.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "sources": [
+    {
+      "events": {
+        "query": {
+          "partitionColumn": "notds",
+          "selects": {
+            "purchase_price": "purchase_price",
+            "user_id": "user_id"
+          },
+          "startPartition": "2023-11-01",
+          "timeColumn": "ts"
+        },
+        "table": "data.purchases_notds"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/azure/purchases.v1_test__0
+++ b/python/test/canary/canary_compiled/group_bys/azure/purchases.v1_test__0
@@ -1,0 +1,128 @@
+{
+  "aggregations": [
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 6,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {
+        "k": "10"
+      },
+      "inputColumn": "purchase_price",
+      "operation": 13
+    }
+  ],
+  "keyColumns": [
+    "user_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "purchase_price_average_1d": "cb0c629ccfbaf136f5a337da31f8ba98",
+      "purchase_price_average_3d": "cb0c629ccfbaf136f5a337da31f8ba98",
+      "purchase_price_average_7d": "cb0c629ccfbaf136f5a337da31f8ba98",
+      "purchase_price_count_1d": "cb0c629ccfbaf136f5a337da31f8ba98",
+      "purchase_price_count_3d": "cb0c629ccfbaf136f5a337da31f8ba98",
+      "purchase_price_count_7d": "cb0c629ccfbaf136f5a337da31f8ba98",
+      "purchase_price_last10": "cb0c629ccfbaf136f5a337da31f8ba98",
+      "purchase_price_sum_1d": "cb0c629ccfbaf136f5a337da31f8ba98",
+      "purchase_price_sum_3d": "cb0c629ccfbaf136f5a337da31f8ba98",
+      "purchase_price_sum_7d": "cb0c629ccfbaf136f5a337da31f8ba98",
+      "user_id": "2a2caca3ea4afb84a2271533b1a1bae1"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily"
+    },
+    "name": "azure.purchases.v1_test__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/azure/purchases.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "sources": [
+    {
+      "events": {
+        "query": {
+          "selects": {
+            "purchase_price": "purchase_price",
+            "user_id": "user_id"
+          },
+          "startPartition": "2023-11-01",
+          "timeColumn": "ts"
+        },
+        "table": "data.purchases"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/azure/purchases.v1_test_notds__0
+++ b/python/test/canary/canary_compiled/group_bys/azure/purchases.v1_test_notds__0
@@ -1,0 +1,129 @@
+{
+  "aggregations": [
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 6,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {
+        "k": "10"
+      },
+      "inputColumn": "purchase_price",
+      "operation": 13
+    }
+  ],
+  "keyColumns": [
+    "user_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "purchase_price_average_1d": "3b0e94ffc1c3612c36f18fc42bd080e9",
+      "purchase_price_average_3d": "3b0e94ffc1c3612c36f18fc42bd080e9",
+      "purchase_price_average_7d": "3b0e94ffc1c3612c36f18fc42bd080e9",
+      "purchase_price_count_1d": "3b0e94ffc1c3612c36f18fc42bd080e9",
+      "purchase_price_count_3d": "3b0e94ffc1c3612c36f18fc42bd080e9",
+      "purchase_price_count_7d": "3b0e94ffc1c3612c36f18fc42bd080e9",
+      "purchase_price_last10": "3b0e94ffc1c3612c36f18fc42bd080e9",
+      "purchase_price_sum_1d": "3b0e94ffc1c3612c36f18fc42bd080e9",
+      "purchase_price_sum_3d": "3b0e94ffc1c3612c36f18fc42bd080e9",
+      "purchase_price_sum_7d": "3b0e94ffc1c3612c36f18fc42bd080e9",
+      "user_id": "81dd6ad753af4f7bb8411902a7e9b861"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_purchases_notds_with_offset_0\", \"spec\": \"data.purchases_notds/notds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily"
+    },
+    "name": "azure.purchases.v1_test_notds__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/azure/purchases.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "sources": [
+    {
+      "events": {
+        "query": {
+          "partitionColumn": "notds",
+          "selects": {
+            "purchase_price": "purchase_price",
+            "user_id": "user_id"
+          },
+          "startPartition": "2023-11-01",
+          "timeColumn": "ts"
+        },
+        "table": "data.purchases_notds"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/azure/user_activities.v1__1
+++ b/python/test/canary/canary_compiled/group_bys/azure/user_activities.v1__1
@@ -1,0 +1,443 @@
+{
+  "aggregations": [
+    {
+      "argMap": {},
+      "inputColumn": "view_event",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "click_event",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_event",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "favorite_event",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "add_to_cart_event",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "view_event",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "click_event",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_event",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "favorite_event",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "add_to_cart_event",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "is_mobile",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "is_desktop",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "is_tablet",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {
+        "k": "128"
+      },
+      "inputColumn": "user_event_struct",
+      "operation": 13,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    }
+  ],
+  "keyColumns": [
+    "user_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "add_to_cart_event_average_14d": "e2f564bea15054d7be2275095f7ecc2f",
+      "add_to_cart_event_average_1d": "e2f564bea15054d7be2275095f7ecc2f",
+      "add_to_cart_event_average_30d": "e2f564bea15054d7be2275095f7ecc2f",
+      "add_to_cart_event_average_7d": "e2f564bea15054d7be2275095f7ecc2f",
+      "add_to_cart_event_sum_14d": "e2f564bea15054d7be2275095f7ecc2f",
+      "add_to_cart_event_sum_1d": "e2f564bea15054d7be2275095f7ecc2f",
+      "add_to_cart_event_sum_30d": "e2f564bea15054d7be2275095f7ecc2f",
+      "add_to_cart_event_sum_7d": "e2f564bea15054d7be2275095f7ecc2f",
+      "click_event_average_14d": "a1a1b6112c1c414da7aabec456f7c387",
+      "click_event_average_1d": "a1a1b6112c1c414da7aabec456f7c387",
+      "click_event_average_30d": "a1a1b6112c1c414da7aabec456f7c387",
+      "click_event_average_7d": "a1a1b6112c1c414da7aabec456f7c387",
+      "click_event_sum_14d": "a1a1b6112c1c414da7aabec456f7c387",
+      "click_event_sum_1d": "a1a1b6112c1c414da7aabec456f7c387",
+      "click_event_sum_30d": "a1a1b6112c1c414da7aabec456f7c387",
+      "click_event_sum_7d": "a1a1b6112c1c414da7aabec456f7c387",
+      "favorite_event_average_14d": "4c647a9fee0c872575089a5e2ae84d62",
+      "favorite_event_average_1d": "4c647a9fee0c872575089a5e2ae84d62",
+      "favorite_event_average_30d": "4c647a9fee0c872575089a5e2ae84d62",
+      "favorite_event_average_7d": "4c647a9fee0c872575089a5e2ae84d62",
+      "favorite_event_sum_14d": "4c647a9fee0c872575089a5e2ae84d62",
+      "favorite_event_sum_1d": "4c647a9fee0c872575089a5e2ae84d62",
+      "favorite_event_sum_30d": "4c647a9fee0c872575089a5e2ae84d62",
+      "favorite_event_sum_7d": "4c647a9fee0c872575089a5e2ae84d62",
+      "is_desktop_sum_14d": "d04ee65e38ed0d4846b6384cec536722",
+      "is_desktop_sum_1d": "d04ee65e38ed0d4846b6384cec536722",
+      "is_desktop_sum_30d": "d04ee65e38ed0d4846b6384cec536722",
+      "is_desktop_sum_7d": "d04ee65e38ed0d4846b6384cec536722",
+      "is_mobile_sum_14d": "4ee127814f1b1ed412ae2d3b2fdfe9dc",
+      "is_mobile_sum_1d": "4ee127814f1b1ed412ae2d3b2fdfe9dc",
+      "is_mobile_sum_30d": "4ee127814f1b1ed412ae2d3b2fdfe9dc",
+      "is_mobile_sum_7d": "4ee127814f1b1ed412ae2d3b2fdfe9dc",
+      "is_tablet_sum_14d": "2d67c65fb85c83534324da088da8ade6",
+      "is_tablet_sum_1d": "2d67c65fb85c83534324da088da8ade6",
+      "is_tablet_sum_30d": "2d67c65fb85c83534324da088da8ade6",
+      "is_tablet_sum_7d": "2d67c65fb85c83534324da088da8ade6",
+      "purchase_event_average_14d": "32ed062033999096f35f30a700005c65",
+      "purchase_event_average_1d": "32ed062033999096f35f30a700005c65",
+      "purchase_event_average_30d": "32ed062033999096f35f30a700005c65",
+      "purchase_event_average_7d": "32ed062033999096f35f30a700005c65",
+      "purchase_event_sum_14d": "32ed062033999096f35f30a700005c65",
+      "purchase_event_sum_1d": "32ed062033999096f35f30a700005c65",
+      "purchase_event_sum_30d": "32ed062033999096f35f30a700005c65",
+      "purchase_event_sum_7d": "32ed062033999096f35f30a700005c65",
+      "user_event_struct_last128_14d": "b33f8face5b74b386ae203f338e8ebde",
+      "user_event_struct_last128_1d": "b33f8face5b74b386ae203f338e8ebde",
+      "user_event_struct_last128_30d": "b33f8face5b74b386ae203f338e8ebde",
+      "user_event_struct_last128_7d": "b33f8face5b74b386ae203f338e8ebde",
+      "user_id": "e4042ff932e74c0d141afe3e2c44969d",
+      "view_event_average_14d": "dba8c5b21cc19fe07ceea1891fcfd226",
+      "view_event_average_1d": "dba8c5b21cc19fe07ceea1891fcfd226",
+      "view_event_average_30d": "dba8c5b21cc19fe07ceea1891fcfd226",
+      "view_event_average_7d": "dba8c5b21cc19fe07ceea1891fcfd226",
+      "view_event_sum_14d": "dba8c5b21cc19fe07ceea1891fcfd226",
+      "view_event_sum_1d": "dba8c5b21cc19fe07ceea1891fcfd226",
+      "view_event_sum_30d": "dba8c5b21cc19fe07ceea1891fcfd226",
+      "view_event_sum_7d": "dba8c5b21cc19fe07ceea1891fcfd226"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_azure_exports_user_activities__0_with_offset_0\", \"spec\": \"data.azure_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "historicalBackfill": 0,
+      "stepDays": 30
+    },
+    "name": "azure.user_activities.v1__1",
+    "online": 0,
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/azure/user_activities.py",
+    "team": "azure",
+    "version": "1"
+  },
+  "sources": [
+    {
+      "events": {
+        "query": {
+          "selects": {
+            "add_to_cart_event": "IF(event_type = 'add_to_cart', 1, 0)",
+            "click_event": "IF(event_type = 'click', 1, 0)",
+            "favorite_event": "IF(event_type = 'favorite', 1, 0)",
+            "is_desktop": "IF(device_type = 'desktop', 1, 0)",
+            "is_mobile": "IF(device_type = 'mobile', 1, 0)",
+            "is_tablet": "IF(device_type = 'tablet', 1, 0)",
+            "listing_id": "listing_id",
+            "purchase_event": "IF(event_type = 'purchase', 1, 0)",
+            "user_event_struct": "STRUCT(event_type, listing_id, unix_millis(TIMESTAMP(event_time_ms)) as timestamp)",
+            "user_id": "user_id",
+            "view_event": "IF(event_type = 'view', 1, 0)"
+          },
+          "timeColumn": "unix_millis(TIMESTAMP(event_time_ms))"
+        },
+        "table": "data.azure_exports_user_activities__0",
+        "topic": "kafka://user-activities/serde=apicurio_registry/registry_host=apicurio-registry-apicurio-registry.zipline-system.svc.cluster.local/registry_port=8080/artifact_id=user-activities-js/security.protocol=SASL_SSL/sasl.mechanism=PLAIN"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/azure/user_activities_chained.chained_user_gb__0
+++ b/python/test/canary/canary_compiled/group_bys/azure/user_activities_chained.chained_user_gb__0
@@ -1,0 +1,182 @@
+{
+  "aggregations": [
+    {
+      "argMap": {
+        "k": "100"
+      },
+      "inputColumn": "price_cents",
+      "operation": 13,
+      "windows": [
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    }
+  ],
+  "keyColumns": [
+    "user_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "price_cents_last100_7d": "8d7a1fba31093361b1675f65e53748d7",
+      "user_id": "4ecdf09ef20508785edf01ab40f381ed"
+    },
+    "customJson": "{\"airflowDependencies\": []}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily"
+    },
+    "name": "azure.user_activities_chained.chained_user_gb__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/azure/user_activities_chained.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "sources": [
+    {
+      "joinSource": {
+        "join": {
+          "joinParts": [
+            {
+              "groupBy": {
+                "keyColumns": [
+                  "listing_id"
+                ],
+                "metaData": {
+                  "environments": [
+                    0
+                  ],
+                  "executionInfo": {
+                    "conf": {
+                      "common": {
+                        "spark.chronon.partition.column": "ds"
+                      }
+                    },
+                    "env": {
+                      "common": {
+                        "CUSTOMER_ID": "dev",
+                        "FRONTEND_URL": "http://localhost:3000",
+                        "HUB_URL": "http://localhost:3903",
+                        "VERSION": "latest"
+                      }
+                    },
+                    "historicalBackfill": 0,
+                    "onlineSchedule": "@daily"
+                  },
+                  "name": "azure.dim_listings.v3",
+                  "online": 1,
+                  "outputNamespace": "data",
+                  "team": "azure"
+                },
+                "sources": [
+                  {
+                    "entities": {
+                      "query": {
+                        "selects": {
+                          "brief_description": "brief_description",
+                          "currency": "currency",
+                          "headline": "headline",
+                          "inventory_count": "inventory_count",
+                          "is_active": "is_active",
+                          "is_expensive": "IF(price_cents > 10000, 1, 0)",
+                          "is_in_stock": "IF(inventory_count > 0, 1, 0)",
+                          "listing_id": "CAST(listing_id AS INT)",
+                          "long_description": "long_description",
+                          "main_image_path": "main_image_path",
+                          "merchant_id": "merchant_id",
+                          "price_cents": "price_cents",
+                          "primary_category": "primary_category",
+                          "secondary_image_paths": "secondary_image_paths",
+                          "tags": "tags",
+                          "weight_grams": "weight_grams"
+                        },
+                        "startPartition": "2025-01-01"
+                      },
+                      "snapshotTable": "data.azure_exports_dim_listings__0"
+                    }
+                  }
+                ]
+              },
+              "useLongNames": 0
+            }
+          ],
+          "left": {
+            "events": {
+              "query": {
+                "selects": {
+                  "listing_id": "listing_id",
+                  "row_id": "event_id",
+                  "ts": "unix_millis(TIMESTAMP(event_time_ms))",
+                  "user_id": "user_id"
+                },
+                "timeColumn": "unix_millis(TIMESTAMP(event_time_ms))"
+              },
+              "table": "data.azure_exports_user_activities__0",
+              "topic": "pubsub://user-activities-v2/project=canary-443022/subscription=user-activities-v2-sub/serde=pubsub_schema/schemaId=user-activities"
+            }
+          },
+          "metaData": {
+            "environments": [
+              0
+            ],
+            "executionInfo": {
+              "conf": {
+                "common": {
+                  "spark.chronon.partition.column": "ds"
+                }
+              },
+              "env": {
+                "common": {
+                  "CUSTOMER_ID": "dev",
+                  "FRONTEND_URL": "http://localhost:3000",
+                  "HUB_URL": "http://localhost:3903",
+                  "VERSION": "latest"
+                }
+              },
+              "offlineSchedule": "17 0 * * *",
+              "onlineSchedule": "@daily"
+            },
+            "name": "azure.demo_parent.parent_join__0",
+            "online": 1,
+            "outputNamespace": "data",
+            "production": 0,
+            "samplePercent": 100.0,
+            "team": "azure",
+            "version": "0"
+          },
+          "rowIds": [
+            "event_id"
+          ],
+          "useLongNames": 0
+        },
+        "query": {
+          "selects": {
+            "listing_id": "listing_id",
+            "price_cents": "listing_id_price_cents",
+            "user_id": "user_id"
+          },
+          "timeColumn": "ts"
+        }
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/gcp/demo.fake_groupby_3__0
+++ b/python/test/canary/canary_compiled/group_bys/gcp/demo.fake_groupby_3__0
@@ -1,0 +1,125 @@
+{
+  "aggregations": [
+    {
+      "argMap": {},
+      "inputColumn": "fake-col",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    }
+  ],
+  "keyColumns": [
+    "user_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "fake-col_sum_7d": "c79a04aed5de4f6e47c0325320ef12b3",
+      "user_id": "9a6da6b28e68f9bc0b91421707d41660"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_some_table_with_offset_0\", \"spec\": \"some-table/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "historicalBackfill": 0
+    },
+    "name": "gcp.demo.fake_groupby_3__0",
+    "online": 0,
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/gcp/demo.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "sources": [
+    {
+      "events": {
+        "query": {
+          "selects": {
+            "fake-col": "fake-col",
+            "listing_id": "listing_id",
+            "row_id": "event_id",
+            "user_id": "user_id"
+          },
+          "timeColumn": "event_time_ms"
+        },
+        "table": "some-table"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/gcp/demo.fake_groupby__0
+++ b/python/test/canary/canary_compiled/group_bys/gcp/demo.fake_groupby__0
@@ -1,0 +1,126 @@
+{
+  "aggregations": [
+    {
+      "argMap": {},
+      "inputColumn": "fake-col",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    }
+  ],
+  "keyColumns": [
+    "user_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "fake-col_sum_7d": "e1027371477091af9763625eba432862",
+      "user_id": "f9e37dd13f049bc14f9303f34a4314cc"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_exports_user_activities__0_with_offset_0\", \"spec\": \"data.gcp_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily"
+    },
+    "name": "gcp.demo.fake_groupby__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "sourceFile": "joins/gcp/demo.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "sources": [
+    {
+      "events": {
+        "query": {
+          "selects": {
+            "fake-col": "fake-col",
+            "listing_id": "listing_id",
+            "row_id": "event_id",
+            "user_id": "user_id"
+          },
+          "timeColumn": "event_time_ms"
+        },
+        "table": "data.gcp_exports_user_activities__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/gcp/dim_listings.v1__0
+++ b/python/test/canary/canary_compiled/group_bys/gcp/dim_listings.v1__0
@@ -1,0 +1,139 @@
+{
+  "keyColumns": [
+    "listing_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "brief_description": "85c0544e6f2d058e93e6d54956e118e4",
+      "currency": "ff795c264858b08c00d9159c8e4761d5",
+      "headline": "46fb87fe34c8251a81870c83853e15c6",
+      "inventory_count": "10910897373885c1b0fc1420e7a52562",
+      "is_active": "0fe881820ff26668c32d68dc3382a7ff",
+      "is_expensive": "4d6678c92b2194fd9b7e6bfa85366fe5",
+      "is_in_stock": "0cd5441df3d278d3b7a060e4bd23a324",
+      "listing_id": "6ed4569be71307367d24e5fe77626334",
+      "long_description": "51bbdbd4269ccb2d382f835dcfc2eed3",
+      "main_image_path": "a5ab50facb20e01a0d93a4ed0eac1a9d",
+      "merchant_id": "60a2c0a6662b1bdb97061e9b9566e451",
+      "price_cents": "058f7df64e0544d392a31bb6dc08209f",
+      "primary_category": "62f56fda8558ec54a85da33a3934c182",
+      "secondary_image_paths": "e8ec969f13b6db533bca510f235fd069",
+      "tags": "589de0914f9ffabf8c80a0fe10eaa866",
+      "weight_grams": "041362c5ebf87a340a139e6b53034b7c"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_exports_dim_listings__0_with_offset_0\", \"spec\": \"data.gcp_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily"
+    },
+    "name": "gcp.dim_listings.v1__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/gcp/dim_listings.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "sources": [
+    {
+      "entities": {
+        "query": {
+          "selects": {
+            "brief_description": "brief_description",
+            "currency": "currency",
+            "headline": "headline",
+            "inventory_count": "inventory_count",
+            "is_active": "is_active",
+            "is_expensive": "IF(price_cents > 10000, 1, 0)",
+            "is_in_stock": "IF(inventory_count > 0, 1, 0)",
+            "listing_id": "listing_id",
+            "long_description": "long_description",
+            "main_image_path": "main_image_path",
+            "merchant_id": "merchant_id",
+            "price_cents": "price_cents",
+            "primary_category": "primary_category",
+            "secondary_image_paths": "secondary_image_paths",
+            "tags": "tags",
+            "weight_grams": "weight_grams"
+          },
+          "startPartition": "2025-01-01"
+        },
+        "snapshotTable": "data.gcp_exports_dim_listings__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/gcp/dim_listings_with_mutations.v2__0
+++ b/python/test/canary/canary_compiled/group_bys/gcp/dim_listings_with_mutations.v2__0
@@ -1,0 +1,218 @@
+{
+  "accuracy": 0,
+  "aggregations": [
+    {
+      "argMap": {},
+      "inputColumn": "merchant_id",
+      "operation": 3
+    },
+    {
+      "argMap": {},
+      "inputColumn": "headline",
+      "operation": 3
+    },
+    {
+      "argMap": {},
+      "inputColumn": "brief_description",
+      "operation": 3
+    },
+    {
+      "argMap": {},
+      "inputColumn": "long_description",
+      "operation": 3
+    },
+    {
+      "argMap": {},
+      "inputColumn": "price_cents",
+      "operation": 3
+    },
+    {
+      "argMap": {},
+      "inputColumn": "currency",
+      "operation": 3
+    },
+    {
+      "argMap": {},
+      "inputColumn": "inventory_count",
+      "operation": 3
+    },
+    {
+      "argMap": {},
+      "inputColumn": "primary_category",
+      "operation": 3
+    },
+    {
+      "argMap": {},
+      "inputColumn": "is_active",
+      "operation": 3
+    },
+    {
+      "argMap": {},
+      "inputColumn": "weight_grams",
+      "operation": 3
+    },
+    {
+      "argMap": {},
+      "inputColumn": "tags",
+      "operation": 3
+    },
+    {
+      "argMap": {},
+      "inputColumn": "is_expensive",
+      "operation": 3
+    },
+    {
+      "argMap": {},
+      "inputColumn": "is_in_stock",
+      "operation": 3
+    },
+    {
+      "argMap": {},
+      "inputColumn": "main_image_path",
+      "operation": 3
+    },
+    {
+      "argMap": {},
+      "inputColumn": "secondary_image_paths",
+      "operation": 3
+    }
+  ],
+  "keyColumns": [
+    "listing_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "brief_description_last": "0a1386de070d704b0d2c5d1c87fe519a",
+      "currency_last": "5121fca8b3fe87a914b5ee279b648e95",
+      "headline_last": "45ea540639c06959f17b71c3e554175a",
+      "inventory_count_last": "da8c9a07f97c968c72d2073a8d0f67c8",
+      "is_active_last": "1fec57d936cc463617bac897e12be096",
+      "is_expensive_last": "805f3d530ac6f8e7623c21a73a1f18b6",
+      "is_in_stock_last": "0c23362ef6a4871d3324889b1549563d",
+      "listing_id": "886183f17e4eac643e2068a1ff1c9e13",
+      "long_description_last": "3cc8017f1420a64fd7b2254dae7f1e75",
+      "main_image_path_last": "af1e43d33658f520fd74c426eb9aaf8c",
+      "merchant_id_last": "c1dd7d3842c0b00e1f65fa7bf15c11aa",
+      "price_cents_last": "97455a3821b0ffbf3ec0e5567426673c",
+      "primary_category_last": "7d771f16ef459f9b442390ce6e4941fe",
+      "secondary_image_paths_last": "815571cc5ddb0b27ad2722957f7c0080",
+      "tags_last": "127ced2578a540a522f3f437101d7726",
+      "weight_grams_last": "5b19e9ed87508482695b4e3606acfa97"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_exports_dim_listings__0_with_offset_0\", \"spec\": \"data.gcp_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_gcp_exports_dim_listing_mutations__0_with_offset_0\", \"spec\": \"data.gcp_exports_dim_listing_mutations__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily"
+    },
+    "name": "gcp.dim_listings_with_mutations.v2__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/gcp/dim_listings_with_mutations.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "sources": [
+    {
+      "entities": {
+        "mutationTable": "data.gcp_exports_dim_listing_mutations__0",
+        "query": {
+          "selects": {
+            "brief_description": "brief_description",
+            "currency": "currency",
+            "headline": "headline",
+            "inventory_count": "inventory_count",
+            "is_active": "is_active",
+            "is_expensive": "IF(price_cents > 10000, 1, 0)",
+            "is_in_stock": "IF(inventory_count > 0, 1, 0)",
+            "listing_id": "listing_id",
+            "long_description": "long_description",
+            "main_image_path": "main_image_path",
+            "merchant_id": "merchant_id",
+            "price_cents": "price_cents",
+            "primary_category": "primary_category",
+            "secondary_image_paths": "secondary_image_paths",
+            "tags": "tags",
+            "weight_grams": "weight_grams"
+          },
+          "startPartition": "2025-01-01"
+        },
+        "snapshotTable": "data.gcp_exports_dim_listings__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/gcp/dim_merchants.v1__0
+++ b/python/test/canary/canary_compiled/group_bys/gcp/dim_merchants.v1__0
@@ -1,0 +1,111 @@
+{
+  "keyColumns": [
+    "listing_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "listing_id": "56b684bc2ca64fd442ccd845604e5e70",
+      "primary_category": "62491a3e7c13a27a3eeb765ba460169f"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_exports_dim_merchants__0_with_offset_0\", \"spec\": \"data.gcp_exports_dim_merchants__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily"
+    },
+    "name": "gcp.dim_merchants.v1__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/gcp/dim_merchants.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "sources": [
+    {
+      "entities": {
+        "query": {
+          "selects": {
+            "listing_id": "merchant_id",
+            "primary_category": "primary_category"
+          },
+          "startPartition": "2025-01-01"
+        },
+        "snapshotTable": "data.gcp_exports_dim_merchants__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/gcp/item_event_canary.actions_pubsub_v2__0
+++ b/python/test/canary/canary_compiled/group_bys/gcp/item_event_canary.actions_pubsub_v2__0
@@ -1,0 +1,167 @@
+{
+  "aggregations": [
+    {
+      "argMap": {},
+      "inputColumn": "add_cart",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "view",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "favorite",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        }
+      ]
+    }
+  ],
+  "keyColumns": [
+    "listing_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "add_cart_sum_1d": "ed104cb5e34d9ac3c193cda31fec5db4",
+      "favorite_sum_1d": "ecce467f5cef9f4f6742ce4a0650499b",
+      "listing_id": "63b9f4d87c1cc4fb39f6f5230ae29034",
+      "purchase_sum_1d": "8461cac7c35b38bae99562beb4060578",
+      "view_sum_1d": "d4bc995b2e1955c153a0d1d78927f07c"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_item_events_parquet_compat_partitioned_with_offset_0\", \"spec\": \"data.item_events_parquet_compat_partitioned/_DATE={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "_DATE",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": "-Ztasks=4 -Zbootstrap=bootstrap.zipline-kafka-cluster.us-central1.managedkafka.canary-443022.cloud.goog:9092",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": "-Ztasks=4 -Zbootstrap=bootstrap.zipline-kafka-cluster.us-central1.managedkafka.canary-443022.cloud.goog:9092",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily"
+    },
+    "name": "gcp.item_event_canary.actions_pubsub_v2__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/gcp/item_event_canary.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "sources": [
+    {
+      "events": {
+        "query": {
+          "selects": {
+            "add_cart": "IF(event_type = 'backend_add_to_cart', 1, 0)",
+            "favorite": "IF(event_type = 'backend_favorite_item2', 1, 0)",
+            "listing_id": "EXPLODE(TRANSFORM(SPLIT(COALESCE(attributes['sold_listing_ids'], attributes['listing_id']), ','), e -> CAST(e AS LONG)))",
+            "purchase": "IF(event_type = 'backend_cart_payment', 1, 0)",
+            "view": "IF(event_type = 'view_listing', 1, 0)"
+          },
+          "timeColumn": "timestamp",
+          "wheres": [
+            "event_type in ('backend_add_to_cart', 'view_listing', 'backend_cart_payment', 'backend_favorite_item2')"
+          ]
+        },
+        "table": "data.item_events_parquet_compat_partitioned",
+        "topic": "pubsub://test-item-event-data/serde=pubsub_schema/project=canary-443022/schemaId=item-event/tasks=4/subscription=test-item-event-data-sub"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/gcp/item_event_canary.actions_v1__0
+++ b/python/test/canary/canary_compiled/group_bys/gcp/item_event_canary.actions_v1__0
@@ -1,0 +1,167 @@
+{
+  "aggregations": [
+    {
+      "argMap": {},
+      "inputColumn": "add_cart",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "view",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "favorite",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        }
+      ]
+    }
+  ],
+  "keyColumns": [
+    "listing_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "add_cart_sum_1d": "f79226e7757c6aa927fc1007d6749a94",
+      "favorite_sum_1d": "b2d5bbaffe0b5b5d3e186bb0022ee041",
+      "listing_id": "27435c7763a514975682fcc80c73e199",
+      "purchase_sum_1d": "8e26d6cb81cb2f557be0d86f88836b4e",
+      "view_sum_1d": "cbf9c10a17d7f4669437872708303738"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_item_events_parquet_compat_partitioned_with_offset_0\", \"spec\": \"data.item_events_parquet_compat_partitioned/_DATE={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "_DATE",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": "-Ztasks=4 -Zbootstrap=bootstrap.zipline-kafka-cluster.us-central1.managedkafka.canary-443022.cloud.goog:9092",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": "-Ztasks=4 -Zbootstrap=bootstrap.zipline-kafka-cluster.us-central1.managedkafka.canary-443022.cloud.goog:9092",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily"
+    },
+    "name": "gcp.item_event_canary.actions_v1__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/gcp/item_event_canary.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "sources": [
+    {
+      "events": {
+        "query": {
+          "selects": {
+            "add_cart": "IF(event_type = 'backend_add_to_cart', 1, 0)",
+            "favorite": "IF(event_type = 'backend_favorite_item2', 1, 0)",
+            "listing_id": "EXPLODE(TRANSFORM(SPLIT(COALESCE(attributes['sold_listing_ids'], attributes['listing_id']), ','), e -> CAST(e AS LONG)))",
+            "purchase": "IF(event_type = 'backend_cart_payment', 1, 0)",
+            "view": "IF(event_type = 'view_listing', 1, 0)"
+          },
+          "timeColumn": "timestamp",
+          "wheres": [
+            "event_type in ('backend_add_to_cart', 'view_listing', 'backend_cart_payment', 'backend_favorite_item2')"
+          ]
+        },
+        "table": "data.item_events_parquet_compat_partitioned",
+        "topic": "kafka://test-item-event-data/serde=custom/provider_class=ai.chronon.flink.deser.MockCustomSchemaProvider/schema_name=item_event/security.protocol=SASL_SSL/sasl.mechanism=OAUTHBEARER/sasl.login.callback.handler.class=com.google.cloud.hosted.kafka.auth.GcpLoginCallbackHandler/sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/gcp/logging_schema.v1__2
+++ b/python/test/canary/canary_compiled/group_bys/gcp/logging_schema.v1__2
@@ -1,0 +1,122 @@
+{
+  "accuracy": 1,
+  "aggregations": [
+    {
+      "argMap": {},
+      "inputColumn": "schema_value",
+      "operation": 3
+    }
+  ],
+  "keyColumns": [
+    "schema_hash"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "schema_hash": "d56f2fe27d07b7fd394789f8c6266408",
+      "schema_value_last": "dd8bd8fdc7f11b58dcbbd9fafe0a957d"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_partitioned_logging_v0__2_with_offset_0\", \"spec\": \"data.gcp_partitioned_logging_v0__2/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "historicalBackfill": 0
+    },
+    "name": "gcp.logging_schema.v1__2",
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/gcp/logging_schema.py",
+    "team": "gcp",
+    "version": "2"
+  },
+  "sources": [
+    {
+      "events": {
+        "query": {
+          "partitionColumn": "ds",
+          "selects": {
+            "schema_hash": "CAST(keyBytes AS STRING)",
+            "schema_value": "CAST(valueBytes AS STRING)"
+          },
+          "startPartition": "2025-09-23",
+          "timeColumn": "ts_millis",
+          "wheres": [
+            "name='SCHEMA_PUBLISH_EVENT'"
+          ]
+        },
+        "table": "data.gcp_partitioned_logging_v0__2"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/gcp/purchases.v1_dev__0
+++ b/python/test/canary/canary_compiled/group_bys/gcp/purchases.v1_dev__0
@@ -1,0 +1,187 @@
+{
+  "aggregations": [
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 6,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {
+        "k": "10"
+      },
+      "inputColumn": "purchase_price",
+      "operation": 13
+    }
+  ],
+  "keyColumns": [
+    "user_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "purchase_price_average_1d": "29fd3a1d4f15d0f15f3eb9f755f56a1d",
+      "purchase_price_average_3d": "29fd3a1d4f15d0f15f3eb9f755f56a1d",
+      "purchase_price_average_7d": "29fd3a1d4f15d0f15f3eb9f755f56a1d",
+      "purchase_price_count_1d": "29fd3a1d4f15d0f15f3eb9f755f56a1d",
+      "purchase_price_count_3d": "29fd3a1d4f15d0f15f3eb9f755f56a1d",
+      "purchase_price_count_7d": "29fd3a1d4f15d0f15f3eb9f755f56a1d",
+      "purchase_price_last10": "29fd3a1d4f15d0f15f3eb9f755f56a1d",
+      "purchase_price_sum_1d": "29fd3a1d4f15d0f15f3eb9f755f56a1d",
+      "purchase_price_sum_3d": "29fd3a1d4f15d0f15f3eb9f755f56a1d",
+      "purchase_price_sum_7d": "29fd3a1d4f15d0f15f3eb9f755f56a1d",
+      "user_id": "990d1cc2263011ec3386075d3a66b1a1"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_purchases_import_v1__0_with_offset_0\", \"spec\": \"data.gcp_purchases_import_v1__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily"
+    },
+    "name": "gcp.purchases.v1_dev__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/gcp/purchases.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "sources": [
+    {
+      "events": {
+        "query": {
+          "selects": {
+            "purchase_price": "purchase_price",
+            "user_id": "user_id"
+          },
+          "startPartition": "2023-11-01",
+          "timeColumn": "ts"
+        },
+        "table": "data.gcp_purchases_import_v1__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/gcp/purchases.v1_dev_notds__0
+++ b/python/test/canary/canary_compiled/group_bys/gcp/purchases.v1_dev_notds__0
@@ -1,0 +1,188 @@
+{
+  "aggregations": [
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 6,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {
+        "k": "10"
+      },
+      "inputColumn": "purchase_price",
+      "operation": 13
+    }
+  ],
+  "keyColumns": [
+    "user_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "purchase_price_average_1d": "fd68ef8ce11f66fb65d9bf80e3f9ece5",
+      "purchase_price_average_3d": "fd68ef8ce11f66fb65d9bf80e3f9ece5",
+      "purchase_price_average_7d": "fd68ef8ce11f66fb65d9bf80e3f9ece5",
+      "purchase_price_count_1d": "fd68ef8ce11f66fb65d9bf80e3f9ece5",
+      "purchase_price_count_3d": "fd68ef8ce11f66fb65d9bf80e3f9ece5",
+      "purchase_price_count_7d": "fd68ef8ce11f66fb65d9bf80e3f9ece5",
+      "purchase_price_last10": "fd68ef8ce11f66fb65d9bf80e3f9ece5",
+      "purchase_price_sum_1d": "fd68ef8ce11f66fb65d9bf80e3f9ece5",
+      "purchase_price_sum_3d": "fd68ef8ce11f66fb65d9bf80e3f9ece5",
+      "purchase_price_sum_7d": "fd68ef8ce11f66fb65d9bf80e3f9ece5",
+      "user_id": "659acfa58500e1f693d923b698c6e4c9"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_purchases_notds_import_v1__0_with_offset_0\", \"spec\": \"data.gcp_purchases_notds_import_v1__0/notds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily"
+    },
+    "name": "gcp.purchases.v1_dev_notds__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/gcp/purchases.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "sources": [
+    {
+      "events": {
+        "query": {
+          "partitionColumn": "notds",
+          "selects": {
+            "purchase_price": "purchase_price",
+            "user_id": "user_id"
+          },
+          "startPartition": "2023-11-01",
+          "timeColumn": "ts"
+        },
+        "table": "data.gcp_purchases_notds_import_v1__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/gcp/purchases.v1_test__0
+++ b/python/test/canary/canary_compiled/group_bys/gcp/purchases.v1_test__0
@@ -1,0 +1,187 @@
+{
+  "aggregations": [
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 6,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {
+        "k": "10"
+      },
+      "inputColumn": "purchase_price",
+      "operation": 13
+    }
+  ],
+  "keyColumns": [
+    "user_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "purchase_price_average_1d": "631fab32648531978032f3b417da5d52",
+      "purchase_price_average_3d": "631fab32648531978032f3b417da5d52",
+      "purchase_price_average_7d": "631fab32648531978032f3b417da5d52",
+      "purchase_price_count_1d": "631fab32648531978032f3b417da5d52",
+      "purchase_price_count_3d": "631fab32648531978032f3b417da5d52",
+      "purchase_price_count_7d": "631fab32648531978032f3b417da5d52",
+      "purchase_price_last10": "631fab32648531978032f3b417da5d52",
+      "purchase_price_sum_1d": "631fab32648531978032f3b417da5d52",
+      "purchase_price_sum_3d": "631fab32648531978032f3b417da5d52",
+      "purchase_price_sum_7d": "631fab32648531978032f3b417da5d52",
+      "user_id": "a406c2de0040b2e926dba6334f299281"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_purchases_import_v1__0_with_offset_0\", \"spec\": \"data.gcp_purchases_import_v1__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily"
+    },
+    "name": "gcp.purchases.v1_test__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/gcp/purchases.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "sources": [
+    {
+      "events": {
+        "query": {
+          "selects": {
+            "purchase_price": "purchase_price",
+            "user_id": "user_id"
+          },
+          "startPartition": "2023-11-01",
+          "timeColumn": "ts"
+        },
+        "table": "data.gcp_purchases_import_v1__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/gcp/purchases.v1_test_notds__0
+++ b/python/test/canary/canary_compiled/group_bys/gcp/purchases.v1_test_notds__0
@@ -1,0 +1,188 @@
+{
+  "aggregations": [
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 6,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 3,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {
+        "k": "10"
+      },
+      "inputColumn": "purchase_price",
+      "operation": 13
+    }
+  ],
+  "keyColumns": [
+    "user_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "purchase_price_average_1d": "75c7ab0be06806e6086fcdd7de7077ea",
+      "purchase_price_average_3d": "75c7ab0be06806e6086fcdd7de7077ea",
+      "purchase_price_average_7d": "75c7ab0be06806e6086fcdd7de7077ea",
+      "purchase_price_count_1d": "75c7ab0be06806e6086fcdd7de7077ea",
+      "purchase_price_count_3d": "75c7ab0be06806e6086fcdd7de7077ea",
+      "purchase_price_count_7d": "75c7ab0be06806e6086fcdd7de7077ea",
+      "purchase_price_last10": "75c7ab0be06806e6086fcdd7de7077ea",
+      "purchase_price_sum_1d": "75c7ab0be06806e6086fcdd7de7077ea",
+      "purchase_price_sum_3d": "75c7ab0be06806e6086fcdd7de7077ea",
+      "purchase_price_sum_7d": "75c7ab0be06806e6086fcdd7de7077ea",
+      "user_id": "e2bd778ac7f0e189c7f627b51b0eaa13"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_purchases_notds_import_v1__0_with_offset_0\", \"spec\": \"data.gcp_purchases_notds_import_v1__0/notds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily"
+    },
+    "name": "gcp.purchases.v1_test_notds__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/gcp/purchases.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "sources": [
+    {
+      "events": {
+        "query": {
+          "partitionColumn": "notds",
+          "selects": {
+            "purchase_price": "purchase_price",
+            "user_id": "user_id"
+          },
+          "startPartition": "2023-11-01",
+          "timeColumn": "ts"
+        },
+        "table": "data.gcp_purchases_notds_import_v1__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/gcp/team_default_ns_gb.v1__0
+++ b/python/test/canary/canary_compiled/group_bys/gcp/team_default_ns_gb.v1__0
@@ -1,0 +1,123 @@
+{
+  "aggregations": [
+    {
+      "argMap": {},
+      "inputColumn": "purchase_price",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        }
+      ]
+    }
+  ],
+  "keyColumns": [
+    "user_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "purchase_price_sum_1d": "cddb4e13f02083ccc7787eaaf53a42ee",
+      "user_id": "b5e979370e2291cded7a3af5a33adf58"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_purchases_import_v1__0_with_offset_0\", \"spec\": \"data.gcp_purchases_import_v1__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "historicalBackfill": 0
+    },
+    "name": "gcp.team_default_ns_gb.v1__0",
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/gcp/team_default_ns_gb.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "sources": [
+    {
+      "events": {
+        "query": {
+          "selects": {
+            "purchase_price": "purchase_price",
+            "user_id": "user_id"
+          },
+          "startPartition": "2023-11-01",
+          "timeColumn": "ts"
+        },
+        "table": "data.gcp_purchases_import_v1__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/gcp/user_activities.v1__1
+++ b/python/test/canary/canary_compiled/group_bys/gcp/user_activities.v1__1
@@ -1,0 +1,503 @@
+{
+  "aggregations": [
+    {
+      "argMap": {},
+      "inputColumn": "view_event",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "click_event",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_event",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "favorite_event",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "add_to_cart_event",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "view_event",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "click_event",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_event",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "favorite_event",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "add_to_cart_event",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "is_mobile",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "is_desktop",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "is_tablet",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {
+        "k": "128"
+      },
+      "inputColumn": "user_event_struct",
+      "operation": 13,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    }
+  ],
+  "keyColumns": [
+    "user_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "add_to_cart_event_average_14d": "ac7d8c6d6a4d0ddd7fdbab6517207fa0",
+      "add_to_cart_event_average_1d": "ac7d8c6d6a4d0ddd7fdbab6517207fa0",
+      "add_to_cart_event_average_30d": "ac7d8c6d6a4d0ddd7fdbab6517207fa0",
+      "add_to_cart_event_average_7d": "ac7d8c6d6a4d0ddd7fdbab6517207fa0",
+      "add_to_cart_event_sum_14d": "ac7d8c6d6a4d0ddd7fdbab6517207fa0",
+      "add_to_cart_event_sum_1d": "ac7d8c6d6a4d0ddd7fdbab6517207fa0",
+      "add_to_cart_event_sum_30d": "ac7d8c6d6a4d0ddd7fdbab6517207fa0",
+      "add_to_cart_event_sum_7d": "ac7d8c6d6a4d0ddd7fdbab6517207fa0",
+      "click_event_average_14d": "1d544b33eebdfc17a3a5afe87b81eb53",
+      "click_event_average_1d": "1d544b33eebdfc17a3a5afe87b81eb53",
+      "click_event_average_30d": "1d544b33eebdfc17a3a5afe87b81eb53",
+      "click_event_average_7d": "1d544b33eebdfc17a3a5afe87b81eb53",
+      "click_event_sum_14d": "1d544b33eebdfc17a3a5afe87b81eb53",
+      "click_event_sum_1d": "1d544b33eebdfc17a3a5afe87b81eb53",
+      "click_event_sum_30d": "1d544b33eebdfc17a3a5afe87b81eb53",
+      "click_event_sum_7d": "1d544b33eebdfc17a3a5afe87b81eb53",
+      "favorite_event_average_14d": "9236810c6ed256e2ce111114fcdf2468",
+      "favorite_event_average_1d": "9236810c6ed256e2ce111114fcdf2468",
+      "favorite_event_average_30d": "9236810c6ed256e2ce111114fcdf2468",
+      "favorite_event_average_7d": "9236810c6ed256e2ce111114fcdf2468",
+      "favorite_event_sum_14d": "9236810c6ed256e2ce111114fcdf2468",
+      "favorite_event_sum_1d": "9236810c6ed256e2ce111114fcdf2468",
+      "favorite_event_sum_30d": "9236810c6ed256e2ce111114fcdf2468",
+      "favorite_event_sum_7d": "9236810c6ed256e2ce111114fcdf2468",
+      "is_desktop_sum_14d": "751be38cbc62b37986a93da55ea3bb53",
+      "is_desktop_sum_1d": "751be38cbc62b37986a93da55ea3bb53",
+      "is_desktop_sum_30d": "751be38cbc62b37986a93da55ea3bb53",
+      "is_desktop_sum_7d": "751be38cbc62b37986a93da55ea3bb53",
+      "is_mobile_sum_14d": "736a00d8d3e5cc6458f666ceb2840ddf",
+      "is_mobile_sum_1d": "736a00d8d3e5cc6458f666ceb2840ddf",
+      "is_mobile_sum_30d": "736a00d8d3e5cc6458f666ceb2840ddf",
+      "is_mobile_sum_7d": "736a00d8d3e5cc6458f666ceb2840ddf",
+      "is_tablet_sum_14d": "c9f1e7cc6f8dee7506aa0d04fab1fe02",
+      "is_tablet_sum_1d": "c9f1e7cc6f8dee7506aa0d04fab1fe02",
+      "is_tablet_sum_30d": "c9f1e7cc6f8dee7506aa0d04fab1fe02",
+      "is_tablet_sum_7d": "c9f1e7cc6f8dee7506aa0d04fab1fe02",
+      "purchase_event_average_14d": "903c18bce150f38415fb70a46f0eaba5",
+      "purchase_event_average_1d": "903c18bce150f38415fb70a46f0eaba5",
+      "purchase_event_average_30d": "903c18bce150f38415fb70a46f0eaba5",
+      "purchase_event_average_7d": "903c18bce150f38415fb70a46f0eaba5",
+      "purchase_event_sum_14d": "903c18bce150f38415fb70a46f0eaba5",
+      "purchase_event_sum_1d": "903c18bce150f38415fb70a46f0eaba5",
+      "purchase_event_sum_30d": "903c18bce150f38415fb70a46f0eaba5",
+      "purchase_event_sum_7d": "903c18bce150f38415fb70a46f0eaba5",
+      "user_event_struct_last128_14d": "9615edd561708d3aa83e1efae33be4a0",
+      "user_event_struct_last128_1d": "9615edd561708d3aa83e1efae33be4a0",
+      "user_event_struct_last128_30d": "9615edd561708d3aa83e1efae33be4a0",
+      "user_event_struct_last128_7d": "9615edd561708d3aa83e1efae33be4a0",
+      "user_id": "006bbceaf919145938ec06d702ad51b9",
+      "view_event_average_14d": "f597dd2f8e5d672fbac0445fb935469b",
+      "view_event_average_1d": "f597dd2f8e5d672fbac0445fb935469b",
+      "view_event_average_30d": "f597dd2f8e5d672fbac0445fb935469b",
+      "view_event_average_7d": "f597dd2f8e5d672fbac0445fb935469b",
+      "view_event_sum_14d": "f597dd2f8e5d672fbac0445fb935469b",
+      "view_event_sum_1d": "f597dd2f8e5d672fbac0445fb935469b",
+      "view_event_sum_30d": "f597dd2f8e5d672fbac0445fb935469b",
+      "view_event_sum_7d": "f597dd2f8e5d672fbac0445fb935469b"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_exports_user_activities__0_with_offset_0\", \"spec\": \"data.gcp_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "gcp.user_activities.v1__1",
+    "online": 1,
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/gcp/user_activities.py",
+    "team": "gcp",
+    "version": "1"
+  },
+  "sources": [
+    {
+      "events": {
+        "query": {
+          "selects": {
+            "add_to_cart_event": "IF(event_type = 'add_to_cart', 1, 0)",
+            "click_event": "IF(event_type = 'click', 1, 0)",
+            "favorite_event": "IF(event_type = 'favorite', 1, 0)",
+            "is_desktop": "IF(device_type = 'desktop', 1, 0)",
+            "is_mobile": "IF(device_type = 'mobile', 1, 0)",
+            "is_tablet": "IF(device_type = 'tablet', 1, 0)",
+            "listing_id": "listing_id",
+            "purchase_event": "IF(event_type = 'purchase', 1, 0)",
+            "user_event_struct": "STRUCT(event_type, listing_id, unix_millis(TIMESTAMP(event_time_ms)) as timestamp)",
+            "user_id": "user_id",
+            "view_event": "IF(event_type = 'view', 1, 0)"
+          },
+          "timeColumn": "unix_millis(TIMESTAMP(event_time_ms))"
+        },
+        "table": "data.gcp_exports_user_activities__0",
+        "topic": "pubsub://user-activities-v2/project=canary-443022/subscription=user-activities-v2-sub/serde=pubsub_schema/schemaId=user-activities"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/gcp/user_activities_chained.chained_user_gb__0
+++ b/python/test/canary/canary_compiled/group_bys/gcp/user_activities_chained.chained_user_gb__0
@@ -1,0 +1,359 @@
+{
+  "aggregations": [
+    {
+      "argMap": {
+        "k": "100"
+      },
+      "inputColumn": "price_cents",
+      "operation": 13,
+      "windows": [
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    }
+  ],
+  "keyColumns": [
+    "user_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "price_cents_last100_7d": "c4c5a4063613d69fbe6ac20408f7cc07",
+      "user_id": "e3d702eb6c23558f50233c39f7718309"
+    },
+    "customJson": "{\"airflowDependencies\": []}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily"
+    },
+    "name": "gcp.user_activities_chained.chained_user_gb__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "sourceFile": "group_bys/gcp/user_activities_chained.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "sources": [
+    {
+      "joinSource": {
+        "join": {
+          "joinParts": [
+            {
+              "groupBy": {
+                "keyColumns": [
+                  "listing_id"
+                ],
+                "metaData": {
+                  "environments": [
+                    0
+                  ],
+                  "executionInfo": {
+                    "clusterConf": {
+                      "modeClusterConfigs": {
+                        "upload": {
+                          "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                          "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                        }
+                      }
+                    },
+                    "conf": {
+                      "common": {
+                        "spark.chronon.coalesce.factor": "10",
+                        "spark.chronon.partition.column": "ds",
+                        "spark.chronon.partition.format": "yyyy-MM-dd",
+                        "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+                        "spark.chronon.table_write.format": "iceberg",
+                        "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+                        "spark.default.parallelism": "10",
+                        "spark.driver.cores": "1",
+                        "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+                        "spark.driver.memory": "512m",
+                        "spark.executor.cores": "1",
+                        "spark.executor.memory": "512m",
+                        "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                        "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+                        "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+                        "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+                        "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+                        "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+                        "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                        "spark.sql.shuffle.partitions": "10"
+                      }
+                    },
+                    "env": {
+                      "common": {
+                        "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                        "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                        "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                        "CLOUD_PROVIDER": "gcp",
+                        "CUSTOMER_ID": "canary",
+                        "ENABLE_PUBSUB": "true",
+                        "EVAL_URL": "http://localhost:3904",
+                        "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                        "FRONTEND_URL": "http://localhost:3000",
+                        "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                        "GCP_PROJECT_ID": "canary-443022",
+                        "GCP_REGION": "us-central1",
+                        "HUB_URL": "http://localhost:3903",
+                        "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+                        "VERSION": "latest",
+                        "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                      },
+                      "modeEnvironments": {
+                        "upload": {
+                          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                          "CLOUD_PROVIDER": "gcp",
+                          "CUSTOMER_ID": "canary",
+                          "ENABLE_PUBSUB": "true",
+                          "EVAL_URL": "http://localhost:3904",
+                          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                          "FRONTEND_URL": "http://localhost:3000",
+                          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                          "GCP_PROJECT_ID": "canary-443022",
+                          "GCP_REGION": "us-central1",
+                          "HUB_URL": "http://localhost:3903",
+                          "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                          "VERSION": "latest",
+                          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                        }
+                      }
+                    },
+                    "historicalBackfill": 0,
+                    "onlineSchedule": "@daily"
+                  },
+                  "name": "gcp.dim_listings.v1__0",
+                  "online": 1,
+                  "outputNamespace": "data",
+                  "team": "gcp",
+                  "version": "0"
+                },
+                "sources": [
+                  {
+                    "entities": {
+                      "query": {
+                        "selects": {
+                          "brief_description": "brief_description",
+                          "currency": "currency",
+                          "headline": "headline",
+                          "inventory_count": "inventory_count",
+                          "is_active": "is_active",
+                          "is_expensive": "IF(price_cents > 10000, 1, 0)",
+                          "is_in_stock": "IF(inventory_count > 0, 1, 0)",
+                          "listing_id": "listing_id",
+                          "long_description": "long_description",
+                          "main_image_path": "main_image_path",
+                          "merchant_id": "merchant_id",
+                          "price_cents": "price_cents",
+                          "primary_category": "primary_category",
+                          "secondary_image_paths": "secondary_image_paths",
+                          "tags": "tags",
+                          "weight_grams": "weight_grams"
+                        },
+                        "startPartition": "2025-01-01"
+                      },
+                      "snapshotTable": "data.gcp_exports_dim_listings__0"
+                    }
+                  }
+                ]
+              },
+              "useLongNames": 0
+            }
+          ],
+          "left": {
+            "events": {
+              "query": {
+                "selects": {
+                  "listing_id": "listing_id",
+                  "row_id": "event_id",
+                  "ts": "unix_millis(TIMESTAMP(event_time_ms))",
+                  "user_id": "user_id"
+                },
+                "timeColumn": "unix_millis(TIMESTAMP(event_time_ms))"
+              },
+              "table": "data.gcp_exports_user_activities__0",
+              "topic": "pubsub://user-activities-v2/project=canary-443022/subscription=user-activities-v2-sub/serde=pubsub_schema/schemaId=user-activities"
+            }
+          },
+          "metaData": {
+            "environments": [
+              0
+            ],
+            "executionInfo": {
+              "clusterConf": {
+                "modeClusterConfigs": {
+                  "upload": {
+                    "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                    "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                  }
+                }
+              },
+              "conf": {
+                "common": {
+                  "spark.chronon.coalesce.factor": "10",
+                  "spark.chronon.partition.column": "ds",
+                  "spark.chronon.partition.format": "yyyy-MM-dd",
+                  "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+                  "spark.chronon.table_write.format": "iceberg",
+                  "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+                  "spark.default.parallelism": "10",
+                  "spark.driver.cores": "1",
+                  "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+                  "spark.driver.memory": "512m",
+                  "spark.executor.cores": "1",
+                  "spark.executor.memory": "512m",
+                  "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                  "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+                  "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+                  "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+                  "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+                  "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+                  "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                  "spark.sql.shuffle.partitions": "10"
+                }
+              },
+              "env": {
+                "common": {
+                  "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                  "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                  "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                  "CLOUD_PROVIDER": "gcp",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_PUBSUB": "true",
+                  "EVAL_URL": "http://localhost:3904",
+                  "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "http://localhost:3000",
+                  "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                  "GCP_PROJECT_ID": "canary-443022",
+                  "GCP_REGION": "us-central1",
+                  "HUB_URL": "http://localhost:3903",
+                  "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                },
+                "modeEnvironments": {
+                  "upload": {
+                    "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                    "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                    "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                    "CLOUD_PROVIDER": "gcp",
+                    "CUSTOMER_ID": "canary",
+                    "ENABLE_PUBSUB": "true",
+                    "EVAL_URL": "http://localhost:3904",
+                    "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                    "FRONTEND_URL": "http://localhost:3000",
+                    "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                    "GCP_PROJECT_ID": "canary-443022",
+                    "GCP_REGION": "us-central1",
+                    "HUB_URL": "http://localhost:3903",
+                    "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                    "VERSION": "latest",
+                    "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                  }
+                }
+              },
+              "offlineSchedule": "17 0 * * *",
+              "onlineSchedule": "@daily"
+            },
+            "name": "gcp.demo_parent.parent_join__0",
+            "online": 1,
+            "outputNamespace": "data",
+            "production": 0,
+            "samplePercent": 100.0,
+            "team": "gcp",
+            "version": "0"
+          },
+          "rowIds": [
+            "event_id"
+          ],
+          "useLongNames": 0
+        },
+        "query": {
+          "selects": {
+            "listing_id": "listing_id",
+            "price_cents": "listing_id_price_cents",
+            "user_id": "user_id"
+          },
+          "timeColumn": "ts"
+        }
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/quickstart/dim_listings.v1__0
+++ b/python/test/canary/canary_compiled/group_bys/quickstart/dim_listings.v1__0
@@ -1,0 +1,80 @@
+{
+  "keyColumns": [
+    "listing_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "brief_description": "243bd9475048b531e39784ed5a4c5d4c",
+      "currency": "9ab5e4d3c769742611e6e6a21f738f2d",
+      "headline": "81a42c547de455ac521e611ba9481579",
+      "inventory_count": "3960d102ae6397912e352963b24b38dc",
+      "is_active": "379f96022efce3edf51da4b393e79547",
+      "is_expensive": "2504b94d7ac884660d25b2f1244023ae",
+      "is_in_stock": "ebb556dbdf71f816accd53d8c6baa93f",
+      "listing_id": "fbf72f082947fc83693eec35cd952267",
+      "long_description": "595aeee2959d571b6255119efde48896",
+      "main_image_path": "ede172f537c094b47645056183a6a280",
+      "merchant_id": "3771ceeff8397cb4c7ebbd516466b978",
+      "price_cents": "dc1f837ea154688d1fcf185da86bb945",
+      "primary_category": "83ce32a1a4651376edf05ac4c8ecbd11",
+      "secondary_image_paths": "fc4a13046d7659ed39878955d18cf1c4",
+      "tags": "799675961e188b9e4a5a898d7e3f02ff",
+      "weight_grams": "5c3e9f99cb7ec2d0aa56c9bd0e391308"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_quickstart_quickstart_exports_dim_listings__0_with_offset_0\", \"spec\": \"quickstart.quickstart_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily"
+    },
+    "name": "quickstart.dim_listings.v1__0",
+    "online": 1,
+    "outputNamespace": "quickstart",
+    "sourceFile": "group_bys/quickstart/dim_listings.py",
+    "team": "quickstart",
+    "version": "0"
+  },
+  "sources": [
+    {
+      "entities": {
+        "query": {
+          "selects": {
+            "brief_description": "brief_description",
+            "currency": "currency",
+            "headline": "headline",
+            "inventory_count": "inventory_count",
+            "is_active": "is_active",
+            "is_expensive": "IF(price_cents > 10000, 1, 0)",
+            "is_in_stock": "IF(inventory_count > 0, 1, 0)",
+            "listing_id": "listing_id",
+            "long_description": "long_description",
+            "main_image_path": "main_image_path",
+            "merchant_id": "merchant_id",
+            "price_cents": "price_cents",
+            "primary_category": "primary_category",
+            "secondary_image_paths": "secondary_image_paths",
+            "tags": "tags",
+            "weight_grams": "weight_grams"
+          },
+          "startPartition": "2023-11-01"
+        },
+        "snapshotTable": "quickstart.quickstart_exports_dim_listings__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/quickstart/dim_merchants.v1__0
+++ b/python/test/canary/canary_compiled/group_bys/quickstart/dim_merchants.v1__0
@@ -1,0 +1,52 @@
+{
+  "keyColumns": [
+    "merchant_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "merchant_id": "257c1adda98f500cbb6d8cd6cba61b4c",
+      "primary_category": "71dfddda1396b6f421bceff5fcc72ffb"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_quickstart_quickstart_exports_dim_merchants__0_with_offset_0\", \"spec\": \"quickstart.quickstart_exports_dim_merchants__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily"
+    },
+    "name": "quickstart.dim_merchants.v1__0",
+    "online": 1,
+    "outputNamespace": "quickstart",
+    "sourceFile": "group_bys/quickstart/dim_merchants.py",
+    "team": "quickstart",
+    "version": "0"
+  },
+  "sources": [
+    {
+      "entities": {
+        "query": {
+          "selects": {
+            "merchant_id": "merchant_id",
+            "primary_category": "primary_category"
+          },
+          "startPartition": "2023-11-01"
+        },
+        "snapshotTable": "quickstart.quickstart_exports_dim_merchants__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/group_bys/quickstart/user_activities.v1__1
+++ b/python/test/canary/canary_compiled/group_bys/quickstart/user_activities.v1__1
@@ -1,0 +1,445 @@
+{
+  "aggregations": [
+    {
+      "argMap": {},
+      "inputColumn": "view_event",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "click_event",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_event",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "favorite_event",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "add_to_cart_event",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "view_event",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "click_event",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "purchase_event",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "favorite_event",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "add_to_cart_event",
+      "operation": 8,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "is_mobile",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "is_desktop",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {},
+      "inputColumn": "is_tablet",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "argMap": {
+        "k": "128"
+      },
+      "inputColumn": "user_event_struct",
+      "operation": 13,
+      "windows": [
+        {
+          "length": 1,
+          "timeUnit": 1
+        },
+        {
+          "length": 7,
+          "timeUnit": 1
+        },
+        {
+          "length": 14,
+          "timeUnit": 1
+        },
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    }
+  ],
+  "keyColumns": [
+    "user_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "add_to_cart_event_average_14d": "721cedd948fa111b342a27442173c100",
+      "add_to_cart_event_average_1d": "721cedd948fa111b342a27442173c100",
+      "add_to_cart_event_average_30d": "721cedd948fa111b342a27442173c100",
+      "add_to_cart_event_average_7d": "721cedd948fa111b342a27442173c100",
+      "add_to_cart_event_sum_14d": "721cedd948fa111b342a27442173c100",
+      "add_to_cart_event_sum_1d": "721cedd948fa111b342a27442173c100",
+      "add_to_cart_event_sum_30d": "721cedd948fa111b342a27442173c100",
+      "add_to_cart_event_sum_7d": "721cedd948fa111b342a27442173c100",
+      "click_event_average_14d": "ea6d27949c09cfc8b23f5b20f445dcd5",
+      "click_event_average_1d": "ea6d27949c09cfc8b23f5b20f445dcd5",
+      "click_event_average_30d": "ea6d27949c09cfc8b23f5b20f445dcd5",
+      "click_event_average_7d": "ea6d27949c09cfc8b23f5b20f445dcd5",
+      "click_event_sum_14d": "ea6d27949c09cfc8b23f5b20f445dcd5",
+      "click_event_sum_1d": "ea6d27949c09cfc8b23f5b20f445dcd5",
+      "click_event_sum_30d": "ea6d27949c09cfc8b23f5b20f445dcd5",
+      "click_event_sum_7d": "ea6d27949c09cfc8b23f5b20f445dcd5",
+      "favorite_event_average_14d": "8c5dbe13014ce5c05064cd89fede7998",
+      "favorite_event_average_1d": "8c5dbe13014ce5c05064cd89fede7998",
+      "favorite_event_average_30d": "8c5dbe13014ce5c05064cd89fede7998",
+      "favorite_event_average_7d": "8c5dbe13014ce5c05064cd89fede7998",
+      "favorite_event_sum_14d": "8c5dbe13014ce5c05064cd89fede7998",
+      "favorite_event_sum_1d": "8c5dbe13014ce5c05064cd89fede7998",
+      "favorite_event_sum_30d": "8c5dbe13014ce5c05064cd89fede7998",
+      "favorite_event_sum_7d": "8c5dbe13014ce5c05064cd89fede7998",
+      "is_desktop_sum_14d": "cd279c4eecf6966bba76ebcf642e07c1",
+      "is_desktop_sum_1d": "cd279c4eecf6966bba76ebcf642e07c1",
+      "is_desktop_sum_30d": "cd279c4eecf6966bba76ebcf642e07c1",
+      "is_desktop_sum_7d": "cd279c4eecf6966bba76ebcf642e07c1",
+      "is_mobile_sum_14d": "4aad5a5a5bad4a8029ba05cc6b299b8c",
+      "is_mobile_sum_1d": "4aad5a5a5bad4a8029ba05cc6b299b8c",
+      "is_mobile_sum_30d": "4aad5a5a5bad4a8029ba05cc6b299b8c",
+      "is_mobile_sum_7d": "4aad5a5a5bad4a8029ba05cc6b299b8c",
+      "is_tablet_sum_14d": "e45ad389d51304af80f003ab465b215f",
+      "is_tablet_sum_1d": "e45ad389d51304af80f003ab465b215f",
+      "is_tablet_sum_30d": "e45ad389d51304af80f003ab465b215f",
+      "is_tablet_sum_7d": "e45ad389d51304af80f003ab465b215f",
+      "purchase_event_average_14d": "af3161f10b0f6c6fbfd48885ac5943c9",
+      "purchase_event_average_1d": "af3161f10b0f6c6fbfd48885ac5943c9",
+      "purchase_event_average_30d": "af3161f10b0f6c6fbfd48885ac5943c9",
+      "purchase_event_average_7d": "af3161f10b0f6c6fbfd48885ac5943c9",
+      "purchase_event_sum_14d": "af3161f10b0f6c6fbfd48885ac5943c9",
+      "purchase_event_sum_1d": "af3161f10b0f6c6fbfd48885ac5943c9",
+      "purchase_event_sum_30d": "af3161f10b0f6c6fbfd48885ac5943c9",
+      "purchase_event_sum_7d": "af3161f10b0f6c6fbfd48885ac5943c9",
+      "user_event_struct_last128_14d": "47d3f70709072f97d2b414d5403026ce",
+      "user_event_struct_last128_1d": "47d3f70709072f97d2b414d5403026ce",
+      "user_event_struct_last128_30d": "47d3f70709072f97d2b414d5403026ce",
+      "user_event_struct_last128_7d": "47d3f70709072f97d2b414d5403026ce",
+      "user_id": "1cefa43bec1f992629ef61e61e07bd76",
+      "view_event_average_14d": "62a8793addff23c7d8079961a8a07320",
+      "view_event_average_1d": "62a8793addff23c7d8079961a8a07320",
+      "view_event_average_30d": "62a8793addff23c7d8079961a8a07320",
+      "view_event_average_7d": "62a8793addff23c7d8079961a8a07320",
+      "view_event_sum_14d": "62a8793addff23c7d8079961a8a07320",
+      "view_event_sum_1d": "62a8793addff23c7d8079961a8a07320",
+      "view_event_sum_30d": "62a8793addff23c7d8079961a8a07320",
+      "view_event_sum_7d": "62a8793addff23c7d8079961a8a07320"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_quickstart_quickstart_exports_user_activities__0_with_offset_0\", \"spec\": \"quickstart.quickstart_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "historicalBackfill": 0,
+      "onlineSchedule": "@daily",
+      "stepDays": 4
+    },
+    "name": "quickstart.user_activities.v1__1",
+    "online": 1,
+    "outputNamespace": "quickstart",
+    "sourceFile": "group_bys/quickstart/user_activities.py",
+    "team": "quickstart",
+    "version": "1"
+  },
+  "sources": [
+    {
+      "events": {
+        "query": {
+          "selects": {
+            "add_to_cart_event": "IF(event_type = 'add_to_cart', 1, 0)",
+            "click_event": "IF(event_type = 'click', 1, 0)",
+            "favorite_event": "IF(event_type = 'favorite', 1, 0)",
+            "is_desktop": "IF(device_type = 'desktop', 1, 0)",
+            "is_mobile": "IF(device_type = 'mobile', 1, 0)",
+            "is_tablet": "IF(device_type = 'tablet', 1, 0)",
+            "listing_id": "listing_id",
+            "purchase_event": "IF(event_type = 'purchase', 1, 0)",
+            "user_event_struct": "struct(event_type, listing_id, event_time_ms as timestamp)",
+            "user_id": "user_id",
+            "view_event": "IF(event_type = 'view', 1, 0)"
+          },
+          "timeColumn": "event_time_ms"
+        },
+        "table": "quickstart.quickstart_exports_user_activities__0",
+        "topic": "user_activities_stream"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/joins/aws/demo.derivations_v1__2
+++ b/python/test/canary/canary_compiled/joins/aws/demo.derivations_v1__2
@@ -1,0 +1,908 @@
+{
+  "derivations": [
+    {
+      "expression": "IF(listing_id_weight_grams > 1000, 1, 0)",
+      "name": "is_listing_heavy"
+    },
+    {
+      "expression": "array_contains(split(listing_id_tags, ','), 'handmade')",
+      "name": "is_item_handmade"
+    },
+    {
+      "expression": "log1p(listing_id_price_cents)",
+      "name": "price_log"
+    },
+    {
+      "expression": "\n                CASE\n                    WHEN listing_id_price_cents < 1000 THEN 0\n                    WHEN listing_id_price_cents < 5000 THEN 1\n                    WHEN listing_id_price_cents < 10000 THEN 2\n                    WHEN listing_id_price_cents < 50000 THEN 3\n                    ELSE 4\n                END\n            ",
+      "name": "price_bucket"
+    },
+    {
+      "expression": "*",
+      "name": "*"
+    }
+  ],
+  "joinParts": [
+    {
+      "groupBy": {
+        "keyColumns": [
+          "listing_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "brief_description": "c02f5fdfa63b63dc6a593a20cbab7d66",
+            "currency": "27d3da8403941e88f04007211468833e",
+            "headline": "961d1b3f1536af92638c63b2085fa728",
+            "inventory_count": "f3f379de8d3f9e74b60600f0356327d4",
+            "is_active": "b73c53f1089d15c7549d1be9e45bc05a",
+            "is_expensive": "dfe960db190729abde16b0eba360dfc4",
+            "is_in_stock": "6f24425755fd59b8a5a93de6912b111c",
+            "listing_id": "76323e9628393438a3d9bd1e0a0dcf40",
+            "long_description": "0588c5abbb679b56d18028e929d62124",
+            "main_image_path": "e670b87ebe0042f36d6dcb0379ce12da",
+            "merchant_id": "14059af75922b7fe7d8993867667f4af",
+            "price_cents": "33f80b9b819b9b68c65fc31652d4cc26",
+            "primary_category": "76c07f8cf4d4c3465843d890b89f8bb0",
+            "secondary_image_paths": "2d21e3616fce29041df8387677ef5193",
+            "tags": "b02298b5dc181fd94c357eef9f0623ca",
+            "weight_grams": "8b5ac3514f1c8f0db67748e07de128f4"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "clusterConf": {
+              "common": {
+                "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+              }
+            },
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.table_write.upload.format": "ion",
+                "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.memory": "1g",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "1g",
+                "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                "spark.sql.shuffle.partitions": "10",
+                "taskmanager.memory.process.size": "4G"
+              },
+              "modeConfigs": {
+                "backfill": {
+                  "spark.chronon.coalesce.factor": "10",
+                  "spark.chronon.partition.column": "ds",
+                  "spark.chronon.partition.format": "yyyy-MM-dd",
+                  "spark.chronon.table_write.format": "iceberg",
+                  "spark.chronon.table_write.upload.format": "ion",
+                  "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                  "spark.default.parallelism": "10",
+                  "spark.driver.cores": "1",
+                  "spark.driver.memory": "1g",
+                  "spark.executor.cores": "1",
+                  "spark.executor.memory": "1g",
+                  "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                  "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                  "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                  "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                  "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                  "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                  "spark.sql.shuffle.partitions": "10",
+                  "taskmanager.memory.process.size": "4G"
+                }
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                "AWS_REGION": "us-west-2",
+                "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                "CLOUD_PROVIDER": "aws",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_KINESIS": "true",
+                "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+              },
+              "modeEnvironments": {
+                "upload": {
+                  "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                  "AWS_REGION": "us-west-2",
+                  "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                  "CLOUD_PROVIDER": "aws",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_KINESIS": "true",
+                  "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                  "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                  "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                  "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                  "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                }
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily",
+            "stepDays": 10
+          },
+          "name": "aws.dim_listings.v1__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "aws",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "entities": {
+              "query": {
+                "selects": {
+                  "brief_description": "brief_description",
+                  "currency": "currency",
+                  "headline": "headline",
+                  "inventory_count": "inventory_count",
+                  "is_active": "is_active",
+                  "is_expensive": "IF(price_cents > 10000, 1, 0)",
+                  "is_in_stock": "IF(inventory_count > 0, 1, 0)",
+                  "listing_id": "listing_id",
+                  "long_description": "long_description",
+                  "main_image_path": "main_image_path",
+                  "merchant_id": "merchant_id",
+                  "price_cents": "price_cents",
+                  "primary_category": "primary_category",
+                  "secondary_image_paths": "secondary_image_paths",
+                  "tags": "tags",
+                  "weight_grams": "weight_grams"
+                },
+                "startPartition": "2025-01-01"
+              },
+              "snapshotTable": "data.aws_exports_dim_listings__0"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    },
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "view_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "click_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "favorite_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "add_to_cart_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "view_event",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "click_event",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_event",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "favorite_event",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "add_to_cart_event",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "is_mobile",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "is_desktop",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "is_tablet",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {
+              "k": "128"
+            },
+            "inputColumn": "user_event_struct",
+            "operation": 13,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          }
+        ],
+        "keyColumns": [
+          "user_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "add_to_cart_event_average_14d": "881d7a0a7d626d6c949db88d26cca669",
+            "add_to_cart_event_average_1d": "881d7a0a7d626d6c949db88d26cca669",
+            "add_to_cart_event_average_30d": "881d7a0a7d626d6c949db88d26cca669",
+            "add_to_cart_event_average_7d": "881d7a0a7d626d6c949db88d26cca669",
+            "add_to_cart_event_sum_14d": "881d7a0a7d626d6c949db88d26cca669",
+            "add_to_cart_event_sum_1d": "881d7a0a7d626d6c949db88d26cca669",
+            "add_to_cart_event_sum_30d": "881d7a0a7d626d6c949db88d26cca669",
+            "add_to_cart_event_sum_7d": "881d7a0a7d626d6c949db88d26cca669",
+            "click_event_average_14d": "e76cb96f6bdd94e36ac8be957089e0c7",
+            "click_event_average_1d": "e76cb96f6bdd94e36ac8be957089e0c7",
+            "click_event_average_30d": "e76cb96f6bdd94e36ac8be957089e0c7",
+            "click_event_average_7d": "e76cb96f6bdd94e36ac8be957089e0c7",
+            "click_event_sum_14d": "e76cb96f6bdd94e36ac8be957089e0c7",
+            "click_event_sum_1d": "e76cb96f6bdd94e36ac8be957089e0c7",
+            "click_event_sum_30d": "e76cb96f6bdd94e36ac8be957089e0c7",
+            "click_event_sum_7d": "e76cb96f6bdd94e36ac8be957089e0c7",
+            "favorite_event_average_14d": "e1a70c7033ed72888f782bb64b55b83b",
+            "favorite_event_average_1d": "e1a70c7033ed72888f782bb64b55b83b",
+            "favorite_event_average_30d": "e1a70c7033ed72888f782bb64b55b83b",
+            "favorite_event_average_7d": "e1a70c7033ed72888f782bb64b55b83b",
+            "favorite_event_sum_14d": "e1a70c7033ed72888f782bb64b55b83b",
+            "favorite_event_sum_1d": "e1a70c7033ed72888f782bb64b55b83b",
+            "favorite_event_sum_30d": "e1a70c7033ed72888f782bb64b55b83b",
+            "favorite_event_sum_7d": "e1a70c7033ed72888f782bb64b55b83b",
+            "is_desktop_sum_14d": "7a31d2cccd4268f15e72a3937ccdb132",
+            "is_desktop_sum_1d": "7a31d2cccd4268f15e72a3937ccdb132",
+            "is_desktop_sum_30d": "7a31d2cccd4268f15e72a3937ccdb132",
+            "is_desktop_sum_7d": "7a31d2cccd4268f15e72a3937ccdb132",
+            "is_mobile_sum_14d": "7c8d7f0fd04e17bfc46d3302b7962940",
+            "is_mobile_sum_1d": "7c8d7f0fd04e17bfc46d3302b7962940",
+            "is_mobile_sum_30d": "7c8d7f0fd04e17bfc46d3302b7962940",
+            "is_mobile_sum_7d": "7c8d7f0fd04e17bfc46d3302b7962940",
+            "is_tablet_sum_14d": "df94715e84196a8c29a674fad4c5517d",
+            "is_tablet_sum_1d": "df94715e84196a8c29a674fad4c5517d",
+            "is_tablet_sum_30d": "df94715e84196a8c29a674fad4c5517d",
+            "is_tablet_sum_7d": "df94715e84196a8c29a674fad4c5517d",
+            "purchase_event_average_14d": "f12000e102555d8a10eb745375fd5473",
+            "purchase_event_average_1d": "f12000e102555d8a10eb745375fd5473",
+            "purchase_event_average_30d": "f12000e102555d8a10eb745375fd5473",
+            "purchase_event_average_7d": "f12000e102555d8a10eb745375fd5473",
+            "purchase_event_sum_14d": "f12000e102555d8a10eb745375fd5473",
+            "purchase_event_sum_1d": "f12000e102555d8a10eb745375fd5473",
+            "purchase_event_sum_30d": "f12000e102555d8a10eb745375fd5473",
+            "purchase_event_sum_7d": "f12000e102555d8a10eb745375fd5473",
+            "user_event_struct_last128_14d": "ea8aea62e71ac12cd4ffc67b8b75a708",
+            "user_event_struct_last128_1d": "ea8aea62e71ac12cd4ffc67b8b75a708",
+            "user_event_struct_last128_30d": "ea8aea62e71ac12cd4ffc67b8b75a708",
+            "user_event_struct_last128_7d": "ea8aea62e71ac12cd4ffc67b8b75a708",
+            "user_id": "2426812b8e21edb4ab790123c864c598",
+            "view_event_average_14d": "c96e2586b4fbcb1b88553f770a5868e8",
+            "view_event_average_1d": "c96e2586b4fbcb1b88553f770a5868e8",
+            "view_event_average_30d": "c96e2586b4fbcb1b88553f770a5868e8",
+            "view_event_average_7d": "c96e2586b4fbcb1b88553f770a5868e8",
+            "view_event_sum_14d": "c96e2586b4fbcb1b88553f770a5868e8",
+            "view_event_sum_1d": "c96e2586b4fbcb1b88553f770a5868e8",
+            "view_event_sum_30d": "c96e2586b4fbcb1b88553f770a5868e8",
+            "view_event_sum_7d": "c96e2586b4fbcb1b88553f770a5868e8"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "clusterConf": {
+              "common": {
+                "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+              }
+            },
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.table_write.upload.format": "ion",
+                "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.memory": "1g",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "1g",
+                "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                "spark.sql.shuffle.partitions": "10",
+                "taskmanager.memory.process.size": "4G"
+              },
+              "modeConfigs": {
+                "backfill": {
+                  "spark.chronon.coalesce.factor": "10",
+                  "spark.chronon.partition.column": "ds",
+                  "spark.chronon.partition.format": "yyyy-MM-dd",
+                  "spark.chronon.table_write.format": "iceberg",
+                  "spark.chronon.table_write.upload.format": "ion",
+                  "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                  "spark.default.parallelism": "10",
+                  "spark.driver.cores": "1",
+                  "spark.driver.memory": "1g",
+                  "spark.executor.cores": "1",
+                  "spark.executor.memory": "1g",
+                  "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                  "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                  "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                  "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                  "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                  "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                  "spark.sql.shuffle.partitions": "10",
+                  "taskmanager.memory.process.size": "4G"
+                }
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                "AWS_REGION": "us-west-2",
+                "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+                "CLOUD_PROVIDER": "aws",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_KINESIS": "true",
+                "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+              },
+              "modeEnvironments": {
+                "upload": {
+                  "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                  "AWS_REGION": "us-west-2",
+                  "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+                  "CLOUD_PROVIDER": "aws",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_KINESIS": "true",
+                  "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                  "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                  "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                  "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                  "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                }
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily",
+            "stepDays": 10
+          },
+          "name": "aws.user_activities.v1__1",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "aws",
+          "version": "1"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "selects": {
+                  "add_to_cart_event": "IF(event_type = 'add_to_cart', 1, 0)",
+                  "click_event": "IF(event_type = 'click', 1, 0)",
+                  "favorite_event": "IF(event_type = 'favorite', 1, 0)",
+                  "is_desktop": "IF(device_type = 'desktop', 1, 0)",
+                  "is_mobile": "IF(device_type = 'mobile', 1, 0)",
+                  "is_tablet": "IF(device_type = 'tablet', 1, 0)",
+                  "listing_id": "listing_id",
+                  "purchase_event": "IF(event_type = 'purchase', 1, 0)",
+                  "user_event_struct": "STRUCT(event_type, listing_id, unix_millis(TIMESTAMP(event_time_ms)) as timestamp)",
+                  "user_id": "user_id",
+                  "view_event": "IF(event_type = 'view', 1, 0)"
+                },
+                "timeColumn": "unix_millis(TIMESTAMP(event_time_ms))"
+              },
+              "table": "demo.user_activities_raw",
+              "topic": "kinesis://user-activities/serde=glue_registry/registry_name=zipline-canary/schema_name=user-activities"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "listing_id": "listing_id",
+          "row_id": "event_id",
+          "ts": "event_time_ms",
+          "user_id": "user_id"
+        },
+        "timeColumn": "event_time_ms"
+      },
+      "table": "data.aws_exports_user_activities__0"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "is_item_handmade": "c32477f0978e9d0e8b21ad5615e72c06",
+      "is_listing_heavy": "7d6cb6b0bc8928db5816869d8f62b406",
+      "listing_id": "5d9731b2eaa30b6e4b448d932e7ac6d6",
+      "listing_id_brief_description": "f5a516deea870f07bb0008f30bb0ae25",
+      "listing_id_currency": "05aa1eb0d28c86435784c94fba851d10",
+      "listing_id_headline": "c4ffab402f28e0f4bfe65f74890b5564",
+      "listing_id_inventory_count": "cb5b5e7c038d663da13c4d8d92cb3090",
+      "listing_id_is_active": "ef33441ced50d99828ff705449e54f1b",
+      "listing_id_is_expensive": "40cf0185ef61cb96cc8b6466e8b8d171",
+      "listing_id_is_in_stock": "b985765be62c280609787992a993564a",
+      "listing_id_listing_id": "b83cbc9b68f8cb9470a46e63339e401a",
+      "listing_id_long_description": "2b2157cab236d2a1ef595752cf73c94a",
+      "listing_id_main_image_path": "0e0c5ff4e0664d1ca2bceea36ae64db6",
+      "listing_id_merchant_id": "52466767463f5a785e8f48e435671d99",
+      "listing_id_price_cents": "2b4646e1ebbeb2b1441c2d871fc18c61",
+      "listing_id_primary_category": "2bb7f0bd371d76016507c47ea52f0fef",
+      "listing_id_secondary_image_paths": "787b3b5864b70deb5aa6660cb7cc101e",
+      "listing_id_tags": "279b7d347b5acfda8f89848c01f6c4dc",
+      "listing_id_weight_grams": "58061c72136c5815edddc0da7b80f2f1",
+      "price_bucket": "97e5adc10ccda5259663a62e8fff2d38",
+      "price_log": "94b43b84fdbff71695051ab50c448784",
+      "row_id": "5975f7f41ebb94e022a33bc9067f37c8",
+      "ts": "9704a89fc4ea9beffe33345ba8087150",
+      "user_id": "d79642f27adf8373a7acd0db93c18e65",
+      "user_id_add_to_cart_event_average_14d": "77d795900ae447d4b216e9aec2b9e2bb",
+      "user_id_add_to_cart_event_average_1d": "77d795900ae447d4b216e9aec2b9e2bb",
+      "user_id_add_to_cart_event_average_30d": "77d795900ae447d4b216e9aec2b9e2bb",
+      "user_id_add_to_cart_event_average_7d": "77d795900ae447d4b216e9aec2b9e2bb",
+      "user_id_add_to_cart_event_sum_14d": "77d795900ae447d4b216e9aec2b9e2bb",
+      "user_id_add_to_cart_event_sum_1d": "77d795900ae447d4b216e9aec2b9e2bb",
+      "user_id_add_to_cart_event_sum_30d": "77d795900ae447d4b216e9aec2b9e2bb",
+      "user_id_add_to_cart_event_sum_7d": "77d795900ae447d4b216e9aec2b9e2bb",
+      "user_id_click_event_average_14d": "a16394c17d043d49995d6b54fc86d0f8",
+      "user_id_click_event_average_1d": "a16394c17d043d49995d6b54fc86d0f8",
+      "user_id_click_event_average_30d": "a16394c17d043d49995d6b54fc86d0f8",
+      "user_id_click_event_average_7d": "a16394c17d043d49995d6b54fc86d0f8",
+      "user_id_click_event_sum_14d": "a16394c17d043d49995d6b54fc86d0f8",
+      "user_id_click_event_sum_1d": "a16394c17d043d49995d6b54fc86d0f8",
+      "user_id_click_event_sum_30d": "a16394c17d043d49995d6b54fc86d0f8",
+      "user_id_click_event_sum_7d": "a16394c17d043d49995d6b54fc86d0f8",
+      "user_id_favorite_event_average_14d": "102ddcb2a626fb6ca93181e446b909c1",
+      "user_id_favorite_event_average_1d": "102ddcb2a626fb6ca93181e446b909c1",
+      "user_id_favorite_event_average_30d": "102ddcb2a626fb6ca93181e446b909c1",
+      "user_id_favorite_event_average_7d": "102ddcb2a626fb6ca93181e446b909c1",
+      "user_id_favorite_event_sum_14d": "102ddcb2a626fb6ca93181e446b909c1",
+      "user_id_favorite_event_sum_1d": "102ddcb2a626fb6ca93181e446b909c1",
+      "user_id_favorite_event_sum_30d": "102ddcb2a626fb6ca93181e446b909c1",
+      "user_id_favorite_event_sum_7d": "102ddcb2a626fb6ca93181e446b909c1",
+      "user_id_is_desktop_sum_14d": "a34e29b8bf89e18d203d447e08a71cd2",
+      "user_id_is_desktop_sum_1d": "a34e29b8bf89e18d203d447e08a71cd2",
+      "user_id_is_desktop_sum_30d": "a34e29b8bf89e18d203d447e08a71cd2",
+      "user_id_is_desktop_sum_7d": "a34e29b8bf89e18d203d447e08a71cd2",
+      "user_id_is_mobile_sum_14d": "3bc7607a1f56888df3a9d899051ff712",
+      "user_id_is_mobile_sum_1d": "3bc7607a1f56888df3a9d899051ff712",
+      "user_id_is_mobile_sum_30d": "3bc7607a1f56888df3a9d899051ff712",
+      "user_id_is_mobile_sum_7d": "3bc7607a1f56888df3a9d899051ff712",
+      "user_id_is_tablet_sum_14d": "9d7e26d4b8765bda45f25e5154b422dd",
+      "user_id_is_tablet_sum_1d": "9d7e26d4b8765bda45f25e5154b422dd",
+      "user_id_is_tablet_sum_30d": "9d7e26d4b8765bda45f25e5154b422dd",
+      "user_id_is_tablet_sum_7d": "9d7e26d4b8765bda45f25e5154b422dd",
+      "user_id_purchase_event_average_14d": "88806352d28a54207990e6b7f71e0647",
+      "user_id_purchase_event_average_1d": "88806352d28a54207990e6b7f71e0647",
+      "user_id_purchase_event_average_30d": "88806352d28a54207990e6b7f71e0647",
+      "user_id_purchase_event_average_7d": "88806352d28a54207990e6b7f71e0647",
+      "user_id_purchase_event_sum_14d": "88806352d28a54207990e6b7f71e0647",
+      "user_id_purchase_event_sum_1d": "88806352d28a54207990e6b7f71e0647",
+      "user_id_purchase_event_sum_30d": "88806352d28a54207990e6b7f71e0647",
+      "user_id_purchase_event_sum_7d": "88806352d28a54207990e6b7f71e0647",
+      "user_id_user_event_struct_last128_14d": "599520fd2c1a28a29ece4a6433820c7e",
+      "user_id_user_event_struct_last128_1d": "599520fd2c1a28a29ece4a6433820c7e",
+      "user_id_user_event_struct_last128_30d": "599520fd2c1a28a29ece4a6433820c7e",
+      "user_id_user_event_struct_last128_7d": "599520fd2c1a28a29ece4a6433820c7e",
+      "user_id_view_event_average_14d": "90eb1026d49d637d24bd34ba85f84781",
+      "user_id_view_event_average_1d": "90eb1026d49d637d24bd34ba85f84781",
+      "user_id_view_event_average_30d": "90eb1026d49d637d24bd34ba85f84781",
+      "user_id_view_event_average_7d": "90eb1026d49d637d24bd34ba85f84781",
+      "user_id_view_event_sum_14d": "90eb1026d49d637d24bd34ba85f84781",
+      "user_id_view_event_sum_1d": "90eb1026d49d637d24bd34ba85f84781",
+      "user_id_view_event_sum_30d": "90eb1026d49d637d24bd34ba85f84781",
+      "user_id_view_event_sum_7d": "90eb1026d49d637d24bd34ba85f84781"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_exports_user_activities__0_with_offset_0\", \"spec\": \"data.aws_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_aws_exports_dim_listings__0_with_offset_0\", \"spec\": \"data.aws_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_demo_user_activities_raw_with_offset_0\", \"spec\": \"demo.user_activities_raw/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "enableStatsCompute": 1,
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "onlineSchedule": "@daily",
+      "stepDays": 10
+    },
+    "name": "aws.demo.derivations_v1__2",
+    "online": 1,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/aws/demo.py",
+    "team": "aws",
+    "version": "2"
+  },
+  "rowIds": [
+    "event_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/aws/demo.v1__1
+++ b/python/test/canary/canary_compiled/joins/aws/demo.v1__1
@@ -1,0 +1,1013 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "view_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "click_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "favorite_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "add_to_cart_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "view_event",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "click_event",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_event",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "favorite_event",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "add_to_cart_event",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "is_mobile",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "is_desktop",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "is_tablet",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {
+              "k": "128"
+            },
+            "inputColumn": "user_event_struct",
+            "operation": 13,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          }
+        ],
+        "keyColumns": [
+          "user_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "add_to_cart_event_average_14d": "881d7a0a7d626d6c949db88d26cca669",
+            "add_to_cart_event_average_1d": "881d7a0a7d626d6c949db88d26cca669",
+            "add_to_cart_event_average_30d": "881d7a0a7d626d6c949db88d26cca669",
+            "add_to_cart_event_average_7d": "881d7a0a7d626d6c949db88d26cca669",
+            "add_to_cart_event_sum_14d": "881d7a0a7d626d6c949db88d26cca669",
+            "add_to_cart_event_sum_1d": "881d7a0a7d626d6c949db88d26cca669",
+            "add_to_cart_event_sum_30d": "881d7a0a7d626d6c949db88d26cca669",
+            "add_to_cart_event_sum_7d": "881d7a0a7d626d6c949db88d26cca669",
+            "click_event_average_14d": "e76cb96f6bdd94e36ac8be957089e0c7",
+            "click_event_average_1d": "e76cb96f6bdd94e36ac8be957089e0c7",
+            "click_event_average_30d": "e76cb96f6bdd94e36ac8be957089e0c7",
+            "click_event_average_7d": "e76cb96f6bdd94e36ac8be957089e0c7",
+            "click_event_sum_14d": "e76cb96f6bdd94e36ac8be957089e0c7",
+            "click_event_sum_1d": "e76cb96f6bdd94e36ac8be957089e0c7",
+            "click_event_sum_30d": "e76cb96f6bdd94e36ac8be957089e0c7",
+            "click_event_sum_7d": "e76cb96f6bdd94e36ac8be957089e0c7",
+            "favorite_event_average_14d": "e1a70c7033ed72888f782bb64b55b83b",
+            "favorite_event_average_1d": "e1a70c7033ed72888f782bb64b55b83b",
+            "favorite_event_average_30d": "e1a70c7033ed72888f782bb64b55b83b",
+            "favorite_event_average_7d": "e1a70c7033ed72888f782bb64b55b83b",
+            "favorite_event_sum_14d": "e1a70c7033ed72888f782bb64b55b83b",
+            "favorite_event_sum_1d": "e1a70c7033ed72888f782bb64b55b83b",
+            "favorite_event_sum_30d": "e1a70c7033ed72888f782bb64b55b83b",
+            "favorite_event_sum_7d": "e1a70c7033ed72888f782bb64b55b83b",
+            "is_desktop_sum_14d": "7a31d2cccd4268f15e72a3937ccdb132",
+            "is_desktop_sum_1d": "7a31d2cccd4268f15e72a3937ccdb132",
+            "is_desktop_sum_30d": "7a31d2cccd4268f15e72a3937ccdb132",
+            "is_desktop_sum_7d": "7a31d2cccd4268f15e72a3937ccdb132",
+            "is_mobile_sum_14d": "7c8d7f0fd04e17bfc46d3302b7962940",
+            "is_mobile_sum_1d": "7c8d7f0fd04e17bfc46d3302b7962940",
+            "is_mobile_sum_30d": "7c8d7f0fd04e17bfc46d3302b7962940",
+            "is_mobile_sum_7d": "7c8d7f0fd04e17bfc46d3302b7962940",
+            "is_tablet_sum_14d": "df94715e84196a8c29a674fad4c5517d",
+            "is_tablet_sum_1d": "df94715e84196a8c29a674fad4c5517d",
+            "is_tablet_sum_30d": "df94715e84196a8c29a674fad4c5517d",
+            "is_tablet_sum_7d": "df94715e84196a8c29a674fad4c5517d",
+            "purchase_event_average_14d": "f12000e102555d8a10eb745375fd5473",
+            "purchase_event_average_1d": "f12000e102555d8a10eb745375fd5473",
+            "purchase_event_average_30d": "f12000e102555d8a10eb745375fd5473",
+            "purchase_event_average_7d": "f12000e102555d8a10eb745375fd5473",
+            "purchase_event_sum_14d": "f12000e102555d8a10eb745375fd5473",
+            "purchase_event_sum_1d": "f12000e102555d8a10eb745375fd5473",
+            "purchase_event_sum_30d": "f12000e102555d8a10eb745375fd5473",
+            "purchase_event_sum_7d": "f12000e102555d8a10eb745375fd5473",
+            "user_event_struct_last128_14d": "ea8aea62e71ac12cd4ffc67b8b75a708",
+            "user_event_struct_last128_1d": "ea8aea62e71ac12cd4ffc67b8b75a708",
+            "user_event_struct_last128_30d": "ea8aea62e71ac12cd4ffc67b8b75a708",
+            "user_event_struct_last128_7d": "ea8aea62e71ac12cd4ffc67b8b75a708",
+            "user_id": "2426812b8e21edb4ab790123c864c598",
+            "view_event_average_14d": "c96e2586b4fbcb1b88553f770a5868e8",
+            "view_event_average_1d": "c96e2586b4fbcb1b88553f770a5868e8",
+            "view_event_average_30d": "c96e2586b4fbcb1b88553f770a5868e8",
+            "view_event_average_7d": "c96e2586b4fbcb1b88553f770a5868e8",
+            "view_event_sum_14d": "c96e2586b4fbcb1b88553f770a5868e8",
+            "view_event_sum_1d": "c96e2586b4fbcb1b88553f770a5868e8",
+            "view_event_sum_30d": "c96e2586b4fbcb1b88553f770a5868e8",
+            "view_event_sum_7d": "c96e2586b4fbcb1b88553f770a5868e8"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "clusterConf": {
+              "common": {
+                "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+              }
+            },
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.table_write.upload.format": "ion",
+                "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.memory": "1g",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "1g",
+                "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                "spark.sql.shuffle.partitions": "10",
+                "taskmanager.memory.process.size": "4G"
+              },
+              "modeConfigs": {
+                "backfill": {
+                  "spark.chronon.coalesce.factor": "10",
+                  "spark.chronon.partition.column": "ds",
+                  "spark.chronon.partition.format": "yyyy-MM-dd",
+                  "spark.chronon.table_write.format": "iceberg",
+                  "spark.chronon.table_write.upload.format": "ion",
+                  "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                  "spark.default.parallelism": "10",
+                  "spark.driver.cores": "1",
+                  "spark.driver.memory": "1g",
+                  "spark.executor.cores": "1",
+                  "spark.executor.memory": "1g",
+                  "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                  "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                  "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                  "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                  "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                  "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                  "spark.sql.shuffle.partitions": "10",
+                  "taskmanager.memory.process.size": "4G"
+                }
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                "AWS_REGION": "us-west-2",
+                "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+                "CLOUD_PROVIDER": "aws",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_KINESIS": "true",
+                "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+              },
+              "modeEnvironments": {
+                "upload": {
+                  "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                  "AWS_REGION": "us-west-2",
+                  "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+                  "CLOUD_PROVIDER": "aws",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_KINESIS": "true",
+                  "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                  "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                  "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                  "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                  "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                }
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily",
+            "stepDays": 10
+          },
+          "name": "aws.user_activities.v1__1",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "aws",
+          "version": "1"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "selects": {
+                  "add_to_cart_event": "IF(event_type = 'add_to_cart', 1, 0)",
+                  "click_event": "IF(event_type = 'click', 1, 0)",
+                  "favorite_event": "IF(event_type = 'favorite', 1, 0)",
+                  "is_desktop": "IF(device_type = 'desktop', 1, 0)",
+                  "is_mobile": "IF(device_type = 'mobile', 1, 0)",
+                  "is_tablet": "IF(device_type = 'tablet', 1, 0)",
+                  "listing_id": "listing_id",
+                  "purchase_event": "IF(event_type = 'purchase', 1, 0)",
+                  "user_event_struct": "STRUCT(event_type, listing_id, unix_millis(TIMESTAMP(event_time_ms)) as timestamp)",
+                  "user_id": "user_id",
+                  "view_event": "IF(event_type = 'view', 1, 0)"
+                },
+                "timeColumn": "unix_millis(TIMESTAMP(event_time_ms))"
+              },
+              "table": "demo.user_activities_raw",
+              "topic": "kinesis://user-activities/serde=glue_registry/registry_name=zipline-canary/schema_name=user-activities"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    },
+    {
+      "groupBy": {
+        "keyColumns": [
+          "listing_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "brief_description": "c02f5fdfa63b63dc6a593a20cbab7d66",
+            "currency": "27d3da8403941e88f04007211468833e",
+            "headline": "961d1b3f1536af92638c63b2085fa728",
+            "inventory_count": "f3f379de8d3f9e74b60600f0356327d4",
+            "is_active": "b73c53f1089d15c7549d1be9e45bc05a",
+            "is_expensive": "dfe960db190729abde16b0eba360dfc4",
+            "is_in_stock": "6f24425755fd59b8a5a93de6912b111c",
+            "listing_id": "76323e9628393438a3d9bd1e0a0dcf40",
+            "long_description": "0588c5abbb679b56d18028e929d62124",
+            "main_image_path": "e670b87ebe0042f36d6dcb0379ce12da",
+            "merchant_id": "14059af75922b7fe7d8993867667f4af",
+            "price_cents": "33f80b9b819b9b68c65fc31652d4cc26",
+            "primary_category": "76c07f8cf4d4c3465843d890b89f8bb0",
+            "secondary_image_paths": "2d21e3616fce29041df8387677ef5193",
+            "tags": "b02298b5dc181fd94c357eef9f0623ca",
+            "weight_grams": "8b5ac3514f1c8f0db67748e07de128f4"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "clusterConf": {
+              "common": {
+                "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+              }
+            },
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.table_write.upload.format": "ion",
+                "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.memory": "1g",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "1g",
+                "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                "spark.sql.shuffle.partitions": "10",
+                "taskmanager.memory.process.size": "4G"
+              },
+              "modeConfigs": {
+                "backfill": {
+                  "spark.chronon.coalesce.factor": "10",
+                  "spark.chronon.partition.column": "ds",
+                  "spark.chronon.partition.format": "yyyy-MM-dd",
+                  "spark.chronon.table_write.format": "iceberg",
+                  "spark.chronon.table_write.upload.format": "ion",
+                  "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                  "spark.default.parallelism": "10",
+                  "spark.driver.cores": "1",
+                  "spark.driver.memory": "1g",
+                  "spark.executor.cores": "1",
+                  "spark.executor.memory": "1g",
+                  "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                  "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                  "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                  "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                  "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                  "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                  "spark.sql.shuffle.partitions": "10",
+                  "taskmanager.memory.process.size": "4G"
+                }
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                "AWS_REGION": "us-west-2",
+                "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                "CLOUD_PROVIDER": "aws",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_KINESIS": "true",
+                "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+              },
+              "modeEnvironments": {
+                "upload": {
+                  "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                  "AWS_REGION": "us-west-2",
+                  "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                  "CLOUD_PROVIDER": "aws",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_KINESIS": "true",
+                  "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                  "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                  "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                  "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                  "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                }
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily",
+            "stepDays": 10
+          },
+          "name": "aws.dim_listings.v1__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "aws",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "entities": {
+              "query": {
+                "selects": {
+                  "brief_description": "brief_description",
+                  "currency": "currency",
+                  "headline": "headline",
+                  "inventory_count": "inventory_count",
+                  "is_active": "is_active",
+                  "is_expensive": "IF(price_cents > 10000, 1, 0)",
+                  "is_in_stock": "IF(inventory_count > 0, 1, 0)",
+                  "listing_id": "listing_id",
+                  "long_description": "long_description",
+                  "main_image_path": "main_image_path",
+                  "merchant_id": "merchant_id",
+                  "price_cents": "price_cents",
+                  "primary_category": "primary_category",
+                  "secondary_image_paths": "secondary_image_paths",
+                  "tags": "tags",
+                  "weight_grams": "weight_grams"
+                },
+                "startPartition": "2025-01-01"
+              },
+              "snapshotTable": "data.aws_exports_dim_listings__0"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    },
+    {
+      "groupBy": {
+        "keyColumns": [
+          "listing_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "listing_id": "d06b93d848d96f30e2870c8317667b51",
+            "primary_category": "7b4dbbd91897982b4f6672bb24202751"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "clusterConf": {
+              "common": {
+                "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+              }
+            },
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.table_write.upload.format": "ion",
+                "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.memory": "1g",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "1g",
+                "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                "spark.sql.shuffle.partitions": "10",
+                "taskmanager.memory.process.size": "4G"
+              },
+              "modeConfigs": {
+                "backfill": {
+                  "spark.chronon.coalesce.factor": "10",
+                  "spark.chronon.partition.column": "ds",
+                  "spark.chronon.partition.format": "yyyy-MM-dd",
+                  "spark.chronon.table_write.format": "iceberg",
+                  "spark.chronon.table_write.upload.format": "ion",
+                  "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                  "spark.default.parallelism": "10",
+                  "spark.driver.cores": "1",
+                  "spark.driver.memory": "1g",
+                  "spark.executor.cores": "1",
+                  "spark.executor.memory": "1g",
+                  "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                  "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                  "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                  "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                  "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                  "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                  "spark.sql.shuffle.partitions": "10",
+                  "taskmanager.memory.process.size": "4G"
+                }
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                "AWS_REGION": "us-west-2",
+                "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                "CLOUD_PROVIDER": "aws",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_KINESIS": "true",
+                "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+              },
+              "modeEnvironments": {
+                "upload": {
+                  "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                  "AWS_REGION": "us-west-2",
+                  "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                  "CLOUD_PROVIDER": "aws",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_KINESIS": "true",
+                  "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                  "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                  "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                  "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                  "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                }
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily",
+            "stepDays": 10
+          },
+          "name": "aws.dim_merchants.v1__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "aws",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "entities": {
+              "query": {
+                "selects": {
+                  "listing_id": "merchant_id",
+                  "primary_category": "primary_category"
+                },
+                "startPartition": "2025-01-01"
+              },
+              "snapshotTable": "data.aws_exports_dim_merchants__0"
+            }
+          }
+        ]
+      },
+      "prefix": "merchant_",
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "listing_id": "listing_id",
+          "row_id": "event_id",
+          "ts": "event_time_ms",
+          "user_id": "user_id"
+        },
+        "timeColumn": "event_time_ms"
+      },
+      "table": "data.aws_exports_user_activities__0"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "listing_id": "5d9731b2eaa30b6e4b448d932e7ac6d6",
+      "listing_id_brief_description": "f5a516deea870f07bb0008f30bb0ae25",
+      "listing_id_currency": "05aa1eb0d28c86435784c94fba851d10",
+      "listing_id_headline": "c4ffab402f28e0f4bfe65f74890b5564",
+      "listing_id_inventory_count": "cb5b5e7c038d663da13c4d8d92cb3090",
+      "listing_id_is_active": "ef33441ced50d99828ff705449e54f1b",
+      "listing_id_is_expensive": "40cf0185ef61cb96cc8b6466e8b8d171",
+      "listing_id_is_in_stock": "b985765be62c280609787992a993564a",
+      "listing_id_listing_id": "b83cbc9b68f8cb9470a46e63339e401a",
+      "listing_id_long_description": "2b2157cab236d2a1ef595752cf73c94a",
+      "listing_id_main_image_path": "0e0c5ff4e0664d1ca2bceea36ae64db6",
+      "listing_id_merchant_id": "52466767463f5a785e8f48e435671d99",
+      "listing_id_price_cents": "2b4646e1ebbeb2b1441c2d871fc18c61",
+      "listing_id_primary_category": "2bb7f0bd371d76016507c47ea52f0fef",
+      "listing_id_secondary_image_paths": "787b3b5864b70deb5aa6660cb7cc101e",
+      "listing_id_tags": "279b7d347b5acfda8f89848c01f6c4dc",
+      "listing_id_weight_grams": "58061c72136c5815edddc0da7b80f2f1",
+      "merchant__listing_id_listing_id": "e59dcad0205a6d28b27e78e4a401f010",
+      "merchant__listing_id_primary_category": "57be88aa7e3f60fa8f7cbccd34ffd6ad",
+      "row_id": "5975f7f41ebb94e022a33bc9067f37c8",
+      "ts": "9704a89fc4ea9beffe33345ba8087150",
+      "user_id": "d79642f27adf8373a7acd0db93c18e65",
+      "user_id_add_to_cart_event_average_14d": "77d795900ae447d4b216e9aec2b9e2bb",
+      "user_id_add_to_cart_event_average_1d": "77d795900ae447d4b216e9aec2b9e2bb",
+      "user_id_add_to_cart_event_average_30d": "77d795900ae447d4b216e9aec2b9e2bb",
+      "user_id_add_to_cart_event_average_7d": "77d795900ae447d4b216e9aec2b9e2bb",
+      "user_id_add_to_cart_event_sum_14d": "77d795900ae447d4b216e9aec2b9e2bb",
+      "user_id_add_to_cart_event_sum_1d": "77d795900ae447d4b216e9aec2b9e2bb",
+      "user_id_add_to_cart_event_sum_30d": "77d795900ae447d4b216e9aec2b9e2bb",
+      "user_id_add_to_cart_event_sum_7d": "77d795900ae447d4b216e9aec2b9e2bb",
+      "user_id_click_event_average_14d": "a16394c17d043d49995d6b54fc86d0f8",
+      "user_id_click_event_average_1d": "a16394c17d043d49995d6b54fc86d0f8",
+      "user_id_click_event_average_30d": "a16394c17d043d49995d6b54fc86d0f8",
+      "user_id_click_event_average_7d": "a16394c17d043d49995d6b54fc86d0f8",
+      "user_id_click_event_sum_14d": "a16394c17d043d49995d6b54fc86d0f8",
+      "user_id_click_event_sum_1d": "a16394c17d043d49995d6b54fc86d0f8",
+      "user_id_click_event_sum_30d": "a16394c17d043d49995d6b54fc86d0f8",
+      "user_id_click_event_sum_7d": "a16394c17d043d49995d6b54fc86d0f8",
+      "user_id_favorite_event_average_14d": "102ddcb2a626fb6ca93181e446b909c1",
+      "user_id_favorite_event_average_1d": "102ddcb2a626fb6ca93181e446b909c1",
+      "user_id_favorite_event_average_30d": "102ddcb2a626fb6ca93181e446b909c1",
+      "user_id_favorite_event_average_7d": "102ddcb2a626fb6ca93181e446b909c1",
+      "user_id_favorite_event_sum_14d": "102ddcb2a626fb6ca93181e446b909c1",
+      "user_id_favorite_event_sum_1d": "102ddcb2a626fb6ca93181e446b909c1",
+      "user_id_favorite_event_sum_30d": "102ddcb2a626fb6ca93181e446b909c1",
+      "user_id_favorite_event_sum_7d": "102ddcb2a626fb6ca93181e446b909c1",
+      "user_id_is_desktop_sum_14d": "a34e29b8bf89e18d203d447e08a71cd2",
+      "user_id_is_desktop_sum_1d": "a34e29b8bf89e18d203d447e08a71cd2",
+      "user_id_is_desktop_sum_30d": "a34e29b8bf89e18d203d447e08a71cd2",
+      "user_id_is_desktop_sum_7d": "a34e29b8bf89e18d203d447e08a71cd2",
+      "user_id_is_mobile_sum_14d": "3bc7607a1f56888df3a9d899051ff712",
+      "user_id_is_mobile_sum_1d": "3bc7607a1f56888df3a9d899051ff712",
+      "user_id_is_mobile_sum_30d": "3bc7607a1f56888df3a9d899051ff712",
+      "user_id_is_mobile_sum_7d": "3bc7607a1f56888df3a9d899051ff712",
+      "user_id_is_tablet_sum_14d": "9d7e26d4b8765bda45f25e5154b422dd",
+      "user_id_is_tablet_sum_1d": "9d7e26d4b8765bda45f25e5154b422dd",
+      "user_id_is_tablet_sum_30d": "9d7e26d4b8765bda45f25e5154b422dd",
+      "user_id_is_tablet_sum_7d": "9d7e26d4b8765bda45f25e5154b422dd",
+      "user_id_purchase_event_average_14d": "88806352d28a54207990e6b7f71e0647",
+      "user_id_purchase_event_average_1d": "88806352d28a54207990e6b7f71e0647",
+      "user_id_purchase_event_average_30d": "88806352d28a54207990e6b7f71e0647",
+      "user_id_purchase_event_average_7d": "88806352d28a54207990e6b7f71e0647",
+      "user_id_purchase_event_sum_14d": "88806352d28a54207990e6b7f71e0647",
+      "user_id_purchase_event_sum_1d": "88806352d28a54207990e6b7f71e0647",
+      "user_id_purchase_event_sum_30d": "88806352d28a54207990e6b7f71e0647",
+      "user_id_purchase_event_sum_7d": "88806352d28a54207990e6b7f71e0647",
+      "user_id_user_event_struct_last128_14d": "599520fd2c1a28a29ece4a6433820c7e",
+      "user_id_user_event_struct_last128_1d": "599520fd2c1a28a29ece4a6433820c7e",
+      "user_id_user_event_struct_last128_30d": "599520fd2c1a28a29ece4a6433820c7e",
+      "user_id_user_event_struct_last128_7d": "599520fd2c1a28a29ece4a6433820c7e",
+      "user_id_view_event_average_14d": "90eb1026d49d637d24bd34ba85f84781",
+      "user_id_view_event_average_1d": "90eb1026d49d637d24bd34ba85f84781",
+      "user_id_view_event_average_30d": "90eb1026d49d637d24bd34ba85f84781",
+      "user_id_view_event_average_7d": "90eb1026d49d637d24bd34ba85f84781",
+      "user_id_view_event_sum_14d": "90eb1026d49d637d24bd34ba85f84781",
+      "user_id_view_event_sum_1d": "90eb1026d49d637d24bd34ba85f84781",
+      "user_id_view_event_sum_30d": "90eb1026d49d637d24bd34ba85f84781",
+      "user_id_view_event_sum_7d": "90eb1026d49d637d24bd34ba85f84781"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_exports_user_activities__0_with_offset_0\", \"spec\": \"data.aws_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_demo_user_activities_raw_with_offset_0\", \"spec\": \"demo.user_activities_raw/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_aws_exports_dim_listings__0_with_offset_0\", \"spec\": \"data.aws_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_aws_exports_dim_merchants__0_with_offset_0\", \"spec\": \"data.aws_exports_dim_merchants__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "enableStatsCompute": 1,
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "onlineSchedule": "@daily",
+      "stepDays": 10
+    },
+    "name": "aws.demo.v1__1",
+    "online": 1,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/aws/demo.py",
+    "team": "aws",
+    "version": "1"
+  },
+  "rowIds": [
+    "event_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/aws/demo_chaining.downstream_join__0
+++ b/python/test/canary/canary_compiled/joins/aws/demo_chaining.downstream_join__0
@@ -1,0 +1,541 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {
+              "k": "100"
+            },
+            "inputColumn": "price_cents",
+            "operation": 13,
+            "windows": [
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          }
+        ],
+        "keyColumns": [
+          "user_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "price_cents_last100_7d": "5377edbf5107cc02a5f74238b3c3696e",
+            "user_id": "96df20bb89ae17fa8229552a8afe4f3f"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "clusterConf": {
+              "common": {
+                "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+              }
+            },
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.table_write.upload.format": "ion",
+                "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.memory": "1g",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "1g",
+                "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                "spark.sql.shuffle.partitions": "10",
+                "taskmanager.memory.process.size": "4G"
+              },
+              "modeConfigs": {
+                "backfill": {
+                  "spark.chronon.coalesce.factor": "10",
+                  "spark.chronon.partition.column": "ds",
+                  "spark.chronon.partition.format": "yyyy-MM-dd",
+                  "spark.chronon.table_write.format": "iceberg",
+                  "spark.chronon.table_write.upload.format": "ion",
+                  "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                  "spark.default.parallelism": "10",
+                  "spark.driver.cores": "1",
+                  "spark.driver.memory": "1g",
+                  "spark.executor.cores": "1",
+                  "spark.executor.memory": "1g",
+                  "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                  "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                  "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                  "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                  "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                  "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                  "spark.sql.shuffle.partitions": "10",
+                  "taskmanager.memory.process.size": "4G"
+                }
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                "AWS_REGION": "us-west-2",
+                "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+                "CLOUD_PROVIDER": "aws",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_KINESIS": "true",
+                "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+              },
+              "modeEnvironments": {
+                "upload": {
+                  "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                  "AWS_REGION": "us-west-2",
+                  "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+                  "CLOUD_PROVIDER": "aws",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_KINESIS": "true",
+                  "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                  "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                  "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                  "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                  "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                }
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "aws.user_activities_chained.chained_user_gb__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "aws",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "joinSource": {
+              "join": {
+                "joinParts": [
+                  {
+                    "groupBy": {
+                      "keyColumns": [
+                        "listing_id"
+                      ],
+                      "metaData": {
+                        "environments": [
+                          0
+                        ],
+                        "executionInfo": {
+                          "clusterConf": {
+                            "common": {
+                              "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+                            }
+                          },
+                          "conf": {
+                            "common": {
+                              "spark.chronon.coalesce.factor": "10",
+                              "spark.chronon.partition.column": "ds",
+                              "spark.chronon.partition.format": "yyyy-MM-dd",
+                              "spark.chronon.table_write.format": "iceberg",
+                              "spark.chronon.table_write.upload.format": "ion",
+                              "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                              "spark.default.parallelism": "10",
+                              "spark.driver.cores": "1",
+                              "spark.driver.memory": "1g",
+                              "spark.executor.cores": "1",
+                              "spark.executor.memory": "1g",
+                              "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                              "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                              "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                              "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                              "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                              "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                              "spark.sql.shuffle.partitions": "10",
+                              "taskmanager.memory.process.size": "4G"
+                            },
+                            "modeConfigs": {
+                              "backfill": {
+                                "spark.chronon.coalesce.factor": "10",
+                                "spark.chronon.partition.column": "ds",
+                                "spark.chronon.partition.format": "yyyy-MM-dd",
+                                "spark.chronon.table_write.format": "iceberg",
+                                "spark.chronon.table_write.upload.format": "ion",
+                                "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                                "spark.default.parallelism": "10",
+                                "spark.driver.cores": "1",
+                                "spark.driver.memory": "1g",
+                                "spark.executor.cores": "1",
+                                "spark.executor.memory": "1g",
+                                "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                                "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                                "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                                "spark.sql.shuffle.partitions": "10",
+                                "taskmanager.memory.process.size": "4G"
+                              }
+                            }
+                          },
+                          "env": {
+                            "common": {
+                              "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                              "AWS_REGION": "us-west-2",
+                              "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                              "CLOUD_PROVIDER": "aws",
+                              "CUSTOMER_ID": "canary",
+                              "ENABLE_KINESIS": "true",
+                              "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                              "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                              "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                              "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                              "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                              "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                              "VERSION": "latest",
+                              "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                            },
+                            "modeEnvironments": {
+                              "upload": {
+                                "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                                "AWS_REGION": "us-west-2",
+                                "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                                "CLOUD_PROVIDER": "aws",
+                                "CUSTOMER_ID": "canary",
+                                "ENABLE_KINESIS": "true",
+                                "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                                "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                                "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                                "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                                "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                                "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                                "VERSION": "latest",
+                                "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                              }
+                            }
+                          },
+                          "historicalBackfill": 0,
+                          "onlineSchedule": "@daily",
+                          "stepDays": 10
+                        },
+                        "name": "aws.dim_listings.v1__0",
+                        "online": 1,
+                        "outputNamespace": "data",
+                        "team": "aws",
+                        "version": "0"
+                      },
+                      "sources": [
+                        {
+                          "entities": {
+                            "query": {
+                              "selects": {
+                                "brief_description": "brief_description",
+                                "currency": "currency",
+                                "headline": "headline",
+                                "inventory_count": "inventory_count",
+                                "is_active": "is_active",
+                                "is_expensive": "IF(price_cents > 10000, 1, 0)",
+                                "is_in_stock": "IF(inventory_count > 0, 1, 0)",
+                                "listing_id": "listing_id",
+                                "long_description": "long_description",
+                                "main_image_path": "main_image_path",
+                                "merchant_id": "merchant_id",
+                                "price_cents": "price_cents",
+                                "primary_category": "primary_category",
+                                "secondary_image_paths": "secondary_image_paths",
+                                "tags": "tags",
+                                "weight_grams": "weight_grams"
+                              },
+                              "startPartition": "2025-01-01"
+                            },
+                            "snapshotTable": "data.aws_exports_dim_listings__0"
+                          }
+                        }
+                      ]
+                    },
+                    "useLongNames": 0
+                  }
+                ],
+                "left": {
+                  "events": {
+                    "query": {
+                      "selects": {
+                        "listing_id": "listing_id",
+                        "row_id": "event_id",
+                        "ts": "unix_millis(TIMESTAMP(event_time_ms))",
+                        "user_id": "user_id"
+                      },
+                      "timeColumn": "unix_millis(TIMESTAMP(event_time_ms))"
+                    },
+                    "table": "data.aws_exports_user_activities__0",
+                    "topic": "kafka://user-activities-v2/serde=custom/provider_class=ai.chronon.flink.deser.MockCustomSchemaProvider/schema_name=user-activities"
+                  }
+                },
+                "metaData": {
+                  "environments": [
+                    0
+                  ],
+                  "executionInfo": {
+                    "clusterConf": {
+                      "common": {
+                        "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+                      }
+                    },
+                    "conf": {
+                      "common": {
+                        "spark.chronon.coalesce.factor": "10",
+                        "spark.chronon.partition.column": "ds",
+                        "spark.chronon.partition.format": "yyyy-MM-dd",
+                        "spark.chronon.table_write.format": "iceberg",
+                        "spark.chronon.table_write.upload.format": "ion",
+                        "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                        "spark.default.parallelism": "10",
+                        "spark.driver.cores": "1",
+                        "spark.driver.memory": "1g",
+                        "spark.executor.cores": "1",
+                        "spark.executor.memory": "1g",
+                        "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                        "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                        "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                        "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                        "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                        "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                        "spark.sql.shuffle.partitions": "10",
+                        "taskmanager.memory.process.size": "4G"
+                      },
+                      "modeConfigs": {
+                        "backfill": {
+                          "spark.chronon.coalesce.factor": "10",
+                          "spark.chronon.partition.column": "ds",
+                          "spark.chronon.partition.format": "yyyy-MM-dd",
+                          "spark.chronon.table_write.format": "iceberg",
+                          "spark.chronon.table_write.upload.format": "ion",
+                          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                          "spark.default.parallelism": "10",
+                          "spark.driver.cores": "1",
+                          "spark.driver.memory": "1g",
+                          "spark.executor.cores": "1",
+                          "spark.executor.memory": "1g",
+                          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                          "spark.sql.shuffle.partitions": "10",
+                          "taskmanager.memory.process.size": "4G"
+                        }
+                      }
+                    },
+                    "env": {
+                      "common": {
+                        "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                        "AWS_REGION": "us-west-2",
+                        "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                        "CLOUD_PROVIDER": "aws",
+                        "CUSTOMER_ID": "canary",
+                        "ENABLE_KINESIS": "true",
+                        "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                        "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                        "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                        "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                        "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                        "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                        "VERSION": "latest",
+                        "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                      },
+                      "modeEnvironments": {
+                        "upload": {
+                          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                          "AWS_REGION": "us-west-2",
+                          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                          "CLOUD_PROVIDER": "aws",
+                          "CUSTOMER_ID": "canary",
+                          "ENABLE_KINESIS": "true",
+                          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                          "VERSION": "latest",
+                          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                        }
+                      }
+                    },
+                    "offlineSchedule": "@daily",
+                    "onlineSchedule": "@daily"
+                  },
+                  "name": "aws.demo_parent.parent_join__0",
+                  "online": 1,
+                  "outputNamespace": "data",
+                  "production": 0,
+                  "samplePercent": 100.0,
+                  "team": "aws",
+                  "version": "0"
+                },
+                "rowIds": [
+                  "event_id"
+                ],
+                "useLongNames": 0
+              },
+              "query": {
+                "selects": {
+                  "listing_id": "listing_id",
+                  "price_cents": "listing_id_price_cents",
+                  "user_id": "user_id"
+                },
+                "timeColumn": "ts"
+              }
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "listing_id": "listing_id",
+          "row_id": "event_id",
+          "ts": "unix_millis(TIMESTAMP(event_time_ms))",
+          "user_id": "user_id"
+        },
+        "timeColumn": "unix_millis(TIMESTAMP(event_time_ms))"
+      },
+      "table": "data.aws_exports_user_activities__0",
+      "topic": "kafka://user-activities-v2/serde=custom/provider_class=ai.chronon.flink.deser.MockCustomSchemaProvider/schema_name=user-activities"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "listing_id": "9c581c20ffbeac3eebf3395422444847",
+      "row_id": "cba9fe1d5c9102f200a5e83ad5e52a7a",
+      "ts": "f4b345f80a5c6a195363f36ce3a36d79",
+      "user_id": "dd9efd48a53433b894292d805f052703",
+      "user_id_price_cents_last100_7d": "3fc813a69e5409dcb620a9173e4d1141"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_exports_user_activities__0_with_offset_0\", \"spec\": \"data.aws_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "onlineSchedule": "@daily"
+    },
+    "name": "aws.demo_chaining.downstream_join__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/aws/demo_chaining.py",
+    "team": "aws",
+    "version": "0"
+  },
+  "rowIds": [
+    "event_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/aws/demo_parent.parent_join__0
+++ b/python/test/canary/canary_compiled/joins/aws/demo_parent.parent_join__0
@@ -1,0 +1,306 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "keyColumns": [
+          "listing_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "brief_description": "c02f5fdfa63b63dc6a593a20cbab7d66",
+            "currency": "27d3da8403941e88f04007211468833e",
+            "headline": "961d1b3f1536af92638c63b2085fa728",
+            "inventory_count": "f3f379de8d3f9e74b60600f0356327d4",
+            "is_active": "b73c53f1089d15c7549d1be9e45bc05a",
+            "is_expensive": "dfe960db190729abde16b0eba360dfc4",
+            "is_in_stock": "6f24425755fd59b8a5a93de6912b111c",
+            "listing_id": "76323e9628393438a3d9bd1e0a0dcf40",
+            "long_description": "0588c5abbb679b56d18028e929d62124",
+            "main_image_path": "e670b87ebe0042f36d6dcb0379ce12da",
+            "merchant_id": "14059af75922b7fe7d8993867667f4af",
+            "price_cents": "33f80b9b819b9b68c65fc31652d4cc26",
+            "primary_category": "76c07f8cf4d4c3465843d890b89f8bb0",
+            "secondary_image_paths": "2d21e3616fce29041df8387677ef5193",
+            "tags": "b02298b5dc181fd94c357eef9f0623ca",
+            "weight_grams": "8b5ac3514f1c8f0db67748e07de128f4"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "clusterConf": {
+              "common": {
+                "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+              }
+            },
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.table_write.upload.format": "ion",
+                "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.memory": "1g",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "1g",
+                "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                "spark.sql.shuffle.partitions": "10",
+                "taskmanager.memory.process.size": "4G"
+              },
+              "modeConfigs": {
+                "backfill": {
+                  "spark.chronon.coalesce.factor": "10",
+                  "spark.chronon.partition.column": "ds",
+                  "spark.chronon.partition.format": "yyyy-MM-dd",
+                  "spark.chronon.table_write.format": "iceberg",
+                  "spark.chronon.table_write.upload.format": "ion",
+                  "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                  "spark.default.parallelism": "10",
+                  "spark.driver.cores": "1",
+                  "spark.driver.memory": "1g",
+                  "spark.executor.cores": "1",
+                  "spark.executor.memory": "1g",
+                  "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                  "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                  "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                  "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                  "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                  "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                  "spark.sql.shuffle.partitions": "10",
+                  "taskmanager.memory.process.size": "4G"
+                }
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                "AWS_REGION": "us-west-2",
+                "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                "CLOUD_PROVIDER": "aws",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_KINESIS": "true",
+                "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+              },
+              "modeEnvironments": {
+                "upload": {
+                  "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                  "AWS_REGION": "us-west-2",
+                  "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                  "CLOUD_PROVIDER": "aws",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_KINESIS": "true",
+                  "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                  "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                  "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                  "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                  "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                }
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily",
+            "stepDays": 10
+          },
+          "name": "aws.dim_listings.v1__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "aws",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "entities": {
+              "query": {
+                "selects": {
+                  "brief_description": "brief_description",
+                  "currency": "currency",
+                  "headline": "headline",
+                  "inventory_count": "inventory_count",
+                  "is_active": "is_active",
+                  "is_expensive": "IF(price_cents > 10000, 1, 0)",
+                  "is_in_stock": "IF(inventory_count > 0, 1, 0)",
+                  "listing_id": "listing_id",
+                  "long_description": "long_description",
+                  "main_image_path": "main_image_path",
+                  "merchant_id": "merchant_id",
+                  "price_cents": "price_cents",
+                  "primary_category": "primary_category",
+                  "secondary_image_paths": "secondary_image_paths",
+                  "tags": "tags",
+                  "weight_grams": "weight_grams"
+                },
+                "startPartition": "2025-01-01"
+              },
+              "snapshotTable": "data.aws_exports_dim_listings__0"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "listing_id": "listing_id",
+          "row_id": "event_id",
+          "ts": "unix_millis(TIMESTAMP(event_time_ms))",
+          "user_id": "user_id"
+        },
+        "timeColumn": "unix_millis(TIMESTAMP(event_time_ms))"
+      },
+      "table": "data.aws_exports_user_activities__0",
+      "topic": "kafka://user-activities-v2/serde=custom/provider_class=ai.chronon.flink.deser.MockCustomSchemaProvider/schema_name=user-activities"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "listing_id": "9c581c20ffbeac3eebf3395422444847",
+      "listing_id_brief_description": "8a709d88c43614d12f9e61961c4e568f",
+      "listing_id_currency": "48c8f58c7fb5e23de1748c004c2b37a2",
+      "listing_id_headline": "172230f231537883dd1685fa6e38e01e",
+      "listing_id_inventory_count": "bb016f9581fe11fe42b7286e679d5d4c",
+      "listing_id_is_active": "6314ac1dc66f4046b399fbfa4af52fc0",
+      "listing_id_is_expensive": "0441ac5e6d9e56f9b0d9c9d52dc5bed6",
+      "listing_id_is_in_stock": "e657396e987ffcb0c30cbb092ce1ce04",
+      "listing_id_listing_id": "72f6e6247d5e1516bbdf05855d0b6345",
+      "listing_id_long_description": "33a7ae01ba819796908fba685d33ff54",
+      "listing_id_main_image_path": "5988884c17b409d22ffb2ac7eb4a4635",
+      "listing_id_merchant_id": "fd0bc48993817eddbd91ceff3542d7d2",
+      "listing_id_price_cents": "23498e0dc546e29a7d3b75d7ef878b4d",
+      "listing_id_primary_category": "5b1d17e1d1290ab046ecbf2f542528e0",
+      "listing_id_secondary_image_paths": "f15587d69bf665a79b158c41c1a17a39",
+      "listing_id_tags": "55aa3dcb8c25505560ab2d0edb7976c7",
+      "listing_id_weight_grams": "b020156334ebdca822b31de138d762e8",
+      "row_id": "cba9fe1d5c9102f200a5e83ad5e52a7a",
+      "ts": "f4b345f80a5c6a195363f36ce3a36d79",
+      "user_id": "dd9efd48a53433b894292d805f052703"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_exports_user_activities__0_with_offset_0\", \"spec\": \"data.aws_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_aws_exports_dim_listings__0_with_offset_0\", \"spec\": \"data.aws_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "onlineSchedule": "@daily"
+    },
+    "name": "aws.demo_parent.parent_join__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/aws/demo_parent.py",
+    "team": "aws",
+    "version": "0"
+  },
+  "rowIds": [
+    "event_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/aws/item_event_join.canary_batch_v1__0
+++ b/python/test/canary/canary_compiled/joins/aws/item_event_join.canary_batch_v1__0
@@ -1,0 +1,344 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 6,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {
+              "k": "10"
+            },
+            "inputColumn": "purchase_price",
+            "operation": 13
+          }
+        ],
+        "keyColumns": [
+          "user_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "purchase_price_average_1d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "purchase_price_average_3d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "purchase_price_average_7d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "purchase_price_count_1d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "purchase_price_count_3d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "purchase_price_count_7d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "purchase_price_last10": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "purchase_price_sum_1d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "purchase_price_sum_3d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "purchase_price_sum_7d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "user_id": "dec6601a613992b4b6cdc50ac8014a29"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "clusterConf": {
+              "common": {
+                "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+              }
+            },
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.table_write.upload.format": "ion",
+                "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.memory": "1g",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "1g",
+                "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                "spark.sql.shuffle.partitions": "10",
+                "taskmanager.memory.process.size": "4G"
+              },
+              "modeConfigs": {
+                "backfill": {
+                  "spark.chronon.coalesce.factor": "10",
+                  "spark.chronon.partition.column": "ds",
+                  "spark.chronon.partition.format": "yyyy-MM-dd",
+                  "spark.chronon.table_write.format": "iceberg",
+                  "spark.chronon.table_write.upload.format": "ion",
+                  "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                  "spark.default.parallelism": "10",
+                  "spark.driver.cores": "1",
+                  "spark.driver.memory": "1g",
+                  "spark.executor.cores": "1",
+                  "spark.executor.memory": "1g",
+                  "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                  "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                  "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                  "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                  "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                  "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                  "spark.sql.shuffle.partitions": "10",
+                  "taskmanager.memory.process.size": "4G"
+                }
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                "AWS_REGION": "us-west-2",
+                "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                "CLOUD_PROVIDER": "aws",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_KINESIS": "true",
+                "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+              },
+              "modeEnvironments": {
+                "upload": {
+                  "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                  "AWS_REGION": "us-west-2",
+                  "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                  "CLOUD_PROVIDER": "aws",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_KINESIS": "true",
+                  "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                  "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                  "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                  "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                  "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                }
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "aws.purchases.v1_test__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "aws",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "selects": {
+                  "purchase_price": "purchase_price",
+                  "user_id": "user_id"
+                },
+                "startPartition": "2023-11-01",
+                "timeColumn": "ts"
+              },
+              "table": "data.purchases"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "listing_id": "EXPLODE(TRANSFORM(SPLIT(COALESCE(attributes['sold_listing_ids'], attributes['listing_id']), ','), e -> CAST(e AS LONG)))",
+          "ts": "timestamp",
+          "user_id": "attributes['user_id']"
+        },
+        "timeColumn": "timestamp"
+      },
+      "table": "data.item_events_parquet_compat"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "listing_id": "f2f6c814b8ae1521176b22a1ae7f2d0d",
+      "ts": "ad9fd4c611e20ad833819a4ce9d752bf",
+      "user_id": "493d3df28f80664abd11b19fcd33b6e6",
+      "user_id_purchase_price_average_1d": "5609e04d61a47a8cafc67970785a3a59",
+      "user_id_purchase_price_average_3d": "5609e04d61a47a8cafc67970785a3a59",
+      "user_id_purchase_price_average_7d": "5609e04d61a47a8cafc67970785a3a59",
+      "user_id_purchase_price_count_1d": "5609e04d61a47a8cafc67970785a3a59",
+      "user_id_purchase_price_count_3d": "5609e04d61a47a8cafc67970785a3a59",
+      "user_id_purchase_price_count_7d": "5609e04d61a47a8cafc67970785a3a59",
+      "user_id_purchase_price_last10": "5609e04d61a47a8cafc67970785a3a59",
+      "user_id_purchase_price_sum_1d": "5609e04d61a47a8cafc67970785a3a59",
+      "user_id_purchase_price_sum_3d": "5609e04d61a47a8cafc67970785a3a59",
+      "user_id_purchase_price_sum_7d": "5609e04d61a47a8cafc67970785a3a59"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_item_events_parquet_compat_with_offset_0\", \"spec\": \"data.item_events_parquet_compat/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "onlineSchedule": "@daily"
+    },
+    "name": "aws.item_event_join.canary_batch_v1__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/aws/item_event_join.py",
+    "team": "aws",
+    "version": "0"
+  },
+  "rowIds": [
+    "listing_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/aws/item_event_join.canary_combined_v1__0
+++ b/python/test/canary/canary_compiled/joins/aws/item_event_join.canary_combined_v1__0
@@ -1,0 +1,531 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "add_cart",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "view",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "favorite",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              }
+            ]
+          }
+        ],
+        "keyColumns": [
+          "listing_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "add_cart_sum_1d": "1c84943e7da62cf176256a84020804bd",
+            "favorite_sum_1d": "c713f3f34dbb05d29f7f4a8379eee695",
+            "listing_id": "609094d15d01b15cd3c2f7b39a399409",
+            "purchase_sum_1d": "fb8cfc84fca71682f8d758092259323f",
+            "view_sum_1d": "cc58ae369bab825653562d7cd27aa09c"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "clusterConf": {
+              "common": {
+                "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+              }
+            },
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "_DATE",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.table_write.upload.format": "ion",
+                "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.memory": "1g",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "1g",
+                "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                "spark.sql.shuffle.partitions": "10",
+                "taskmanager.memory.process.size": "4G"
+              },
+              "modeConfigs": {
+                "backfill": {
+                  "spark.chronon.coalesce.factor": "10",
+                  "spark.chronon.partition.column": "_DATE",
+                  "spark.chronon.partition.format": "yyyy-MM-dd",
+                  "spark.chronon.table_write.format": "iceberg",
+                  "spark.chronon.table_write.upload.format": "ion",
+                  "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                  "spark.default.parallelism": "10",
+                  "spark.driver.cores": "1",
+                  "spark.driver.memory": "1g",
+                  "spark.executor.cores": "1",
+                  "spark.executor.memory": "1g",
+                  "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                  "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                  "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                  "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                  "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                  "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                  "spark.sql.shuffle.partitions": "10",
+                  "taskmanager.memory.process.size": "4G"
+                }
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                "AWS_REGION": "us-west-2",
+                "CHRONON_ONLINE_ARGS": "-Ztasks=4",
+                "CLOUD_PROVIDER": "aws",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_KINESIS": "true",
+                "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+              },
+              "modeEnvironments": {
+                "upload": {
+                  "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                  "AWS_REGION": "us-west-2",
+                  "CHRONON_ONLINE_ARGS": "-Ztasks=4",
+                  "CLOUD_PROVIDER": "aws",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_KINESIS": "true",
+                  "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                  "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                  "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                  "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                  "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                }
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "aws.item_event_canary.actions_v1__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "aws",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "selects": {
+                  "add_cart": "IF(event_type = 'backend_add_to_cart', 1, 0)",
+                  "favorite": "IF(event_type = 'backend_favorite_item2', 1, 0)",
+                  "listing_id": "EXPLODE(TRANSFORM(SPLIT(COALESCE(attributes['sold_listing_ids'], attributes['listing_id']), ','), e -> CAST(e AS LONG)))",
+                  "purchase": "IF(event_type = 'backend_cart_payment', 1, 0)",
+                  "view": "IF(event_type = 'view_listing', 1, 0)"
+                },
+                "timeColumn": "timestamp",
+                "wheres": [
+                  "event_type in ('backend_add_to_cart', 'view_listing', 'backend_cart_payment', 'backend_favorite_item2')"
+                ]
+              },
+              "table": "data.item_events_parquet_compat_partitioned",
+              "topic": "kafka://test-item-event-data/serde=custom/provider_class=ai.chronon.flink.deser.MockCustomSchemaProvider/schema_name=item_event"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    },
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 6,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {
+              "k": "10"
+            },
+            "inputColumn": "purchase_price",
+            "operation": 13
+          }
+        ],
+        "keyColumns": [
+          "user_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "purchase_price_average_1d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "purchase_price_average_3d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "purchase_price_average_7d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "purchase_price_count_1d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "purchase_price_count_3d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "purchase_price_count_7d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "purchase_price_last10": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "purchase_price_sum_1d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "purchase_price_sum_3d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "purchase_price_sum_7d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "user_id": "dec6601a613992b4b6cdc50ac8014a29"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "clusterConf": {
+              "common": {
+                "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+              }
+            },
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.table_write.upload.format": "ion",
+                "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.memory": "1g",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "1g",
+                "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                "spark.sql.shuffle.partitions": "10",
+                "taskmanager.memory.process.size": "4G"
+              },
+              "modeConfigs": {
+                "backfill": {
+                  "spark.chronon.coalesce.factor": "10",
+                  "spark.chronon.partition.column": "ds",
+                  "spark.chronon.partition.format": "yyyy-MM-dd",
+                  "spark.chronon.table_write.format": "iceberg",
+                  "spark.chronon.table_write.upload.format": "ion",
+                  "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                  "spark.default.parallelism": "10",
+                  "spark.driver.cores": "1",
+                  "spark.driver.memory": "1g",
+                  "spark.executor.cores": "1",
+                  "spark.executor.memory": "1g",
+                  "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                  "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                  "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                  "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                  "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                  "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                  "spark.sql.shuffle.partitions": "10",
+                  "taskmanager.memory.process.size": "4G"
+                }
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                "AWS_REGION": "us-west-2",
+                "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                "CLOUD_PROVIDER": "aws",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_KINESIS": "true",
+                "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+              },
+              "modeEnvironments": {
+                "upload": {
+                  "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                  "AWS_REGION": "us-west-2",
+                  "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                  "CLOUD_PROVIDER": "aws",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_KINESIS": "true",
+                  "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                  "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                  "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                  "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                  "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                }
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "aws.purchases.v1_test__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "aws",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "selects": {
+                  "purchase_price": "purchase_price",
+                  "user_id": "user_id"
+                },
+                "startPartition": "2023-11-01",
+                "timeColumn": "ts"
+              },
+              "table": "data.purchases"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "listing_id": "EXPLODE(TRANSFORM(SPLIT(COALESCE(attributes['sold_listing_ids'], attributes['listing_id']), ','), e -> CAST(e AS LONG)))",
+          "ts": "timestamp",
+          "user_id": "attributes['user_id']"
+        },
+        "timeColumn": "timestamp"
+      },
+      "table": "data.item_events_parquet_compat"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "listing_id": "f2f6c814b8ae1521176b22a1ae7f2d0d",
+      "listing_id_add_cart_sum_1d": "6b9c42bf45158c93b823dcf0b5bea7ab",
+      "listing_id_favorite_sum_1d": "bb07e39a4b7ea81aca5baf027fd8f555",
+      "listing_id_purchase_sum_1d": "12f0cd5674381064326148e7eb352a40",
+      "listing_id_view_sum_1d": "c92a7a66f21979b327788447d063fe2b",
+      "ts": "ad9fd4c611e20ad833819a4ce9d752bf",
+      "user_id": "493d3df28f80664abd11b19fcd33b6e6",
+      "user_id_purchase_price_average_1d": "5609e04d61a47a8cafc67970785a3a59",
+      "user_id_purchase_price_average_3d": "5609e04d61a47a8cafc67970785a3a59",
+      "user_id_purchase_price_average_7d": "5609e04d61a47a8cafc67970785a3a59",
+      "user_id_purchase_price_count_1d": "5609e04d61a47a8cafc67970785a3a59",
+      "user_id_purchase_price_count_3d": "5609e04d61a47a8cafc67970785a3a59",
+      "user_id_purchase_price_count_7d": "5609e04d61a47a8cafc67970785a3a59",
+      "user_id_purchase_price_last10": "5609e04d61a47a8cafc67970785a3a59",
+      "user_id_purchase_price_sum_1d": "5609e04d61a47a8cafc67970785a3a59",
+      "user_id_purchase_price_sum_3d": "5609e04d61a47a8cafc67970785a3a59",
+      "user_id_purchase_price_sum_7d": "5609e04d61a47a8cafc67970785a3a59"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_item_events_parquet_compat_with_offset_0\", \"spec\": \"data.item_events_parquet_compat/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_item_events_parquet_compat_partitioned_with_offset_0\", \"spec\": \"data.item_events_parquet_compat_partitioned/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "onlineSchedule": "@daily"
+    },
+    "name": "aws.item_event_join.canary_combined_v1__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/aws/item_event_join.py",
+    "team": "aws",
+    "version": "0"
+  },
+  "rowIds": [
+    "user_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/aws/item_event_join.canary_streaming_v1__0
+++ b/python/test/canary/canary_compiled/joins/aws/item_event_join.canary_streaming_v1__0
@@ -1,0 +1,318 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "add_cart",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "view",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "favorite",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              }
+            ]
+          }
+        ],
+        "keyColumns": [
+          "listing_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "add_cart_sum_1d": "1c84943e7da62cf176256a84020804bd",
+            "favorite_sum_1d": "c713f3f34dbb05d29f7f4a8379eee695",
+            "listing_id": "609094d15d01b15cd3c2f7b39a399409",
+            "purchase_sum_1d": "fb8cfc84fca71682f8d758092259323f",
+            "view_sum_1d": "cc58ae369bab825653562d7cd27aa09c"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "clusterConf": {
+              "common": {
+                "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+              }
+            },
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "_DATE",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.table_write.upload.format": "ion",
+                "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.memory": "1g",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "1g",
+                "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                "spark.sql.shuffle.partitions": "10",
+                "taskmanager.memory.process.size": "4G"
+              },
+              "modeConfigs": {
+                "backfill": {
+                  "spark.chronon.coalesce.factor": "10",
+                  "spark.chronon.partition.column": "_DATE",
+                  "spark.chronon.partition.format": "yyyy-MM-dd",
+                  "spark.chronon.table_write.format": "iceberg",
+                  "spark.chronon.table_write.upload.format": "ion",
+                  "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                  "spark.default.parallelism": "10",
+                  "spark.driver.cores": "1",
+                  "spark.driver.memory": "1g",
+                  "spark.executor.cores": "1",
+                  "spark.executor.memory": "1g",
+                  "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                  "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                  "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                  "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                  "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                  "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                  "spark.sql.shuffle.partitions": "10",
+                  "taskmanager.memory.process.size": "4G"
+                }
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                "AWS_REGION": "us-west-2",
+                "CHRONON_ONLINE_ARGS": "-Ztasks=4",
+                "CLOUD_PROVIDER": "aws",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_KINESIS": "true",
+                "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+              },
+              "modeEnvironments": {
+                "upload": {
+                  "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                  "AWS_REGION": "us-west-2",
+                  "CHRONON_ONLINE_ARGS": "-Ztasks=4",
+                  "CLOUD_PROVIDER": "aws",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_KINESIS": "true",
+                  "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                  "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                  "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                  "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                  "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                }
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "aws.item_event_canary.actions_v1__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "aws",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "selects": {
+                  "add_cart": "IF(event_type = 'backend_add_to_cart', 1, 0)",
+                  "favorite": "IF(event_type = 'backend_favorite_item2', 1, 0)",
+                  "listing_id": "EXPLODE(TRANSFORM(SPLIT(COALESCE(attributes['sold_listing_ids'], attributes['listing_id']), ','), e -> CAST(e AS LONG)))",
+                  "purchase": "IF(event_type = 'backend_cart_payment', 1, 0)",
+                  "view": "IF(event_type = 'view_listing', 1, 0)"
+                },
+                "timeColumn": "timestamp",
+                "wheres": [
+                  "event_type in ('backend_add_to_cart', 'view_listing', 'backend_cart_payment', 'backend_favorite_item2')"
+                ]
+              },
+              "table": "data.item_events_parquet_compat_partitioned",
+              "topic": "kafka://test-item-event-data/serde=custom/provider_class=ai.chronon.flink.deser.MockCustomSchemaProvider/schema_name=item_event"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "listing_id": "EXPLODE(TRANSFORM(SPLIT(COALESCE(attributes['sold_listing_ids'], attributes['listing_id']), ','), e -> CAST(e AS LONG)))",
+          "ts": "timestamp",
+          "user_id": "attributes['user_id']"
+        },
+        "timeColumn": "timestamp"
+      },
+      "table": "data.item_events_parquet_compat"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "listing_id": "f2f6c814b8ae1521176b22a1ae7f2d0d",
+      "listing_id_add_cart_sum_1d": "6b9c42bf45158c93b823dcf0b5bea7ab",
+      "listing_id_favorite_sum_1d": "bb07e39a4b7ea81aca5baf027fd8f555",
+      "listing_id_purchase_sum_1d": "12f0cd5674381064326148e7eb352a40",
+      "listing_id_view_sum_1d": "c92a7a66f21979b327788447d063fe2b",
+      "ts": "ad9fd4c611e20ad833819a4ce9d752bf",
+      "user_id": "493d3df28f80664abd11b19fcd33b6e6"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_item_events_parquet_compat_with_offset_0\", \"spec\": \"data.item_events_parquet_compat/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_item_events_parquet_compat_partitioned_with_offset_0\", \"spec\": \"data.item_events_parquet_compat_partitioned/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "onlineSchedule": "@daily"
+    },
+    "name": "aws.item_event_join.canary_streaming_v1__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/aws/item_event_join.py",
+    "team": "aws",
+    "version": "0"
+  },
+  "rowIds": [
+    "user_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/aws/training_set.v1_dev__0
+++ b/python/test/canary/canary_compiled/joins/aws/training_set.v1_dev__0
@@ -1,0 +1,341 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 6,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {
+              "k": "10"
+            },
+            "inputColumn": "purchase_price",
+            "operation": 13
+          }
+        ],
+        "keyColumns": [
+          "user_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "purchase_price_average_1d": "bd4c481c4e592608ace5a2930f61d45a",
+            "purchase_price_average_3d": "bd4c481c4e592608ace5a2930f61d45a",
+            "purchase_price_average_7d": "bd4c481c4e592608ace5a2930f61d45a",
+            "purchase_price_count_1d": "bd4c481c4e592608ace5a2930f61d45a",
+            "purchase_price_count_3d": "bd4c481c4e592608ace5a2930f61d45a",
+            "purchase_price_count_7d": "bd4c481c4e592608ace5a2930f61d45a",
+            "purchase_price_last10": "bd4c481c4e592608ace5a2930f61d45a",
+            "purchase_price_sum_1d": "bd4c481c4e592608ace5a2930f61d45a",
+            "purchase_price_sum_3d": "bd4c481c4e592608ace5a2930f61d45a",
+            "purchase_price_sum_7d": "bd4c481c4e592608ace5a2930f61d45a",
+            "user_id": "677635fb8fabe631108435c5cffe73ce"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "clusterConf": {
+              "common": {
+                "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+              }
+            },
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.table_write.upload.format": "ion",
+                "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.memory": "1g",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "1g",
+                "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                "spark.sql.shuffle.partitions": "10",
+                "taskmanager.memory.process.size": "4G"
+              },
+              "modeConfigs": {
+                "backfill": {
+                  "spark.chronon.coalesce.factor": "10",
+                  "spark.chronon.partition.column": "ds",
+                  "spark.chronon.partition.format": "yyyy-MM-dd",
+                  "spark.chronon.table_write.format": "iceberg",
+                  "spark.chronon.table_write.upload.format": "ion",
+                  "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                  "spark.default.parallelism": "10",
+                  "spark.driver.cores": "1",
+                  "spark.driver.memory": "1g",
+                  "spark.executor.cores": "1",
+                  "spark.executor.memory": "1g",
+                  "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                  "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                  "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                  "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                  "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                  "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                  "spark.sql.shuffle.partitions": "10",
+                  "taskmanager.memory.process.size": "4G"
+                }
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                "AWS_REGION": "us-west-2",
+                "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                "CLOUD_PROVIDER": "aws",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_KINESIS": "true",
+                "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+              },
+              "modeEnvironments": {
+                "upload": {
+                  "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                  "AWS_REGION": "us-west-2",
+                  "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                  "CLOUD_PROVIDER": "aws",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_KINESIS": "true",
+                  "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                  "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                  "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                  "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                  "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                }
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "aws.purchases.v1_dev__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "aws",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "selects": {
+                  "purchase_price": "purchase_price",
+                  "user_id": "user_id"
+                },
+                "startPartition": "2023-11-01",
+                "timeColumn": "ts"
+              },
+              "table": "data.purchases"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "ts": "ts",
+          "user_id": "user_id"
+        },
+        "timeColumn": "ts"
+      },
+      "table": "data.checkouts"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "ts": "a173b2adccfe3c386f262c4cd7ffe9bd",
+      "user_id": "a673c80ffc3260ee5ca173869ba07f7c",
+      "user_id_purchase_price_average_1d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_average_3d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_average_7d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_count_1d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_count_3d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_count_7d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_last10": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_sum_1d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_sum_3d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_sum_7d": "e3351cc3265d17cfd1b99f8da7fb083d"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_checkouts_with_offset_0\", \"spec\": \"data.checkouts/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily"
+    },
+    "name": "aws.training_set.v1_dev__0",
+    "online": 0,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/aws/training_set.py",
+    "team": "aws",
+    "version": "0"
+  },
+  "rowIds": [
+    "user_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/aws/training_set.v1_hub__0
+++ b/python/test/canary/canary_compiled/joins/aws/training_set.v1_hub__0
@@ -1,0 +1,341 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 6,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {
+              "k": "10"
+            },
+            "inputColumn": "purchase_price",
+            "operation": 13
+          }
+        ],
+        "keyColumns": [
+          "user_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "purchase_price_average_1d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "purchase_price_average_3d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "purchase_price_average_7d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "purchase_price_count_1d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "purchase_price_count_3d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "purchase_price_count_7d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "purchase_price_last10": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "purchase_price_sum_1d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "purchase_price_sum_3d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "purchase_price_sum_7d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "user_id": "dec6601a613992b4b6cdc50ac8014a29"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "clusterConf": {
+              "common": {
+                "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+              }
+            },
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.table_write.upload.format": "ion",
+                "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.memory": "1g",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "1g",
+                "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                "spark.sql.shuffle.partitions": "10",
+                "taskmanager.memory.process.size": "4G"
+              },
+              "modeConfigs": {
+                "backfill": {
+                  "spark.chronon.coalesce.factor": "10",
+                  "spark.chronon.partition.column": "ds",
+                  "spark.chronon.partition.format": "yyyy-MM-dd",
+                  "spark.chronon.table_write.format": "iceberg",
+                  "spark.chronon.table_write.upload.format": "ion",
+                  "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                  "spark.default.parallelism": "10",
+                  "spark.driver.cores": "1",
+                  "spark.driver.memory": "1g",
+                  "spark.executor.cores": "1",
+                  "spark.executor.memory": "1g",
+                  "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                  "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                  "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                  "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                  "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                  "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                  "spark.sql.shuffle.partitions": "10",
+                  "taskmanager.memory.process.size": "4G"
+                }
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                "AWS_REGION": "us-west-2",
+                "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                "CLOUD_PROVIDER": "aws",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_KINESIS": "true",
+                "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+              },
+              "modeEnvironments": {
+                "upload": {
+                  "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                  "AWS_REGION": "us-west-2",
+                  "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                  "CLOUD_PROVIDER": "aws",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_KINESIS": "true",
+                  "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                  "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                  "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                  "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                  "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                }
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "aws.purchases.v1_test__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "aws",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "selects": {
+                  "purchase_price": "purchase_price",
+                  "user_id": "user_id"
+                },
+                "startPartition": "2023-11-01",
+                "timeColumn": "ts"
+              },
+              "table": "data.purchases"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "ts": "ts",
+          "user_id": "user_id"
+        },
+        "timeColumn": "ts"
+      },
+      "table": "data.checkouts"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "ts": "a173b2adccfe3c386f262c4cd7ffe9bd",
+      "user_id": "a673c80ffc3260ee5ca173869ba07f7c",
+      "user_id_purchase_price_average_1d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_average_3d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_average_7d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_count_1d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_count_3d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_count_7d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_last10": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_sum_1d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_sum_3d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_sum_7d": "e3351cc3265d17cfd1b99f8da7fb083d"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_checkouts_with_offset_0\", \"spec\": \"data.checkouts/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily"
+    },
+    "name": "aws.training_set.v1_hub__0",
+    "online": 0,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/aws/training_set.py",
+    "team": "aws",
+    "version": "0"
+  },
+  "rowIds": [
+    "user_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/aws/training_set.v1_test__0
+++ b/python/test/canary/canary_compiled/joins/aws/training_set.v1_test__0
@@ -1,0 +1,341 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 6,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {
+              "k": "10"
+            },
+            "inputColumn": "purchase_price",
+            "operation": 13
+          }
+        ],
+        "keyColumns": [
+          "user_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "purchase_price_average_1d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "purchase_price_average_3d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "purchase_price_average_7d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "purchase_price_count_1d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "purchase_price_count_3d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "purchase_price_count_7d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "purchase_price_last10": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "purchase_price_sum_1d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "purchase_price_sum_3d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "purchase_price_sum_7d": "5814df4e6a1e2eb06b9fab89e70ea97d",
+            "user_id": "dec6601a613992b4b6cdc50ac8014a29"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "clusterConf": {
+              "common": {
+                "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+              }
+            },
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.table_write.upload.format": "ion",
+                "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.memory": "1g",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "1g",
+                "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                "spark.sql.shuffle.partitions": "10",
+                "taskmanager.memory.process.size": "4G"
+              },
+              "modeConfigs": {
+                "backfill": {
+                  "spark.chronon.coalesce.factor": "10",
+                  "spark.chronon.partition.column": "ds",
+                  "spark.chronon.partition.format": "yyyy-MM-dd",
+                  "spark.chronon.table_write.format": "iceberg",
+                  "spark.chronon.table_write.upload.format": "ion",
+                  "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                  "spark.default.parallelism": "10",
+                  "spark.driver.cores": "1",
+                  "spark.driver.memory": "1g",
+                  "spark.executor.cores": "1",
+                  "spark.executor.memory": "1g",
+                  "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                  "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                  "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                  "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                  "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                  "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                  "spark.sql.shuffle.partitions": "10",
+                  "taskmanager.memory.process.size": "4G"
+                }
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                "AWS_REGION": "us-west-2",
+                "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                "CLOUD_PROVIDER": "aws",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_KINESIS": "true",
+                "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+              },
+              "modeEnvironments": {
+                "upload": {
+                  "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                  "AWS_REGION": "us-west-2",
+                  "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                  "CLOUD_PROVIDER": "aws",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_KINESIS": "true",
+                  "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                  "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                  "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                  "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                  "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                }
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "aws.purchases.v1_test__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "aws",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "selects": {
+                  "purchase_price": "purchase_price",
+                  "user_id": "user_id"
+                },
+                "startPartition": "2023-11-01",
+                "timeColumn": "ts"
+              },
+              "table": "data.purchases"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "ts": "ts",
+          "user_id": "user_id"
+        },
+        "timeColumn": "ts"
+      },
+      "table": "data.checkouts"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "ts": "a173b2adccfe3c386f262c4cd7ffe9bd",
+      "user_id": "a673c80ffc3260ee5ca173869ba07f7c",
+      "user_id_purchase_price_average_1d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_average_3d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_average_7d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_count_1d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_count_3d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_count_7d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_last10": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_sum_1d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_sum_3d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_sum_7d": "e3351cc3265d17cfd1b99f8da7fb083d"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_checkouts_with_offset_0\", \"spec\": \"data.checkouts/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily"
+    },
+    "name": "aws.training_set.v1_test__0",
+    "online": 0,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/aws/training_set.py",
+    "team": "aws",
+    "version": "0"
+  },
+  "rowIds": [
+    "user_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/azure/crucible_stress.training_set__0
+++ b/python/test/canary/canary_compiled/joins/azure/crucible_stress.training_set__0
@@ -1,0 +1,279 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 6,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {
+              "k": "10"
+            },
+            "inputColumn": "purchase_price",
+            "operation": 13
+          }
+        ],
+        "keyColumns": [
+          "user_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "purchase_price_average_1d": "8c780fb5b00f55c0545cc6e48ef21c92",
+            "purchase_price_average_3d": "8c780fb5b00f55c0545cc6e48ef21c92",
+            "purchase_price_average_7d": "8c780fb5b00f55c0545cc6e48ef21c92",
+            "purchase_price_count_1d": "8c780fb5b00f55c0545cc6e48ef21c92",
+            "purchase_price_count_3d": "8c780fb5b00f55c0545cc6e48ef21c92",
+            "purchase_price_count_7d": "8c780fb5b00f55c0545cc6e48ef21c92",
+            "purchase_price_last10": "8c780fb5b00f55c0545cc6e48ef21c92",
+            "purchase_price_sum_1d": "8c780fb5b00f55c0545cc6e48ef21c92",
+            "purchase_price_sum_3d": "8c780fb5b00f55c0545cc6e48ef21c92",
+            "purchase_price_sum_7d": "8c780fb5b00f55c0545cc6e48ef21c92",
+            "user_id": "43dbce4df14238a2622226be130fb913"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_azure.AzureFormatProvider",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.extraJavaOptions": "-Dlog4j.configurationFile=/opt/chronon/log4j2.properties",
+                "spark.driver.memory": "4g",
+                "spark.driver.memoryOverhead": "1g",
+                "spark.executor.cores": "1",
+                "spark.executor.extraJavaOptions": "-Dlog4j.configurationFile=/opt/chronon/log4j2.properties",
+                "spark.executor.memory": "512m",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkCatalog",
+                "spark.sql.catalog.spark_catalog.credential": "",
+                "spark.sql.catalog.spark_catalog.header.X-Iceberg-Access-Delegation": "",
+                "spark.sql.catalog.spark_catalog.jdbc.password": "{POSTGRES_PASSWORD}",
+                "spark.sql.catalog.spark_catalog.jdbc.user": "chronon",
+                "spark.sql.catalog.spark_catalog.scope": "",
+                "spark.sql.catalog.spark_catalog.type": "jdbc",
+                "spark.sql.catalog.spark_catalog.uri": "jdbc:postgresql://{POSTGRES_HOST}:5432/iceberg_catalog?sslmode=require",
+                "spark.sql.catalog.spark_catalog.warehouse": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/warehouse",
+                "spark.sql.defaultCatalog": "spark_catalog",
+                "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                "spark.sql.shuffle.partitions": "10"
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/artifacts",
+                "CLOUD_PROVIDER": "azure",
+                "CUSTOMER_ID": "claims-demo",
+                "EVAL_URL": "http://hub.claims-demo-hub.svc.cluster.local:3903",
+                "FLINK_STATE_URI": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/flink-state",
+                "FRONTEND_URL": "http://hub.claims-demo-hub.svc.cluster.local:3903",
+                "HUB_URL": "http://hub.claims-demo-hub.svc.cluster.local:3903",
+                "K8S_NAMESPACE": "claims-demo-hub",
+                "OC_CREDENTIAL_VAULT_URI": "",
+                "POSTGRES_HOST": "crucible-claims-pg-westus.postgres.database.azure.com",
+                "POSTGRES_PASSWORD_VAULT_URI": "https://crucible-azure-kv.vault.azure.net/secrets/postgres-password",
+                "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=CLAIMS_DEMO&warehouse=demo_wh",
+                "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+                "SPARK_CLUSTER_NAME": "http://crucible.crucible-system.svc.cluster.local:8080",
+                "SPARK_EVENT_LOG_DIR": "abfss://crucible@ziplineai2.dfs.core.windows.net/spark-events",
+                "SPARK_EVENT_LOG_ENABLED": "true",
+                "SPARK_HISTORY_SERVER_URL": "http://spark-history-server.crucible-system.svc.cluster.local:18080",
+                "SPARK_IMAGE": "ziplinecanary.azurecr.io/chronon-spark-azure:latest",
+                "SPARK_SERVICE_ACCOUNT": "spark",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/warehouse"
+              }
+            },
+            "historicalBackfill": 0,
+            "stepDays": 1
+          },
+          "name": "azure.crucible_stress.user_purchase_features__0",
+          "online": 0,
+          "outputNamespace": "claims_demo",
+          "team": "azure",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "selects": {
+                  "purchase_price": "purchase_price",
+                  "user_id": "user_id"
+                },
+                "startPartition": "2026-05-01",
+                "timeColumn": "ts"
+              },
+              "table": "claims_demo.azure_crucible_stress_sources_purchases__0"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "checkout_id": "checkout_id",
+          "ts": "ts",
+          "user_id": "user_id"
+        },
+        "timeColumn": "ts"
+      },
+      "table": "claims_demo.azure_crucible_stress_sources_checkouts__0"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "checkout_id": "c2e6d14fbb0e3b94856f5b9a7814aab8",
+      "ts": "ff0c2ed6d5d839f477b50b0e6813570b",
+      "user_id": "0cae3630c2a593e40a419c918d23e4df",
+      "user_id_purchase_price_average_1d": "fcc7e330b079c5fd6f94b29cd8e9fb5e",
+      "user_id_purchase_price_average_3d": "fcc7e330b079c5fd6f94b29cd8e9fb5e",
+      "user_id_purchase_price_average_7d": "fcc7e330b079c5fd6f94b29cd8e9fb5e",
+      "user_id_purchase_price_count_1d": "fcc7e330b079c5fd6f94b29cd8e9fb5e",
+      "user_id_purchase_price_count_3d": "fcc7e330b079c5fd6f94b29cd8e9fb5e",
+      "user_id_purchase_price_count_7d": "fcc7e330b079c5fd6f94b29cd8e9fb5e",
+      "user_id_purchase_price_last10": "fcc7e330b079c5fd6f94b29cd8e9fb5e",
+      "user_id_purchase_price_sum_1d": "fcc7e330b079c5fd6f94b29cd8e9fb5e",
+      "user_id_purchase_price_sum_3d": "fcc7e330b079c5fd6f94b29cd8e9fb5e",
+      "user_id_purchase_price_sum_7d": "fcc7e330b079c5fd6f94b29cd8e9fb5e"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_claims_demo_azure_crucible_stress_sources_checkouts__0_with_offset_0\", \"spec\": \"claims_demo.azure_crucible_stress_sources_checkouts__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_claims_demo_azure_crucible_stress_sources_purchases__0_with_offset_0\", \"spec\": \"claims_demo.azure_crucible_stress_sources_purchases__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_azure.AzureFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dlog4j.configurationFile=/opt/chronon/log4j2.properties",
+          "spark.driver.memory": "4g",
+          "spark.driver.memoryOverhead": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.extraJavaOptions": "-Dlog4j.configurationFile=/opt/chronon/log4j2.properties",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkCatalog",
+          "spark.sql.catalog.spark_catalog.credential": "",
+          "spark.sql.catalog.spark_catalog.header.X-Iceberg-Access-Delegation": "",
+          "spark.sql.catalog.spark_catalog.jdbc.password": "{POSTGRES_PASSWORD}",
+          "spark.sql.catalog.spark_catalog.jdbc.user": "chronon",
+          "spark.sql.catalog.spark_catalog.scope": "",
+          "spark.sql.catalog.spark_catalog.type": "jdbc",
+          "spark.sql.catalog.spark_catalog.uri": "jdbc:postgresql://{POSTGRES_HOST}:5432/iceberg_catalog?sslmode=require",
+          "spark.sql.catalog.spark_catalog.warehouse": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/warehouse",
+          "spark.sql.defaultCatalog": "spark_catalog",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "enableStatsCompute": 0,
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/artifacts",
+          "CLOUD_PROVIDER": "azure",
+          "CUSTOMER_ID": "claims-demo",
+          "EVAL_URL": "http://hub.claims-demo-hub.svc.cluster.local:3903",
+          "FLINK_STATE_URI": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/flink-state",
+          "FRONTEND_URL": "http://hub.claims-demo-hub.svc.cluster.local:3903",
+          "HUB_URL": "http://hub.claims-demo-hub.svc.cluster.local:3903",
+          "K8S_NAMESPACE": "claims-demo-hub",
+          "OC_CREDENTIAL_VAULT_URI": "",
+          "POSTGRES_HOST": "crucible-claims-pg-westus.postgres.database.azure.com",
+          "POSTGRES_PASSWORD_VAULT_URI": "https://crucible-azure-kv.vault.azure.net/secrets/postgres-password",
+          "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=CLAIMS_DEMO&warehouse=demo_wh",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SPARK_CLUSTER_NAME": "http://crucible.crucible-system.svc.cluster.local:8080",
+          "SPARK_EVENT_LOG_DIR": "abfss://crucible@ziplineai2.dfs.core.windows.net/spark-events",
+          "SPARK_EVENT_LOG_ENABLED": "true",
+          "SPARK_HISTORY_SERVER_URL": "http://spark-history-server.crucible-system.svc.cluster.local:18080",
+          "SPARK_IMAGE": "ziplinecanary.azurecr.io/chronon-spark-azure:latest",
+          "SPARK_SERVICE_ACCOUNT": "spark",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/warehouse"
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 1
+    },
+    "name": "azure.crucible_stress.training_set__0",
+    "online": 0,
+    "outputNamespace": "claims_demo",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/azure/crucible_stress.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "rowIds": [
+    "checkout_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/azure/demo.derivations_v3
+++ b/python/test/canary/canary_compiled/joins/azure/demo.derivations_v3
@@ -1,0 +1,181 @@
+{
+  "derivations": [
+    {
+      "expression": "IF(listing_id_weight_grams > 1000, 1, 0)",
+      "name": "is_listing_heavy"
+    },
+    {
+      "expression": "array_contains(split(listing_id_tags, ','), 'handmade')",
+      "name": "is_item_handmade"
+    },
+    {
+      "expression": "log1p(listing_id_price_cents)",
+      "name": "price_log"
+    },
+    {
+      "expression": "\n                CASE\n                    WHEN listing_id_price_cents < 1000 THEN 0\n                    WHEN listing_id_price_cents < 5000 THEN 1\n                    WHEN listing_id_price_cents < 10000 THEN 2\n                    WHEN listing_id_price_cents < 50000 THEN 3\n                    ELSE 4\n                END\n            ",
+      "name": "price_bucket"
+    },
+    {
+      "expression": "*",
+      "name": "*"
+    }
+  ],
+  "joinParts": [
+    {
+      "groupBy": {
+        "keyColumns": [
+          "listing_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "brief_description": "3c179cccf0a9f57fda2fdfe3085a239f",
+            "currency": "8477ea4ad6b46f96255ce0905dfed26d",
+            "headline": "6bf685e11e97f4863d36fa953b964800",
+            "inventory_count": "9d63ce6eddf70502ad498603ec8b18b3",
+            "is_active": "9c9adf7999f230fc316c491f829b12d0",
+            "is_expensive": "255e0f554c8337c87a2a7f0b799c8d4b",
+            "is_in_stock": "80d7c029ebb919cfa22a82600ae3a3e1",
+            "listing_id": "e1d191582f23aad87ee1f5422600051f",
+            "long_description": "f3f74af9625f16c5d935e96d96e08698",
+            "main_image_path": "3ff96284663e8d05ad728b37f6acf122",
+            "merchant_id": "56b9c531a57e6d3f5320b72df8d63521",
+            "price_cents": "7be4ba1e811c96c5a4e5023ce1e05c38",
+            "primary_category": "d6beb0afb36cada1f65a9b1acdb5b995",
+            "secondary_image_paths": "de717ca6563464c24d63f8473a75ef85",
+            "tags": "f9ead5f03020ff66ff14e98fec19a774",
+            "weight_grams": "ac84b5b0b11dca76306214d5d2f12fa9"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "conf": {
+              "common": {
+                "spark.chronon.partition.column": "ds"
+              }
+            },
+            "env": {
+              "common": {
+                "CUSTOMER_ID": "dev",
+                "FRONTEND_URL": "http://localhost:3000",
+                "HUB_URL": "http://localhost:3903",
+                "VERSION": "latest"
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "azure.dim_listings.v3",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "azure"
+        },
+        "sources": [
+          {
+            "entities": {
+              "query": {
+                "selects": {
+                  "brief_description": "brief_description",
+                  "currency": "currency",
+                  "headline": "headline",
+                  "inventory_count": "inventory_count",
+                  "is_active": "is_active",
+                  "is_expensive": "IF(price_cents > 10000, 1, 0)",
+                  "is_in_stock": "IF(inventory_count > 0, 1, 0)",
+                  "listing_id": "CAST(listing_id AS INT)",
+                  "long_description": "long_description",
+                  "main_image_path": "main_image_path",
+                  "merchant_id": "merchant_id",
+                  "price_cents": "price_cents",
+                  "primary_category": "primary_category",
+                  "secondary_image_paths": "secondary_image_paths",
+                  "tags": "tags",
+                  "weight_grams": "weight_grams"
+                },
+                "startPartition": "2025-01-01"
+              },
+              "snapshotTable": "data.azure_exports_dim_listings__0"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "listing_id": "listing_id",
+          "row_id": "event_id",
+          "ts": "event_time_ms",
+          "user_id": "user_id"
+        },
+        "timeColumn": "event_time_ms"
+      },
+      "table": "data.azure_exports_user_activities__0"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "is_item_handmade": "2fb2522ff4adeac32f05686bee2d8d8e",
+      "is_listing_heavy": "1be94badd40cf81cbff8b05e0069565b",
+      "listing_id": "169fe859cf16964bfae45b091ae63769",
+      "listing_id_brief_description": "bb3240742aec4fc8bec0ed9bcfda9b03",
+      "listing_id_currency": "c5a50fc5261c9f707bb7979f25761cec",
+      "listing_id_headline": "761f756b2479285509779ded8eaf2767",
+      "listing_id_inventory_count": "7b37fa556442e2cb27931a263f80d6e7",
+      "listing_id_is_active": "18754af218f4e2b44dcd1ef4461cb915",
+      "listing_id_is_expensive": "47054babc081734ed1bb08ae4a71cd50",
+      "listing_id_is_in_stock": "224bb9f53e0871ed5417b4d3edbc5b96",
+      "listing_id_listing_id": "12b88a8392e563be9603ae9eadccb2c0",
+      "listing_id_long_description": "ea939a5259a2c737c544310098d86286",
+      "listing_id_main_image_path": "0d1b029c606c4a0100fb6cb941de4d51",
+      "listing_id_merchant_id": "92312d3a2445abca5e447d4ad58227d7",
+      "listing_id_price_cents": "0fad1929e7343b282b3e19d4ef598e22",
+      "listing_id_primary_category": "32de6b5cd92cafe148585c3d14cdd1d0",
+      "listing_id_secondary_image_paths": "90f77c6a0f615fa07948a4a05ffcd17b",
+      "listing_id_tags": "4233cdf7843465bc57c7b4ba2c9d40fc",
+      "listing_id_weight_grams": "9ddae537d9ebb737cb74c858664b7927",
+      "price_bucket": "0c4acb2cd4603ecc8f61346910bf2275",
+      "price_log": "0dbebba1946bafd7c04bcdcbabe326cd",
+      "row_id": "3411429041d3961c193d1ea1f8d857c9",
+      "ts": "64679de4e31d9876b38b2c7a4889991e",
+      "user_id": "32bdee94577162313d260c96add2652d"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_azure_exports_user_activities__0_with_offset_0\", \"spec\": \"data.azure_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_azure_exports_dim_listings__0_with_offset_0\", \"spec\": \"data.azure_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "offlineSchedule": "@daily",
+      "onlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "azure.demo.derivations_v3",
+    "online": 1,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/azure/demo.py",
+    "team": "azure"
+  },
+  "rowIds": [
+    "event_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/azure/demo.pc_v2
+++ b/python/test/canary/canary_compiled/joins/azure/demo.pc_v2
@@ -1,0 +1,176 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "keyColumns": [
+          "listing_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "brief_description": "d8f700f63471993b54a19d71122ec11b",
+            "currency": "ca2881e80e9a9b877c2824d1072d337d",
+            "headline": "3336296614f6be325954fd9ba86eb0cf",
+            "inventory_count": "31547342ddbeb4a831724186b289ea87",
+            "is_active": "faf50877bb5bd0b8f8d920fa0105bd1d",
+            "is_expensive": "e637a3ddd3c42a1edf54251b574b481f",
+            "is_in_stock": "c5fc4a74834fb45b6d5af196310c0f31",
+            "listing_id": "e486882fe8630828862beed3908c72f6",
+            "long_description": "639ab6183464bef6ec2c16118a2cde83",
+            "main_image_path": "647aece2b7dd9c084a447f06db6c9078",
+            "merchant_id": "f00635e9f0582cc0a4504e90e7bc469f",
+            "price_cents": "89610b09ce4e5c7cdba038c3d9ded2ef",
+            "primary_category": "f7e610e63a0809f8b26f9d196b40d35e",
+            "secondary_image_paths": "f9194618378f2ea3855aa792c0bd9317",
+            "tags": "318519d7ab1453a331685dc7f165bb85",
+            "weight_grams": "f8f34e81434169852c03e62a335c20aa"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "conf": {
+              "common": {
+                "spark.chronon.partition.column": "ds"
+              }
+            },
+            "env": {
+              "common": {
+                "CUSTOMER_ID": "dev",
+                "FRONTEND_URL": "http://localhost:3000",
+                "HUB_URL": "http://localhost:3903",
+                "VERSION": "latest"
+              }
+            },
+            "historicalBackfill": 0
+          },
+          "name": "azure.dim_listings.pc_v3",
+          "online": 0,
+          "outputNamespace": "data",
+          "team": "azure"
+        },
+        "sources": [
+          {
+            "entities": {
+              "query": {
+                "selects": {
+                  "brief_description": "brief_description",
+                  "currency": "currency",
+                  "headline": "headline",
+                  "inventory_count": "inventory_count",
+                  "is_active": "is_active",
+                  "is_expensive": "IF(price_cents > 10000, 1, 0)",
+                  "is_in_stock": "IF(inventory_count > 0, 1, 0)",
+                  "listing_id": "CAST(listing_id AS INT)",
+                  "long_description": "long_description",
+                  "main_image_path": "main_image_path",
+                  "merchant_id": "merchant_id",
+                  "price_cents": "price_cents",
+                  "primary_category": "primary_category",
+                  "secondary_image_paths": "secondary_image_paths",
+                  "tags": "tags",
+                  "weight_grams": "weight_grams"
+                },
+                "startPartition": "2025-01-01"
+              },
+              "snapshotTable": "data.azure_exports_dim_listings_pc__1"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "entities": {
+      "query": {
+        "selects": {
+          "brief_description": "brief_description",
+          "currency": "currency",
+          "headline": "headline",
+          "inventory_count": "inventory_count",
+          "is_active": "is_active",
+          "is_expensive": "IF(price_cents > 10000, 1, 0)",
+          "is_in_stock": "IF(inventory_count > 0, 1, 0)",
+          "listing_id": "CAST(listing_id AS INT)",
+          "long_description": "long_description",
+          "main_image_path": "main_image_path",
+          "merchant_id": "merchant_id",
+          "price_cents": "price_cents",
+          "primary_category": "primary_category",
+          "secondary_image_paths": "secondary_image_paths",
+          "tags": "tags",
+          "weight_grams": "weight_grams"
+        },
+        "startPartition": "2025-01-01"
+      },
+      "snapshotTable": "data.azure_exports_dim_listings_pc__1"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "brief_description": "5ae40fa9963d02d1f8afcbae02869b08",
+      "currency": "384574f30fe984988c7f736d83309a1a",
+      "headline": "000015ca5c9b191c2c9b520dcf8e0a1c",
+      "inventory_count": "6a786936e98006983e160915875e593d",
+      "is_active": "133b82620e1c926d0853614ac2002039",
+      "is_expensive": "6eaa23bf9cd94987b8905b1e861a7661",
+      "is_in_stock": "1f3cf734bfd0cf20cb656b2938b9f0cd",
+      "listing_id": "07fa41bbfe808a6524a7a16ab712fd4c",
+      "listing_id_brief_description": "31868234a42424279e00fce7f2520214",
+      "listing_id_currency": "61473201211c1afd3a1d9116fb3a9072",
+      "listing_id_headline": "9146c233c1ea889f05471ba8f3bc46d2",
+      "listing_id_inventory_count": "ff7e89d74ad170478ea1232eb5e41fb9",
+      "listing_id_is_active": "eaf3404ef754943dfa769b255fb351a0",
+      "listing_id_is_expensive": "62317488c4de93bf10d2c0cf09b8506c",
+      "listing_id_is_in_stock": "4d2f1173522465ab4bcd03aa5c5a85c7",
+      "listing_id_listing_id": "0e6bb1208bb63ccc0da0771cb4a2ab1b",
+      "listing_id_long_description": "b293571116db4c10f5f1d2ff42a57b85",
+      "listing_id_main_image_path": "fb103f1f840e9700e5bb6c67c868678e",
+      "listing_id_merchant_id": "dac397a502736222f6984f54074ecb12",
+      "listing_id_price_cents": "587f0eac8381823fb2a546f6fe1fc8b5",
+      "listing_id_primary_category": "7e08626200c9028926bf8af6462b1dd6",
+      "listing_id_secondary_image_paths": "0a44c83cfa2493c8ba715a5833475759",
+      "listing_id_tags": "5979de3fc49571d9ccec8f21e69a31e5",
+      "listing_id_weight_grams": "53700fe5e54d5350be5dacbbc9b8aa0d",
+      "long_description": "756b272483270065098e5d4e7a1e1996",
+      "main_image_path": "ee8f4253c2be3bbc3ab771aebeaff658",
+      "merchant_id": "70e7a60026c000d42380322c75cbb4d3",
+      "price_cents": "992b998ed1d9a9e72b7eec8722225f7f",
+      "primary_category": "f50570d493cbeca365386a2f9c503147",
+      "secondary_image_paths": "9ee5811f3edd43580cb230469677c955",
+      "tags": "a43e930fdfbad711713a725eccb39cbd",
+      "weight_grams": "3563150a7e46318bf3395d3d08e7b27d"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_azure_exports_dim_listings_pc__1_with_offset_0\", \"spec\": \"data.azure_exports_dim_listings_pc__1/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "enableStatsCompute": 0,
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "azure.demo.pc_v2",
+    "online": 0,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/azure/demo.py",
+    "team": "azure"
+  },
+  "rowIds": [],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/azure/demo.v2
+++ b/python/test/canary/canary_compiled/joins/azure/demo.v2
@@ -1,0 +1,211 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "keyColumns": [
+          "listing_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "brief_description": "3c179cccf0a9f57fda2fdfe3085a239f",
+            "currency": "8477ea4ad6b46f96255ce0905dfed26d",
+            "headline": "6bf685e11e97f4863d36fa953b964800",
+            "inventory_count": "9d63ce6eddf70502ad498603ec8b18b3",
+            "is_active": "9c9adf7999f230fc316c491f829b12d0",
+            "is_expensive": "255e0f554c8337c87a2a7f0b799c8d4b",
+            "is_in_stock": "80d7c029ebb919cfa22a82600ae3a3e1",
+            "listing_id": "e1d191582f23aad87ee1f5422600051f",
+            "long_description": "f3f74af9625f16c5d935e96d96e08698",
+            "main_image_path": "3ff96284663e8d05ad728b37f6acf122",
+            "merchant_id": "56b9c531a57e6d3f5320b72df8d63521",
+            "price_cents": "7be4ba1e811c96c5a4e5023ce1e05c38",
+            "primary_category": "d6beb0afb36cada1f65a9b1acdb5b995",
+            "secondary_image_paths": "de717ca6563464c24d63f8473a75ef85",
+            "tags": "f9ead5f03020ff66ff14e98fec19a774",
+            "weight_grams": "ac84b5b0b11dca76306214d5d2f12fa9"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "conf": {
+              "common": {
+                "spark.chronon.partition.column": "ds"
+              }
+            },
+            "env": {
+              "common": {
+                "CUSTOMER_ID": "dev",
+                "FRONTEND_URL": "http://localhost:3000",
+                "HUB_URL": "http://localhost:3903",
+                "VERSION": "latest"
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "azure.dim_listings.v3",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "azure"
+        },
+        "sources": [
+          {
+            "entities": {
+              "query": {
+                "selects": {
+                  "brief_description": "brief_description",
+                  "currency": "currency",
+                  "headline": "headline",
+                  "inventory_count": "inventory_count",
+                  "is_active": "is_active",
+                  "is_expensive": "IF(price_cents > 10000, 1, 0)",
+                  "is_in_stock": "IF(inventory_count > 0, 1, 0)",
+                  "listing_id": "CAST(listing_id AS INT)",
+                  "long_description": "long_description",
+                  "main_image_path": "main_image_path",
+                  "merchant_id": "merchant_id",
+                  "price_cents": "price_cents",
+                  "primary_category": "primary_category",
+                  "secondary_image_paths": "secondary_image_paths",
+                  "tags": "tags",
+                  "weight_grams": "weight_grams"
+                },
+                "startPartition": "2025-01-01"
+              },
+              "snapshotTable": "data.azure_exports_dim_listings__0"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    },
+    {
+      "groupBy": {
+        "keyColumns": [
+          "listing_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "listing_id": "ef0459db5af8e98e7b54b6dbec987680",
+            "primary_category": "41f7c36859f55e0908a0e2ee1cea4fb3"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "conf": {
+              "common": {
+                "spark.chronon.partition.column": "ds"
+              }
+            },
+            "env": {
+              "common": {
+                "CUSTOMER_ID": "dev",
+                "FRONTEND_URL": "http://localhost:3000",
+                "HUB_URL": "http://localhost:3903",
+                "VERSION": "latest"
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "azure.dim_merchants.v2",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "azure"
+        },
+        "sources": [
+          {
+            "entities": {
+              "query": {
+                "selects": {
+                  "listing_id": "CAST(merchant_id AS INT)",
+                  "primary_category": "primary_category"
+                },
+                "startPartition": "2025-01-01"
+              },
+              "snapshotTable": "data.azure_exports_dim_merchants__0"
+            }
+          }
+        ]
+      },
+      "prefix": "merchant_",
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "listing_id": "listing_id",
+          "row_id": "event_id",
+          "ts": "event_time_ms",
+          "user_id": "user_id"
+        },
+        "timeColumn": "event_time_ms"
+      },
+      "table": "data.azure_exports_user_activities__0"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "listing_id": "169fe859cf16964bfae45b091ae63769",
+      "listing_id_brief_description": "bb3240742aec4fc8bec0ed9bcfda9b03",
+      "listing_id_currency": "c5a50fc5261c9f707bb7979f25761cec",
+      "listing_id_headline": "761f756b2479285509779ded8eaf2767",
+      "listing_id_inventory_count": "7b37fa556442e2cb27931a263f80d6e7",
+      "listing_id_is_active": "18754af218f4e2b44dcd1ef4461cb915",
+      "listing_id_is_expensive": "47054babc081734ed1bb08ae4a71cd50",
+      "listing_id_is_in_stock": "224bb9f53e0871ed5417b4d3edbc5b96",
+      "listing_id_listing_id": "12b88a8392e563be9603ae9eadccb2c0",
+      "listing_id_long_description": "ea939a5259a2c737c544310098d86286",
+      "listing_id_main_image_path": "0d1b029c606c4a0100fb6cb941de4d51",
+      "listing_id_merchant_id": "92312d3a2445abca5e447d4ad58227d7",
+      "listing_id_price_cents": "0fad1929e7343b282b3e19d4ef598e22",
+      "listing_id_primary_category": "32de6b5cd92cafe148585c3d14cdd1d0",
+      "listing_id_secondary_image_paths": "90f77c6a0f615fa07948a4a05ffcd17b",
+      "listing_id_tags": "4233cdf7843465bc57c7b4ba2c9d40fc",
+      "listing_id_weight_grams": "9ddae537d9ebb737cb74c858664b7927",
+      "merchant__listing_id_listing_id": "ac059ec1c2e5dabfe0ce96c4639e29c8",
+      "merchant__listing_id_primary_category": "71573fcf9a807b70b36f08476e897600",
+      "row_id": "3411429041d3961c193d1ea1f8d857c9",
+      "ts": "64679de4e31d9876b38b2c7a4889991e",
+      "user_id": "32bdee94577162313d260c96add2652d"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_azure_exports_user_activities__0_with_offset_0\", \"spec\": \"data.azure_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_azure_exports_dim_listings__0_with_offset_0\", \"spec\": \"data.azure_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_azure_exports_dim_merchants__0_with_offset_0\", \"spec\": \"data.azure_exports_dim_merchants__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "enableStatsCompute": 1,
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "offlineSchedule": "@daily",
+      "onlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "azure.demo.v2",
+    "online": 1,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/azure/demo.py",
+    "team": "azure"
+  },
+  "rowIds": [
+    "event_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/azure/demo_chaining.downstream_join__0
+++ b/python/test/canary/canary_compiled/joins/azure/demo_chaining.downstream_join__0
@@ -1,0 +1,244 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {
+              "k": "100"
+            },
+            "inputColumn": "price_cents",
+            "operation": 13,
+            "windows": [
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          }
+        ],
+        "keyColumns": [
+          "user_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "price_cents_last100_7d": "8d7a1fba31093361b1675f65e53748d7",
+            "user_id": "4ecdf09ef20508785edf01ab40f381ed"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "conf": {
+              "common": {
+                "spark.chronon.partition.column": "ds"
+              }
+            },
+            "env": {
+              "common": {
+                "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+                "CUSTOMER_ID": "dev",
+                "FRONTEND_URL": "http://localhost:3000",
+                "HUB_URL": "http://localhost:3903",
+                "VERSION": "latest"
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "azure.user_activities_chained.chained_user_gb__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "azure",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "joinSource": {
+              "join": {
+                "joinParts": [
+                  {
+                    "groupBy": {
+                      "keyColumns": [
+                        "listing_id"
+                      ],
+                      "metaData": {
+                        "environments": [
+                          0
+                        ],
+                        "executionInfo": {
+                          "conf": {
+                            "common": {
+                              "spark.chronon.partition.column": "ds"
+                            }
+                          },
+                          "env": {
+                            "common": {
+                              "CUSTOMER_ID": "dev",
+                              "FRONTEND_URL": "http://localhost:3000",
+                              "HUB_URL": "http://localhost:3903",
+                              "VERSION": "latest"
+                            }
+                          },
+                          "historicalBackfill": 0,
+                          "onlineSchedule": "@daily"
+                        },
+                        "name": "azure.dim_listings.v3",
+                        "online": 1,
+                        "outputNamespace": "data",
+                        "team": "azure"
+                      },
+                      "sources": [
+                        {
+                          "entities": {
+                            "query": {
+                              "selects": {
+                                "brief_description": "brief_description",
+                                "currency": "currency",
+                                "headline": "headline",
+                                "inventory_count": "inventory_count",
+                                "is_active": "is_active",
+                                "is_expensive": "IF(price_cents > 10000, 1, 0)",
+                                "is_in_stock": "IF(inventory_count > 0, 1, 0)",
+                                "listing_id": "CAST(listing_id AS INT)",
+                                "long_description": "long_description",
+                                "main_image_path": "main_image_path",
+                                "merchant_id": "merchant_id",
+                                "price_cents": "price_cents",
+                                "primary_category": "primary_category",
+                                "secondary_image_paths": "secondary_image_paths",
+                                "tags": "tags",
+                                "weight_grams": "weight_grams"
+                              },
+                              "startPartition": "2025-01-01"
+                            },
+                            "snapshotTable": "data.azure_exports_dim_listings__0"
+                          }
+                        }
+                      ]
+                    },
+                    "useLongNames": 0
+                  }
+                ],
+                "left": {
+                  "events": {
+                    "query": {
+                      "selects": {
+                        "listing_id": "listing_id",
+                        "row_id": "event_id",
+                        "ts": "unix_millis(TIMESTAMP(event_time_ms))",
+                        "user_id": "user_id"
+                      },
+                      "timeColumn": "unix_millis(TIMESTAMP(event_time_ms))"
+                    },
+                    "table": "data.azure_exports_user_activities__0",
+                    "topic": "pubsub://user-activities-v2/project=canary-443022/subscription=user-activities-v2-sub/serde=pubsub_schema/schemaId=user-activities"
+                  }
+                },
+                "metaData": {
+                  "environments": [
+                    0
+                  ],
+                  "executionInfo": {
+                    "conf": {
+                      "common": {
+                        "spark.chronon.partition.column": "ds"
+                      }
+                    },
+                    "env": {
+                      "common": {
+                        "CUSTOMER_ID": "dev",
+                        "FRONTEND_URL": "http://localhost:3000",
+                        "HUB_URL": "http://localhost:3903",
+                        "VERSION": "latest"
+                      }
+                    },
+                    "offlineSchedule": "17 0 * * *",
+                    "onlineSchedule": "@daily"
+                  },
+                  "name": "azure.demo_parent.parent_join__0",
+                  "online": 1,
+                  "outputNamespace": "data",
+                  "production": 0,
+                  "samplePercent": 100.0,
+                  "team": "azure",
+                  "version": "0"
+                },
+                "rowIds": [
+                  "event_id"
+                ],
+                "useLongNames": 0
+              },
+              "query": {
+                "selects": {
+                  "listing_id": "listing_id",
+                  "price_cents": "listing_id_price_cents",
+                  "user_id": "user_id"
+                },
+                "timeColumn": "ts"
+              }
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "listing_id": "listing_id",
+          "row_id": "event_id",
+          "ts": "unix_millis(TIMESTAMP(event_time_ms))",
+          "user_id": "user_id"
+        },
+        "timeColumn": "unix_millis(TIMESTAMP(event_time_ms))"
+      },
+      "table": "data.azure_exports_user_activities__0",
+      "topic": "pubsub://user-activities-v2/project=canary-443022/subscription=user-activities-v2-sub/serde=pubsub_schema/schemaId=user-activities"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "listing_id": "a781ec55d64e705d8ce51d0c587b40e2",
+      "row_id": "a815aba076a56303f2c896256f1ba0ff",
+      "ts": "32cfb4df811008307e03612be49442ec",
+      "user_id": "275e18a643e12228f787cd9a9b03eaed",
+      "user_id_price_cents_last100_7d": "bddd7571d888b859ebeae7da9e49f6af"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_azure_exports_user_activities__0_with_offset_0\", \"spec\": \"data.azure_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "offlineSchedule": "@daily",
+      "onlineSchedule": "@daily"
+    },
+    "name": "azure.demo_chaining.downstream_join__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/azure/demo_chaining.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "rowIds": [
+    "event_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/azure/demo_parent.parent_join__0
+++ b/python/test/canary/canary_compiled/joins/azure/demo_parent.parent_join__0
@@ -1,0 +1,156 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "keyColumns": [
+          "listing_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "brief_description": "3c179cccf0a9f57fda2fdfe3085a239f",
+            "currency": "8477ea4ad6b46f96255ce0905dfed26d",
+            "headline": "6bf685e11e97f4863d36fa953b964800",
+            "inventory_count": "9d63ce6eddf70502ad498603ec8b18b3",
+            "is_active": "9c9adf7999f230fc316c491f829b12d0",
+            "is_expensive": "255e0f554c8337c87a2a7f0b799c8d4b",
+            "is_in_stock": "80d7c029ebb919cfa22a82600ae3a3e1",
+            "listing_id": "e1d191582f23aad87ee1f5422600051f",
+            "long_description": "f3f74af9625f16c5d935e96d96e08698",
+            "main_image_path": "3ff96284663e8d05ad728b37f6acf122",
+            "merchant_id": "56b9c531a57e6d3f5320b72df8d63521",
+            "price_cents": "7be4ba1e811c96c5a4e5023ce1e05c38",
+            "primary_category": "d6beb0afb36cada1f65a9b1acdb5b995",
+            "secondary_image_paths": "de717ca6563464c24d63f8473a75ef85",
+            "tags": "f9ead5f03020ff66ff14e98fec19a774",
+            "weight_grams": "ac84b5b0b11dca76306214d5d2f12fa9"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "conf": {
+              "common": {
+                "spark.chronon.partition.column": "ds"
+              }
+            },
+            "env": {
+              "common": {
+                "CUSTOMER_ID": "dev",
+                "FRONTEND_URL": "http://localhost:3000",
+                "HUB_URL": "http://localhost:3903",
+                "VERSION": "latest"
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "azure.dim_listings.v3",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "azure"
+        },
+        "sources": [
+          {
+            "entities": {
+              "query": {
+                "selects": {
+                  "brief_description": "brief_description",
+                  "currency": "currency",
+                  "headline": "headline",
+                  "inventory_count": "inventory_count",
+                  "is_active": "is_active",
+                  "is_expensive": "IF(price_cents > 10000, 1, 0)",
+                  "is_in_stock": "IF(inventory_count > 0, 1, 0)",
+                  "listing_id": "CAST(listing_id AS INT)",
+                  "long_description": "long_description",
+                  "main_image_path": "main_image_path",
+                  "merchant_id": "merchant_id",
+                  "price_cents": "price_cents",
+                  "primary_category": "primary_category",
+                  "secondary_image_paths": "secondary_image_paths",
+                  "tags": "tags",
+                  "weight_grams": "weight_grams"
+                },
+                "startPartition": "2025-01-01"
+              },
+              "snapshotTable": "data.azure_exports_dim_listings__0"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "listing_id": "listing_id",
+          "row_id": "event_id",
+          "ts": "unix_millis(TIMESTAMP(event_time_ms))",
+          "user_id": "user_id"
+        },
+        "timeColumn": "unix_millis(TIMESTAMP(event_time_ms))"
+      },
+      "table": "data.azure_exports_user_activities__0",
+      "topic": "pubsub://user-activities-v2/project=canary-443022/subscription=user-activities-v2-sub/serde=pubsub_schema/schemaId=user-activities"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "listing_id": "a781ec55d64e705d8ce51d0c587b40e2",
+      "listing_id_brief_description": "b96d5becf2658a66afe8c8a0e9b9f2d5",
+      "listing_id_currency": "45826e45199d48668b21465ff002c2d8",
+      "listing_id_headline": "a1769b8d92ae9b95f2c6446ac41b8229",
+      "listing_id_inventory_count": "986aed22f9c8471e18edce1e828d290a",
+      "listing_id_is_active": "27f958bac2b8eabb23551bf8221a1401",
+      "listing_id_is_expensive": "9acfbac83a11c5d91dc2d1004f85156a",
+      "listing_id_is_in_stock": "4cce091dcbd28805c474bcda0092dce5",
+      "listing_id_listing_id": "1300f351e6450538a6a18b6faa422fc1",
+      "listing_id_long_description": "5d8f289cc48193c21b584ebaa224f6e8",
+      "listing_id_main_image_path": "99ca3d1632007760b2161e57bf9a67ac",
+      "listing_id_merchant_id": "eb1873d87e1f53a6faee6ba43adef019",
+      "listing_id_price_cents": "ef37b2a77b73b56083739233e5c92c35",
+      "listing_id_primary_category": "e10b1e53275e0cd7b1214c8f5778c0b0",
+      "listing_id_secondary_image_paths": "7c400bbaf41234338820447d2074d757",
+      "listing_id_tags": "ddc35d6e9b8ae3b0948a3c083485dc8d",
+      "listing_id_weight_grams": "9ad552c5fceef5c31116f090b6175924",
+      "row_id": "a815aba076a56303f2c896256f1ba0ff",
+      "ts": "32cfb4df811008307e03612be49442ec",
+      "user_id": "275e18a643e12228f787cd9a9b03eaed"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_azure_exports_user_activities__0_with_offset_0\", \"spec\": \"data.azure_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_azure_exports_dim_listings__0_with_offset_0\", \"spec\": \"data.azure_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "offlineSchedule": "17 0 * * *",
+      "onlineSchedule": "@daily"
+    },
+    "name": "azure.demo_parent.parent_join__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/azure/demo_parent.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "rowIds": [
+    "event_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/azure/item_event_join.canary_batch_v1__0
+++ b/python/test/canary/canary_compiled/joins/azure/item_event_join.canary_batch_v1__0
@@ -1,0 +1,196 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 6,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {
+              "k": "10"
+            },
+            "inputColumn": "purchase_price",
+            "operation": 13
+          }
+        ],
+        "keyColumns": [
+          "user_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "purchase_price_average_1d": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "purchase_price_average_3d": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "purchase_price_average_7d": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "purchase_price_count_1d": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "purchase_price_count_3d": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "purchase_price_count_7d": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "purchase_price_last10": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "purchase_price_sum_1d": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "purchase_price_sum_3d": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "purchase_price_sum_7d": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "user_id": "2a2caca3ea4afb84a2271533b1a1bae1"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "conf": {
+              "common": {
+                "spark.chronon.partition.column": "ds"
+              }
+            },
+            "env": {
+              "common": {
+                "CUSTOMER_ID": "dev",
+                "FRONTEND_URL": "http://localhost:3000",
+                "HUB_URL": "http://localhost:3903",
+                "VERSION": "latest"
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "azure.purchases.v1_test__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "azure",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "selects": {
+                  "purchase_price": "purchase_price",
+                  "user_id": "user_id"
+                },
+                "startPartition": "2023-11-01",
+                "timeColumn": "ts"
+              },
+              "table": "data.purchases"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "listing_id": "EXPLODE(TRANSFORM(SPLIT(COALESCE(attributes['sold_listing_ids'], attributes['listing_id']), ','), e -> CAST(e AS LONG)))",
+          "ts": "timestamp",
+          "user_id": "attributes['user_id']"
+        },
+        "timeColumn": "timestamp"
+      },
+      "table": "data.item_events_parquet_compat"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "listing_id": "f2f6c814b8ae1521176b22a1ae7f2d0d",
+      "ts": "ad9fd4c611e20ad833819a4ce9d752bf",
+      "user_id": "493d3df28f80664abd11b19fcd33b6e6",
+      "user_id_purchase_price_average_1d": "5609e04d61a47a8cafc67970785a3a59",
+      "user_id_purchase_price_average_3d": "5609e04d61a47a8cafc67970785a3a59",
+      "user_id_purchase_price_average_7d": "5609e04d61a47a8cafc67970785a3a59",
+      "user_id_purchase_price_count_1d": "5609e04d61a47a8cafc67970785a3a59",
+      "user_id_purchase_price_count_3d": "5609e04d61a47a8cafc67970785a3a59",
+      "user_id_purchase_price_count_7d": "5609e04d61a47a8cafc67970785a3a59",
+      "user_id_purchase_price_last10": "5609e04d61a47a8cafc67970785a3a59",
+      "user_id_purchase_price_sum_1d": "5609e04d61a47a8cafc67970785a3a59",
+      "user_id_purchase_price_sum_3d": "5609e04d61a47a8cafc67970785a3a59",
+      "user_id_purchase_price_sum_7d": "5609e04d61a47a8cafc67970785a3a59"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_item_events_parquet_compat_with_offset_0\", \"spec\": \"data.item_events_parquet_compat/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "offlineSchedule": "@daily",
+      "onlineSchedule": "@daily"
+    },
+    "name": "azure.item_event_join.canary_batch_v1__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/azure/item_event_join.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "rowIds": [
+    "listing_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/azure/item_event_join.canary_combined_v1__0
+++ b/python/test/canary/canary_compiled/joins/azure/item_event_join.canary_combined_v1__0
@@ -1,0 +1,310 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "add_cart",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "view",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "favorite",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              }
+            ]
+          }
+        ],
+        "keyColumns": [
+          "listing_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "add_cart_sum_1d": "fd09e7f474cf0e3cd35100a8e393001e",
+            "favorite_sum_1d": "ec11648e296c67967b03bf92b4718e96",
+            "listing_id": "2b415bfb2391528543f06ac089fbee82",
+            "purchase_sum_1d": "ae525baa20eea731a1270dd356ec611a",
+            "view_sum_1d": "10afd70aaef55fd280157c808724d63a"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "conf": {
+              "common": {
+                "spark.chronon.partition.column": "_DATE"
+              }
+            },
+            "env": {
+              "common": {
+                "CHRONON_ONLINE_ARGS": "-Ztasks=4 -Zbootstrap=bootstrap.zipline-kafka-cluster.us-central1.managedkafka.canary-443022.cloud.goog:9092",
+                "CUSTOMER_ID": "dev",
+                "FRONTEND_URL": "http://localhost:3000",
+                "HUB_URL": "http://localhost:3903",
+                "VERSION": "latest"
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "azure.item_event_canary.actions_pubsub_v2__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "azure",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "selects": {
+                  "add_cart": "IF(event_type = 'backend_add_to_cart', 1, 0)",
+                  "favorite": "IF(event_type = 'backend_favorite_item2', 1, 0)",
+                  "listing_id": "EXPLODE(TRANSFORM(SPLIT(COALESCE(attributes['sold_listing_ids'], attributes['listing_id']), ','), e -> CAST(e AS LONG)))",
+                  "purchase": "IF(event_type = 'backend_cart_payment', 1, 0)",
+                  "view": "IF(event_type = 'view_listing', 1, 0)"
+                },
+                "timeColumn": "timestamp",
+                "wheres": [
+                  "event_type in ('backend_add_to_cart', 'view_listing', 'backend_cart_payment', 'backend_favorite_item2')"
+                ]
+              },
+              "table": "data.item_events_parquet_compat_partitioned",
+              "topic": "pubsub://test-item-event-data/serde=pubsub_schema/project=canary-443022/schemaId=item-event/tasks=4/subscription=test-item-event-data-sub"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    },
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 6,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {
+              "k": "10"
+            },
+            "inputColumn": "purchase_price",
+            "operation": 13
+          }
+        ],
+        "keyColumns": [
+          "user_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "purchase_price_average_1d": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "purchase_price_average_3d": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "purchase_price_average_7d": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "purchase_price_count_1d": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "purchase_price_count_3d": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "purchase_price_count_7d": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "purchase_price_last10": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "purchase_price_sum_1d": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "purchase_price_sum_3d": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "purchase_price_sum_7d": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "user_id": "2a2caca3ea4afb84a2271533b1a1bae1"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "conf": {
+              "common": {
+                "spark.chronon.partition.column": "ds"
+              }
+            },
+            "env": {
+              "common": {
+                "CUSTOMER_ID": "dev",
+                "FRONTEND_URL": "http://localhost:3000",
+                "HUB_URL": "http://localhost:3903",
+                "VERSION": "latest"
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "azure.purchases.v1_test__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "azure",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "selects": {
+                  "purchase_price": "purchase_price",
+                  "user_id": "user_id"
+                },
+                "startPartition": "2023-11-01",
+                "timeColumn": "ts"
+              },
+              "table": "data.purchases"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "listing_id": "EXPLODE(TRANSFORM(SPLIT(COALESCE(attributes['sold_listing_ids'], attributes['listing_id']), ','), e -> CAST(e AS LONG)))",
+          "ts": "timestamp",
+          "user_id": "attributes['user_id']"
+        },
+        "timeColumn": "timestamp"
+      },
+      "table": "data.item_events_parquet_compat"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "listing_id": "f2f6c814b8ae1521176b22a1ae7f2d0d",
+      "listing_id_add_cart_sum_1d": "6b9c42bf45158c93b823dcf0b5bea7ab",
+      "listing_id_favorite_sum_1d": "bb07e39a4b7ea81aca5baf027fd8f555",
+      "listing_id_purchase_sum_1d": "12f0cd5674381064326148e7eb352a40",
+      "listing_id_view_sum_1d": "c92a7a66f21979b327788447d063fe2b",
+      "ts": "ad9fd4c611e20ad833819a4ce9d752bf",
+      "user_id": "493d3df28f80664abd11b19fcd33b6e6",
+      "user_id_purchase_price_average_1d": "5609e04d61a47a8cafc67970785a3a59",
+      "user_id_purchase_price_average_3d": "5609e04d61a47a8cafc67970785a3a59",
+      "user_id_purchase_price_average_7d": "5609e04d61a47a8cafc67970785a3a59",
+      "user_id_purchase_price_count_1d": "5609e04d61a47a8cafc67970785a3a59",
+      "user_id_purchase_price_count_3d": "5609e04d61a47a8cafc67970785a3a59",
+      "user_id_purchase_price_count_7d": "5609e04d61a47a8cafc67970785a3a59",
+      "user_id_purchase_price_last10": "5609e04d61a47a8cafc67970785a3a59",
+      "user_id_purchase_price_sum_1d": "5609e04d61a47a8cafc67970785a3a59",
+      "user_id_purchase_price_sum_3d": "5609e04d61a47a8cafc67970785a3a59",
+      "user_id_purchase_price_sum_7d": "5609e04d61a47a8cafc67970785a3a59"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_item_events_parquet_compat_with_offset_0\", \"spec\": \"data.item_events_parquet_compat/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_item_events_parquet_compat_partitioned_with_offset_0\", \"spec\": \"data.item_events_parquet_compat_partitioned/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "offlineSchedule": "@daily",
+      "onlineSchedule": "@daily"
+    },
+    "name": "azure.item_event_join.canary_combined_v1__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/azure/item_event_join.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "rowIds": [
+    "user_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/azure/item_event_join.canary_streaming_v1__0
+++ b/python/test/canary/canary_compiled/joins/azure/item_event_join.canary_streaming_v1__0
@@ -1,0 +1,171 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "add_cart",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "view",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "favorite",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              }
+            ]
+          }
+        ],
+        "keyColumns": [
+          "listing_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "add_cart_sum_1d": "fd09e7f474cf0e3cd35100a8e393001e",
+            "favorite_sum_1d": "ec11648e296c67967b03bf92b4718e96",
+            "listing_id": "2b415bfb2391528543f06ac089fbee82",
+            "purchase_sum_1d": "ae525baa20eea731a1270dd356ec611a",
+            "view_sum_1d": "10afd70aaef55fd280157c808724d63a"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "conf": {
+              "common": {
+                "spark.chronon.partition.column": "_DATE"
+              }
+            },
+            "env": {
+              "common": {
+                "CHRONON_ONLINE_ARGS": "-Ztasks=4 -Zbootstrap=bootstrap.zipline-kafka-cluster.us-central1.managedkafka.canary-443022.cloud.goog:9092",
+                "CUSTOMER_ID": "dev",
+                "FRONTEND_URL": "http://localhost:3000",
+                "HUB_URL": "http://localhost:3903",
+                "VERSION": "latest"
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "azure.item_event_canary.actions_pubsub_v2__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "azure",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "selects": {
+                  "add_cart": "IF(event_type = 'backend_add_to_cart', 1, 0)",
+                  "favorite": "IF(event_type = 'backend_favorite_item2', 1, 0)",
+                  "listing_id": "EXPLODE(TRANSFORM(SPLIT(COALESCE(attributes['sold_listing_ids'], attributes['listing_id']), ','), e -> CAST(e AS LONG)))",
+                  "purchase": "IF(event_type = 'backend_cart_payment', 1, 0)",
+                  "view": "IF(event_type = 'view_listing', 1, 0)"
+                },
+                "timeColumn": "timestamp",
+                "wheres": [
+                  "event_type in ('backend_add_to_cart', 'view_listing', 'backend_cart_payment', 'backend_favorite_item2')"
+                ]
+              },
+              "table": "data.item_events_parquet_compat_partitioned",
+              "topic": "pubsub://test-item-event-data/serde=pubsub_schema/project=canary-443022/schemaId=item-event/tasks=4/subscription=test-item-event-data-sub"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "listing_id": "EXPLODE(TRANSFORM(SPLIT(COALESCE(attributes['sold_listing_ids'], attributes['listing_id']), ','), e -> CAST(e AS LONG)))",
+          "ts": "timestamp",
+          "user_id": "attributes['user_id']"
+        },
+        "timeColumn": "timestamp"
+      },
+      "table": "data.item_events_parquet_compat"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "listing_id": "f2f6c814b8ae1521176b22a1ae7f2d0d",
+      "listing_id_add_cart_sum_1d": "6b9c42bf45158c93b823dcf0b5bea7ab",
+      "listing_id_favorite_sum_1d": "bb07e39a4b7ea81aca5baf027fd8f555",
+      "listing_id_purchase_sum_1d": "12f0cd5674381064326148e7eb352a40",
+      "listing_id_view_sum_1d": "c92a7a66f21979b327788447d063fe2b",
+      "ts": "ad9fd4c611e20ad833819a4ce9d752bf",
+      "user_id": "493d3df28f80664abd11b19fcd33b6e6"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_item_events_parquet_compat_with_offset_0\", \"spec\": \"data.item_events_parquet_compat/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_item_events_parquet_compat_partitioned_with_offset_0\", \"spec\": \"data.item_events_parquet_compat_partitioned/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "offlineSchedule": "@daily",
+      "onlineSchedule": "@daily"
+    },
+    "name": "azure.item_event_join.canary_streaming_v1__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/azure/item_event_join.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "rowIds": [
+    "user_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/azure/training_set.v1_dev__0
+++ b/python/test/canary/canary_compiled/joins/azure/training_set.v1_dev__0
@@ -1,0 +1,193 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 6,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {
+              "k": "10"
+            },
+            "inputColumn": "purchase_price",
+            "operation": 13
+          }
+        ],
+        "keyColumns": [
+          "user_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "purchase_price_average_1d": "3ee572f0e355659fc086d52ec43333f6",
+            "purchase_price_average_3d": "3ee572f0e355659fc086d52ec43333f6",
+            "purchase_price_average_7d": "3ee572f0e355659fc086d52ec43333f6",
+            "purchase_price_count_1d": "3ee572f0e355659fc086d52ec43333f6",
+            "purchase_price_count_3d": "3ee572f0e355659fc086d52ec43333f6",
+            "purchase_price_count_7d": "3ee572f0e355659fc086d52ec43333f6",
+            "purchase_price_last10": "3ee572f0e355659fc086d52ec43333f6",
+            "purchase_price_sum_1d": "3ee572f0e355659fc086d52ec43333f6",
+            "purchase_price_sum_3d": "3ee572f0e355659fc086d52ec43333f6",
+            "purchase_price_sum_7d": "3ee572f0e355659fc086d52ec43333f6",
+            "user_id": "e0009a36a0838b4549d689008bac5afd"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "conf": {
+              "common": {
+                "spark.chronon.partition.column": "ds"
+              }
+            },
+            "env": {
+              "common": {
+                "CUSTOMER_ID": "dev",
+                "FRONTEND_URL": "http://localhost:3000",
+                "HUB_URL": "http://localhost:3903",
+                "VERSION": "latest"
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "azure.purchases.v1_dev__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "azure",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "selects": {
+                  "purchase_price": "purchase_price",
+                  "user_id": "user_id"
+                },
+                "startPartition": "2023-11-01",
+                "timeColumn": "ts"
+              },
+              "table": "data.purchases"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "ts": "ts",
+          "user_id": "user_id"
+        },
+        "timeColumn": "ts"
+      },
+      "table": "data.checkouts"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "ts": "a173b2adccfe3c386f262c4cd7ffe9bd",
+      "user_id": "a673c80ffc3260ee5ca173869ba07f7c",
+      "user_id_purchase_price_average_1d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_average_3d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_average_7d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_count_1d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_count_3d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_count_7d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_last10": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_sum_1d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_sum_3d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_sum_7d": "e3351cc3265d17cfd1b99f8da7fb083d"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_checkouts_with_offset_0\", \"spec\": \"data.checkouts/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "offlineSchedule": "@daily"
+    },
+    "name": "azure.training_set.v1_dev__0",
+    "online": 0,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/azure/training_set.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "rowIds": [
+    "user_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/azure/training_set.v1_dev_notds__0
+++ b/python/test/canary/canary_compiled/joins/azure/training_set.v1_dev_notds__0
@@ -1,0 +1,195 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 6,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {
+              "k": "10"
+            },
+            "inputColumn": "purchase_price",
+            "operation": 13
+          }
+        ],
+        "keyColumns": [
+          "user_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "purchase_price_average_1d": "7a943d6f94aa1c892adff82c36cc0d8a",
+            "purchase_price_average_3d": "7a943d6f94aa1c892adff82c36cc0d8a",
+            "purchase_price_average_7d": "7a943d6f94aa1c892adff82c36cc0d8a",
+            "purchase_price_count_1d": "7a943d6f94aa1c892adff82c36cc0d8a",
+            "purchase_price_count_3d": "7a943d6f94aa1c892adff82c36cc0d8a",
+            "purchase_price_count_7d": "7a943d6f94aa1c892adff82c36cc0d8a",
+            "purchase_price_last10": "7a943d6f94aa1c892adff82c36cc0d8a",
+            "purchase_price_sum_1d": "7a943d6f94aa1c892adff82c36cc0d8a",
+            "purchase_price_sum_3d": "7a943d6f94aa1c892adff82c36cc0d8a",
+            "purchase_price_sum_7d": "7a943d6f94aa1c892adff82c36cc0d8a",
+            "user_id": "5039d7bfb147f14cea3f30f7379e9d6f"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "conf": {
+              "common": {
+                "spark.chronon.partition.column": "ds"
+              }
+            },
+            "env": {
+              "common": {
+                "CUSTOMER_ID": "dev",
+                "FRONTEND_URL": "http://localhost:3000",
+                "HUB_URL": "http://localhost:3903",
+                "VERSION": "latest"
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "azure.purchases.v1_dev_notds__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "azure",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "partitionColumn": "notds",
+                "selects": {
+                  "purchase_price": "purchase_price",
+                  "user_id": "user_id"
+                },
+                "startPartition": "2023-11-01",
+                "timeColumn": "ts"
+              },
+              "table": "data.purchases_notds"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "partitionColumn": "notds",
+        "selects": {
+          "ts": "ts",
+          "user_id": "user_id"
+        },
+        "timeColumn": "ts"
+      },
+      "table": "data.checkouts_notds"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "ts": "c4364195d7639fb8b71e2f87ee017d4d",
+      "user_id": "fbc25deb4a5dd5d9c1d6e960c3922d0e",
+      "user_id_purchase_price_average_1d": "1d85a493771d48ac9fb6581c18f186e2",
+      "user_id_purchase_price_average_3d": "1d85a493771d48ac9fb6581c18f186e2",
+      "user_id_purchase_price_average_7d": "1d85a493771d48ac9fb6581c18f186e2",
+      "user_id_purchase_price_count_1d": "1d85a493771d48ac9fb6581c18f186e2",
+      "user_id_purchase_price_count_3d": "1d85a493771d48ac9fb6581c18f186e2",
+      "user_id_purchase_price_count_7d": "1d85a493771d48ac9fb6581c18f186e2",
+      "user_id_purchase_price_last10": "1d85a493771d48ac9fb6581c18f186e2",
+      "user_id_purchase_price_sum_1d": "1d85a493771d48ac9fb6581c18f186e2",
+      "user_id_purchase_price_sum_3d": "1d85a493771d48ac9fb6581c18f186e2",
+      "user_id_purchase_price_sum_7d": "1d85a493771d48ac9fb6581c18f186e2"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_checkouts_notds_with_offset_0\", \"spec\": \"data.checkouts_notds/notds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_purchases_notds_with_offset_0\", \"spec\": \"data.purchases_notds/notds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "offlineSchedule": "@daily"
+    },
+    "name": "azure.training_set.v1_dev_notds__0",
+    "online": 0,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/azure/training_set.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "rowIds": [
+    "user_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/azure/training_set.v1_hub__0
+++ b/python/test/canary/canary_compiled/joins/azure/training_set.v1_hub__0
@@ -1,0 +1,193 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 6,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {
+              "k": "10"
+            },
+            "inputColumn": "purchase_price",
+            "operation": 13
+          }
+        ],
+        "keyColumns": [
+          "user_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "purchase_price_average_1d": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "purchase_price_average_3d": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "purchase_price_average_7d": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "purchase_price_count_1d": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "purchase_price_count_3d": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "purchase_price_count_7d": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "purchase_price_last10": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "purchase_price_sum_1d": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "purchase_price_sum_3d": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "purchase_price_sum_7d": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "user_id": "2a2caca3ea4afb84a2271533b1a1bae1"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "conf": {
+              "common": {
+                "spark.chronon.partition.column": "ds"
+              }
+            },
+            "env": {
+              "common": {
+                "CUSTOMER_ID": "dev",
+                "FRONTEND_URL": "http://localhost:3000",
+                "HUB_URL": "http://localhost:3903",
+                "VERSION": "latest"
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "azure.purchases.v1_test__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "azure",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "selects": {
+                  "purchase_price": "purchase_price",
+                  "user_id": "user_id"
+                },
+                "startPartition": "2023-11-01",
+                "timeColumn": "ts"
+              },
+              "table": "data.purchases"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "ts": "ts",
+          "user_id": "user_id"
+        },
+        "timeColumn": "ts"
+      },
+      "table": "data.checkouts"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "ts": "a173b2adccfe3c386f262c4cd7ffe9bd",
+      "user_id": "a673c80ffc3260ee5ca173869ba07f7c",
+      "user_id_purchase_price_average_1d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_average_3d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_average_7d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_count_1d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_count_3d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_count_7d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_last10": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_sum_1d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_sum_3d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_sum_7d": "e3351cc3265d17cfd1b99f8da7fb083d"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_checkouts_with_offset_0\", \"spec\": \"data.checkouts/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "offlineSchedule": "@daily"
+    },
+    "name": "azure.training_set.v1_hub__0",
+    "online": 0,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/azure/training_set.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "rowIds": [
+    "user_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/azure/training_set.v1_test__0
+++ b/python/test/canary/canary_compiled/joins/azure/training_set.v1_test__0
@@ -1,0 +1,193 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 6,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {
+              "k": "10"
+            },
+            "inputColumn": "purchase_price",
+            "operation": 13
+          }
+        ],
+        "keyColumns": [
+          "user_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "purchase_price_average_1d": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "purchase_price_average_3d": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "purchase_price_average_7d": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "purchase_price_count_1d": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "purchase_price_count_3d": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "purchase_price_count_7d": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "purchase_price_last10": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "purchase_price_sum_1d": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "purchase_price_sum_3d": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "purchase_price_sum_7d": "cb0c629ccfbaf136f5a337da31f8ba98",
+            "user_id": "2a2caca3ea4afb84a2271533b1a1bae1"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "conf": {
+              "common": {
+                "spark.chronon.partition.column": "ds"
+              }
+            },
+            "env": {
+              "common": {
+                "CUSTOMER_ID": "dev",
+                "FRONTEND_URL": "http://localhost:3000",
+                "HUB_URL": "http://localhost:3903",
+                "VERSION": "latest"
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "azure.purchases.v1_test__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "azure",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "selects": {
+                  "purchase_price": "purchase_price",
+                  "user_id": "user_id"
+                },
+                "startPartition": "2023-11-01",
+                "timeColumn": "ts"
+              },
+              "table": "data.purchases"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "ts": "ts",
+          "user_id": "user_id"
+        },
+        "timeColumn": "ts"
+      },
+      "table": "data.checkouts"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "ts": "a173b2adccfe3c386f262c4cd7ffe9bd",
+      "user_id": "a673c80ffc3260ee5ca173869ba07f7c",
+      "user_id_purchase_price_average_1d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_average_3d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_average_7d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_count_1d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_count_3d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_count_7d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_last10": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_sum_1d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_sum_3d": "e3351cc3265d17cfd1b99f8da7fb083d",
+      "user_id_purchase_price_sum_7d": "e3351cc3265d17cfd1b99f8da7fb083d"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_checkouts_with_offset_0\", \"spec\": \"data.checkouts/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "offlineSchedule": "@daily"
+    },
+    "name": "azure.training_set.v1_test__0",
+    "online": 0,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/azure/training_set.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "rowIds": [
+    "user_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/azure/training_set.v1_test_notds__0
+++ b/python/test/canary/canary_compiled/joins/azure/training_set.v1_test_notds__0
@@ -1,0 +1,195 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 6,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {
+              "k": "10"
+            },
+            "inputColumn": "purchase_price",
+            "operation": 13
+          }
+        ],
+        "keyColumns": [
+          "user_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "purchase_price_average_1d": "3b0e94ffc1c3612c36f18fc42bd080e9",
+            "purchase_price_average_3d": "3b0e94ffc1c3612c36f18fc42bd080e9",
+            "purchase_price_average_7d": "3b0e94ffc1c3612c36f18fc42bd080e9",
+            "purchase_price_count_1d": "3b0e94ffc1c3612c36f18fc42bd080e9",
+            "purchase_price_count_3d": "3b0e94ffc1c3612c36f18fc42bd080e9",
+            "purchase_price_count_7d": "3b0e94ffc1c3612c36f18fc42bd080e9",
+            "purchase_price_last10": "3b0e94ffc1c3612c36f18fc42bd080e9",
+            "purchase_price_sum_1d": "3b0e94ffc1c3612c36f18fc42bd080e9",
+            "purchase_price_sum_3d": "3b0e94ffc1c3612c36f18fc42bd080e9",
+            "purchase_price_sum_7d": "3b0e94ffc1c3612c36f18fc42bd080e9",
+            "user_id": "81dd6ad753af4f7bb8411902a7e9b861"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "conf": {
+              "common": {
+                "spark.chronon.partition.column": "ds"
+              }
+            },
+            "env": {
+              "common": {
+                "CUSTOMER_ID": "dev",
+                "FRONTEND_URL": "http://localhost:3000",
+                "HUB_URL": "http://localhost:3903",
+                "VERSION": "latest"
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "azure.purchases.v1_test_notds__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "azure",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "partitionColumn": "notds",
+                "selects": {
+                  "purchase_price": "purchase_price",
+                  "user_id": "user_id"
+                },
+                "startPartition": "2023-11-01",
+                "timeColumn": "ts"
+              },
+              "table": "data.purchases_notds"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "partitionColumn": "notds",
+        "selects": {
+          "ts": "ts",
+          "user_id": "user_id"
+        },
+        "timeColumn": "ts"
+      },
+      "table": "data.checkouts_notds"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "ts": "c4364195d7639fb8b71e2f87ee017d4d",
+      "user_id": "fbc25deb4a5dd5d9c1d6e960c3922d0e",
+      "user_id_purchase_price_average_1d": "1d85a493771d48ac9fb6581c18f186e2",
+      "user_id_purchase_price_average_3d": "1d85a493771d48ac9fb6581c18f186e2",
+      "user_id_purchase_price_average_7d": "1d85a493771d48ac9fb6581c18f186e2",
+      "user_id_purchase_price_count_1d": "1d85a493771d48ac9fb6581c18f186e2",
+      "user_id_purchase_price_count_3d": "1d85a493771d48ac9fb6581c18f186e2",
+      "user_id_purchase_price_count_7d": "1d85a493771d48ac9fb6581c18f186e2",
+      "user_id_purchase_price_last10": "1d85a493771d48ac9fb6581c18f186e2",
+      "user_id_purchase_price_sum_1d": "1d85a493771d48ac9fb6581c18f186e2",
+      "user_id_purchase_price_sum_3d": "1d85a493771d48ac9fb6581c18f186e2",
+      "user_id_purchase_price_sum_7d": "1d85a493771d48ac9fb6581c18f186e2"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_checkouts_notds_with_offset_0\", \"spec\": \"data.checkouts_notds/notds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_purchases_notds_with_offset_0\", \"spec\": \"data.purchases_notds/notds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "offlineSchedule": "@daily"
+    },
+    "name": "azure.training_set.v1_test_notds__0",
+    "online": 0,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/azure/training_set.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "rowIds": [
+    "user_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/gcp/demo.derivations_v1__2
+++ b/python/test/canary/canary_compiled/joins/gcp/demo.derivations_v1__2
@@ -1,0 +1,861 @@
+{
+  "derivations": [
+    {
+      "expression": "IF(listing_id_weight_grams > 1000, 1, 0)",
+      "name": "is_listing_heavy"
+    },
+    {
+      "expression": "array_contains(split(listing_id_tags, ','), 'handmade')",
+      "name": "is_item_handmade"
+    },
+    {
+      "expression": "log1p(listing_id_price_cents)",
+      "name": "price_log"
+    },
+    {
+      "expression": "\n                CASE\n                    WHEN listing_id_price_cents < 1000 THEN 0\n                    WHEN listing_id_price_cents < 5000 THEN 1\n                    WHEN listing_id_price_cents < 10000 THEN 2\n                    WHEN listing_id_price_cents < 50000 THEN 3\n                    ELSE 4\n                END\n            ",
+      "name": "price_bucket"
+    },
+    {
+      "expression": "*",
+      "name": "*"
+    }
+  ],
+  "joinParts": [
+    {
+      "groupBy": {
+        "keyColumns": [
+          "listing_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "brief_description": "85c0544e6f2d058e93e6d54956e118e4",
+            "currency": "ff795c264858b08c00d9159c8e4761d5",
+            "headline": "46fb87fe34c8251a81870c83853e15c6",
+            "inventory_count": "10910897373885c1b0fc1420e7a52562",
+            "is_active": "0fe881820ff26668c32d68dc3382a7ff",
+            "is_expensive": "4d6678c92b2194fd9b7e6bfa85366fe5",
+            "is_in_stock": "0cd5441df3d278d3b7a060e4bd23a324",
+            "listing_id": "6ed4569be71307367d24e5fe77626334",
+            "long_description": "51bbdbd4269ccb2d382f835dcfc2eed3",
+            "main_image_path": "a5ab50facb20e01a0d93a4ed0eac1a9d",
+            "merchant_id": "60a2c0a6662b1bdb97061e9b9566e451",
+            "price_cents": "058f7df64e0544d392a31bb6dc08209f",
+            "primary_category": "62f56fda8558ec54a85da33a3934c182",
+            "secondary_image_paths": "e8ec969f13b6db533bca510f235fd069",
+            "tags": "589de0914f9ffabf8c80a0fe10eaa866",
+            "weight_grams": "041362c5ebf87a340a139e6b53034b7c"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "clusterConf": {
+              "modeClusterConfigs": {
+                "upload": {
+                  "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                }
+              }
+            },
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+                "spark.driver.memory": "512m",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "512m",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+                "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+                "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.shuffle.partitions": "10"
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                "CLOUD_PROVIDER": "gcp",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_PUBSUB": "true",
+                "EVAL_URL": "http://localhost:3904",
+                "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "http://localhost:3000",
+                "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                "GCP_PROJECT_ID": "canary-443022",
+                "GCP_REGION": "us-central1",
+                "HUB_URL": "http://localhost:3903",
+                "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+              },
+              "modeEnvironments": {
+                "upload": {
+                  "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                  "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                  "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                  "CLOUD_PROVIDER": "gcp",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_PUBSUB": "true",
+                  "EVAL_URL": "http://localhost:3904",
+                  "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "http://localhost:3000",
+                  "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                  "GCP_PROJECT_ID": "canary-443022",
+                  "GCP_REGION": "us-central1",
+                  "HUB_URL": "http://localhost:3903",
+                  "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                }
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "gcp.dim_listings.v1__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "gcp",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "entities": {
+              "query": {
+                "selects": {
+                  "brief_description": "brief_description",
+                  "currency": "currency",
+                  "headline": "headline",
+                  "inventory_count": "inventory_count",
+                  "is_active": "is_active",
+                  "is_expensive": "IF(price_cents > 10000, 1, 0)",
+                  "is_in_stock": "IF(inventory_count > 0, 1, 0)",
+                  "listing_id": "listing_id",
+                  "long_description": "long_description",
+                  "main_image_path": "main_image_path",
+                  "merchant_id": "merchant_id",
+                  "price_cents": "price_cents",
+                  "primary_category": "primary_category",
+                  "secondary_image_paths": "secondary_image_paths",
+                  "tags": "tags",
+                  "weight_grams": "weight_grams"
+                },
+                "startPartition": "2025-01-01"
+              },
+              "snapshotTable": "data.gcp_exports_dim_listings__0"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    },
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "view_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "click_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "favorite_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "add_to_cart_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "view_event",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "click_event",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_event",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "favorite_event",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "add_to_cart_event",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "is_mobile",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "is_desktop",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "is_tablet",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {
+              "k": "128"
+            },
+            "inputColumn": "user_event_struct",
+            "operation": 13,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          }
+        ],
+        "keyColumns": [
+          "user_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "add_to_cart_event_average_14d": "ac7d8c6d6a4d0ddd7fdbab6517207fa0",
+            "add_to_cart_event_average_1d": "ac7d8c6d6a4d0ddd7fdbab6517207fa0",
+            "add_to_cart_event_average_30d": "ac7d8c6d6a4d0ddd7fdbab6517207fa0",
+            "add_to_cart_event_average_7d": "ac7d8c6d6a4d0ddd7fdbab6517207fa0",
+            "add_to_cart_event_sum_14d": "ac7d8c6d6a4d0ddd7fdbab6517207fa0",
+            "add_to_cart_event_sum_1d": "ac7d8c6d6a4d0ddd7fdbab6517207fa0",
+            "add_to_cart_event_sum_30d": "ac7d8c6d6a4d0ddd7fdbab6517207fa0",
+            "add_to_cart_event_sum_7d": "ac7d8c6d6a4d0ddd7fdbab6517207fa0",
+            "click_event_average_14d": "1d544b33eebdfc17a3a5afe87b81eb53",
+            "click_event_average_1d": "1d544b33eebdfc17a3a5afe87b81eb53",
+            "click_event_average_30d": "1d544b33eebdfc17a3a5afe87b81eb53",
+            "click_event_average_7d": "1d544b33eebdfc17a3a5afe87b81eb53",
+            "click_event_sum_14d": "1d544b33eebdfc17a3a5afe87b81eb53",
+            "click_event_sum_1d": "1d544b33eebdfc17a3a5afe87b81eb53",
+            "click_event_sum_30d": "1d544b33eebdfc17a3a5afe87b81eb53",
+            "click_event_sum_7d": "1d544b33eebdfc17a3a5afe87b81eb53",
+            "favorite_event_average_14d": "9236810c6ed256e2ce111114fcdf2468",
+            "favorite_event_average_1d": "9236810c6ed256e2ce111114fcdf2468",
+            "favorite_event_average_30d": "9236810c6ed256e2ce111114fcdf2468",
+            "favorite_event_average_7d": "9236810c6ed256e2ce111114fcdf2468",
+            "favorite_event_sum_14d": "9236810c6ed256e2ce111114fcdf2468",
+            "favorite_event_sum_1d": "9236810c6ed256e2ce111114fcdf2468",
+            "favorite_event_sum_30d": "9236810c6ed256e2ce111114fcdf2468",
+            "favorite_event_sum_7d": "9236810c6ed256e2ce111114fcdf2468",
+            "is_desktop_sum_14d": "751be38cbc62b37986a93da55ea3bb53",
+            "is_desktop_sum_1d": "751be38cbc62b37986a93da55ea3bb53",
+            "is_desktop_sum_30d": "751be38cbc62b37986a93da55ea3bb53",
+            "is_desktop_sum_7d": "751be38cbc62b37986a93da55ea3bb53",
+            "is_mobile_sum_14d": "736a00d8d3e5cc6458f666ceb2840ddf",
+            "is_mobile_sum_1d": "736a00d8d3e5cc6458f666ceb2840ddf",
+            "is_mobile_sum_30d": "736a00d8d3e5cc6458f666ceb2840ddf",
+            "is_mobile_sum_7d": "736a00d8d3e5cc6458f666ceb2840ddf",
+            "is_tablet_sum_14d": "c9f1e7cc6f8dee7506aa0d04fab1fe02",
+            "is_tablet_sum_1d": "c9f1e7cc6f8dee7506aa0d04fab1fe02",
+            "is_tablet_sum_30d": "c9f1e7cc6f8dee7506aa0d04fab1fe02",
+            "is_tablet_sum_7d": "c9f1e7cc6f8dee7506aa0d04fab1fe02",
+            "purchase_event_average_14d": "903c18bce150f38415fb70a46f0eaba5",
+            "purchase_event_average_1d": "903c18bce150f38415fb70a46f0eaba5",
+            "purchase_event_average_30d": "903c18bce150f38415fb70a46f0eaba5",
+            "purchase_event_average_7d": "903c18bce150f38415fb70a46f0eaba5",
+            "purchase_event_sum_14d": "903c18bce150f38415fb70a46f0eaba5",
+            "purchase_event_sum_1d": "903c18bce150f38415fb70a46f0eaba5",
+            "purchase_event_sum_30d": "903c18bce150f38415fb70a46f0eaba5",
+            "purchase_event_sum_7d": "903c18bce150f38415fb70a46f0eaba5",
+            "user_event_struct_last128_14d": "9615edd561708d3aa83e1efae33be4a0",
+            "user_event_struct_last128_1d": "9615edd561708d3aa83e1efae33be4a0",
+            "user_event_struct_last128_30d": "9615edd561708d3aa83e1efae33be4a0",
+            "user_event_struct_last128_7d": "9615edd561708d3aa83e1efae33be4a0",
+            "user_id": "006bbceaf919145938ec06d702ad51b9",
+            "view_event_average_14d": "f597dd2f8e5d672fbac0445fb935469b",
+            "view_event_average_1d": "f597dd2f8e5d672fbac0445fb935469b",
+            "view_event_average_30d": "f597dd2f8e5d672fbac0445fb935469b",
+            "view_event_average_7d": "f597dd2f8e5d672fbac0445fb935469b",
+            "view_event_sum_14d": "f597dd2f8e5d672fbac0445fb935469b",
+            "view_event_sum_1d": "f597dd2f8e5d672fbac0445fb935469b",
+            "view_event_sum_30d": "f597dd2f8e5d672fbac0445fb935469b",
+            "view_event_sum_7d": "f597dd2f8e5d672fbac0445fb935469b"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "clusterConf": {
+              "modeClusterConfigs": {
+                "upload": {
+                  "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                }
+              }
+            },
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+                "spark.driver.memory": "512m",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "512m",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+                "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+                "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.shuffle.partitions": "10"
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+                "CLOUD_PROVIDER": "gcp",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_PUBSUB": "true",
+                "EVAL_URL": "http://localhost:3904",
+                "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "http://localhost:3000",
+                "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                "GCP_PROJECT_ID": "canary-443022",
+                "GCP_REGION": "us-central1",
+                "HUB_URL": "http://localhost:3903",
+                "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+              },
+              "modeEnvironments": {
+                "upload": {
+                  "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                  "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                  "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+                  "CLOUD_PROVIDER": "gcp",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_PUBSUB": "true",
+                  "EVAL_URL": "http://localhost:3904",
+                  "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "http://localhost:3000",
+                  "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                  "GCP_PROJECT_ID": "canary-443022",
+                  "GCP_REGION": "us-central1",
+                  "HUB_URL": "http://localhost:3903",
+                  "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                }
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily",
+            "stepDays": 30
+          },
+          "name": "gcp.user_activities.v1__1",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "gcp",
+          "version": "1"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "selects": {
+                  "add_to_cart_event": "IF(event_type = 'add_to_cart', 1, 0)",
+                  "click_event": "IF(event_type = 'click', 1, 0)",
+                  "favorite_event": "IF(event_type = 'favorite', 1, 0)",
+                  "is_desktop": "IF(device_type = 'desktop', 1, 0)",
+                  "is_mobile": "IF(device_type = 'mobile', 1, 0)",
+                  "is_tablet": "IF(device_type = 'tablet', 1, 0)",
+                  "listing_id": "listing_id",
+                  "purchase_event": "IF(event_type = 'purchase', 1, 0)",
+                  "user_event_struct": "STRUCT(event_type, listing_id, unix_millis(TIMESTAMP(event_time_ms)) as timestamp)",
+                  "user_id": "user_id",
+                  "view_event": "IF(event_type = 'view', 1, 0)"
+                },
+                "timeColumn": "unix_millis(TIMESTAMP(event_time_ms))"
+              },
+              "table": "data.gcp_exports_user_activities__0",
+              "topic": "pubsub://user-activities-v2/project=canary-443022/subscription=user-activities-v2-sub/serde=pubsub_schema/schemaId=user-activities"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "listing_id": "listing_id",
+          "row_id": "event_id",
+          "ts": "event_time_ms",
+          "user_id": "user_id"
+        },
+        "timeColumn": "event_time_ms"
+      },
+      "table": "data.gcp_exports_user_activities__0"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "is_item_handmade": "7bbca2d1a43ed4c78bbfc9d3caff41d3",
+      "is_listing_heavy": "a7c7bd6eca54141ba20219c5f53d8dbf",
+      "listing_id": "47aa3759ce41fc6ccf91367592e35f6d",
+      "listing_id_brief_description": "7d445defa77854b8d6ae94ae180f195f",
+      "listing_id_currency": "a7d9bc3b7f1787df899659e6f0e56679",
+      "listing_id_headline": "4ed73e13e0c394e445c4906b63d01b8a",
+      "listing_id_inventory_count": "b68673a19b32f38f45874dc0078e0f7a",
+      "listing_id_is_active": "616642f4d27a8e00d7250f7f91cb1646",
+      "listing_id_is_expensive": "38ee87f5b11a42d891ec52616a2d7b52",
+      "listing_id_is_in_stock": "6c5685ed65e91bcb3fe9ce2cb53ddbcd",
+      "listing_id_listing_id": "15395806521d79e682aa3274a46c5104",
+      "listing_id_long_description": "e3fda2158f5d126aef5ebbfdfc848174",
+      "listing_id_main_image_path": "ce9bc184baf01f9c7818e88e25b446d0",
+      "listing_id_merchant_id": "69baf448f70fdb4997071c81e8474a34",
+      "listing_id_price_cents": "905a32e196759066f782c617b83c2cbf",
+      "listing_id_primary_category": "0bd33fd7f627e669247b61302962627c",
+      "listing_id_secondary_image_paths": "1001bcbe2b97f447bb20a64c6d8ab297",
+      "listing_id_tags": "b4a3e64fad103c2caf6fcadb2e68f1dd",
+      "listing_id_weight_grams": "7d01ad6aa1db30922ff461f2d0d62ee7",
+      "price_bucket": "8342f36b22cd801272e29110432dc4d5",
+      "price_log": "947a4c1a7b445b6fb8a3e0c7c4e1aa39",
+      "row_id": "596506e0a4fef5508ebdcda7e6eb1072",
+      "ts": "d1ae44a8f84a262685dbf1bdb9f8d46e",
+      "user_id": "80c458b68b34de93d3c4c555ef2b2ddc",
+      "user_id_add_to_cart_event_average_14d": "9a69a159117eb15389ce17f93363a8cb",
+      "user_id_add_to_cart_event_average_1d": "9a69a159117eb15389ce17f93363a8cb",
+      "user_id_add_to_cart_event_average_30d": "9a69a159117eb15389ce17f93363a8cb",
+      "user_id_add_to_cart_event_average_7d": "9a69a159117eb15389ce17f93363a8cb",
+      "user_id_add_to_cart_event_sum_14d": "9a69a159117eb15389ce17f93363a8cb",
+      "user_id_add_to_cart_event_sum_1d": "9a69a159117eb15389ce17f93363a8cb",
+      "user_id_add_to_cart_event_sum_30d": "9a69a159117eb15389ce17f93363a8cb",
+      "user_id_add_to_cart_event_sum_7d": "9a69a159117eb15389ce17f93363a8cb",
+      "user_id_click_event_average_14d": "6d5df9cd495943195fd26343e889a08b",
+      "user_id_click_event_average_1d": "6d5df9cd495943195fd26343e889a08b",
+      "user_id_click_event_average_30d": "6d5df9cd495943195fd26343e889a08b",
+      "user_id_click_event_average_7d": "6d5df9cd495943195fd26343e889a08b",
+      "user_id_click_event_sum_14d": "6d5df9cd495943195fd26343e889a08b",
+      "user_id_click_event_sum_1d": "6d5df9cd495943195fd26343e889a08b",
+      "user_id_click_event_sum_30d": "6d5df9cd495943195fd26343e889a08b",
+      "user_id_click_event_sum_7d": "6d5df9cd495943195fd26343e889a08b",
+      "user_id_favorite_event_average_14d": "41973df600d5d46659f60ac0c808f438",
+      "user_id_favorite_event_average_1d": "41973df600d5d46659f60ac0c808f438",
+      "user_id_favorite_event_average_30d": "41973df600d5d46659f60ac0c808f438",
+      "user_id_favorite_event_average_7d": "41973df600d5d46659f60ac0c808f438",
+      "user_id_favorite_event_sum_14d": "41973df600d5d46659f60ac0c808f438",
+      "user_id_favorite_event_sum_1d": "41973df600d5d46659f60ac0c808f438",
+      "user_id_favorite_event_sum_30d": "41973df600d5d46659f60ac0c808f438",
+      "user_id_favorite_event_sum_7d": "41973df600d5d46659f60ac0c808f438",
+      "user_id_is_desktop_sum_14d": "248157ff361a5b1aee3aab6d459e2315",
+      "user_id_is_desktop_sum_1d": "248157ff361a5b1aee3aab6d459e2315",
+      "user_id_is_desktop_sum_30d": "248157ff361a5b1aee3aab6d459e2315",
+      "user_id_is_desktop_sum_7d": "248157ff361a5b1aee3aab6d459e2315",
+      "user_id_is_mobile_sum_14d": "29bd4cafff87531f073912d981f5df7b",
+      "user_id_is_mobile_sum_1d": "29bd4cafff87531f073912d981f5df7b",
+      "user_id_is_mobile_sum_30d": "29bd4cafff87531f073912d981f5df7b",
+      "user_id_is_mobile_sum_7d": "29bd4cafff87531f073912d981f5df7b",
+      "user_id_is_tablet_sum_14d": "4e93d18e08e8e6d0f51cc4fd54840a4c",
+      "user_id_is_tablet_sum_1d": "4e93d18e08e8e6d0f51cc4fd54840a4c",
+      "user_id_is_tablet_sum_30d": "4e93d18e08e8e6d0f51cc4fd54840a4c",
+      "user_id_is_tablet_sum_7d": "4e93d18e08e8e6d0f51cc4fd54840a4c",
+      "user_id_purchase_event_average_14d": "06b4654ea4a2b6fce7f1e5d0ecbab540",
+      "user_id_purchase_event_average_1d": "06b4654ea4a2b6fce7f1e5d0ecbab540",
+      "user_id_purchase_event_average_30d": "06b4654ea4a2b6fce7f1e5d0ecbab540",
+      "user_id_purchase_event_average_7d": "06b4654ea4a2b6fce7f1e5d0ecbab540",
+      "user_id_purchase_event_sum_14d": "06b4654ea4a2b6fce7f1e5d0ecbab540",
+      "user_id_purchase_event_sum_1d": "06b4654ea4a2b6fce7f1e5d0ecbab540",
+      "user_id_purchase_event_sum_30d": "06b4654ea4a2b6fce7f1e5d0ecbab540",
+      "user_id_purchase_event_sum_7d": "06b4654ea4a2b6fce7f1e5d0ecbab540",
+      "user_id_user_event_struct_last128_14d": "d3568d09600aa635e00f5bbe12ed46f4",
+      "user_id_user_event_struct_last128_1d": "d3568d09600aa635e00f5bbe12ed46f4",
+      "user_id_user_event_struct_last128_30d": "d3568d09600aa635e00f5bbe12ed46f4",
+      "user_id_user_event_struct_last128_7d": "d3568d09600aa635e00f5bbe12ed46f4",
+      "user_id_view_event_average_14d": "bcc46a7a6a6ee73aa8bebbcaaf039347",
+      "user_id_view_event_average_1d": "bcc46a7a6a6ee73aa8bebbcaaf039347",
+      "user_id_view_event_average_30d": "bcc46a7a6a6ee73aa8bebbcaaf039347",
+      "user_id_view_event_average_7d": "bcc46a7a6a6ee73aa8bebbcaaf039347",
+      "user_id_view_event_sum_14d": "bcc46a7a6a6ee73aa8bebbcaaf039347",
+      "user_id_view_event_sum_1d": "bcc46a7a6a6ee73aa8bebbcaaf039347",
+      "user_id_view_event_sum_30d": "bcc46a7a6a6ee73aa8bebbcaaf039347",
+      "user_id_view_event_sum_7d": "bcc46a7a6a6ee73aa8bebbcaaf039347"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_exports_user_activities__0_with_offset_0\", \"spec\": \"data.gcp_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_gcp_exports_dim_listings__0_with_offset_0\", \"spec\": \"data.gcp_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "0 4 * * *",
+      "onlineSchedule": "0 3 * * *",
+      "stepDays": 30
+    },
+    "name": "gcp.demo.derivations_v1__2",
+    "online": 1,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/gcp/demo.py",
+    "team": "gcp",
+    "version": "2"
+  },
+  "rowIds": [
+    "event_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/gcp/demo.mutation_test__1
+++ b/python/test/canary/canary_compiled/joins/gcp/demo.mutation_test__1
@@ -1,0 +1,353 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "accuracy": 0,
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "merchant_id",
+            "operation": 3
+          },
+          {
+            "argMap": {},
+            "inputColumn": "headline",
+            "operation": 3
+          },
+          {
+            "argMap": {},
+            "inputColumn": "brief_description",
+            "operation": 3
+          },
+          {
+            "argMap": {},
+            "inputColumn": "long_description",
+            "operation": 3
+          },
+          {
+            "argMap": {},
+            "inputColumn": "price_cents",
+            "operation": 3
+          },
+          {
+            "argMap": {},
+            "inputColumn": "currency",
+            "operation": 3
+          },
+          {
+            "argMap": {},
+            "inputColumn": "inventory_count",
+            "operation": 3
+          },
+          {
+            "argMap": {},
+            "inputColumn": "primary_category",
+            "operation": 3
+          },
+          {
+            "argMap": {},
+            "inputColumn": "is_active",
+            "operation": 3
+          },
+          {
+            "argMap": {},
+            "inputColumn": "weight_grams",
+            "operation": 3
+          },
+          {
+            "argMap": {},
+            "inputColumn": "tags",
+            "operation": 3
+          },
+          {
+            "argMap": {},
+            "inputColumn": "is_expensive",
+            "operation": 3
+          },
+          {
+            "argMap": {},
+            "inputColumn": "is_in_stock",
+            "operation": 3
+          },
+          {
+            "argMap": {},
+            "inputColumn": "main_image_path",
+            "operation": 3
+          },
+          {
+            "argMap": {},
+            "inputColumn": "secondary_image_paths",
+            "operation": 3
+          }
+        ],
+        "keyColumns": [
+          "listing_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "brief_description_last": "0a1386de070d704b0d2c5d1c87fe519a",
+            "currency_last": "5121fca8b3fe87a914b5ee279b648e95",
+            "headline_last": "45ea540639c06959f17b71c3e554175a",
+            "inventory_count_last": "da8c9a07f97c968c72d2073a8d0f67c8",
+            "is_active_last": "1fec57d936cc463617bac897e12be096",
+            "is_expensive_last": "805f3d530ac6f8e7623c21a73a1f18b6",
+            "is_in_stock_last": "0c23362ef6a4871d3324889b1549563d",
+            "listing_id": "886183f17e4eac643e2068a1ff1c9e13",
+            "long_description_last": "3cc8017f1420a64fd7b2254dae7f1e75",
+            "main_image_path_last": "af1e43d33658f520fd74c426eb9aaf8c",
+            "merchant_id_last": "c1dd7d3842c0b00e1f65fa7bf15c11aa",
+            "price_cents_last": "97455a3821b0ffbf3ec0e5567426673c",
+            "primary_category_last": "7d771f16ef459f9b442390ce6e4941fe",
+            "secondary_image_paths_last": "815571cc5ddb0b27ad2722957f7c0080",
+            "tags_last": "127ced2578a540a522f3f437101d7726",
+            "weight_grams_last": "5b19e9ed87508482695b4e3606acfa97"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "clusterConf": {
+              "modeClusterConfigs": {
+                "upload": {
+                  "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                }
+              }
+            },
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+                "spark.driver.memory": "512m",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "512m",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+                "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+                "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.shuffle.partitions": "10"
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                "CLOUD_PROVIDER": "gcp",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_PUBSUB": "true",
+                "EVAL_URL": "http://localhost:3904",
+                "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "http://localhost:3000",
+                "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                "GCP_PROJECT_ID": "canary-443022",
+                "GCP_REGION": "us-central1",
+                "HUB_URL": "http://localhost:3903",
+                "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+              },
+              "modeEnvironments": {
+                "upload": {
+                  "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                  "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                  "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                  "CLOUD_PROVIDER": "gcp",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_PUBSUB": "true",
+                  "EVAL_URL": "http://localhost:3904",
+                  "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "http://localhost:3000",
+                  "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                  "GCP_PROJECT_ID": "canary-443022",
+                  "GCP_REGION": "us-central1",
+                  "HUB_URL": "http://localhost:3903",
+                  "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                }
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "gcp.dim_listings_with_mutations.v2__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "gcp",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "entities": {
+              "mutationTable": "data.gcp_exports_dim_listing_mutations__0",
+              "query": {
+                "selects": {
+                  "brief_description": "brief_description",
+                  "currency": "currency",
+                  "headline": "headline",
+                  "inventory_count": "inventory_count",
+                  "is_active": "is_active",
+                  "is_expensive": "IF(price_cents > 10000, 1, 0)",
+                  "is_in_stock": "IF(inventory_count > 0, 1, 0)",
+                  "listing_id": "listing_id",
+                  "long_description": "long_description",
+                  "main_image_path": "main_image_path",
+                  "merchant_id": "merchant_id",
+                  "price_cents": "price_cents",
+                  "primary_category": "primary_category",
+                  "secondary_image_paths": "secondary_image_paths",
+                  "tags": "tags",
+                  "weight_grams": "weight_grams"
+                },
+                "startPartition": "2025-01-01"
+              },
+              "snapshotTable": "data.gcp_exports_dim_listings__0"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "listing_id": "listing_id",
+          "row_id": "event_id",
+          "ts": "event_time_ms",
+          "user_id": "user_id"
+        },
+        "timeColumn": "event_time_ms"
+      },
+      "table": "data.gcp_exports_user_activities__0"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "listing_id": "47aa3759ce41fc6ccf91367592e35f6d",
+      "listing_id_brief_description_last": "0169875656d2de09c49df6445351006a",
+      "listing_id_currency_last": "b6b93c59c83720262d6c2efc45f6d816",
+      "listing_id_headline_last": "94f02b3b99124313f9097253edb0f4ee",
+      "listing_id_inventory_count_last": "2bc1d749d9a976ed9bc392d1ec15ab10",
+      "listing_id_is_active_last": "8e0dea7804d0441e44626d2557ae22ad",
+      "listing_id_is_expensive_last": "cb8ca0dcdf70da5538b571d252daa643",
+      "listing_id_is_in_stock_last": "a060c2ea288a175756920e1326d05266",
+      "listing_id_long_description_last": "d0b56457ff7259d958e7a318ed557776",
+      "listing_id_main_image_path_last": "4f7759442b0f99390cc0de9ee9605614",
+      "listing_id_merchant_id_last": "e879f09eb8f94d0675fdcd3299108fc1",
+      "listing_id_price_cents_last": "fa43d18793086fd6eeccda31695e084b",
+      "listing_id_primary_category_last": "9c9f7cddb5be5f0a2207eb07a28bf54b",
+      "listing_id_secondary_image_paths_last": "3e761b20785b51728d11b7d2ead8eac7",
+      "listing_id_tags_last": "3f0f0c8b2e01a0869be696eac850101e",
+      "listing_id_weight_grams_last": "bcf3a2cb490ef8ac2edce3dffd17983d",
+      "row_id": "596506e0a4fef5508ebdcda7e6eb1072",
+      "ts": "d1ae44a8f84a262685dbf1bdb9f8d46e",
+      "user_id": "80c458b68b34de93d3c4c555ef2b2ddc"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_exports_user_activities__0_with_offset_0\", \"spec\": \"data.gcp_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_gcp_exports_dim_listings__0_with_offset_0\", \"spec\": \"data.gcp_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_gcp_exports_dim_listing_mutations__0_with_offset_0\", \"spec\": \"data.gcp_exports_dim_listing_mutations__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "enableStatsCompute": 1,
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "gcp.demo.mutation_test__1",
+    "online": 0,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/gcp/demo.py",
+    "team": "gcp",
+    "version": "1"
+  },
+  "rowIds": [
+    "event_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/gcp/demo.mutation_test_modular__2
+++ b/python/test/canary/canary_compiled/joins/gcp/demo.mutation_test_modular__2
@@ -1,0 +1,914 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "accuracy": 0,
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "merchant_id",
+            "operation": 3
+          },
+          {
+            "argMap": {},
+            "inputColumn": "headline",
+            "operation": 3
+          },
+          {
+            "argMap": {},
+            "inputColumn": "brief_description",
+            "operation": 3
+          },
+          {
+            "argMap": {},
+            "inputColumn": "long_description",
+            "operation": 3
+          },
+          {
+            "argMap": {},
+            "inputColumn": "price_cents",
+            "operation": 3
+          },
+          {
+            "argMap": {},
+            "inputColumn": "currency",
+            "operation": 3
+          },
+          {
+            "argMap": {},
+            "inputColumn": "inventory_count",
+            "operation": 3
+          },
+          {
+            "argMap": {},
+            "inputColumn": "primary_category",
+            "operation": 3
+          },
+          {
+            "argMap": {},
+            "inputColumn": "is_active",
+            "operation": 3
+          },
+          {
+            "argMap": {},
+            "inputColumn": "weight_grams",
+            "operation": 3
+          },
+          {
+            "argMap": {},
+            "inputColumn": "tags",
+            "operation": 3
+          },
+          {
+            "argMap": {},
+            "inputColumn": "is_expensive",
+            "operation": 3
+          },
+          {
+            "argMap": {},
+            "inputColumn": "is_in_stock",
+            "operation": 3
+          },
+          {
+            "argMap": {},
+            "inputColumn": "main_image_path",
+            "operation": 3
+          },
+          {
+            "argMap": {},
+            "inputColumn": "secondary_image_paths",
+            "operation": 3
+          }
+        ],
+        "keyColumns": [
+          "listing_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "brief_description_last": "0a1386de070d704b0d2c5d1c87fe519a",
+            "currency_last": "5121fca8b3fe87a914b5ee279b648e95",
+            "headline_last": "45ea540639c06959f17b71c3e554175a",
+            "inventory_count_last": "da8c9a07f97c968c72d2073a8d0f67c8",
+            "is_active_last": "1fec57d936cc463617bac897e12be096",
+            "is_expensive_last": "805f3d530ac6f8e7623c21a73a1f18b6",
+            "is_in_stock_last": "0c23362ef6a4871d3324889b1549563d",
+            "listing_id": "886183f17e4eac643e2068a1ff1c9e13",
+            "long_description_last": "3cc8017f1420a64fd7b2254dae7f1e75",
+            "main_image_path_last": "af1e43d33658f520fd74c426eb9aaf8c",
+            "merchant_id_last": "c1dd7d3842c0b00e1f65fa7bf15c11aa",
+            "price_cents_last": "97455a3821b0ffbf3ec0e5567426673c",
+            "primary_category_last": "7d771f16ef459f9b442390ce6e4941fe",
+            "secondary_image_paths_last": "815571cc5ddb0b27ad2722957f7c0080",
+            "tags_last": "127ced2578a540a522f3f437101d7726",
+            "weight_grams_last": "5b19e9ed87508482695b4e3606acfa97"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "clusterConf": {
+              "modeClusterConfigs": {
+                "upload": {
+                  "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                }
+              }
+            },
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+                "spark.driver.memory": "512m",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "512m",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+                "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+                "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.shuffle.partitions": "10"
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                "CLOUD_PROVIDER": "gcp",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_PUBSUB": "true",
+                "EVAL_URL": "http://localhost:3904",
+                "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "http://localhost:3000",
+                "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                "GCP_PROJECT_ID": "canary-443022",
+                "GCP_REGION": "us-central1",
+                "HUB_URL": "http://localhost:3903",
+                "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+              },
+              "modeEnvironments": {
+                "upload": {
+                  "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                  "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                  "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                  "CLOUD_PROVIDER": "gcp",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_PUBSUB": "true",
+                  "EVAL_URL": "http://localhost:3904",
+                  "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "http://localhost:3000",
+                  "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                  "GCP_PROJECT_ID": "canary-443022",
+                  "GCP_REGION": "us-central1",
+                  "HUB_URL": "http://localhost:3903",
+                  "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                }
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "gcp.dim_listings_with_mutations.v2__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "gcp",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "entities": {
+              "mutationTable": "data.gcp_exports_dim_listing_mutations__0",
+              "query": {
+                "selects": {
+                  "brief_description": "brief_description",
+                  "currency": "currency",
+                  "headline": "headline",
+                  "inventory_count": "inventory_count",
+                  "is_active": "is_active",
+                  "is_expensive": "IF(price_cents > 10000, 1, 0)",
+                  "is_in_stock": "IF(inventory_count > 0, 1, 0)",
+                  "listing_id": "listing_id",
+                  "long_description": "long_description",
+                  "main_image_path": "main_image_path",
+                  "merchant_id": "merchant_id",
+                  "price_cents": "price_cents",
+                  "primary_category": "primary_category",
+                  "secondary_image_paths": "secondary_image_paths",
+                  "tags": "tags",
+                  "weight_grams": "weight_grams"
+                },
+                "startPartition": "2025-01-01"
+              },
+              "snapshotTable": "data.gcp_exports_dim_listings__0"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    },
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "view_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "click_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "favorite_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "add_to_cart_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "view_event",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "click_event",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_event",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "favorite_event",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "add_to_cart_event",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "is_mobile",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "is_desktop",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "is_tablet",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {
+              "k": "128"
+            },
+            "inputColumn": "user_event_struct",
+            "operation": 13,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          }
+        ],
+        "keyColumns": [
+          "user_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "add_to_cart_event_average_14d": "ac7d8c6d6a4d0ddd7fdbab6517207fa0",
+            "add_to_cart_event_average_1d": "ac7d8c6d6a4d0ddd7fdbab6517207fa0",
+            "add_to_cart_event_average_30d": "ac7d8c6d6a4d0ddd7fdbab6517207fa0",
+            "add_to_cart_event_average_7d": "ac7d8c6d6a4d0ddd7fdbab6517207fa0",
+            "add_to_cart_event_sum_14d": "ac7d8c6d6a4d0ddd7fdbab6517207fa0",
+            "add_to_cart_event_sum_1d": "ac7d8c6d6a4d0ddd7fdbab6517207fa0",
+            "add_to_cart_event_sum_30d": "ac7d8c6d6a4d0ddd7fdbab6517207fa0",
+            "add_to_cart_event_sum_7d": "ac7d8c6d6a4d0ddd7fdbab6517207fa0",
+            "click_event_average_14d": "1d544b33eebdfc17a3a5afe87b81eb53",
+            "click_event_average_1d": "1d544b33eebdfc17a3a5afe87b81eb53",
+            "click_event_average_30d": "1d544b33eebdfc17a3a5afe87b81eb53",
+            "click_event_average_7d": "1d544b33eebdfc17a3a5afe87b81eb53",
+            "click_event_sum_14d": "1d544b33eebdfc17a3a5afe87b81eb53",
+            "click_event_sum_1d": "1d544b33eebdfc17a3a5afe87b81eb53",
+            "click_event_sum_30d": "1d544b33eebdfc17a3a5afe87b81eb53",
+            "click_event_sum_7d": "1d544b33eebdfc17a3a5afe87b81eb53",
+            "favorite_event_average_14d": "9236810c6ed256e2ce111114fcdf2468",
+            "favorite_event_average_1d": "9236810c6ed256e2ce111114fcdf2468",
+            "favorite_event_average_30d": "9236810c6ed256e2ce111114fcdf2468",
+            "favorite_event_average_7d": "9236810c6ed256e2ce111114fcdf2468",
+            "favorite_event_sum_14d": "9236810c6ed256e2ce111114fcdf2468",
+            "favorite_event_sum_1d": "9236810c6ed256e2ce111114fcdf2468",
+            "favorite_event_sum_30d": "9236810c6ed256e2ce111114fcdf2468",
+            "favorite_event_sum_7d": "9236810c6ed256e2ce111114fcdf2468",
+            "is_desktop_sum_14d": "751be38cbc62b37986a93da55ea3bb53",
+            "is_desktop_sum_1d": "751be38cbc62b37986a93da55ea3bb53",
+            "is_desktop_sum_30d": "751be38cbc62b37986a93da55ea3bb53",
+            "is_desktop_sum_7d": "751be38cbc62b37986a93da55ea3bb53",
+            "is_mobile_sum_14d": "736a00d8d3e5cc6458f666ceb2840ddf",
+            "is_mobile_sum_1d": "736a00d8d3e5cc6458f666ceb2840ddf",
+            "is_mobile_sum_30d": "736a00d8d3e5cc6458f666ceb2840ddf",
+            "is_mobile_sum_7d": "736a00d8d3e5cc6458f666ceb2840ddf",
+            "is_tablet_sum_14d": "c9f1e7cc6f8dee7506aa0d04fab1fe02",
+            "is_tablet_sum_1d": "c9f1e7cc6f8dee7506aa0d04fab1fe02",
+            "is_tablet_sum_30d": "c9f1e7cc6f8dee7506aa0d04fab1fe02",
+            "is_tablet_sum_7d": "c9f1e7cc6f8dee7506aa0d04fab1fe02",
+            "purchase_event_average_14d": "903c18bce150f38415fb70a46f0eaba5",
+            "purchase_event_average_1d": "903c18bce150f38415fb70a46f0eaba5",
+            "purchase_event_average_30d": "903c18bce150f38415fb70a46f0eaba5",
+            "purchase_event_average_7d": "903c18bce150f38415fb70a46f0eaba5",
+            "purchase_event_sum_14d": "903c18bce150f38415fb70a46f0eaba5",
+            "purchase_event_sum_1d": "903c18bce150f38415fb70a46f0eaba5",
+            "purchase_event_sum_30d": "903c18bce150f38415fb70a46f0eaba5",
+            "purchase_event_sum_7d": "903c18bce150f38415fb70a46f0eaba5",
+            "user_event_struct_last128_14d": "9615edd561708d3aa83e1efae33be4a0",
+            "user_event_struct_last128_1d": "9615edd561708d3aa83e1efae33be4a0",
+            "user_event_struct_last128_30d": "9615edd561708d3aa83e1efae33be4a0",
+            "user_event_struct_last128_7d": "9615edd561708d3aa83e1efae33be4a0",
+            "user_id": "006bbceaf919145938ec06d702ad51b9",
+            "view_event_average_14d": "f597dd2f8e5d672fbac0445fb935469b",
+            "view_event_average_1d": "f597dd2f8e5d672fbac0445fb935469b",
+            "view_event_average_30d": "f597dd2f8e5d672fbac0445fb935469b",
+            "view_event_average_7d": "f597dd2f8e5d672fbac0445fb935469b",
+            "view_event_sum_14d": "f597dd2f8e5d672fbac0445fb935469b",
+            "view_event_sum_1d": "f597dd2f8e5d672fbac0445fb935469b",
+            "view_event_sum_30d": "f597dd2f8e5d672fbac0445fb935469b",
+            "view_event_sum_7d": "f597dd2f8e5d672fbac0445fb935469b"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "clusterConf": {
+              "modeClusterConfigs": {
+                "upload": {
+                  "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                }
+              }
+            },
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+                "spark.driver.memory": "512m",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "512m",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+                "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+                "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.shuffle.partitions": "10"
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+                "CLOUD_PROVIDER": "gcp",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_PUBSUB": "true",
+                "EVAL_URL": "http://localhost:3904",
+                "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "http://localhost:3000",
+                "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                "GCP_PROJECT_ID": "canary-443022",
+                "GCP_REGION": "us-central1",
+                "HUB_URL": "http://localhost:3903",
+                "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+              },
+              "modeEnvironments": {
+                "upload": {
+                  "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                  "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                  "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+                  "CLOUD_PROVIDER": "gcp",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_PUBSUB": "true",
+                  "EVAL_URL": "http://localhost:3904",
+                  "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "http://localhost:3000",
+                  "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                  "GCP_PROJECT_ID": "canary-443022",
+                  "GCP_REGION": "us-central1",
+                  "HUB_URL": "http://localhost:3903",
+                  "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                }
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily",
+            "stepDays": 30
+          },
+          "name": "gcp.user_activities.v1__1",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "gcp",
+          "version": "1"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "selects": {
+                  "add_to_cart_event": "IF(event_type = 'add_to_cart', 1, 0)",
+                  "click_event": "IF(event_type = 'click', 1, 0)",
+                  "favorite_event": "IF(event_type = 'favorite', 1, 0)",
+                  "is_desktop": "IF(device_type = 'desktop', 1, 0)",
+                  "is_mobile": "IF(device_type = 'mobile', 1, 0)",
+                  "is_tablet": "IF(device_type = 'tablet', 1, 0)",
+                  "listing_id": "listing_id",
+                  "purchase_event": "IF(event_type = 'purchase', 1, 0)",
+                  "user_event_struct": "STRUCT(event_type, listing_id, unix_millis(TIMESTAMP(event_time_ms)) as timestamp)",
+                  "user_id": "user_id",
+                  "view_event": "IF(event_type = 'view', 1, 0)"
+                },
+                "timeColumn": "unix_millis(TIMESTAMP(event_time_ms))"
+              },
+              "table": "data.gcp_exports_user_activities__0",
+              "topic": "pubsub://user-activities-v2/project=canary-443022/subscription=user-activities-v2-sub/serde=pubsub_schema/schemaId=user-activities"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "listing_id": "listing_id",
+          "row_id": "event_id",
+          "ts": "event_time_ms",
+          "user_id": "user_id"
+        },
+        "timeColumn": "event_time_ms"
+      },
+      "table": "data.gcp_exports_user_activities__0"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "listing_id": "47aa3759ce41fc6ccf91367592e35f6d",
+      "listing_id_brief_description_last": "0169875656d2de09c49df6445351006a",
+      "listing_id_currency_last": "b6b93c59c83720262d6c2efc45f6d816",
+      "listing_id_headline_last": "94f02b3b99124313f9097253edb0f4ee",
+      "listing_id_inventory_count_last": "2bc1d749d9a976ed9bc392d1ec15ab10",
+      "listing_id_is_active_last": "8e0dea7804d0441e44626d2557ae22ad",
+      "listing_id_is_expensive_last": "cb8ca0dcdf70da5538b571d252daa643",
+      "listing_id_is_in_stock_last": "a060c2ea288a175756920e1326d05266",
+      "listing_id_long_description_last": "d0b56457ff7259d958e7a318ed557776",
+      "listing_id_main_image_path_last": "4f7759442b0f99390cc0de9ee9605614",
+      "listing_id_merchant_id_last": "e879f09eb8f94d0675fdcd3299108fc1",
+      "listing_id_price_cents_last": "fa43d18793086fd6eeccda31695e084b",
+      "listing_id_primary_category_last": "9c9f7cddb5be5f0a2207eb07a28bf54b",
+      "listing_id_secondary_image_paths_last": "3e761b20785b51728d11b7d2ead8eac7",
+      "listing_id_tags_last": "3f0f0c8b2e01a0869be696eac850101e",
+      "listing_id_weight_grams_last": "bcf3a2cb490ef8ac2edce3dffd17983d",
+      "row_id": "596506e0a4fef5508ebdcda7e6eb1072",
+      "ts": "d1ae44a8f84a262685dbf1bdb9f8d46e",
+      "user_id": "80c458b68b34de93d3c4c555ef2b2ddc",
+      "user_id_add_to_cart_event_average_14d": "9a69a159117eb15389ce17f93363a8cb",
+      "user_id_add_to_cart_event_average_1d": "9a69a159117eb15389ce17f93363a8cb",
+      "user_id_add_to_cart_event_average_30d": "9a69a159117eb15389ce17f93363a8cb",
+      "user_id_add_to_cart_event_average_7d": "9a69a159117eb15389ce17f93363a8cb",
+      "user_id_add_to_cart_event_sum_14d": "9a69a159117eb15389ce17f93363a8cb",
+      "user_id_add_to_cart_event_sum_1d": "9a69a159117eb15389ce17f93363a8cb",
+      "user_id_add_to_cart_event_sum_30d": "9a69a159117eb15389ce17f93363a8cb",
+      "user_id_add_to_cart_event_sum_7d": "9a69a159117eb15389ce17f93363a8cb",
+      "user_id_click_event_average_14d": "6d5df9cd495943195fd26343e889a08b",
+      "user_id_click_event_average_1d": "6d5df9cd495943195fd26343e889a08b",
+      "user_id_click_event_average_30d": "6d5df9cd495943195fd26343e889a08b",
+      "user_id_click_event_average_7d": "6d5df9cd495943195fd26343e889a08b",
+      "user_id_click_event_sum_14d": "6d5df9cd495943195fd26343e889a08b",
+      "user_id_click_event_sum_1d": "6d5df9cd495943195fd26343e889a08b",
+      "user_id_click_event_sum_30d": "6d5df9cd495943195fd26343e889a08b",
+      "user_id_click_event_sum_7d": "6d5df9cd495943195fd26343e889a08b",
+      "user_id_favorite_event_average_14d": "41973df600d5d46659f60ac0c808f438",
+      "user_id_favorite_event_average_1d": "41973df600d5d46659f60ac0c808f438",
+      "user_id_favorite_event_average_30d": "41973df600d5d46659f60ac0c808f438",
+      "user_id_favorite_event_average_7d": "41973df600d5d46659f60ac0c808f438",
+      "user_id_favorite_event_sum_14d": "41973df600d5d46659f60ac0c808f438",
+      "user_id_favorite_event_sum_1d": "41973df600d5d46659f60ac0c808f438",
+      "user_id_favorite_event_sum_30d": "41973df600d5d46659f60ac0c808f438",
+      "user_id_favorite_event_sum_7d": "41973df600d5d46659f60ac0c808f438",
+      "user_id_is_desktop_sum_14d": "248157ff361a5b1aee3aab6d459e2315",
+      "user_id_is_desktop_sum_1d": "248157ff361a5b1aee3aab6d459e2315",
+      "user_id_is_desktop_sum_30d": "248157ff361a5b1aee3aab6d459e2315",
+      "user_id_is_desktop_sum_7d": "248157ff361a5b1aee3aab6d459e2315",
+      "user_id_is_mobile_sum_14d": "29bd4cafff87531f073912d981f5df7b",
+      "user_id_is_mobile_sum_1d": "29bd4cafff87531f073912d981f5df7b",
+      "user_id_is_mobile_sum_30d": "29bd4cafff87531f073912d981f5df7b",
+      "user_id_is_mobile_sum_7d": "29bd4cafff87531f073912d981f5df7b",
+      "user_id_is_tablet_sum_14d": "4e93d18e08e8e6d0f51cc4fd54840a4c",
+      "user_id_is_tablet_sum_1d": "4e93d18e08e8e6d0f51cc4fd54840a4c",
+      "user_id_is_tablet_sum_30d": "4e93d18e08e8e6d0f51cc4fd54840a4c",
+      "user_id_is_tablet_sum_7d": "4e93d18e08e8e6d0f51cc4fd54840a4c",
+      "user_id_purchase_event_average_14d": "06b4654ea4a2b6fce7f1e5d0ecbab540",
+      "user_id_purchase_event_average_1d": "06b4654ea4a2b6fce7f1e5d0ecbab540",
+      "user_id_purchase_event_average_30d": "06b4654ea4a2b6fce7f1e5d0ecbab540",
+      "user_id_purchase_event_average_7d": "06b4654ea4a2b6fce7f1e5d0ecbab540",
+      "user_id_purchase_event_sum_14d": "06b4654ea4a2b6fce7f1e5d0ecbab540",
+      "user_id_purchase_event_sum_1d": "06b4654ea4a2b6fce7f1e5d0ecbab540",
+      "user_id_purchase_event_sum_30d": "06b4654ea4a2b6fce7f1e5d0ecbab540",
+      "user_id_purchase_event_sum_7d": "06b4654ea4a2b6fce7f1e5d0ecbab540",
+      "user_id_user_event_struct_last128_14d": "d3568d09600aa635e00f5bbe12ed46f4",
+      "user_id_user_event_struct_last128_1d": "d3568d09600aa635e00f5bbe12ed46f4",
+      "user_id_user_event_struct_last128_30d": "d3568d09600aa635e00f5bbe12ed46f4",
+      "user_id_user_event_struct_last128_7d": "d3568d09600aa635e00f5bbe12ed46f4",
+      "user_id_view_event_average_14d": "bcc46a7a6a6ee73aa8bebbcaaf039347",
+      "user_id_view_event_average_1d": "bcc46a7a6a6ee73aa8bebbcaaf039347",
+      "user_id_view_event_average_30d": "bcc46a7a6a6ee73aa8bebbcaaf039347",
+      "user_id_view_event_average_7d": "bcc46a7a6a6ee73aa8bebbcaaf039347",
+      "user_id_view_event_sum_14d": "bcc46a7a6a6ee73aa8bebbcaaf039347",
+      "user_id_view_event_sum_1d": "bcc46a7a6a6ee73aa8bebbcaaf039347",
+      "user_id_view_event_sum_30d": "bcc46a7a6a6ee73aa8bebbcaaf039347",
+      "user_id_view_event_sum_7d": "bcc46a7a6a6ee73aa8bebbcaaf039347"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_exports_user_activities__0_with_offset_0\", \"spec\": \"data.gcp_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_gcp_exports_dim_listings__0_with_offset_0\", \"spec\": \"data.gcp_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_gcp_exports_dim_listing_mutations__0_with_offset_0\", \"spec\": \"data.gcp_exports_dim_listing_mutations__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "modular_execution": "true",
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "enableStatsCompute": 1,
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "gcp.demo.mutation_test_modular__2",
+    "online": 0,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/gcp/demo.py",
+    "team": "gcp",
+    "version": "2"
+  },
+  "rowIds": [
+    "event_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/gcp/demo.v1__1
+++ b/python/test/canary/canary_compiled/joins/gcp/demo.v1__1
@@ -1,0 +1,951 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "view_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "click_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "favorite_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "add_to_cart_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "view_event",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "click_event",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_event",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "favorite_event",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "add_to_cart_event",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "is_mobile",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "is_desktop",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "is_tablet",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {
+              "k": "128"
+            },
+            "inputColumn": "user_event_struct",
+            "operation": 13,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          }
+        ],
+        "keyColumns": [
+          "user_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "add_to_cart_event_average_14d": "ac7d8c6d6a4d0ddd7fdbab6517207fa0",
+            "add_to_cart_event_average_1d": "ac7d8c6d6a4d0ddd7fdbab6517207fa0",
+            "add_to_cart_event_average_30d": "ac7d8c6d6a4d0ddd7fdbab6517207fa0",
+            "add_to_cart_event_average_7d": "ac7d8c6d6a4d0ddd7fdbab6517207fa0",
+            "add_to_cart_event_sum_14d": "ac7d8c6d6a4d0ddd7fdbab6517207fa0",
+            "add_to_cart_event_sum_1d": "ac7d8c6d6a4d0ddd7fdbab6517207fa0",
+            "add_to_cart_event_sum_30d": "ac7d8c6d6a4d0ddd7fdbab6517207fa0",
+            "add_to_cart_event_sum_7d": "ac7d8c6d6a4d0ddd7fdbab6517207fa0",
+            "click_event_average_14d": "1d544b33eebdfc17a3a5afe87b81eb53",
+            "click_event_average_1d": "1d544b33eebdfc17a3a5afe87b81eb53",
+            "click_event_average_30d": "1d544b33eebdfc17a3a5afe87b81eb53",
+            "click_event_average_7d": "1d544b33eebdfc17a3a5afe87b81eb53",
+            "click_event_sum_14d": "1d544b33eebdfc17a3a5afe87b81eb53",
+            "click_event_sum_1d": "1d544b33eebdfc17a3a5afe87b81eb53",
+            "click_event_sum_30d": "1d544b33eebdfc17a3a5afe87b81eb53",
+            "click_event_sum_7d": "1d544b33eebdfc17a3a5afe87b81eb53",
+            "favorite_event_average_14d": "9236810c6ed256e2ce111114fcdf2468",
+            "favorite_event_average_1d": "9236810c6ed256e2ce111114fcdf2468",
+            "favorite_event_average_30d": "9236810c6ed256e2ce111114fcdf2468",
+            "favorite_event_average_7d": "9236810c6ed256e2ce111114fcdf2468",
+            "favorite_event_sum_14d": "9236810c6ed256e2ce111114fcdf2468",
+            "favorite_event_sum_1d": "9236810c6ed256e2ce111114fcdf2468",
+            "favorite_event_sum_30d": "9236810c6ed256e2ce111114fcdf2468",
+            "favorite_event_sum_7d": "9236810c6ed256e2ce111114fcdf2468",
+            "is_desktop_sum_14d": "751be38cbc62b37986a93da55ea3bb53",
+            "is_desktop_sum_1d": "751be38cbc62b37986a93da55ea3bb53",
+            "is_desktop_sum_30d": "751be38cbc62b37986a93da55ea3bb53",
+            "is_desktop_sum_7d": "751be38cbc62b37986a93da55ea3bb53",
+            "is_mobile_sum_14d": "736a00d8d3e5cc6458f666ceb2840ddf",
+            "is_mobile_sum_1d": "736a00d8d3e5cc6458f666ceb2840ddf",
+            "is_mobile_sum_30d": "736a00d8d3e5cc6458f666ceb2840ddf",
+            "is_mobile_sum_7d": "736a00d8d3e5cc6458f666ceb2840ddf",
+            "is_tablet_sum_14d": "c9f1e7cc6f8dee7506aa0d04fab1fe02",
+            "is_tablet_sum_1d": "c9f1e7cc6f8dee7506aa0d04fab1fe02",
+            "is_tablet_sum_30d": "c9f1e7cc6f8dee7506aa0d04fab1fe02",
+            "is_tablet_sum_7d": "c9f1e7cc6f8dee7506aa0d04fab1fe02",
+            "purchase_event_average_14d": "903c18bce150f38415fb70a46f0eaba5",
+            "purchase_event_average_1d": "903c18bce150f38415fb70a46f0eaba5",
+            "purchase_event_average_30d": "903c18bce150f38415fb70a46f0eaba5",
+            "purchase_event_average_7d": "903c18bce150f38415fb70a46f0eaba5",
+            "purchase_event_sum_14d": "903c18bce150f38415fb70a46f0eaba5",
+            "purchase_event_sum_1d": "903c18bce150f38415fb70a46f0eaba5",
+            "purchase_event_sum_30d": "903c18bce150f38415fb70a46f0eaba5",
+            "purchase_event_sum_7d": "903c18bce150f38415fb70a46f0eaba5",
+            "user_event_struct_last128_14d": "9615edd561708d3aa83e1efae33be4a0",
+            "user_event_struct_last128_1d": "9615edd561708d3aa83e1efae33be4a0",
+            "user_event_struct_last128_30d": "9615edd561708d3aa83e1efae33be4a0",
+            "user_event_struct_last128_7d": "9615edd561708d3aa83e1efae33be4a0",
+            "user_id": "006bbceaf919145938ec06d702ad51b9",
+            "view_event_average_14d": "f597dd2f8e5d672fbac0445fb935469b",
+            "view_event_average_1d": "f597dd2f8e5d672fbac0445fb935469b",
+            "view_event_average_30d": "f597dd2f8e5d672fbac0445fb935469b",
+            "view_event_average_7d": "f597dd2f8e5d672fbac0445fb935469b",
+            "view_event_sum_14d": "f597dd2f8e5d672fbac0445fb935469b",
+            "view_event_sum_1d": "f597dd2f8e5d672fbac0445fb935469b",
+            "view_event_sum_30d": "f597dd2f8e5d672fbac0445fb935469b",
+            "view_event_sum_7d": "f597dd2f8e5d672fbac0445fb935469b"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "clusterConf": {
+              "modeClusterConfigs": {
+                "upload": {
+                  "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                }
+              }
+            },
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+                "spark.driver.memory": "512m",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "512m",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+                "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+                "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.shuffle.partitions": "10"
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+                "CLOUD_PROVIDER": "gcp",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_PUBSUB": "true",
+                "EVAL_URL": "http://localhost:3904",
+                "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "http://localhost:3000",
+                "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                "GCP_PROJECT_ID": "canary-443022",
+                "GCP_REGION": "us-central1",
+                "HUB_URL": "http://localhost:3903",
+                "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+              },
+              "modeEnvironments": {
+                "upload": {
+                  "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                  "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                  "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+                  "CLOUD_PROVIDER": "gcp",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_PUBSUB": "true",
+                  "EVAL_URL": "http://localhost:3904",
+                  "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "http://localhost:3000",
+                  "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                  "GCP_PROJECT_ID": "canary-443022",
+                  "GCP_REGION": "us-central1",
+                  "HUB_URL": "http://localhost:3903",
+                  "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                }
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily",
+            "stepDays": 30
+          },
+          "name": "gcp.user_activities.v1__1",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "gcp",
+          "version": "1"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "selects": {
+                  "add_to_cart_event": "IF(event_type = 'add_to_cart', 1, 0)",
+                  "click_event": "IF(event_type = 'click', 1, 0)",
+                  "favorite_event": "IF(event_type = 'favorite', 1, 0)",
+                  "is_desktop": "IF(device_type = 'desktop', 1, 0)",
+                  "is_mobile": "IF(device_type = 'mobile', 1, 0)",
+                  "is_tablet": "IF(device_type = 'tablet', 1, 0)",
+                  "listing_id": "listing_id",
+                  "purchase_event": "IF(event_type = 'purchase', 1, 0)",
+                  "user_event_struct": "STRUCT(event_type, listing_id, unix_millis(TIMESTAMP(event_time_ms)) as timestamp)",
+                  "user_id": "user_id",
+                  "view_event": "IF(event_type = 'view', 1, 0)"
+                },
+                "timeColumn": "unix_millis(TIMESTAMP(event_time_ms))"
+              },
+              "table": "data.gcp_exports_user_activities__0",
+              "topic": "pubsub://user-activities-v2/project=canary-443022/subscription=user-activities-v2-sub/serde=pubsub_schema/schemaId=user-activities"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    },
+    {
+      "groupBy": {
+        "keyColumns": [
+          "listing_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "brief_description": "85c0544e6f2d058e93e6d54956e118e4",
+            "currency": "ff795c264858b08c00d9159c8e4761d5",
+            "headline": "46fb87fe34c8251a81870c83853e15c6",
+            "inventory_count": "10910897373885c1b0fc1420e7a52562",
+            "is_active": "0fe881820ff26668c32d68dc3382a7ff",
+            "is_expensive": "4d6678c92b2194fd9b7e6bfa85366fe5",
+            "is_in_stock": "0cd5441df3d278d3b7a060e4bd23a324",
+            "listing_id": "6ed4569be71307367d24e5fe77626334",
+            "long_description": "51bbdbd4269ccb2d382f835dcfc2eed3",
+            "main_image_path": "a5ab50facb20e01a0d93a4ed0eac1a9d",
+            "merchant_id": "60a2c0a6662b1bdb97061e9b9566e451",
+            "price_cents": "058f7df64e0544d392a31bb6dc08209f",
+            "primary_category": "62f56fda8558ec54a85da33a3934c182",
+            "secondary_image_paths": "e8ec969f13b6db533bca510f235fd069",
+            "tags": "589de0914f9ffabf8c80a0fe10eaa866",
+            "weight_grams": "041362c5ebf87a340a139e6b53034b7c"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "clusterConf": {
+              "modeClusterConfigs": {
+                "upload": {
+                  "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                }
+              }
+            },
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+                "spark.driver.memory": "512m",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "512m",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+                "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+                "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.shuffle.partitions": "10"
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                "CLOUD_PROVIDER": "gcp",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_PUBSUB": "true",
+                "EVAL_URL": "http://localhost:3904",
+                "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "http://localhost:3000",
+                "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                "GCP_PROJECT_ID": "canary-443022",
+                "GCP_REGION": "us-central1",
+                "HUB_URL": "http://localhost:3903",
+                "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+              },
+              "modeEnvironments": {
+                "upload": {
+                  "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                  "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                  "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                  "CLOUD_PROVIDER": "gcp",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_PUBSUB": "true",
+                  "EVAL_URL": "http://localhost:3904",
+                  "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "http://localhost:3000",
+                  "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                  "GCP_PROJECT_ID": "canary-443022",
+                  "GCP_REGION": "us-central1",
+                  "HUB_URL": "http://localhost:3903",
+                  "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                }
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "gcp.dim_listings.v1__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "gcp",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "entities": {
+              "query": {
+                "selects": {
+                  "brief_description": "brief_description",
+                  "currency": "currency",
+                  "headline": "headline",
+                  "inventory_count": "inventory_count",
+                  "is_active": "is_active",
+                  "is_expensive": "IF(price_cents > 10000, 1, 0)",
+                  "is_in_stock": "IF(inventory_count > 0, 1, 0)",
+                  "listing_id": "listing_id",
+                  "long_description": "long_description",
+                  "main_image_path": "main_image_path",
+                  "merchant_id": "merchant_id",
+                  "price_cents": "price_cents",
+                  "primary_category": "primary_category",
+                  "secondary_image_paths": "secondary_image_paths",
+                  "tags": "tags",
+                  "weight_grams": "weight_grams"
+                },
+                "startPartition": "2025-01-01"
+              },
+              "snapshotTable": "data.gcp_exports_dim_listings__0"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    },
+    {
+      "groupBy": {
+        "keyColumns": [
+          "listing_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "listing_id": "56b684bc2ca64fd442ccd845604e5e70",
+            "primary_category": "62491a3e7c13a27a3eeb765ba460169f"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "clusterConf": {
+              "modeClusterConfigs": {
+                "upload": {
+                  "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                }
+              }
+            },
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+                "spark.driver.memory": "512m",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "512m",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+                "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+                "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.shuffle.partitions": "10"
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                "CLOUD_PROVIDER": "gcp",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_PUBSUB": "true",
+                "EVAL_URL": "http://localhost:3904",
+                "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "http://localhost:3000",
+                "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                "GCP_PROJECT_ID": "canary-443022",
+                "GCP_REGION": "us-central1",
+                "HUB_URL": "http://localhost:3903",
+                "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+              },
+              "modeEnvironments": {
+                "upload": {
+                  "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                  "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                  "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                  "CLOUD_PROVIDER": "gcp",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_PUBSUB": "true",
+                  "EVAL_URL": "http://localhost:3904",
+                  "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "http://localhost:3000",
+                  "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                  "GCP_PROJECT_ID": "canary-443022",
+                  "GCP_REGION": "us-central1",
+                  "HUB_URL": "http://localhost:3903",
+                  "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                }
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "gcp.dim_merchants.v1__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "gcp",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "entities": {
+              "query": {
+                "selects": {
+                  "listing_id": "merchant_id",
+                  "primary_category": "primary_category"
+                },
+                "startPartition": "2025-01-01"
+              },
+              "snapshotTable": "data.gcp_exports_dim_merchants__0"
+            }
+          }
+        ]
+      },
+      "prefix": "merchant_",
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "listing_id": "listing_id",
+          "row_id": "event_id",
+          "ts": "event_time_ms",
+          "user_id": "user_id"
+        },
+        "timeColumn": "event_time_ms"
+      },
+      "table": "data.gcp_exports_user_activities__0"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "listing_id": "47aa3759ce41fc6ccf91367592e35f6d",
+      "listing_id_brief_description": "7d445defa77854b8d6ae94ae180f195f",
+      "listing_id_currency": "a7d9bc3b7f1787df899659e6f0e56679",
+      "listing_id_headline": "4ed73e13e0c394e445c4906b63d01b8a",
+      "listing_id_inventory_count": "b68673a19b32f38f45874dc0078e0f7a",
+      "listing_id_is_active": "616642f4d27a8e00d7250f7f91cb1646",
+      "listing_id_is_expensive": "38ee87f5b11a42d891ec52616a2d7b52",
+      "listing_id_is_in_stock": "6c5685ed65e91bcb3fe9ce2cb53ddbcd",
+      "listing_id_listing_id": "15395806521d79e682aa3274a46c5104",
+      "listing_id_long_description": "e3fda2158f5d126aef5ebbfdfc848174",
+      "listing_id_main_image_path": "ce9bc184baf01f9c7818e88e25b446d0",
+      "listing_id_merchant_id": "69baf448f70fdb4997071c81e8474a34",
+      "listing_id_price_cents": "905a32e196759066f782c617b83c2cbf",
+      "listing_id_primary_category": "0bd33fd7f627e669247b61302962627c",
+      "listing_id_secondary_image_paths": "1001bcbe2b97f447bb20a64c6d8ab297",
+      "listing_id_tags": "b4a3e64fad103c2caf6fcadb2e68f1dd",
+      "listing_id_weight_grams": "7d01ad6aa1db30922ff461f2d0d62ee7",
+      "merchant__listing_id_listing_id": "74857a06805db28ecb0d7e350f031dfd",
+      "merchant__listing_id_primary_category": "c4a356b0561263aa879220c3829eb41f",
+      "row_id": "596506e0a4fef5508ebdcda7e6eb1072",
+      "ts": "d1ae44a8f84a262685dbf1bdb9f8d46e",
+      "user_id": "80c458b68b34de93d3c4c555ef2b2ddc",
+      "user_id_add_to_cart_event_average_14d": "9a69a159117eb15389ce17f93363a8cb",
+      "user_id_add_to_cart_event_average_1d": "9a69a159117eb15389ce17f93363a8cb",
+      "user_id_add_to_cart_event_average_30d": "9a69a159117eb15389ce17f93363a8cb",
+      "user_id_add_to_cart_event_average_7d": "9a69a159117eb15389ce17f93363a8cb",
+      "user_id_add_to_cart_event_sum_14d": "9a69a159117eb15389ce17f93363a8cb",
+      "user_id_add_to_cart_event_sum_1d": "9a69a159117eb15389ce17f93363a8cb",
+      "user_id_add_to_cart_event_sum_30d": "9a69a159117eb15389ce17f93363a8cb",
+      "user_id_add_to_cart_event_sum_7d": "9a69a159117eb15389ce17f93363a8cb",
+      "user_id_click_event_average_14d": "6d5df9cd495943195fd26343e889a08b",
+      "user_id_click_event_average_1d": "6d5df9cd495943195fd26343e889a08b",
+      "user_id_click_event_average_30d": "6d5df9cd495943195fd26343e889a08b",
+      "user_id_click_event_average_7d": "6d5df9cd495943195fd26343e889a08b",
+      "user_id_click_event_sum_14d": "6d5df9cd495943195fd26343e889a08b",
+      "user_id_click_event_sum_1d": "6d5df9cd495943195fd26343e889a08b",
+      "user_id_click_event_sum_30d": "6d5df9cd495943195fd26343e889a08b",
+      "user_id_click_event_sum_7d": "6d5df9cd495943195fd26343e889a08b",
+      "user_id_favorite_event_average_14d": "41973df600d5d46659f60ac0c808f438",
+      "user_id_favorite_event_average_1d": "41973df600d5d46659f60ac0c808f438",
+      "user_id_favorite_event_average_30d": "41973df600d5d46659f60ac0c808f438",
+      "user_id_favorite_event_average_7d": "41973df600d5d46659f60ac0c808f438",
+      "user_id_favorite_event_sum_14d": "41973df600d5d46659f60ac0c808f438",
+      "user_id_favorite_event_sum_1d": "41973df600d5d46659f60ac0c808f438",
+      "user_id_favorite_event_sum_30d": "41973df600d5d46659f60ac0c808f438",
+      "user_id_favorite_event_sum_7d": "41973df600d5d46659f60ac0c808f438",
+      "user_id_is_desktop_sum_14d": "248157ff361a5b1aee3aab6d459e2315",
+      "user_id_is_desktop_sum_1d": "248157ff361a5b1aee3aab6d459e2315",
+      "user_id_is_desktop_sum_30d": "248157ff361a5b1aee3aab6d459e2315",
+      "user_id_is_desktop_sum_7d": "248157ff361a5b1aee3aab6d459e2315",
+      "user_id_is_mobile_sum_14d": "29bd4cafff87531f073912d981f5df7b",
+      "user_id_is_mobile_sum_1d": "29bd4cafff87531f073912d981f5df7b",
+      "user_id_is_mobile_sum_30d": "29bd4cafff87531f073912d981f5df7b",
+      "user_id_is_mobile_sum_7d": "29bd4cafff87531f073912d981f5df7b",
+      "user_id_is_tablet_sum_14d": "4e93d18e08e8e6d0f51cc4fd54840a4c",
+      "user_id_is_tablet_sum_1d": "4e93d18e08e8e6d0f51cc4fd54840a4c",
+      "user_id_is_tablet_sum_30d": "4e93d18e08e8e6d0f51cc4fd54840a4c",
+      "user_id_is_tablet_sum_7d": "4e93d18e08e8e6d0f51cc4fd54840a4c",
+      "user_id_purchase_event_average_14d": "06b4654ea4a2b6fce7f1e5d0ecbab540",
+      "user_id_purchase_event_average_1d": "06b4654ea4a2b6fce7f1e5d0ecbab540",
+      "user_id_purchase_event_average_30d": "06b4654ea4a2b6fce7f1e5d0ecbab540",
+      "user_id_purchase_event_average_7d": "06b4654ea4a2b6fce7f1e5d0ecbab540",
+      "user_id_purchase_event_sum_14d": "06b4654ea4a2b6fce7f1e5d0ecbab540",
+      "user_id_purchase_event_sum_1d": "06b4654ea4a2b6fce7f1e5d0ecbab540",
+      "user_id_purchase_event_sum_30d": "06b4654ea4a2b6fce7f1e5d0ecbab540",
+      "user_id_purchase_event_sum_7d": "06b4654ea4a2b6fce7f1e5d0ecbab540",
+      "user_id_user_event_struct_last128_14d": "d3568d09600aa635e00f5bbe12ed46f4",
+      "user_id_user_event_struct_last128_1d": "d3568d09600aa635e00f5bbe12ed46f4",
+      "user_id_user_event_struct_last128_30d": "d3568d09600aa635e00f5bbe12ed46f4",
+      "user_id_user_event_struct_last128_7d": "d3568d09600aa635e00f5bbe12ed46f4",
+      "user_id_view_event_average_14d": "bcc46a7a6a6ee73aa8bebbcaaf039347",
+      "user_id_view_event_average_1d": "bcc46a7a6a6ee73aa8bebbcaaf039347",
+      "user_id_view_event_average_30d": "bcc46a7a6a6ee73aa8bebbcaaf039347",
+      "user_id_view_event_average_7d": "bcc46a7a6a6ee73aa8bebbcaaf039347",
+      "user_id_view_event_sum_14d": "bcc46a7a6a6ee73aa8bebbcaaf039347",
+      "user_id_view_event_sum_1d": "bcc46a7a6a6ee73aa8bebbcaaf039347",
+      "user_id_view_event_sum_30d": "bcc46a7a6a6ee73aa8bebbcaaf039347",
+      "user_id_view_event_sum_7d": "bcc46a7a6a6ee73aa8bebbcaaf039347"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_exports_user_activities__0_with_offset_0\", \"spec\": \"data.gcp_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_gcp_exports_dim_listings__0_with_offset_0\", \"spec\": \"data.gcp_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_gcp_exports_dim_merchants__0_with_offset_0\", \"spec\": \"data.gcp_exports_dim_merchants__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "enableStatsCompute": 1,
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "onlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "gcp.demo.v1__1",
+    "online": 1,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/gcp/demo.py",
+    "team": "gcp",
+    "version": "1"
+  },
+  "rowIds": [
+    "event_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/gcp/demo_chaining.downstream_join__0
+++ b/python/test/canary/canary_compiled/joins/gcp/demo_chaining.downstream_join__0
@@ -1,0 +1,480 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {
+              "k": "100"
+            },
+            "inputColumn": "price_cents",
+            "operation": 13,
+            "windows": [
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          }
+        ],
+        "keyColumns": [
+          "user_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "price_cents_last100_7d": "c4c5a4063613d69fbe6ac20408f7cc07",
+            "user_id": "e3d702eb6c23558f50233c39f7718309"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "clusterConf": {
+              "modeClusterConfigs": {
+                "upload": {
+                  "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                }
+              }
+            },
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+                "spark.driver.memory": "512m",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "512m",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+                "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+                "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.shuffle.partitions": "10"
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+                "CLOUD_PROVIDER": "gcp",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_PUBSUB": "true",
+                "EVAL_URL": "http://localhost:3904",
+                "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "http://localhost:3000",
+                "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                "GCP_PROJECT_ID": "canary-443022",
+                "GCP_REGION": "us-central1",
+                "HUB_URL": "http://localhost:3903",
+                "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+              },
+              "modeEnvironments": {
+                "upload": {
+                  "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                  "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                  "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+                  "CLOUD_PROVIDER": "gcp",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_PUBSUB": "true",
+                  "EVAL_URL": "http://localhost:3904",
+                  "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "http://localhost:3000",
+                  "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                  "GCP_PROJECT_ID": "canary-443022",
+                  "GCP_REGION": "us-central1",
+                  "HUB_URL": "http://localhost:3903",
+                  "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                }
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "gcp.user_activities_chained.chained_user_gb__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "gcp",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "joinSource": {
+              "join": {
+                "joinParts": [
+                  {
+                    "groupBy": {
+                      "keyColumns": [
+                        "listing_id"
+                      ],
+                      "metaData": {
+                        "environments": [
+                          0
+                        ],
+                        "executionInfo": {
+                          "clusterConf": {
+                            "modeClusterConfigs": {
+                              "upload": {
+                                "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                                "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                              }
+                            }
+                          },
+                          "conf": {
+                            "common": {
+                              "spark.chronon.coalesce.factor": "10",
+                              "spark.chronon.partition.column": "ds",
+                              "spark.chronon.partition.format": "yyyy-MM-dd",
+                              "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+                              "spark.chronon.table_write.format": "iceberg",
+                              "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+                              "spark.default.parallelism": "10",
+                              "spark.driver.cores": "1",
+                              "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+                              "spark.driver.memory": "512m",
+                              "spark.executor.cores": "1",
+                              "spark.executor.memory": "512m",
+                              "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                              "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+                              "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+                              "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+                              "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+                              "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+                              "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                              "spark.sql.shuffle.partitions": "10"
+                            }
+                          },
+                          "env": {
+                            "common": {
+                              "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                              "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                              "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                              "CLOUD_PROVIDER": "gcp",
+                              "CUSTOMER_ID": "canary",
+                              "ENABLE_PUBSUB": "true",
+                              "EVAL_URL": "http://localhost:3904",
+                              "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                              "FRONTEND_URL": "http://localhost:3000",
+                              "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                              "GCP_PROJECT_ID": "canary-443022",
+                              "GCP_REGION": "us-central1",
+                              "HUB_URL": "http://localhost:3903",
+                              "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+                              "VERSION": "latest",
+                              "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                            },
+                            "modeEnvironments": {
+                              "upload": {
+                                "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                                "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                                "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                                "CLOUD_PROVIDER": "gcp",
+                                "CUSTOMER_ID": "canary",
+                                "ENABLE_PUBSUB": "true",
+                                "EVAL_URL": "http://localhost:3904",
+                                "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                                "FRONTEND_URL": "http://localhost:3000",
+                                "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                                "GCP_PROJECT_ID": "canary-443022",
+                                "GCP_REGION": "us-central1",
+                                "HUB_URL": "http://localhost:3903",
+                                "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                                "VERSION": "latest",
+                                "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                              }
+                            }
+                          },
+                          "historicalBackfill": 0,
+                          "onlineSchedule": "@daily"
+                        },
+                        "name": "gcp.dim_listings.v1__0",
+                        "online": 1,
+                        "outputNamespace": "data",
+                        "team": "gcp",
+                        "version": "0"
+                      },
+                      "sources": [
+                        {
+                          "entities": {
+                            "query": {
+                              "selects": {
+                                "brief_description": "brief_description",
+                                "currency": "currency",
+                                "headline": "headline",
+                                "inventory_count": "inventory_count",
+                                "is_active": "is_active",
+                                "is_expensive": "IF(price_cents > 10000, 1, 0)",
+                                "is_in_stock": "IF(inventory_count > 0, 1, 0)",
+                                "listing_id": "listing_id",
+                                "long_description": "long_description",
+                                "main_image_path": "main_image_path",
+                                "merchant_id": "merchant_id",
+                                "price_cents": "price_cents",
+                                "primary_category": "primary_category",
+                                "secondary_image_paths": "secondary_image_paths",
+                                "tags": "tags",
+                                "weight_grams": "weight_grams"
+                              },
+                              "startPartition": "2025-01-01"
+                            },
+                            "snapshotTable": "data.gcp_exports_dim_listings__0"
+                          }
+                        }
+                      ]
+                    },
+                    "useLongNames": 0
+                  }
+                ],
+                "left": {
+                  "events": {
+                    "query": {
+                      "selects": {
+                        "listing_id": "listing_id",
+                        "row_id": "event_id",
+                        "ts": "unix_millis(TIMESTAMP(event_time_ms))",
+                        "user_id": "user_id"
+                      },
+                      "timeColumn": "unix_millis(TIMESTAMP(event_time_ms))"
+                    },
+                    "table": "data.gcp_exports_user_activities__0",
+                    "topic": "pubsub://user-activities-v2/project=canary-443022/subscription=user-activities-v2-sub/serde=pubsub_schema/schemaId=user-activities"
+                  }
+                },
+                "metaData": {
+                  "environments": [
+                    0
+                  ],
+                  "executionInfo": {
+                    "clusterConf": {
+                      "modeClusterConfigs": {
+                        "upload": {
+                          "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                          "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                        }
+                      }
+                    },
+                    "conf": {
+                      "common": {
+                        "spark.chronon.coalesce.factor": "10",
+                        "spark.chronon.partition.column": "ds",
+                        "spark.chronon.partition.format": "yyyy-MM-dd",
+                        "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+                        "spark.chronon.table_write.format": "iceberg",
+                        "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+                        "spark.default.parallelism": "10",
+                        "spark.driver.cores": "1",
+                        "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+                        "spark.driver.memory": "512m",
+                        "spark.executor.cores": "1",
+                        "spark.executor.memory": "512m",
+                        "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                        "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+                        "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+                        "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+                        "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+                        "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+                        "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                        "spark.sql.shuffle.partitions": "10"
+                      }
+                    },
+                    "env": {
+                      "common": {
+                        "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                        "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                        "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                        "CLOUD_PROVIDER": "gcp",
+                        "CUSTOMER_ID": "canary",
+                        "ENABLE_PUBSUB": "true",
+                        "EVAL_URL": "http://localhost:3904",
+                        "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                        "FRONTEND_URL": "http://localhost:3000",
+                        "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                        "GCP_PROJECT_ID": "canary-443022",
+                        "GCP_REGION": "us-central1",
+                        "HUB_URL": "http://localhost:3903",
+                        "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+                        "VERSION": "latest",
+                        "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                      },
+                      "modeEnvironments": {
+                        "upload": {
+                          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                          "CLOUD_PROVIDER": "gcp",
+                          "CUSTOMER_ID": "canary",
+                          "ENABLE_PUBSUB": "true",
+                          "EVAL_URL": "http://localhost:3904",
+                          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                          "FRONTEND_URL": "http://localhost:3000",
+                          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                          "GCP_PROJECT_ID": "canary-443022",
+                          "GCP_REGION": "us-central1",
+                          "HUB_URL": "http://localhost:3903",
+                          "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                          "VERSION": "latest",
+                          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                        }
+                      }
+                    },
+                    "offlineSchedule": "17 0 * * *",
+                    "onlineSchedule": "@daily"
+                  },
+                  "name": "gcp.demo_parent.parent_join__0",
+                  "online": 1,
+                  "outputNamespace": "data",
+                  "production": 0,
+                  "samplePercent": 100.0,
+                  "team": "gcp",
+                  "version": "0"
+                },
+                "rowIds": [
+                  "event_id"
+                ],
+                "useLongNames": 0
+              },
+              "query": {
+                "selects": {
+                  "listing_id": "listing_id",
+                  "price_cents": "listing_id_price_cents",
+                  "user_id": "user_id"
+                },
+                "timeColumn": "ts"
+              }
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "listing_id": "listing_id",
+          "row_id": "event_id",
+          "ts": "unix_millis(TIMESTAMP(event_time_ms))",
+          "user_id": "user_id"
+        },
+        "timeColumn": "unix_millis(TIMESTAMP(event_time_ms))"
+      },
+      "table": "data.gcp_exports_user_activities__0",
+      "topic": "pubsub://user-activities-v2/project=canary-443022/subscription=user-activities-v2-sub/serde=pubsub_schema/schemaId=user-activities"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "listing_id": "9daddd896246c830f5116831f5df9c0a",
+      "row_id": "17d1b68983ca3d528c3413540e64be13",
+      "ts": "619a104c27477d21da9cfc2eca48f45e",
+      "user_id": "ee0c3f74c13689caeeb88cd8971d3df2",
+      "user_id_price_cents_last100_7d": "ac24fb3bf350137048765b535ac12587"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_exports_user_activities__0_with_offset_0\", \"spec\": \"data.gcp_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "onlineSchedule": "@daily"
+    },
+    "name": "gcp.demo_chaining.downstream_join__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/gcp/demo_chaining.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "rowIds": [
+    "event_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/gcp/demo_parent.parent_join__0
+++ b/python/test/canary/canary_compiled/joins/gcp/demo_parent.parent_join__0
@@ -1,0 +1,275 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "keyColumns": [
+          "listing_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "brief_description": "85c0544e6f2d058e93e6d54956e118e4",
+            "currency": "ff795c264858b08c00d9159c8e4761d5",
+            "headline": "46fb87fe34c8251a81870c83853e15c6",
+            "inventory_count": "10910897373885c1b0fc1420e7a52562",
+            "is_active": "0fe881820ff26668c32d68dc3382a7ff",
+            "is_expensive": "4d6678c92b2194fd9b7e6bfa85366fe5",
+            "is_in_stock": "0cd5441df3d278d3b7a060e4bd23a324",
+            "listing_id": "6ed4569be71307367d24e5fe77626334",
+            "long_description": "51bbdbd4269ccb2d382f835dcfc2eed3",
+            "main_image_path": "a5ab50facb20e01a0d93a4ed0eac1a9d",
+            "merchant_id": "60a2c0a6662b1bdb97061e9b9566e451",
+            "price_cents": "058f7df64e0544d392a31bb6dc08209f",
+            "primary_category": "62f56fda8558ec54a85da33a3934c182",
+            "secondary_image_paths": "e8ec969f13b6db533bca510f235fd069",
+            "tags": "589de0914f9ffabf8c80a0fe10eaa866",
+            "weight_grams": "041362c5ebf87a340a139e6b53034b7c"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "clusterConf": {
+              "modeClusterConfigs": {
+                "upload": {
+                  "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                }
+              }
+            },
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+                "spark.driver.memory": "512m",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "512m",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+                "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+                "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.shuffle.partitions": "10"
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                "CLOUD_PROVIDER": "gcp",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_PUBSUB": "true",
+                "EVAL_URL": "http://localhost:3904",
+                "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "http://localhost:3000",
+                "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                "GCP_PROJECT_ID": "canary-443022",
+                "GCP_REGION": "us-central1",
+                "HUB_URL": "http://localhost:3903",
+                "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+              },
+              "modeEnvironments": {
+                "upload": {
+                  "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                  "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                  "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                  "CLOUD_PROVIDER": "gcp",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_PUBSUB": "true",
+                  "EVAL_URL": "http://localhost:3904",
+                  "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "http://localhost:3000",
+                  "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                  "GCP_PROJECT_ID": "canary-443022",
+                  "GCP_REGION": "us-central1",
+                  "HUB_URL": "http://localhost:3903",
+                  "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                }
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "gcp.dim_listings.v1__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "gcp",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "entities": {
+              "query": {
+                "selects": {
+                  "brief_description": "brief_description",
+                  "currency": "currency",
+                  "headline": "headline",
+                  "inventory_count": "inventory_count",
+                  "is_active": "is_active",
+                  "is_expensive": "IF(price_cents > 10000, 1, 0)",
+                  "is_in_stock": "IF(inventory_count > 0, 1, 0)",
+                  "listing_id": "listing_id",
+                  "long_description": "long_description",
+                  "main_image_path": "main_image_path",
+                  "merchant_id": "merchant_id",
+                  "price_cents": "price_cents",
+                  "primary_category": "primary_category",
+                  "secondary_image_paths": "secondary_image_paths",
+                  "tags": "tags",
+                  "weight_grams": "weight_grams"
+                },
+                "startPartition": "2025-01-01"
+              },
+              "snapshotTable": "data.gcp_exports_dim_listings__0"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "listing_id": "listing_id",
+          "row_id": "event_id",
+          "ts": "unix_millis(TIMESTAMP(event_time_ms))",
+          "user_id": "user_id"
+        },
+        "timeColumn": "unix_millis(TIMESTAMP(event_time_ms))"
+      },
+      "table": "data.gcp_exports_user_activities__0",
+      "topic": "pubsub://user-activities-v2/project=canary-443022/subscription=user-activities-v2-sub/serde=pubsub_schema/schemaId=user-activities"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "listing_id": "9daddd896246c830f5116831f5df9c0a",
+      "listing_id_brief_description": "3232d105db8eb272193349c42c947254",
+      "listing_id_currency": "e02d8e8d0db9de2d1da9668b18cabe40",
+      "listing_id_headline": "05045cd666a90ed6f519aa9fa9a9a478",
+      "listing_id_inventory_count": "bc379ec016ea28cc317a7e4d744799d8",
+      "listing_id_is_active": "b7ffb083f09b322ec274f6af90504115",
+      "listing_id_is_expensive": "aa8de69ba6c73ac203f6e0d68c6a6429",
+      "listing_id_is_in_stock": "7a8acd044fc0e421cf816a9683f7aad7",
+      "listing_id_listing_id": "1b69110a27d99e8eeedd59c98e5887a4",
+      "listing_id_long_description": "076348d89aa9bdd4751ef63c2833bfd4",
+      "listing_id_main_image_path": "e114ec5bec0528feb083d529221a7677",
+      "listing_id_merchant_id": "4c0813a92393f3875b535348bf7fb879",
+      "listing_id_price_cents": "0b87f36782def5abd7d5a4dade1bc197",
+      "listing_id_primary_category": "8de0d03937f8f0ed6032f5b40df5e974",
+      "listing_id_secondary_image_paths": "e773eeb6a5903dbd1b276e7ae6466cd8",
+      "listing_id_tags": "766610cce1ce0881bdb82ed1751357b1",
+      "listing_id_weight_grams": "a29f70eac40fd03b7b81034568032b9a",
+      "row_id": "17d1b68983ca3d528c3413540e64be13",
+      "ts": "619a104c27477d21da9cfc2eca48f45e",
+      "user_id": "ee0c3f74c13689caeeb88cd8971d3df2"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_exports_user_activities__0_with_offset_0\", \"spec\": \"data.gcp_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_gcp_exports_dim_listings__0_with_offset_0\", \"spec\": \"data.gcp_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "17 0 * * *",
+      "onlineSchedule": "@daily"
+    },
+    "name": "gcp.demo_parent.parent_join__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/gcp/demo_parent.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "rowIds": [
+    "event_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/gcp/item_event_join.canary_batch_v1__0
+++ b/python/test/canary/canary_compiled/joins/gcp/item_event_join.canary_batch_v1__0
@@ -1,0 +1,314 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 6,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {
+              "k": "10"
+            },
+            "inputColumn": "purchase_price",
+            "operation": 13
+          }
+        ],
+        "keyColumns": [
+          "user_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "purchase_price_average_1d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_average_3d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_average_7d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_count_1d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_count_3d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_count_7d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_last10": "631fab32648531978032f3b417da5d52",
+            "purchase_price_sum_1d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_sum_3d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_sum_7d": "631fab32648531978032f3b417da5d52",
+            "user_id": "a406c2de0040b2e926dba6334f299281"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "clusterConf": {
+              "modeClusterConfigs": {
+                "upload": {
+                  "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                }
+              }
+            },
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+                "spark.driver.memory": "512m",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "512m",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+                "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+                "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.shuffle.partitions": "10"
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                "CLOUD_PROVIDER": "gcp",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_PUBSUB": "true",
+                "EVAL_URL": "http://localhost:3904",
+                "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "http://localhost:3000",
+                "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                "GCP_PROJECT_ID": "canary-443022",
+                "GCP_REGION": "us-central1",
+                "HUB_URL": "http://localhost:3903",
+                "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+              },
+              "modeEnvironments": {
+                "upload": {
+                  "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                  "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                  "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                  "CLOUD_PROVIDER": "gcp",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_PUBSUB": "true",
+                  "EVAL_URL": "http://localhost:3904",
+                  "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "http://localhost:3000",
+                  "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                  "GCP_PROJECT_ID": "canary-443022",
+                  "GCP_REGION": "us-central1",
+                  "HUB_URL": "http://localhost:3903",
+                  "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                }
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "gcp.purchases.v1_test__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "gcp",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "selects": {
+                  "purchase_price": "purchase_price",
+                  "user_id": "user_id"
+                },
+                "startPartition": "2023-11-01",
+                "timeColumn": "ts"
+              },
+              "table": "data.gcp_purchases_import_v1__0"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "listing_id": "EXPLODE(TRANSFORM(SPLIT(COALESCE(attributes['sold_listing_ids'], attributes['listing_id']), ','), e -> CAST(e AS LONG)))",
+          "ts": "timestamp",
+          "user_id": "attributes['user_id']"
+        },
+        "timeColumn": "timestamp"
+      },
+      "table": "data.item_events_parquet_compat"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "listing_id": "f2f6c814b8ae1521176b22a1ae7f2d0d",
+      "ts": "ad9fd4c611e20ad833819a4ce9d752bf",
+      "user_id": "493d3df28f80664abd11b19fcd33b6e6",
+      "user_id_purchase_price_average_1d": "0167b3659bffb8660e1ea86c541ee6f1",
+      "user_id_purchase_price_average_3d": "0167b3659bffb8660e1ea86c541ee6f1",
+      "user_id_purchase_price_average_7d": "0167b3659bffb8660e1ea86c541ee6f1",
+      "user_id_purchase_price_count_1d": "0167b3659bffb8660e1ea86c541ee6f1",
+      "user_id_purchase_price_count_3d": "0167b3659bffb8660e1ea86c541ee6f1",
+      "user_id_purchase_price_count_7d": "0167b3659bffb8660e1ea86c541ee6f1",
+      "user_id_purchase_price_last10": "0167b3659bffb8660e1ea86c541ee6f1",
+      "user_id_purchase_price_sum_1d": "0167b3659bffb8660e1ea86c541ee6f1",
+      "user_id_purchase_price_sum_3d": "0167b3659bffb8660e1ea86c541ee6f1",
+      "user_id_purchase_price_sum_7d": "0167b3659bffb8660e1ea86c541ee6f1"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_item_events_parquet_compat_with_offset_0\", \"spec\": \"data.item_events_parquet_compat/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_gcp_purchases_import_v1__0_with_offset_0\", \"spec\": \"data.gcp_purchases_import_v1__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "onlineSchedule": "@daily"
+    },
+    "name": "gcp.item_event_join.canary_batch_v1__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/gcp/item_event_join.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "rowIds": [
+    "listing_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/gcp/item_event_join.canary_combined_v1__0
+++ b/python/test/canary/canary_compiled/joins/gcp/item_event_join.canary_combined_v1__0
@@ -1,0 +1,486 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "add_cart",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "view",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "favorite",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              }
+            ]
+          }
+        ],
+        "keyColumns": [
+          "listing_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "add_cart_sum_1d": "ed104cb5e34d9ac3c193cda31fec5db4",
+            "favorite_sum_1d": "ecce467f5cef9f4f6742ce4a0650499b",
+            "listing_id": "63b9f4d87c1cc4fb39f6f5230ae29034",
+            "purchase_sum_1d": "8461cac7c35b38bae99562beb4060578",
+            "view_sum_1d": "d4bc995b2e1955c153a0d1d78927f07c"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "clusterConf": {
+              "modeClusterConfigs": {
+                "upload": {
+                  "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                }
+              }
+            },
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "_DATE",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+                "spark.driver.memory": "512m",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "512m",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+                "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+                "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.shuffle.partitions": "10"
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                "CHRONON_ONLINE_ARGS": "-Ztasks=4 -Zbootstrap=bootstrap.zipline-kafka-cluster.us-central1.managedkafka.canary-443022.cloud.goog:9092",
+                "CLOUD_PROVIDER": "gcp",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_PUBSUB": "true",
+                "EVAL_URL": "http://localhost:3904",
+                "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "http://localhost:3000",
+                "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                "GCP_PROJECT_ID": "canary-443022",
+                "GCP_REGION": "us-central1",
+                "HUB_URL": "http://localhost:3903",
+                "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+              },
+              "modeEnvironments": {
+                "upload": {
+                  "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                  "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                  "CHRONON_ONLINE_ARGS": "-Ztasks=4 -Zbootstrap=bootstrap.zipline-kafka-cluster.us-central1.managedkafka.canary-443022.cloud.goog:9092",
+                  "CLOUD_PROVIDER": "gcp",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_PUBSUB": "true",
+                  "EVAL_URL": "http://localhost:3904",
+                  "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "http://localhost:3000",
+                  "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                  "GCP_PROJECT_ID": "canary-443022",
+                  "GCP_REGION": "us-central1",
+                  "HUB_URL": "http://localhost:3903",
+                  "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                }
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "gcp.item_event_canary.actions_pubsub_v2__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "gcp",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "selects": {
+                  "add_cart": "IF(event_type = 'backend_add_to_cart', 1, 0)",
+                  "favorite": "IF(event_type = 'backend_favorite_item2', 1, 0)",
+                  "listing_id": "EXPLODE(TRANSFORM(SPLIT(COALESCE(attributes['sold_listing_ids'], attributes['listing_id']), ','), e -> CAST(e AS LONG)))",
+                  "purchase": "IF(event_type = 'backend_cart_payment', 1, 0)",
+                  "view": "IF(event_type = 'view_listing', 1, 0)"
+                },
+                "timeColumn": "timestamp",
+                "wheres": [
+                  "event_type in ('backend_add_to_cart', 'view_listing', 'backend_cart_payment', 'backend_favorite_item2')"
+                ]
+              },
+              "table": "data.item_events_parquet_compat_partitioned",
+              "topic": "pubsub://test-item-event-data/serde=pubsub_schema/project=canary-443022/schemaId=item-event/tasks=4/subscription=test-item-event-data-sub"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    },
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 6,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {
+              "k": "10"
+            },
+            "inputColumn": "purchase_price",
+            "operation": 13
+          }
+        ],
+        "keyColumns": [
+          "user_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "purchase_price_average_1d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_average_3d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_average_7d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_count_1d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_count_3d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_count_7d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_last10": "631fab32648531978032f3b417da5d52",
+            "purchase_price_sum_1d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_sum_3d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_sum_7d": "631fab32648531978032f3b417da5d52",
+            "user_id": "a406c2de0040b2e926dba6334f299281"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "clusterConf": {
+              "modeClusterConfigs": {
+                "upload": {
+                  "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                }
+              }
+            },
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+                "spark.driver.memory": "512m",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "512m",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+                "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+                "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.shuffle.partitions": "10"
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                "CLOUD_PROVIDER": "gcp",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_PUBSUB": "true",
+                "EVAL_URL": "http://localhost:3904",
+                "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "http://localhost:3000",
+                "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                "GCP_PROJECT_ID": "canary-443022",
+                "GCP_REGION": "us-central1",
+                "HUB_URL": "http://localhost:3903",
+                "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+              },
+              "modeEnvironments": {
+                "upload": {
+                  "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                  "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                  "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                  "CLOUD_PROVIDER": "gcp",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_PUBSUB": "true",
+                  "EVAL_URL": "http://localhost:3904",
+                  "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "http://localhost:3000",
+                  "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                  "GCP_PROJECT_ID": "canary-443022",
+                  "GCP_REGION": "us-central1",
+                  "HUB_URL": "http://localhost:3903",
+                  "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                }
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "gcp.purchases.v1_test__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "gcp",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "selects": {
+                  "purchase_price": "purchase_price",
+                  "user_id": "user_id"
+                },
+                "startPartition": "2023-11-01",
+                "timeColumn": "ts"
+              },
+              "table": "data.gcp_purchases_import_v1__0"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "listing_id": "EXPLODE(TRANSFORM(SPLIT(COALESCE(attributes['sold_listing_ids'], attributes['listing_id']), ','), e -> CAST(e AS LONG)))",
+          "ts": "timestamp",
+          "user_id": "attributes['user_id']"
+        },
+        "timeColumn": "timestamp"
+      },
+      "table": "data.item_events_parquet_compat"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "listing_id": "f2f6c814b8ae1521176b22a1ae7f2d0d",
+      "listing_id_add_cart_sum_1d": "6b9c42bf45158c93b823dcf0b5bea7ab",
+      "listing_id_favorite_sum_1d": "bb07e39a4b7ea81aca5baf027fd8f555",
+      "listing_id_purchase_sum_1d": "12f0cd5674381064326148e7eb352a40",
+      "listing_id_view_sum_1d": "c92a7a66f21979b327788447d063fe2b",
+      "ts": "ad9fd4c611e20ad833819a4ce9d752bf",
+      "user_id": "493d3df28f80664abd11b19fcd33b6e6",
+      "user_id_purchase_price_average_1d": "0167b3659bffb8660e1ea86c541ee6f1",
+      "user_id_purchase_price_average_3d": "0167b3659bffb8660e1ea86c541ee6f1",
+      "user_id_purchase_price_average_7d": "0167b3659bffb8660e1ea86c541ee6f1",
+      "user_id_purchase_price_count_1d": "0167b3659bffb8660e1ea86c541ee6f1",
+      "user_id_purchase_price_count_3d": "0167b3659bffb8660e1ea86c541ee6f1",
+      "user_id_purchase_price_count_7d": "0167b3659bffb8660e1ea86c541ee6f1",
+      "user_id_purchase_price_last10": "0167b3659bffb8660e1ea86c541ee6f1",
+      "user_id_purchase_price_sum_1d": "0167b3659bffb8660e1ea86c541ee6f1",
+      "user_id_purchase_price_sum_3d": "0167b3659bffb8660e1ea86c541ee6f1",
+      "user_id_purchase_price_sum_7d": "0167b3659bffb8660e1ea86c541ee6f1"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_item_events_parquet_compat_with_offset_0\", \"spec\": \"data.item_events_parquet_compat/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_item_events_parquet_compat_partitioned_with_offset_0\", \"spec\": \"data.item_events_parquet_compat_partitioned/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_gcp_purchases_import_v1__0_with_offset_0\", \"spec\": \"data.gcp_purchases_import_v1__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "onlineSchedule": "@daily"
+    },
+    "name": "gcp.item_event_join.canary_combined_v1__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/gcp/item_event_join.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "rowIds": [
+    "user_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/gcp/item_event_join.canary_streaming_v1__0
+++ b/python/test/canary/canary_compiled/joins/gcp/item_event_join.canary_streaming_v1__0
@@ -1,0 +1,288 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "add_cart",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "view",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "favorite",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              }
+            ]
+          }
+        ],
+        "keyColumns": [
+          "listing_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "add_cart_sum_1d": "ed104cb5e34d9ac3c193cda31fec5db4",
+            "favorite_sum_1d": "ecce467f5cef9f4f6742ce4a0650499b",
+            "listing_id": "63b9f4d87c1cc4fb39f6f5230ae29034",
+            "purchase_sum_1d": "8461cac7c35b38bae99562beb4060578",
+            "view_sum_1d": "d4bc995b2e1955c153a0d1d78927f07c"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "clusterConf": {
+              "modeClusterConfigs": {
+                "upload": {
+                  "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                }
+              }
+            },
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "_DATE",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+                "spark.driver.memory": "512m",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "512m",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+                "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+                "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.shuffle.partitions": "10"
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                "CHRONON_ONLINE_ARGS": "-Ztasks=4 -Zbootstrap=bootstrap.zipline-kafka-cluster.us-central1.managedkafka.canary-443022.cloud.goog:9092",
+                "CLOUD_PROVIDER": "gcp",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_PUBSUB": "true",
+                "EVAL_URL": "http://localhost:3904",
+                "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "http://localhost:3000",
+                "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                "GCP_PROJECT_ID": "canary-443022",
+                "GCP_REGION": "us-central1",
+                "HUB_URL": "http://localhost:3903",
+                "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+              },
+              "modeEnvironments": {
+                "upload": {
+                  "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                  "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                  "CHRONON_ONLINE_ARGS": "-Ztasks=4 -Zbootstrap=bootstrap.zipline-kafka-cluster.us-central1.managedkafka.canary-443022.cloud.goog:9092",
+                  "CLOUD_PROVIDER": "gcp",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_PUBSUB": "true",
+                  "EVAL_URL": "http://localhost:3904",
+                  "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "http://localhost:3000",
+                  "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                  "GCP_PROJECT_ID": "canary-443022",
+                  "GCP_REGION": "us-central1",
+                  "HUB_URL": "http://localhost:3903",
+                  "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                }
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "gcp.item_event_canary.actions_pubsub_v2__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "gcp",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "selects": {
+                  "add_cart": "IF(event_type = 'backend_add_to_cart', 1, 0)",
+                  "favorite": "IF(event_type = 'backend_favorite_item2', 1, 0)",
+                  "listing_id": "EXPLODE(TRANSFORM(SPLIT(COALESCE(attributes['sold_listing_ids'], attributes['listing_id']), ','), e -> CAST(e AS LONG)))",
+                  "purchase": "IF(event_type = 'backend_cart_payment', 1, 0)",
+                  "view": "IF(event_type = 'view_listing', 1, 0)"
+                },
+                "timeColumn": "timestamp",
+                "wheres": [
+                  "event_type in ('backend_add_to_cart', 'view_listing', 'backend_cart_payment', 'backend_favorite_item2')"
+                ]
+              },
+              "table": "data.item_events_parquet_compat_partitioned",
+              "topic": "pubsub://test-item-event-data/serde=pubsub_schema/project=canary-443022/schemaId=item-event/tasks=4/subscription=test-item-event-data-sub"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "listing_id": "EXPLODE(TRANSFORM(SPLIT(COALESCE(attributes['sold_listing_ids'], attributes['listing_id']), ','), e -> CAST(e AS LONG)))",
+          "ts": "timestamp",
+          "user_id": "attributes['user_id']"
+        },
+        "timeColumn": "timestamp"
+      },
+      "table": "data.item_events_parquet_compat"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "listing_id": "f2f6c814b8ae1521176b22a1ae7f2d0d",
+      "listing_id_add_cart_sum_1d": "6b9c42bf45158c93b823dcf0b5bea7ab",
+      "listing_id_favorite_sum_1d": "bb07e39a4b7ea81aca5baf027fd8f555",
+      "listing_id_purchase_sum_1d": "12f0cd5674381064326148e7eb352a40",
+      "listing_id_view_sum_1d": "c92a7a66f21979b327788447d063fe2b",
+      "ts": "ad9fd4c611e20ad833819a4ce9d752bf",
+      "user_id": "493d3df28f80664abd11b19fcd33b6e6"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_item_events_parquet_compat_with_offset_0\", \"spec\": \"data.item_events_parquet_compat/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_item_events_parquet_compat_partitioned_with_offset_0\", \"spec\": \"data.item_events_parquet_compat_partitioned/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "onlineSchedule": "@daily"
+    },
+    "name": "gcp.item_event_join.canary_streaming_v1__0",
+    "online": 1,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/gcp/item_event_join.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "rowIds": [
+    "user_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/gcp/team_default_ns_join.v1__0
+++ b/python/test/canary/canary_compiled/joins/gcp/team_default_ns_join.v1__0
@@ -1,0 +1,311 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 6,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {
+              "k": "10"
+            },
+            "inputColumn": "purchase_price",
+            "operation": 13
+          }
+        ],
+        "keyColumns": [
+          "user_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "purchase_price_average_1d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_average_3d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_average_7d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_count_1d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_count_3d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_count_7d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_last10": "631fab32648531978032f3b417da5d52",
+            "purchase_price_sum_1d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_sum_3d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_sum_7d": "631fab32648531978032f3b417da5d52",
+            "user_id": "a406c2de0040b2e926dba6334f299281"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "clusterConf": {
+              "modeClusterConfigs": {
+                "upload": {
+                  "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                }
+              }
+            },
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+                "spark.driver.memory": "512m",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "512m",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+                "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+                "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.shuffle.partitions": "10"
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                "CLOUD_PROVIDER": "gcp",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_PUBSUB": "true",
+                "EVAL_URL": "http://localhost:3904",
+                "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "http://localhost:3000",
+                "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                "GCP_PROJECT_ID": "canary-443022",
+                "GCP_REGION": "us-central1",
+                "HUB_URL": "http://localhost:3903",
+                "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+              },
+              "modeEnvironments": {
+                "upload": {
+                  "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                  "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                  "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                  "CLOUD_PROVIDER": "gcp",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_PUBSUB": "true",
+                  "EVAL_URL": "http://localhost:3904",
+                  "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "http://localhost:3000",
+                  "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                  "GCP_PROJECT_ID": "canary-443022",
+                  "GCP_REGION": "us-central1",
+                  "HUB_URL": "http://localhost:3903",
+                  "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                }
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "gcp.purchases.v1_test__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "gcp",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "selects": {
+                  "purchase_price": "purchase_price",
+                  "user_id": "user_id"
+                },
+                "startPartition": "2023-11-01",
+                "timeColumn": "ts"
+              },
+              "table": "data.gcp_purchases_import_v1__0"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "ts": "ts",
+          "user_id": "user_id"
+        },
+        "timeColumn": "ts"
+      },
+      "table": "data.gcp_team_default_ns_example_v1__0"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "ts": "cbaa656d083778e4bb83eeb6df918034",
+      "user_id": "8a13663bd72149b242b2a9e466ad3e8e",
+      "user_id_purchase_price_average_1d": "ccfe12e5d18cc66a1d1ff3ec09a44c40",
+      "user_id_purchase_price_average_3d": "ccfe12e5d18cc66a1d1ff3ec09a44c40",
+      "user_id_purchase_price_average_7d": "ccfe12e5d18cc66a1d1ff3ec09a44c40",
+      "user_id_purchase_price_count_1d": "ccfe12e5d18cc66a1d1ff3ec09a44c40",
+      "user_id_purchase_price_count_3d": "ccfe12e5d18cc66a1d1ff3ec09a44c40",
+      "user_id_purchase_price_count_7d": "ccfe12e5d18cc66a1d1ff3ec09a44c40",
+      "user_id_purchase_price_last10": "ccfe12e5d18cc66a1d1ff3ec09a44c40",
+      "user_id_purchase_price_sum_1d": "ccfe12e5d18cc66a1d1ff3ec09a44c40",
+      "user_id_purchase_price_sum_3d": "ccfe12e5d18cc66a1d1ff3ec09a44c40",
+      "user_id_purchase_price_sum_7d": "ccfe12e5d18cc66a1d1ff3ec09a44c40"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_team_default_ns_example_v1__0_with_offset_0\", \"spec\": \"data.gcp_team_default_ns_example_v1__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_gcp_purchases_import_v1__0_with_offset_0\", \"spec\": \"data.gcp_purchases_import_v1__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily"
+    },
+    "name": "gcp.team_default_ns_join.v1__0",
+    "online": 0,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/gcp/team_default_ns_join.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "rowIds": [
+    "user_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/gcp/training_set.v1_dev__0
+++ b/python/test/canary/canary_compiled/joins/gcp/training_set.v1_dev__0
@@ -1,0 +1,311 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 6,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {
+              "k": "10"
+            },
+            "inputColumn": "purchase_price",
+            "operation": 13
+          }
+        ],
+        "keyColumns": [
+          "user_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "purchase_price_average_1d": "29fd3a1d4f15d0f15f3eb9f755f56a1d",
+            "purchase_price_average_3d": "29fd3a1d4f15d0f15f3eb9f755f56a1d",
+            "purchase_price_average_7d": "29fd3a1d4f15d0f15f3eb9f755f56a1d",
+            "purchase_price_count_1d": "29fd3a1d4f15d0f15f3eb9f755f56a1d",
+            "purchase_price_count_3d": "29fd3a1d4f15d0f15f3eb9f755f56a1d",
+            "purchase_price_count_7d": "29fd3a1d4f15d0f15f3eb9f755f56a1d",
+            "purchase_price_last10": "29fd3a1d4f15d0f15f3eb9f755f56a1d",
+            "purchase_price_sum_1d": "29fd3a1d4f15d0f15f3eb9f755f56a1d",
+            "purchase_price_sum_3d": "29fd3a1d4f15d0f15f3eb9f755f56a1d",
+            "purchase_price_sum_7d": "29fd3a1d4f15d0f15f3eb9f755f56a1d",
+            "user_id": "990d1cc2263011ec3386075d3a66b1a1"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "clusterConf": {
+              "modeClusterConfigs": {
+                "upload": {
+                  "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                }
+              }
+            },
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+                "spark.driver.memory": "512m",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "512m",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+                "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+                "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.shuffle.partitions": "10"
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                "CLOUD_PROVIDER": "gcp",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_PUBSUB": "true",
+                "EVAL_URL": "http://localhost:3904",
+                "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "http://localhost:3000",
+                "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                "GCP_PROJECT_ID": "canary-443022",
+                "GCP_REGION": "us-central1",
+                "HUB_URL": "http://localhost:3903",
+                "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+              },
+              "modeEnvironments": {
+                "upload": {
+                  "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                  "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                  "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                  "CLOUD_PROVIDER": "gcp",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_PUBSUB": "true",
+                  "EVAL_URL": "http://localhost:3904",
+                  "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "http://localhost:3000",
+                  "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                  "GCP_PROJECT_ID": "canary-443022",
+                  "GCP_REGION": "us-central1",
+                  "HUB_URL": "http://localhost:3903",
+                  "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                }
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "gcp.purchases.v1_dev__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "gcp",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "selects": {
+                  "purchase_price": "purchase_price",
+                  "user_id": "user_id"
+                },
+                "startPartition": "2023-11-01",
+                "timeColumn": "ts"
+              },
+              "table": "data.gcp_purchases_import_v1__0"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "ts": "ts",
+          "user_id": "user_id"
+        },
+        "timeColumn": "ts"
+      },
+      "table": "data.gcp_checkouts_import_v1__0"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "ts": "5e2e06b487bbd3b891e241d157812ae0",
+      "user_id": "a8c24a19e43e6f69241e57d3976fe77d",
+      "user_id_purchase_price_average_1d": "2e37814af181a4b0552be6c124450c6e",
+      "user_id_purchase_price_average_3d": "2e37814af181a4b0552be6c124450c6e",
+      "user_id_purchase_price_average_7d": "2e37814af181a4b0552be6c124450c6e",
+      "user_id_purchase_price_count_1d": "2e37814af181a4b0552be6c124450c6e",
+      "user_id_purchase_price_count_3d": "2e37814af181a4b0552be6c124450c6e",
+      "user_id_purchase_price_count_7d": "2e37814af181a4b0552be6c124450c6e",
+      "user_id_purchase_price_last10": "2e37814af181a4b0552be6c124450c6e",
+      "user_id_purchase_price_sum_1d": "2e37814af181a4b0552be6c124450c6e",
+      "user_id_purchase_price_sum_3d": "2e37814af181a4b0552be6c124450c6e",
+      "user_id_purchase_price_sum_7d": "2e37814af181a4b0552be6c124450c6e"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_checkouts_import_v1__0_with_offset_0\", \"spec\": \"data.gcp_checkouts_import_v1__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_gcp_purchases_import_v1__0_with_offset_0\", \"spec\": \"data.gcp_purchases_import_v1__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily"
+    },
+    "name": "gcp.training_set.v1_dev__0",
+    "online": 0,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/gcp/training_set.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "rowIds": [
+    "user_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/gcp/training_set.v1_dev_notds__0
+++ b/python/test/canary/canary_compiled/joins/gcp/training_set.v1_dev_notds__0
@@ -1,0 +1,313 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 6,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {
+              "k": "10"
+            },
+            "inputColumn": "purchase_price",
+            "operation": 13
+          }
+        ],
+        "keyColumns": [
+          "user_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "purchase_price_average_1d": "fd68ef8ce11f66fb65d9bf80e3f9ece5",
+            "purchase_price_average_3d": "fd68ef8ce11f66fb65d9bf80e3f9ece5",
+            "purchase_price_average_7d": "fd68ef8ce11f66fb65d9bf80e3f9ece5",
+            "purchase_price_count_1d": "fd68ef8ce11f66fb65d9bf80e3f9ece5",
+            "purchase_price_count_3d": "fd68ef8ce11f66fb65d9bf80e3f9ece5",
+            "purchase_price_count_7d": "fd68ef8ce11f66fb65d9bf80e3f9ece5",
+            "purchase_price_last10": "fd68ef8ce11f66fb65d9bf80e3f9ece5",
+            "purchase_price_sum_1d": "fd68ef8ce11f66fb65d9bf80e3f9ece5",
+            "purchase_price_sum_3d": "fd68ef8ce11f66fb65d9bf80e3f9ece5",
+            "purchase_price_sum_7d": "fd68ef8ce11f66fb65d9bf80e3f9ece5",
+            "user_id": "659acfa58500e1f693d923b698c6e4c9"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "clusterConf": {
+              "modeClusterConfigs": {
+                "upload": {
+                  "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                }
+              }
+            },
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+                "spark.driver.memory": "512m",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "512m",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+                "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+                "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.shuffle.partitions": "10"
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                "CLOUD_PROVIDER": "gcp",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_PUBSUB": "true",
+                "EVAL_URL": "http://localhost:3904",
+                "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "http://localhost:3000",
+                "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                "GCP_PROJECT_ID": "canary-443022",
+                "GCP_REGION": "us-central1",
+                "HUB_URL": "http://localhost:3903",
+                "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+              },
+              "modeEnvironments": {
+                "upload": {
+                  "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                  "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                  "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                  "CLOUD_PROVIDER": "gcp",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_PUBSUB": "true",
+                  "EVAL_URL": "http://localhost:3904",
+                  "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "http://localhost:3000",
+                  "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                  "GCP_PROJECT_ID": "canary-443022",
+                  "GCP_REGION": "us-central1",
+                  "HUB_URL": "http://localhost:3903",
+                  "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                }
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "gcp.purchases.v1_dev_notds__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "gcp",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "partitionColumn": "notds",
+                "selects": {
+                  "purchase_price": "purchase_price",
+                  "user_id": "user_id"
+                },
+                "startPartition": "2023-11-01",
+                "timeColumn": "ts"
+              },
+              "table": "data.gcp_purchases_notds_import_v1__0"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "partitionColumn": "notds",
+        "selects": {
+          "ts": "ts",
+          "user_id": "user_id"
+        },
+        "timeColumn": "ts"
+      },
+      "table": "data.gcp_checkouts_notds_import_v1__0"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "ts": "e2212d8cb616fe6331426d0f64d0a049",
+      "user_id": "805c4121299eea43e17c6c535f568e0f",
+      "user_id_purchase_price_average_1d": "31dfb8cbf0c4d756d1d6725d1b003466",
+      "user_id_purchase_price_average_3d": "31dfb8cbf0c4d756d1d6725d1b003466",
+      "user_id_purchase_price_average_7d": "31dfb8cbf0c4d756d1d6725d1b003466",
+      "user_id_purchase_price_count_1d": "31dfb8cbf0c4d756d1d6725d1b003466",
+      "user_id_purchase_price_count_3d": "31dfb8cbf0c4d756d1d6725d1b003466",
+      "user_id_purchase_price_count_7d": "31dfb8cbf0c4d756d1d6725d1b003466",
+      "user_id_purchase_price_last10": "31dfb8cbf0c4d756d1d6725d1b003466",
+      "user_id_purchase_price_sum_1d": "31dfb8cbf0c4d756d1d6725d1b003466",
+      "user_id_purchase_price_sum_3d": "31dfb8cbf0c4d756d1d6725d1b003466",
+      "user_id_purchase_price_sum_7d": "31dfb8cbf0c4d756d1d6725d1b003466"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_checkouts_notds_import_v1__0_with_offset_0\", \"spec\": \"data.gcp_checkouts_notds_import_v1__0/notds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_gcp_purchases_notds_import_v1__0_with_offset_0\", \"spec\": \"data.gcp_purchases_notds_import_v1__0/notds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily"
+    },
+    "name": "gcp.training_set.v1_dev_notds__0",
+    "online": 0,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/gcp/training_set.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "rowIds": [
+    "user_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/gcp/training_set.v1_hub__0
+++ b/python/test/canary/canary_compiled/joins/gcp/training_set.v1_hub__0
@@ -1,0 +1,311 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 6,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {
+              "k": "10"
+            },
+            "inputColumn": "purchase_price",
+            "operation": 13
+          }
+        ],
+        "keyColumns": [
+          "user_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "purchase_price_average_1d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_average_3d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_average_7d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_count_1d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_count_3d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_count_7d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_last10": "631fab32648531978032f3b417da5d52",
+            "purchase_price_sum_1d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_sum_3d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_sum_7d": "631fab32648531978032f3b417da5d52",
+            "user_id": "a406c2de0040b2e926dba6334f299281"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "clusterConf": {
+              "modeClusterConfigs": {
+                "upload": {
+                  "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                }
+              }
+            },
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+                "spark.driver.memory": "512m",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "512m",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+                "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+                "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.shuffle.partitions": "10"
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                "CLOUD_PROVIDER": "gcp",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_PUBSUB": "true",
+                "EVAL_URL": "http://localhost:3904",
+                "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "http://localhost:3000",
+                "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                "GCP_PROJECT_ID": "canary-443022",
+                "GCP_REGION": "us-central1",
+                "HUB_URL": "http://localhost:3903",
+                "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+              },
+              "modeEnvironments": {
+                "upload": {
+                  "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                  "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                  "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                  "CLOUD_PROVIDER": "gcp",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_PUBSUB": "true",
+                  "EVAL_URL": "http://localhost:3904",
+                  "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "http://localhost:3000",
+                  "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                  "GCP_PROJECT_ID": "canary-443022",
+                  "GCP_REGION": "us-central1",
+                  "HUB_URL": "http://localhost:3903",
+                  "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                }
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "gcp.purchases.v1_test__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "gcp",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "selects": {
+                  "purchase_price": "purchase_price",
+                  "user_id": "user_id"
+                },
+                "startPartition": "2023-11-01",
+                "timeColumn": "ts"
+              },
+              "table": "data.gcp_purchases_import_v1__0"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "ts": "ts",
+          "user_id": "user_id"
+        },
+        "timeColumn": "ts"
+      },
+      "table": "data.gcp_checkouts_import_v1__0"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "ts": "5e2e06b487bbd3b891e241d157812ae0",
+      "user_id": "a8c24a19e43e6f69241e57d3976fe77d",
+      "user_id_purchase_price_average_1d": "2e37814af181a4b0552be6c124450c6e",
+      "user_id_purchase_price_average_3d": "2e37814af181a4b0552be6c124450c6e",
+      "user_id_purchase_price_average_7d": "2e37814af181a4b0552be6c124450c6e",
+      "user_id_purchase_price_count_1d": "2e37814af181a4b0552be6c124450c6e",
+      "user_id_purchase_price_count_3d": "2e37814af181a4b0552be6c124450c6e",
+      "user_id_purchase_price_count_7d": "2e37814af181a4b0552be6c124450c6e",
+      "user_id_purchase_price_last10": "2e37814af181a4b0552be6c124450c6e",
+      "user_id_purchase_price_sum_1d": "2e37814af181a4b0552be6c124450c6e",
+      "user_id_purchase_price_sum_3d": "2e37814af181a4b0552be6c124450c6e",
+      "user_id_purchase_price_sum_7d": "2e37814af181a4b0552be6c124450c6e"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_checkouts_import_v1__0_with_offset_0\", \"spec\": \"data.gcp_checkouts_import_v1__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_gcp_purchases_import_v1__0_with_offset_0\", \"spec\": \"data.gcp_purchases_import_v1__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily"
+    },
+    "name": "gcp.training_set.v1_hub__0",
+    "online": 0,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/gcp/training_set.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "rowIds": [
+    "user_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/gcp/training_set.v1_test__0
+++ b/python/test/canary/canary_compiled/joins/gcp/training_set.v1_test__0
@@ -1,0 +1,311 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 6,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {
+              "k": "10"
+            },
+            "inputColumn": "purchase_price",
+            "operation": 13
+          }
+        ],
+        "keyColumns": [
+          "user_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "purchase_price_average_1d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_average_3d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_average_7d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_count_1d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_count_3d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_count_7d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_last10": "631fab32648531978032f3b417da5d52",
+            "purchase_price_sum_1d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_sum_3d": "631fab32648531978032f3b417da5d52",
+            "purchase_price_sum_7d": "631fab32648531978032f3b417da5d52",
+            "user_id": "a406c2de0040b2e926dba6334f299281"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "clusterConf": {
+              "modeClusterConfigs": {
+                "upload": {
+                  "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                }
+              }
+            },
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+                "spark.driver.memory": "512m",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "512m",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+                "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+                "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.shuffle.partitions": "10"
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                "CLOUD_PROVIDER": "gcp",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_PUBSUB": "true",
+                "EVAL_URL": "http://localhost:3904",
+                "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "http://localhost:3000",
+                "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                "GCP_PROJECT_ID": "canary-443022",
+                "GCP_REGION": "us-central1",
+                "HUB_URL": "http://localhost:3903",
+                "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+              },
+              "modeEnvironments": {
+                "upload": {
+                  "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                  "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                  "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                  "CLOUD_PROVIDER": "gcp",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_PUBSUB": "true",
+                  "EVAL_URL": "http://localhost:3904",
+                  "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "http://localhost:3000",
+                  "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                  "GCP_PROJECT_ID": "canary-443022",
+                  "GCP_REGION": "us-central1",
+                  "HUB_URL": "http://localhost:3903",
+                  "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                }
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "gcp.purchases.v1_test__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "gcp",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "selects": {
+                  "purchase_price": "purchase_price",
+                  "user_id": "user_id"
+                },
+                "startPartition": "2023-11-01",
+                "timeColumn": "ts"
+              },
+              "table": "data.gcp_purchases_import_v1__0"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "ts": "ts",
+          "user_id": "user_id"
+        },
+        "timeColumn": "ts"
+      },
+      "table": "data.gcp_checkouts_import_v1__0"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "ts": "5e2e06b487bbd3b891e241d157812ae0",
+      "user_id": "a8c24a19e43e6f69241e57d3976fe77d",
+      "user_id_purchase_price_average_1d": "2e37814af181a4b0552be6c124450c6e",
+      "user_id_purchase_price_average_3d": "2e37814af181a4b0552be6c124450c6e",
+      "user_id_purchase_price_average_7d": "2e37814af181a4b0552be6c124450c6e",
+      "user_id_purchase_price_count_1d": "2e37814af181a4b0552be6c124450c6e",
+      "user_id_purchase_price_count_3d": "2e37814af181a4b0552be6c124450c6e",
+      "user_id_purchase_price_count_7d": "2e37814af181a4b0552be6c124450c6e",
+      "user_id_purchase_price_last10": "2e37814af181a4b0552be6c124450c6e",
+      "user_id_purchase_price_sum_1d": "2e37814af181a4b0552be6c124450c6e",
+      "user_id_purchase_price_sum_3d": "2e37814af181a4b0552be6c124450c6e",
+      "user_id_purchase_price_sum_7d": "2e37814af181a4b0552be6c124450c6e"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_checkouts_import_v1__0_with_offset_0\", \"spec\": \"data.gcp_checkouts_import_v1__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_gcp_purchases_import_v1__0_with_offset_0\", \"spec\": \"data.gcp_purchases_import_v1__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily"
+    },
+    "name": "gcp.training_set.v1_test__0",
+    "online": 0,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/gcp/training_set.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "rowIds": [
+    "user_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/gcp/training_set.v1_test_notds__0
+++ b/python/test/canary/canary_compiled/joins/gcp/training_set.v1_test_notds__0
@@ -1,0 +1,313 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 6,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_price",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 3,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {
+              "k": "10"
+            },
+            "inputColumn": "purchase_price",
+            "operation": 13
+          }
+        ],
+        "keyColumns": [
+          "user_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "purchase_price_average_1d": "75c7ab0be06806e6086fcdd7de7077ea",
+            "purchase_price_average_3d": "75c7ab0be06806e6086fcdd7de7077ea",
+            "purchase_price_average_7d": "75c7ab0be06806e6086fcdd7de7077ea",
+            "purchase_price_count_1d": "75c7ab0be06806e6086fcdd7de7077ea",
+            "purchase_price_count_3d": "75c7ab0be06806e6086fcdd7de7077ea",
+            "purchase_price_count_7d": "75c7ab0be06806e6086fcdd7de7077ea",
+            "purchase_price_last10": "75c7ab0be06806e6086fcdd7de7077ea",
+            "purchase_price_sum_1d": "75c7ab0be06806e6086fcdd7de7077ea",
+            "purchase_price_sum_3d": "75c7ab0be06806e6086fcdd7de7077ea",
+            "purchase_price_sum_7d": "75c7ab0be06806e6086fcdd7de7077ea",
+            "user_id": "e2bd778ac7f0e189c7f627b51b0eaa13"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "clusterConf": {
+              "modeClusterConfigs": {
+                "upload": {
+                  "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                }
+              }
+            },
+            "conf": {
+              "common": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+                "spark.driver.memory": "512m",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "512m",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+                "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+                "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.shuffle.partitions": "10"
+              }
+            },
+            "env": {
+              "common": {
+                "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                "CLOUD_PROVIDER": "gcp",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_PUBSUB": "true",
+                "EVAL_URL": "http://localhost:3904",
+                "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "http://localhost:3000",
+                "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                "GCP_PROJECT_ID": "canary-443022",
+                "GCP_REGION": "us-central1",
+                "HUB_URL": "http://localhost:3903",
+                "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+              },
+              "modeEnvironments": {
+                "upload": {
+                  "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                  "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                  "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                  "CLOUD_PROVIDER": "gcp",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_PUBSUB": "true",
+                  "EVAL_URL": "http://localhost:3904",
+                  "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "http://localhost:3000",
+                  "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                  "GCP_PROJECT_ID": "canary-443022",
+                  "GCP_REGION": "us-central1",
+                  "HUB_URL": "http://localhost:3903",
+                  "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                }
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "gcp.purchases.v1_test_notds__0",
+          "online": 1,
+          "outputNamespace": "data",
+          "team": "gcp",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "partitionColumn": "notds",
+                "selects": {
+                  "purchase_price": "purchase_price",
+                  "user_id": "user_id"
+                },
+                "startPartition": "2023-11-01",
+                "timeColumn": "ts"
+              },
+              "table": "data.gcp_purchases_notds_import_v1__0"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "partitionColumn": "notds",
+        "selects": {
+          "ts": "ts",
+          "user_id": "user_id"
+        },
+        "timeColumn": "ts"
+      },
+      "table": "data.gcp_checkouts_notds_import_v1__0"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "ts": "e2212d8cb616fe6331426d0f64d0a049",
+      "user_id": "805c4121299eea43e17c6c535f568e0f",
+      "user_id_purchase_price_average_1d": "31dfb8cbf0c4d756d1d6725d1b003466",
+      "user_id_purchase_price_average_3d": "31dfb8cbf0c4d756d1d6725d1b003466",
+      "user_id_purchase_price_average_7d": "31dfb8cbf0c4d756d1d6725d1b003466",
+      "user_id_purchase_price_count_1d": "31dfb8cbf0c4d756d1d6725d1b003466",
+      "user_id_purchase_price_count_3d": "31dfb8cbf0c4d756d1d6725d1b003466",
+      "user_id_purchase_price_count_7d": "31dfb8cbf0c4d756d1d6725d1b003466",
+      "user_id_purchase_price_last10": "31dfb8cbf0c4d756d1d6725d1b003466",
+      "user_id_purchase_price_sum_1d": "31dfb8cbf0c4d756d1d6725d1b003466",
+      "user_id_purchase_price_sum_3d": "31dfb8cbf0c4d756d1d6725d1b003466",
+      "user_id_purchase_price_sum_7d": "31dfb8cbf0c4d756d1d6725d1b003466"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_checkouts_notds_import_v1__0_with_offset_0\", \"spec\": \"data.gcp_checkouts_notds_import_v1__0/notds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_gcp_purchases_notds_import_v1__0_with_offset_0\", \"spec\": \"data.gcp_purchases_notds_import_v1__0/notds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily"
+    },
+    "name": "gcp.training_set.v1_test_notds__0",
+    "online": 0,
+    "outputNamespace": "data",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/gcp/training_set.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "rowIds": [
+    "user_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/quickstart/demo.derivations_v1__1
+++ b/python/test/canary/canary_compiled/joins/quickstart/demo.derivations_v1__1
@@ -1,0 +1,686 @@
+{
+  "derivations": [
+    {
+      "expression": "IF(listing_id_weight_grams > 1000, 1, 0)",
+      "name": "is_listing_heavy"
+    },
+    {
+      "expression": "array_contains(split(listing_id_tags, ','), 'handmade')",
+      "name": "is_item_handmade"
+    },
+    {
+      "expression": "log1p(listing_id_price_cents)",
+      "name": "price_log"
+    },
+    {
+      "expression": "\n                CASE\n                    WHEN listing_id_price_cents < 1000 THEN 0\n                    WHEN listing_id_price_cents < 5000 THEN 1\n                    WHEN listing_id_price_cents < 10000 THEN 2\n                    WHEN listing_id_price_cents < 50000 THEN 3\n                    ELSE 4\n                END\n            ",
+      "name": "price_bucket"
+    },
+    {
+      "expression": "*",
+      "name": "*"
+    }
+  ],
+  "joinParts": [
+    {
+      "groupBy": {
+        "keyColumns": [
+          "listing_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "brief_description": "243bd9475048b531e39784ed5a4c5d4c",
+            "currency": "9ab5e4d3c769742611e6e6a21f738f2d",
+            "headline": "81a42c547de455ac521e611ba9481579",
+            "inventory_count": "3960d102ae6397912e352963b24b38dc",
+            "is_active": "379f96022efce3edf51da4b393e79547",
+            "is_expensive": "2504b94d7ac884660d25b2f1244023ae",
+            "is_in_stock": "ebb556dbdf71f816accd53d8c6baa93f",
+            "listing_id": "fbf72f082947fc83693eec35cd952267",
+            "long_description": "595aeee2959d571b6255119efde48896",
+            "main_image_path": "ede172f537c094b47645056183a6a280",
+            "merchant_id": "3771ceeff8397cb4c7ebbd516466b978",
+            "price_cents": "dc1f837ea154688d1fcf185da86bb945",
+            "primary_category": "83ce32a1a4651376edf05ac4c8ecbd11",
+            "secondary_image_paths": "fc4a13046d7659ed39878955d18cf1c4",
+            "tags": "799675961e188b9e4a5a898d7e3f02ff",
+            "weight_grams": "5c3e9f99cb7ec2d0aa56c9bd0e391308"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "conf": {
+              "common": {
+                "spark.chronon.partition.column": "ds"
+              }
+            },
+            "env": {
+              "common": {
+                "CUSTOMER_ID": "dev",
+                "FRONTEND_URL": "http://localhost:3000",
+                "HUB_URL": "http://localhost:3903",
+                "VERSION": "latest"
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "quickstart.dim_listings.v1__0",
+          "online": 1,
+          "outputNamespace": "quickstart",
+          "team": "quickstart",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "entities": {
+              "query": {
+                "selects": {
+                  "brief_description": "brief_description",
+                  "currency": "currency",
+                  "headline": "headline",
+                  "inventory_count": "inventory_count",
+                  "is_active": "is_active",
+                  "is_expensive": "IF(price_cents > 10000, 1, 0)",
+                  "is_in_stock": "IF(inventory_count > 0, 1, 0)",
+                  "listing_id": "listing_id",
+                  "long_description": "long_description",
+                  "main_image_path": "main_image_path",
+                  "merchant_id": "merchant_id",
+                  "price_cents": "price_cents",
+                  "primary_category": "primary_category",
+                  "secondary_image_paths": "secondary_image_paths",
+                  "tags": "tags",
+                  "weight_grams": "weight_grams"
+                },
+                "startPartition": "2023-11-01"
+              },
+              "snapshotTable": "quickstart.quickstart_exports_dim_listings__0"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    },
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "view_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "click_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "favorite_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "add_to_cart_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "view_event",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "click_event",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_event",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "favorite_event",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "add_to_cart_event",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "is_mobile",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "is_desktop",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "is_tablet",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {
+              "k": "128"
+            },
+            "inputColumn": "user_event_struct",
+            "operation": 13,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          }
+        ],
+        "keyColumns": [
+          "user_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "add_to_cart_event_average_14d": "721cedd948fa111b342a27442173c100",
+            "add_to_cart_event_average_1d": "721cedd948fa111b342a27442173c100",
+            "add_to_cart_event_average_30d": "721cedd948fa111b342a27442173c100",
+            "add_to_cart_event_average_7d": "721cedd948fa111b342a27442173c100",
+            "add_to_cart_event_sum_14d": "721cedd948fa111b342a27442173c100",
+            "add_to_cart_event_sum_1d": "721cedd948fa111b342a27442173c100",
+            "add_to_cart_event_sum_30d": "721cedd948fa111b342a27442173c100",
+            "add_to_cart_event_sum_7d": "721cedd948fa111b342a27442173c100",
+            "click_event_average_14d": "ea6d27949c09cfc8b23f5b20f445dcd5",
+            "click_event_average_1d": "ea6d27949c09cfc8b23f5b20f445dcd5",
+            "click_event_average_30d": "ea6d27949c09cfc8b23f5b20f445dcd5",
+            "click_event_average_7d": "ea6d27949c09cfc8b23f5b20f445dcd5",
+            "click_event_sum_14d": "ea6d27949c09cfc8b23f5b20f445dcd5",
+            "click_event_sum_1d": "ea6d27949c09cfc8b23f5b20f445dcd5",
+            "click_event_sum_30d": "ea6d27949c09cfc8b23f5b20f445dcd5",
+            "click_event_sum_7d": "ea6d27949c09cfc8b23f5b20f445dcd5",
+            "favorite_event_average_14d": "8c5dbe13014ce5c05064cd89fede7998",
+            "favorite_event_average_1d": "8c5dbe13014ce5c05064cd89fede7998",
+            "favorite_event_average_30d": "8c5dbe13014ce5c05064cd89fede7998",
+            "favorite_event_average_7d": "8c5dbe13014ce5c05064cd89fede7998",
+            "favorite_event_sum_14d": "8c5dbe13014ce5c05064cd89fede7998",
+            "favorite_event_sum_1d": "8c5dbe13014ce5c05064cd89fede7998",
+            "favorite_event_sum_30d": "8c5dbe13014ce5c05064cd89fede7998",
+            "favorite_event_sum_7d": "8c5dbe13014ce5c05064cd89fede7998",
+            "is_desktop_sum_14d": "cd279c4eecf6966bba76ebcf642e07c1",
+            "is_desktop_sum_1d": "cd279c4eecf6966bba76ebcf642e07c1",
+            "is_desktop_sum_30d": "cd279c4eecf6966bba76ebcf642e07c1",
+            "is_desktop_sum_7d": "cd279c4eecf6966bba76ebcf642e07c1",
+            "is_mobile_sum_14d": "4aad5a5a5bad4a8029ba05cc6b299b8c",
+            "is_mobile_sum_1d": "4aad5a5a5bad4a8029ba05cc6b299b8c",
+            "is_mobile_sum_30d": "4aad5a5a5bad4a8029ba05cc6b299b8c",
+            "is_mobile_sum_7d": "4aad5a5a5bad4a8029ba05cc6b299b8c",
+            "is_tablet_sum_14d": "e45ad389d51304af80f003ab465b215f",
+            "is_tablet_sum_1d": "e45ad389d51304af80f003ab465b215f",
+            "is_tablet_sum_30d": "e45ad389d51304af80f003ab465b215f",
+            "is_tablet_sum_7d": "e45ad389d51304af80f003ab465b215f",
+            "purchase_event_average_14d": "af3161f10b0f6c6fbfd48885ac5943c9",
+            "purchase_event_average_1d": "af3161f10b0f6c6fbfd48885ac5943c9",
+            "purchase_event_average_30d": "af3161f10b0f6c6fbfd48885ac5943c9",
+            "purchase_event_average_7d": "af3161f10b0f6c6fbfd48885ac5943c9",
+            "purchase_event_sum_14d": "af3161f10b0f6c6fbfd48885ac5943c9",
+            "purchase_event_sum_1d": "af3161f10b0f6c6fbfd48885ac5943c9",
+            "purchase_event_sum_30d": "af3161f10b0f6c6fbfd48885ac5943c9",
+            "purchase_event_sum_7d": "af3161f10b0f6c6fbfd48885ac5943c9",
+            "user_event_struct_last128_14d": "47d3f70709072f97d2b414d5403026ce",
+            "user_event_struct_last128_1d": "47d3f70709072f97d2b414d5403026ce",
+            "user_event_struct_last128_30d": "47d3f70709072f97d2b414d5403026ce",
+            "user_event_struct_last128_7d": "47d3f70709072f97d2b414d5403026ce",
+            "user_id": "1cefa43bec1f992629ef61e61e07bd76",
+            "view_event_average_14d": "62a8793addff23c7d8079961a8a07320",
+            "view_event_average_1d": "62a8793addff23c7d8079961a8a07320",
+            "view_event_average_30d": "62a8793addff23c7d8079961a8a07320",
+            "view_event_average_7d": "62a8793addff23c7d8079961a8a07320",
+            "view_event_sum_14d": "62a8793addff23c7d8079961a8a07320",
+            "view_event_sum_1d": "62a8793addff23c7d8079961a8a07320",
+            "view_event_sum_30d": "62a8793addff23c7d8079961a8a07320",
+            "view_event_sum_7d": "62a8793addff23c7d8079961a8a07320"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "conf": {
+              "common": {
+                "spark.chronon.partition.column": "ds"
+              }
+            },
+            "env": {
+              "common": {
+                "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+                "CUSTOMER_ID": "dev",
+                "FRONTEND_URL": "http://localhost:3000",
+                "HUB_URL": "http://localhost:3903",
+                "VERSION": "latest"
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily",
+            "stepDays": 4
+          },
+          "name": "quickstart.user_activities.v1__1",
+          "online": 1,
+          "outputNamespace": "quickstart",
+          "team": "quickstart",
+          "version": "1"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "selects": {
+                  "add_to_cart_event": "IF(event_type = 'add_to_cart', 1, 0)",
+                  "click_event": "IF(event_type = 'click', 1, 0)",
+                  "favorite_event": "IF(event_type = 'favorite', 1, 0)",
+                  "is_desktop": "IF(device_type = 'desktop', 1, 0)",
+                  "is_mobile": "IF(device_type = 'mobile', 1, 0)",
+                  "is_tablet": "IF(device_type = 'tablet', 1, 0)",
+                  "listing_id": "listing_id",
+                  "purchase_event": "IF(event_type = 'purchase', 1, 0)",
+                  "user_event_struct": "struct(event_type, listing_id, event_time_ms as timestamp)",
+                  "user_id": "user_id",
+                  "view_event": "IF(event_type = 'view', 1, 0)"
+                },
+                "timeColumn": "event_time_ms"
+              },
+              "table": "quickstart.quickstart_exports_user_activities__0",
+              "topic": "user_activities_stream"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "listing_id": "listing_id",
+          "row_id": "event_id",
+          "ts": "event_time_ms",
+          "user_id": "user_id"
+        },
+        "timeColumn": "event_time_ms"
+      },
+      "table": "quickstart.quickstart_exports_user_activities__0"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "is_item_handmade": "238d6734c677868d09ffbd4f01e28f01",
+      "is_listing_heavy": "6294db2aa60c064d77d30edb0504ae98",
+      "listing_id": "4b3027633335c8df64bc8820f4f56fce",
+      "listing_id_brief_description": "c71f33ba349f66c01dcf4557f4cb94de",
+      "listing_id_currency": "f49a33afa3929e6e7c460f8acbd2a4eb",
+      "listing_id_headline": "fc839d4105e1aac4fe1c3de1c8286e1c",
+      "listing_id_inventory_count": "f9f680e671f106750757d3e9b7434fc3",
+      "listing_id_is_active": "fc1a13593a08a049d853425f5048a96d",
+      "listing_id_is_expensive": "2eb7f00ec6398e404f2aec9239446bda",
+      "listing_id_is_in_stock": "4f7e695f325a78276e2dedb8166c2623",
+      "listing_id_listing_id": "52d50ba7ee0e7dccbb3f1073cdba87eb",
+      "listing_id_long_description": "abb42ebe24f787623707f37c4fa0bf6f",
+      "listing_id_main_image_path": "c64891f0aa0e400990bf8ad85bb73f05",
+      "listing_id_merchant_id": "83f8e4cf838d7048d8309caceb5f6097",
+      "listing_id_price_cents": "9b7f6f7e90460e43de9a79170c725dd8",
+      "listing_id_primary_category": "1ea78421a70d9d19b94bb75862ebd6bc",
+      "listing_id_secondary_image_paths": "3ff5eb4424e9710aa123d7ec2b5c97f4",
+      "listing_id_tags": "cc114b56dcde8f9767d3ec8c1f459f66",
+      "listing_id_weight_grams": "35b0897447856c1e916fa5231a46a624",
+      "price_bucket": "52299d4fe1b81ca11d5a6acdfdb97819",
+      "price_log": "69da7377b3bb4f4b0417e503ea2ea663",
+      "row_id": "a9ba055d706957bc41ff081e3b103156",
+      "ts": "ed4e298422a4f5a0412df3165e7a2fa6",
+      "user_id": "a73717a51818e41dcddfd683143c082d",
+      "user_id_add_to_cart_event_average_14d": "27ca57b4dad0cd206d5bb47fddd583cf",
+      "user_id_add_to_cart_event_average_1d": "27ca57b4dad0cd206d5bb47fddd583cf",
+      "user_id_add_to_cart_event_average_30d": "27ca57b4dad0cd206d5bb47fddd583cf",
+      "user_id_add_to_cart_event_average_7d": "27ca57b4dad0cd206d5bb47fddd583cf",
+      "user_id_add_to_cart_event_sum_14d": "27ca57b4dad0cd206d5bb47fddd583cf",
+      "user_id_add_to_cart_event_sum_1d": "27ca57b4dad0cd206d5bb47fddd583cf",
+      "user_id_add_to_cart_event_sum_30d": "27ca57b4dad0cd206d5bb47fddd583cf",
+      "user_id_add_to_cart_event_sum_7d": "27ca57b4dad0cd206d5bb47fddd583cf",
+      "user_id_click_event_average_14d": "9ac6396069fa92eda053ac3364225733",
+      "user_id_click_event_average_1d": "9ac6396069fa92eda053ac3364225733",
+      "user_id_click_event_average_30d": "9ac6396069fa92eda053ac3364225733",
+      "user_id_click_event_average_7d": "9ac6396069fa92eda053ac3364225733",
+      "user_id_click_event_sum_14d": "9ac6396069fa92eda053ac3364225733",
+      "user_id_click_event_sum_1d": "9ac6396069fa92eda053ac3364225733",
+      "user_id_click_event_sum_30d": "9ac6396069fa92eda053ac3364225733",
+      "user_id_click_event_sum_7d": "9ac6396069fa92eda053ac3364225733",
+      "user_id_favorite_event_average_14d": "2561aa654af762623dec196e75a5b763",
+      "user_id_favorite_event_average_1d": "2561aa654af762623dec196e75a5b763",
+      "user_id_favorite_event_average_30d": "2561aa654af762623dec196e75a5b763",
+      "user_id_favorite_event_average_7d": "2561aa654af762623dec196e75a5b763",
+      "user_id_favorite_event_sum_14d": "2561aa654af762623dec196e75a5b763",
+      "user_id_favorite_event_sum_1d": "2561aa654af762623dec196e75a5b763",
+      "user_id_favorite_event_sum_30d": "2561aa654af762623dec196e75a5b763",
+      "user_id_favorite_event_sum_7d": "2561aa654af762623dec196e75a5b763",
+      "user_id_is_desktop_sum_14d": "b1e4a3ef656c7d295be3608837315fee",
+      "user_id_is_desktop_sum_1d": "b1e4a3ef656c7d295be3608837315fee",
+      "user_id_is_desktop_sum_30d": "b1e4a3ef656c7d295be3608837315fee",
+      "user_id_is_desktop_sum_7d": "b1e4a3ef656c7d295be3608837315fee",
+      "user_id_is_mobile_sum_14d": "eb3aab96af7e41d9fb2589d46932f479",
+      "user_id_is_mobile_sum_1d": "eb3aab96af7e41d9fb2589d46932f479",
+      "user_id_is_mobile_sum_30d": "eb3aab96af7e41d9fb2589d46932f479",
+      "user_id_is_mobile_sum_7d": "eb3aab96af7e41d9fb2589d46932f479",
+      "user_id_is_tablet_sum_14d": "f1a3b4bbfe9a338cc40bc3da04d62800",
+      "user_id_is_tablet_sum_1d": "f1a3b4bbfe9a338cc40bc3da04d62800",
+      "user_id_is_tablet_sum_30d": "f1a3b4bbfe9a338cc40bc3da04d62800",
+      "user_id_is_tablet_sum_7d": "f1a3b4bbfe9a338cc40bc3da04d62800",
+      "user_id_purchase_event_average_14d": "035af4a792b491ccc25e8a37d347d255",
+      "user_id_purchase_event_average_1d": "035af4a792b491ccc25e8a37d347d255",
+      "user_id_purchase_event_average_30d": "035af4a792b491ccc25e8a37d347d255",
+      "user_id_purchase_event_average_7d": "035af4a792b491ccc25e8a37d347d255",
+      "user_id_purchase_event_sum_14d": "035af4a792b491ccc25e8a37d347d255",
+      "user_id_purchase_event_sum_1d": "035af4a792b491ccc25e8a37d347d255",
+      "user_id_purchase_event_sum_30d": "035af4a792b491ccc25e8a37d347d255",
+      "user_id_purchase_event_sum_7d": "035af4a792b491ccc25e8a37d347d255",
+      "user_id_user_event_struct_last128_14d": "d2d88f5a9804dfc14b857b628af5bef7",
+      "user_id_user_event_struct_last128_1d": "d2d88f5a9804dfc14b857b628af5bef7",
+      "user_id_user_event_struct_last128_30d": "d2d88f5a9804dfc14b857b628af5bef7",
+      "user_id_user_event_struct_last128_7d": "d2d88f5a9804dfc14b857b628af5bef7",
+      "user_id_view_event_average_14d": "c7ae73b92e2a8aabfb4df9d22d37d2f5",
+      "user_id_view_event_average_1d": "c7ae73b92e2a8aabfb4df9d22d37d2f5",
+      "user_id_view_event_average_30d": "c7ae73b92e2a8aabfb4df9d22d37d2f5",
+      "user_id_view_event_average_7d": "c7ae73b92e2a8aabfb4df9d22d37d2f5",
+      "user_id_view_event_sum_14d": "c7ae73b92e2a8aabfb4df9d22d37d2f5",
+      "user_id_view_event_sum_1d": "c7ae73b92e2a8aabfb4df9d22d37d2f5",
+      "user_id_view_event_sum_30d": "c7ae73b92e2a8aabfb4df9d22d37d2f5",
+      "user_id_view_event_sum_7d": "c7ae73b92e2a8aabfb4df9d22d37d2f5"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_quickstart_quickstart_exports_user_activities__0_with_offset_0\", \"spec\": \"quickstart.quickstart_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_quickstart_quickstart_exports_dim_listings__0_with_offset_0\", \"spec\": \"quickstart.quickstart_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "enableStatsCompute": 1,
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "offlineSchedule": "0 3 * * *",
+      "onlineSchedule": "0 3 * * *",
+      "stepDays": 5
+    },
+    "name": "quickstart.demo.derivations_v1__1",
+    "online": 1,
+    "outputNamespace": "quickstart",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/quickstart/demo.py",
+    "team": "quickstart",
+    "version": "1"
+  },
+  "rowIds": [
+    "event_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/joins/quickstart/demo.v1__1
+++ b/python/test/canary/canary_compiled/joins/quickstart/demo.v1__1
@@ -1,0 +1,660 @@
+{
+  "joinParts": [
+    {
+      "groupBy": {
+        "aggregations": [
+          {
+            "argMap": {},
+            "inputColumn": "view_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "click_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "favorite_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "add_to_cart_event",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "view_event",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "click_event",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "purchase_event",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "favorite_event",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "add_to_cart_event",
+            "operation": 8,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "is_mobile",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "is_desktop",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {},
+            "inputColumn": "is_tablet",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "argMap": {
+              "k": "128"
+            },
+            "inputColumn": "user_event_struct",
+            "operation": 13,
+            "windows": [
+              {
+                "length": 1,
+                "timeUnit": 1
+              },
+              {
+                "length": 7,
+                "timeUnit": 1
+              },
+              {
+                "length": 14,
+                "timeUnit": 1
+              },
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          }
+        ],
+        "keyColumns": [
+          "user_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "add_to_cart_event_average_14d": "721cedd948fa111b342a27442173c100",
+            "add_to_cart_event_average_1d": "721cedd948fa111b342a27442173c100",
+            "add_to_cart_event_average_30d": "721cedd948fa111b342a27442173c100",
+            "add_to_cart_event_average_7d": "721cedd948fa111b342a27442173c100",
+            "add_to_cart_event_sum_14d": "721cedd948fa111b342a27442173c100",
+            "add_to_cart_event_sum_1d": "721cedd948fa111b342a27442173c100",
+            "add_to_cart_event_sum_30d": "721cedd948fa111b342a27442173c100",
+            "add_to_cart_event_sum_7d": "721cedd948fa111b342a27442173c100",
+            "click_event_average_14d": "ea6d27949c09cfc8b23f5b20f445dcd5",
+            "click_event_average_1d": "ea6d27949c09cfc8b23f5b20f445dcd5",
+            "click_event_average_30d": "ea6d27949c09cfc8b23f5b20f445dcd5",
+            "click_event_average_7d": "ea6d27949c09cfc8b23f5b20f445dcd5",
+            "click_event_sum_14d": "ea6d27949c09cfc8b23f5b20f445dcd5",
+            "click_event_sum_1d": "ea6d27949c09cfc8b23f5b20f445dcd5",
+            "click_event_sum_30d": "ea6d27949c09cfc8b23f5b20f445dcd5",
+            "click_event_sum_7d": "ea6d27949c09cfc8b23f5b20f445dcd5",
+            "favorite_event_average_14d": "8c5dbe13014ce5c05064cd89fede7998",
+            "favorite_event_average_1d": "8c5dbe13014ce5c05064cd89fede7998",
+            "favorite_event_average_30d": "8c5dbe13014ce5c05064cd89fede7998",
+            "favorite_event_average_7d": "8c5dbe13014ce5c05064cd89fede7998",
+            "favorite_event_sum_14d": "8c5dbe13014ce5c05064cd89fede7998",
+            "favorite_event_sum_1d": "8c5dbe13014ce5c05064cd89fede7998",
+            "favorite_event_sum_30d": "8c5dbe13014ce5c05064cd89fede7998",
+            "favorite_event_sum_7d": "8c5dbe13014ce5c05064cd89fede7998",
+            "is_desktop_sum_14d": "cd279c4eecf6966bba76ebcf642e07c1",
+            "is_desktop_sum_1d": "cd279c4eecf6966bba76ebcf642e07c1",
+            "is_desktop_sum_30d": "cd279c4eecf6966bba76ebcf642e07c1",
+            "is_desktop_sum_7d": "cd279c4eecf6966bba76ebcf642e07c1",
+            "is_mobile_sum_14d": "4aad5a5a5bad4a8029ba05cc6b299b8c",
+            "is_mobile_sum_1d": "4aad5a5a5bad4a8029ba05cc6b299b8c",
+            "is_mobile_sum_30d": "4aad5a5a5bad4a8029ba05cc6b299b8c",
+            "is_mobile_sum_7d": "4aad5a5a5bad4a8029ba05cc6b299b8c",
+            "is_tablet_sum_14d": "e45ad389d51304af80f003ab465b215f",
+            "is_tablet_sum_1d": "e45ad389d51304af80f003ab465b215f",
+            "is_tablet_sum_30d": "e45ad389d51304af80f003ab465b215f",
+            "is_tablet_sum_7d": "e45ad389d51304af80f003ab465b215f",
+            "purchase_event_average_14d": "af3161f10b0f6c6fbfd48885ac5943c9",
+            "purchase_event_average_1d": "af3161f10b0f6c6fbfd48885ac5943c9",
+            "purchase_event_average_30d": "af3161f10b0f6c6fbfd48885ac5943c9",
+            "purchase_event_average_7d": "af3161f10b0f6c6fbfd48885ac5943c9",
+            "purchase_event_sum_14d": "af3161f10b0f6c6fbfd48885ac5943c9",
+            "purchase_event_sum_1d": "af3161f10b0f6c6fbfd48885ac5943c9",
+            "purchase_event_sum_30d": "af3161f10b0f6c6fbfd48885ac5943c9",
+            "purchase_event_sum_7d": "af3161f10b0f6c6fbfd48885ac5943c9",
+            "user_event_struct_last128_14d": "47d3f70709072f97d2b414d5403026ce",
+            "user_event_struct_last128_1d": "47d3f70709072f97d2b414d5403026ce",
+            "user_event_struct_last128_30d": "47d3f70709072f97d2b414d5403026ce",
+            "user_event_struct_last128_7d": "47d3f70709072f97d2b414d5403026ce",
+            "user_id": "1cefa43bec1f992629ef61e61e07bd76",
+            "view_event_average_14d": "62a8793addff23c7d8079961a8a07320",
+            "view_event_average_1d": "62a8793addff23c7d8079961a8a07320",
+            "view_event_average_30d": "62a8793addff23c7d8079961a8a07320",
+            "view_event_average_7d": "62a8793addff23c7d8079961a8a07320",
+            "view_event_sum_14d": "62a8793addff23c7d8079961a8a07320",
+            "view_event_sum_1d": "62a8793addff23c7d8079961a8a07320",
+            "view_event_sum_30d": "62a8793addff23c7d8079961a8a07320",
+            "view_event_sum_7d": "62a8793addff23c7d8079961a8a07320"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "conf": {
+              "common": {
+                "spark.chronon.partition.column": "ds"
+              }
+            },
+            "env": {
+              "common": {
+                "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+                "CUSTOMER_ID": "dev",
+                "FRONTEND_URL": "http://localhost:3000",
+                "HUB_URL": "http://localhost:3903",
+                "VERSION": "latest"
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily",
+            "stepDays": 4
+          },
+          "name": "quickstart.user_activities.v1__1",
+          "online": 1,
+          "outputNamespace": "quickstart",
+          "team": "quickstart",
+          "version": "1"
+        },
+        "sources": [
+          {
+            "events": {
+              "query": {
+                "selects": {
+                  "add_to_cart_event": "IF(event_type = 'add_to_cart', 1, 0)",
+                  "click_event": "IF(event_type = 'click', 1, 0)",
+                  "favorite_event": "IF(event_type = 'favorite', 1, 0)",
+                  "is_desktop": "IF(device_type = 'desktop', 1, 0)",
+                  "is_mobile": "IF(device_type = 'mobile', 1, 0)",
+                  "is_tablet": "IF(device_type = 'tablet', 1, 0)",
+                  "listing_id": "listing_id",
+                  "purchase_event": "IF(event_type = 'purchase', 1, 0)",
+                  "user_event_struct": "struct(event_type, listing_id, event_time_ms as timestamp)",
+                  "user_id": "user_id",
+                  "view_event": "IF(event_type = 'view', 1, 0)"
+                },
+                "timeColumn": "event_time_ms"
+              },
+              "table": "quickstart.quickstart_exports_user_activities__0",
+              "topic": "user_activities_stream"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    },
+    {
+      "groupBy": {
+        "keyColumns": [
+          "listing_id"
+        ],
+        "metaData": {
+          "columnHashes": {
+            "brief_description": "243bd9475048b531e39784ed5a4c5d4c",
+            "currency": "9ab5e4d3c769742611e6e6a21f738f2d",
+            "headline": "81a42c547de455ac521e611ba9481579",
+            "inventory_count": "3960d102ae6397912e352963b24b38dc",
+            "is_active": "379f96022efce3edf51da4b393e79547",
+            "is_expensive": "2504b94d7ac884660d25b2f1244023ae",
+            "is_in_stock": "ebb556dbdf71f816accd53d8c6baa93f",
+            "listing_id": "fbf72f082947fc83693eec35cd952267",
+            "long_description": "595aeee2959d571b6255119efde48896",
+            "main_image_path": "ede172f537c094b47645056183a6a280",
+            "merchant_id": "3771ceeff8397cb4c7ebbd516466b978",
+            "price_cents": "dc1f837ea154688d1fcf185da86bb945",
+            "primary_category": "83ce32a1a4651376edf05ac4c8ecbd11",
+            "secondary_image_paths": "fc4a13046d7659ed39878955d18cf1c4",
+            "tags": "799675961e188b9e4a5a898d7e3f02ff",
+            "weight_grams": "5c3e9f99cb7ec2d0aa56c9bd0e391308"
+          },
+          "environments": [
+            0
+          ],
+          "executionInfo": {
+            "conf": {
+              "common": {
+                "spark.chronon.partition.column": "ds"
+              }
+            },
+            "env": {
+              "common": {
+                "CUSTOMER_ID": "dev",
+                "FRONTEND_URL": "http://localhost:3000",
+                "HUB_URL": "http://localhost:3903",
+                "VERSION": "latest"
+              }
+            },
+            "historicalBackfill": 0,
+            "onlineSchedule": "@daily"
+          },
+          "name": "quickstart.dim_listings.v1__0",
+          "online": 1,
+          "outputNamespace": "quickstart",
+          "team": "quickstart",
+          "version": "0"
+        },
+        "sources": [
+          {
+            "entities": {
+              "query": {
+                "selects": {
+                  "brief_description": "brief_description",
+                  "currency": "currency",
+                  "headline": "headline",
+                  "inventory_count": "inventory_count",
+                  "is_active": "is_active",
+                  "is_expensive": "IF(price_cents > 10000, 1, 0)",
+                  "is_in_stock": "IF(inventory_count > 0, 1, 0)",
+                  "listing_id": "listing_id",
+                  "long_description": "long_description",
+                  "main_image_path": "main_image_path",
+                  "merchant_id": "merchant_id",
+                  "price_cents": "price_cents",
+                  "primary_category": "primary_category",
+                  "secondary_image_paths": "secondary_image_paths",
+                  "tags": "tags",
+                  "weight_grams": "weight_grams"
+                },
+                "startPartition": "2023-11-01"
+              },
+              "snapshotTable": "quickstart.quickstart_exports_dim_listings__0"
+            }
+          }
+        ]
+      },
+      "useLongNames": 0
+    }
+  ],
+  "left": {
+    "events": {
+      "query": {
+        "selects": {
+          "listing_id": "listing_id",
+          "row_id": "event_id",
+          "ts": "event_time_ms",
+          "user_id": "user_id"
+        },
+        "timeColumn": "event_time_ms"
+      },
+      "table": "quickstart.quickstart_exports_user_activities__0"
+    }
+  },
+  "metaData": {
+    "columnHashes": {
+      "listing_id": "4b3027633335c8df64bc8820f4f56fce",
+      "listing_id_brief_description": "c71f33ba349f66c01dcf4557f4cb94de",
+      "listing_id_currency": "f49a33afa3929e6e7c460f8acbd2a4eb",
+      "listing_id_headline": "fc839d4105e1aac4fe1c3de1c8286e1c",
+      "listing_id_inventory_count": "f9f680e671f106750757d3e9b7434fc3",
+      "listing_id_is_active": "fc1a13593a08a049d853425f5048a96d",
+      "listing_id_is_expensive": "2eb7f00ec6398e404f2aec9239446bda",
+      "listing_id_is_in_stock": "4f7e695f325a78276e2dedb8166c2623",
+      "listing_id_listing_id": "52d50ba7ee0e7dccbb3f1073cdba87eb",
+      "listing_id_long_description": "abb42ebe24f787623707f37c4fa0bf6f",
+      "listing_id_main_image_path": "c64891f0aa0e400990bf8ad85bb73f05",
+      "listing_id_merchant_id": "83f8e4cf838d7048d8309caceb5f6097",
+      "listing_id_price_cents": "9b7f6f7e90460e43de9a79170c725dd8",
+      "listing_id_primary_category": "1ea78421a70d9d19b94bb75862ebd6bc",
+      "listing_id_secondary_image_paths": "3ff5eb4424e9710aa123d7ec2b5c97f4",
+      "listing_id_tags": "cc114b56dcde8f9767d3ec8c1f459f66",
+      "listing_id_weight_grams": "35b0897447856c1e916fa5231a46a624",
+      "row_id": "a9ba055d706957bc41ff081e3b103156",
+      "ts": "ed4e298422a4f5a0412df3165e7a2fa6",
+      "user_id": "a73717a51818e41dcddfd683143c082d",
+      "user_id_add_to_cart_event_average_14d": "27ca57b4dad0cd206d5bb47fddd583cf",
+      "user_id_add_to_cart_event_average_1d": "27ca57b4dad0cd206d5bb47fddd583cf",
+      "user_id_add_to_cart_event_average_30d": "27ca57b4dad0cd206d5bb47fddd583cf",
+      "user_id_add_to_cart_event_average_7d": "27ca57b4dad0cd206d5bb47fddd583cf",
+      "user_id_add_to_cart_event_sum_14d": "27ca57b4dad0cd206d5bb47fddd583cf",
+      "user_id_add_to_cart_event_sum_1d": "27ca57b4dad0cd206d5bb47fddd583cf",
+      "user_id_add_to_cart_event_sum_30d": "27ca57b4dad0cd206d5bb47fddd583cf",
+      "user_id_add_to_cart_event_sum_7d": "27ca57b4dad0cd206d5bb47fddd583cf",
+      "user_id_click_event_average_14d": "9ac6396069fa92eda053ac3364225733",
+      "user_id_click_event_average_1d": "9ac6396069fa92eda053ac3364225733",
+      "user_id_click_event_average_30d": "9ac6396069fa92eda053ac3364225733",
+      "user_id_click_event_average_7d": "9ac6396069fa92eda053ac3364225733",
+      "user_id_click_event_sum_14d": "9ac6396069fa92eda053ac3364225733",
+      "user_id_click_event_sum_1d": "9ac6396069fa92eda053ac3364225733",
+      "user_id_click_event_sum_30d": "9ac6396069fa92eda053ac3364225733",
+      "user_id_click_event_sum_7d": "9ac6396069fa92eda053ac3364225733",
+      "user_id_favorite_event_average_14d": "2561aa654af762623dec196e75a5b763",
+      "user_id_favorite_event_average_1d": "2561aa654af762623dec196e75a5b763",
+      "user_id_favorite_event_average_30d": "2561aa654af762623dec196e75a5b763",
+      "user_id_favorite_event_average_7d": "2561aa654af762623dec196e75a5b763",
+      "user_id_favorite_event_sum_14d": "2561aa654af762623dec196e75a5b763",
+      "user_id_favorite_event_sum_1d": "2561aa654af762623dec196e75a5b763",
+      "user_id_favorite_event_sum_30d": "2561aa654af762623dec196e75a5b763",
+      "user_id_favorite_event_sum_7d": "2561aa654af762623dec196e75a5b763",
+      "user_id_is_desktop_sum_14d": "b1e4a3ef656c7d295be3608837315fee",
+      "user_id_is_desktop_sum_1d": "b1e4a3ef656c7d295be3608837315fee",
+      "user_id_is_desktop_sum_30d": "b1e4a3ef656c7d295be3608837315fee",
+      "user_id_is_desktop_sum_7d": "b1e4a3ef656c7d295be3608837315fee",
+      "user_id_is_mobile_sum_14d": "eb3aab96af7e41d9fb2589d46932f479",
+      "user_id_is_mobile_sum_1d": "eb3aab96af7e41d9fb2589d46932f479",
+      "user_id_is_mobile_sum_30d": "eb3aab96af7e41d9fb2589d46932f479",
+      "user_id_is_mobile_sum_7d": "eb3aab96af7e41d9fb2589d46932f479",
+      "user_id_is_tablet_sum_14d": "f1a3b4bbfe9a338cc40bc3da04d62800",
+      "user_id_is_tablet_sum_1d": "f1a3b4bbfe9a338cc40bc3da04d62800",
+      "user_id_is_tablet_sum_30d": "f1a3b4bbfe9a338cc40bc3da04d62800",
+      "user_id_is_tablet_sum_7d": "f1a3b4bbfe9a338cc40bc3da04d62800",
+      "user_id_purchase_event_average_14d": "035af4a792b491ccc25e8a37d347d255",
+      "user_id_purchase_event_average_1d": "035af4a792b491ccc25e8a37d347d255",
+      "user_id_purchase_event_average_30d": "035af4a792b491ccc25e8a37d347d255",
+      "user_id_purchase_event_average_7d": "035af4a792b491ccc25e8a37d347d255",
+      "user_id_purchase_event_sum_14d": "035af4a792b491ccc25e8a37d347d255",
+      "user_id_purchase_event_sum_1d": "035af4a792b491ccc25e8a37d347d255",
+      "user_id_purchase_event_sum_30d": "035af4a792b491ccc25e8a37d347d255",
+      "user_id_purchase_event_sum_7d": "035af4a792b491ccc25e8a37d347d255",
+      "user_id_user_event_struct_last128_14d": "d2d88f5a9804dfc14b857b628af5bef7",
+      "user_id_user_event_struct_last128_1d": "d2d88f5a9804dfc14b857b628af5bef7",
+      "user_id_user_event_struct_last128_30d": "d2d88f5a9804dfc14b857b628af5bef7",
+      "user_id_user_event_struct_last128_7d": "d2d88f5a9804dfc14b857b628af5bef7",
+      "user_id_view_event_average_14d": "c7ae73b92e2a8aabfb4df9d22d37d2f5",
+      "user_id_view_event_average_1d": "c7ae73b92e2a8aabfb4df9d22d37d2f5",
+      "user_id_view_event_average_30d": "c7ae73b92e2a8aabfb4df9d22d37d2f5",
+      "user_id_view_event_average_7d": "c7ae73b92e2a8aabfb4df9d22d37d2f5",
+      "user_id_view_event_sum_14d": "c7ae73b92e2a8aabfb4df9d22d37d2f5",
+      "user_id_view_event_sum_1d": "c7ae73b92e2a8aabfb4df9d22d37d2f5",
+      "user_id_view_event_sum_30d": "c7ae73b92e2a8aabfb4df9d22d37d2f5",
+      "user_id_view_event_sum_7d": "c7ae73b92e2a8aabfb4df9d22d37d2f5"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_quickstart_quickstart_exports_user_activities__0_with_offset_0\", \"spec\": \"quickstart.quickstart_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_quickstart_quickstart_exports_dim_listings__0_with_offset_0\", \"spec\": \"quickstart.quickstart_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "enableStatsCompute": 1,
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "offlineSchedule": "@daily",
+      "onlineSchedule": "@daily",
+      "stepDays": 5
+    },
+    "name": "quickstart.demo.v1__1",
+    "online": 1,
+    "outputNamespace": "quickstart",
+    "production": 0,
+    "samplePercent": 100.0,
+    "sourceFile": "joins/quickstart/demo.py",
+    "team": "quickstart",
+    "version": "1"
+  },
+  "rowIds": [
+    "event_id"
+  ],
+  "useLongNames": 0
+}

--- a/python/test/canary/canary_compiled/model_transforms/aws/ctr.v1__1
+++ b/python/test/canary/canary_compiled/model_transforms/aws/ctr.v1__1
@@ -1,0 +1,1072 @@
+{
+  "keySchema": {
+    "kind": 13,
+    "name": "modeltransform_key_schema",
+    "params": [
+      {
+        "dataType": {
+          "kind": 6
+        },
+        "name": "user_id_click_event_average_7d"
+      },
+      {
+        "dataType": {
+          "kind": 4
+        },
+        "name": "listing_id_price_cents"
+      },
+      {
+        "dataType": {
+          "kind": 6
+        },
+        "name": "price_log"
+      },
+      {
+        "dataType": {
+          "kind": 3
+        },
+        "name": "price_bucket"
+      }
+    ]
+  },
+  "metaData": {
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      }
+    },
+    "name": "aws.ctr.v1__1",
+    "outputNamespace": "data",
+    "sourceFile": "model_transforms/aws/ctr.py",
+    "team": "aws",
+    "version": "1"
+  },
+  "models": [
+    {
+      "deploymentConf": {
+        "containerConfig": {
+          "image": "763104351884.dkr.ecr.us-east-1.amazonaws.com/xgboost-inference:latest"
+        },
+        "endpointConfig": {
+          "endpointName": "test_ctr_model"
+        },
+        "resourceConfig": {
+          "machineType": "ml.m5.xlarge",
+          "maxReplicaCount": 10,
+          "minReplicaCount": 3
+        },
+        "rolloutStrategy": {
+          "rolloutType": 2
+        }
+      },
+      "inferenceSpec": {
+        "modelBackend": 1,
+        "modelBackendParams": {
+          "model_name": "test_ctr_model",
+          "model_type": "custom"
+        }
+      },
+      "inputMapping": {
+        "instance": "named_struct('user_id_click_event_average_7d', user_id_click_event_average_7d, 'listing_price_cents', listing_id_price_cents, 'price_log', price_log, 'price_bucket', price_bucket)"
+      },
+      "metaData": {
+        "environments": [
+          0
+        ],
+        "executionInfo": {
+          "clusterConf": {
+            "common": {
+              "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+            }
+          },
+          "conf": {
+            "common": {
+              "spark.chronon.coalesce.factor": "10",
+              "spark.chronon.partition.column": "ds",
+              "spark.chronon.partition.format": "yyyy-MM-dd",
+              "spark.chronon.table_write.format": "iceberg",
+              "spark.chronon.table_write.upload.format": "ion",
+              "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+              "spark.default.parallelism": "10",
+              "spark.driver.cores": "1",
+              "spark.driver.memory": "1g",
+              "spark.executor.cores": "1",
+              "spark.executor.memory": "1g",
+              "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+              "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+              "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+              "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+              "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+              "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+              "spark.sql.shuffle.partitions": "10",
+              "taskmanager.memory.process.size": "4G"
+            },
+            "modeConfigs": {
+              "backfill": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.table_write.upload.format": "ion",
+                "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.memory": "1g",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "1g",
+                "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                "spark.sql.shuffle.partitions": "10",
+                "taskmanager.memory.process.size": "4G"
+              }
+            }
+          },
+          "env": {
+            "common": {
+              "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+              "AWS_REGION": "us-west-2",
+              "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+              "CLOUD_PROVIDER": "aws",
+              "CUSTOMER_ID": "canary",
+              "ENABLE_KINESIS": "true",
+              "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+              "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+              "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+              "FRONTEND_URL": "https://canary-aws.zipline.ai",
+              "HUB_URL": "https://canary-orch-aws.zipline.ai",
+              "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+              "VERSION": "latest",
+              "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+            },
+            "modeEnvironments": {
+              "upload": {
+                "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                "AWS_REGION": "us-west-2",
+                "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                "CLOUD_PROVIDER": "aws",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_KINESIS": "true",
+                "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+              }
+            }
+          }
+        },
+        "name": "aws.click_through_rate.ctr_model__1.0",
+        "outputNamespace": "data",
+        "team": "aws",
+        "version": "1.0"
+      },
+      "modelArtifactBaseUri": "s3://zipline-warehouse-models",
+      "outputMapping": {
+        "ctr": "score"
+      },
+      "trainingConf": {
+        "image": "763104351884.dkr.ecr.us-east-1.amazonaws.com/xgboost-training:latest",
+        "jobConfigs": {
+          "eta": "0.1",
+          "max-depth": "4",
+          "n-samples": "1000",
+          "num-boost-round": "50"
+        },
+        "pythonModule": "trainer.train",
+        "resourceConfig": {
+          "machineType": "ml.m5.xlarge",
+          "maxReplicaCount": 1,
+          "minReplicaCount": 1
+        },
+        "schedule": "@daily",
+        "trainingDataSource": {
+          "events": {
+            "query": {
+              "selects": {
+                "ds": "ds",
+                "label": "label",
+                "listing_price_cents": "listing_id_price_cents",
+                "price_bucket": "price_bucket",
+                "price_log": "price_log",
+                "user_id_click_event_average_7d": "user_id_click_event_average_7d"
+              },
+              "startPartition": "2025-07-01"
+            },
+            "table": "data.aws_ctr_labels_v1__0"
+          }
+        },
+        "trainingDataWindow": {
+          "length": 1,
+          "timeUnit": 1
+        }
+      },
+      "valueSchema": {
+        "kind": 13,
+        "name": "model_value_schema",
+        "params": [
+          {
+            "dataType": {
+              "kind": 6
+            },
+            "name": "score"
+          }
+        ]
+      }
+    }
+  ],
+  "passthroughFields": [
+    "user_id",
+    "listing_id",
+    "user_id_click_event_average_7d",
+    "listing_id_price_cents",
+    "price_log",
+    "price_bucket"
+  ],
+  "sources": [
+    {
+      "joinSource": {
+        "join": {
+          "derivations": [
+            {
+              "expression": "IF(listing_id_weight_grams > 1000, 1, 0)",
+              "name": "is_listing_heavy"
+            },
+            {
+              "expression": "array_contains(split(listing_id_tags, ','), 'handmade')",
+              "name": "is_item_handmade"
+            },
+            {
+              "expression": "log1p(listing_id_price_cents)",
+              "name": "price_log"
+            },
+            {
+              "expression": "\n                CASE\n                    WHEN listing_id_price_cents < 1000 THEN 0\n                    WHEN listing_id_price_cents < 5000 THEN 1\n                    WHEN listing_id_price_cents < 10000 THEN 2\n                    WHEN listing_id_price_cents < 50000 THEN 3\n                    ELSE 4\n                END\n            ",
+              "name": "price_bucket"
+            },
+            {
+              "expression": "*",
+              "name": "*"
+            }
+          ],
+          "joinParts": [
+            {
+              "groupBy": {
+                "keyColumns": [
+                  "listing_id"
+                ],
+                "metaData": {
+                  "environments": [
+                    0
+                  ],
+                  "executionInfo": {
+                    "clusterConf": {
+                      "common": {
+                        "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+                      }
+                    },
+                    "conf": {
+                      "common": {
+                        "spark.chronon.coalesce.factor": "10",
+                        "spark.chronon.partition.column": "ds",
+                        "spark.chronon.partition.format": "yyyy-MM-dd",
+                        "spark.chronon.table_write.format": "iceberg",
+                        "spark.chronon.table_write.upload.format": "ion",
+                        "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                        "spark.default.parallelism": "10",
+                        "spark.driver.cores": "1",
+                        "spark.driver.memory": "1g",
+                        "spark.executor.cores": "1",
+                        "spark.executor.memory": "1g",
+                        "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                        "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                        "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                        "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                        "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                        "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                        "spark.sql.shuffle.partitions": "10",
+                        "taskmanager.memory.process.size": "4G"
+                      },
+                      "modeConfigs": {
+                        "backfill": {
+                          "spark.chronon.coalesce.factor": "10",
+                          "spark.chronon.partition.column": "ds",
+                          "spark.chronon.partition.format": "yyyy-MM-dd",
+                          "spark.chronon.table_write.format": "iceberg",
+                          "spark.chronon.table_write.upload.format": "ion",
+                          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                          "spark.default.parallelism": "10",
+                          "spark.driver.cores": "1",
+                          "spark.driver.memory": "1g",
+                          "spark.executor.cores": "1",
+                          "spark.executor.memory": "1g",
+                          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                          "spark.sql.shuffle.partitions": "10",
+                          "taskmanager.memory.process.size": "4G"
+                        }
+                      }
+                    },
+                    "env": {
+                      "common": {
+                        "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                        "AWS_REGION": "us-west-2",
+                        "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                        "CLOUD_PROVIDER": "aws",
+                        "CUSTOMER_ID": "canary",
+                        "ENABLE_KINESIS": "true",
+                        "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                        "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                        "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                        "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                        "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                        "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                        "VERSION": "latest",
+                        "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                      },
+                      "modeEnvironments": {
+                        "upload": {
+                          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                          "AWS_REGION": "us-west-2",
+                          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                          "CLOUD_PROVIDER": "aws",
+                          "CUSTOMER_ID": "canary",
+                          "ENABLE_KINESIS": "true",
+                          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                          "VERSION": "latest",
+                          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                        }
+                      }
+                    },
+                    "historicalBackfill": 0,
+                    "onlineSchedule": "@daily",
+                    "stepDays": 10
+                  },
+                  "name": "aws.dim_listings.v1__0",
+                  "online": 1,
+                  "outputNamespace": "data",
+                  "team": "aws",
+                  "version": "0"
+                },
+                "sources": [
+                  {
+                    "entities": {
+                      "query": {
+                        "selects": {
+                          "brief_description": "brief_description",
+                          "currency": "currency",
+                          "headline": "headline",
+                          "inventory_count": "inventory_count",
+                          "is_active": "is_active",
+                          "is_expensive": "IF(price_cents > 10000, 1, 0)",
+                          "is_in_stock": "IF(inventory_count > 0, 1, 0)",
+                          "listing_id": "listing_id",
+                          "long_description": "long_description",
+                          "main_image_path": "main_image_path",
+                          "merchant_id": "merchant_id",
+                          "price_cents": "price_cents",
+                          "primary_category": "primary_category",
+                          "secondary_image_paths": "secondary_image_paths",
+                          "tags": "tags",
+                          "weight_grams": "weight_grams"
+                        },
+                        "startPartition": "2025-01-01"
+                      },
+                      "snapshotTable": "data.aws_exports_dim_listings__0"
+                    }
+                  }
+                ]
+              },
+              "useLongNames": 0
+            },
+            {
+              "groupBy": {
+                "aggregations": [
+                  {
+                    "argMap": {},
+                    "inputColumn": "view_event",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "click_event",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "purchase_event",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "favorite_event",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "add_to_cart_event",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "view_event",
+                    "operation": 8,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "click_event",
+                    "operation": 8,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "purchase_event",
+                    "operation": 8,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "favorite_event",
+                    "operation": 8,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "add_to_cart_event",
+                    "operation": 8,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "is_mobile",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "is_desktop",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "is_tablet",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {
+                      "k": "128"
+                    },
+                    "inputColumn": "user_event_struct",
+                    "operation": 13,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  }
+                ],
+                "keyColumns": [
+                  "user_id"
+                ],
+                "metaData": {
+                  "environments": [
+                    0
+                  ],
+                  "executionInfo": {
+                    "clusterConf": {
+                      "common": {
+                        "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+                      }
+                    },
+                    "conf": {
+                      "common": {
+                        "spark.chronon.coalesce.factor": "10",
+                        "spark.chronon.partition.column": "ds",
+                        "spark.chronon.partition.format": "yyyy-MM-dd",
+                        "spark.chronon.table_write.format": "iceberg",
+                        "spark.chronon.table_write.upload.format": "ion",
+                        "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                        "spark.default.parallelism": "10",
+                        "spark.driver.cores": "1",
+                        "spark.driver.memory": "1g",
+                        "spark.executor.cores": "1",
+                        "spark.executor.memory": "1g",
+                        "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                        "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                        "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                        "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                        "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                        "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                        "spark.sql.shuffle.partitions": "10",
+                        "taskmanager.memory.process.size": "4G"
+                      },
+                      "modeConfigs": {
+                        "backfill": {
+                          "spark.chronon.coalesce.factor": "10",
+                          "spark.chronon.partition.column": "ds",
+                          "spark.chronon.partition.format": "yyyy-MM-dd",
+                          "spark.chronon.table_write.format": "iceberg",
+                          "spark.chronon.table_write.upload.format": "ion",
+                          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                          "spark.default.parallelism": "10",
+                          "spark.driver.cores": "1",
+                          "spark.driver.memory": "1g",
+                          "spark.executor.cores": "1",
+                          "spark.executor.memory": "1g",
+                          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                          "spark.sql.shuffle.partitions": "10",
+                          "taskmanager.memory.process.size": "4G"
+                        }
+                      }
+                    },
+                    "env": {
+                      "common": {
+                        "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                        "AWS_REGION": "us-west-2",
+                        "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+                        "CLOUD_PROVIDER": "aws",
+                        "CUSTOMER_ID": "canary",
+                        "ENABLE_KINESIS": "true",
+                        "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                        "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                        "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                        "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                        "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                        "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                        "VERSION": "latest",
+                        "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                      },
+                      "modeEnvironments": {
+                        "upload": {
+                          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                          "AWS_REGION": "us-west-2",
+                          "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+                          "CLOUD_PROVIDER": "aws",
+                          "CUSTOMER_ID": "canary",
+                          "ENABLE_KINESIS": "true",
+                          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                          "VERSION": "latest",
+                          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                        }
+                      }
+                    },
+                    "historicalBackfill": 0,
+                    "onlineSchedule": "@daily",
+                    "stepDays": 10
+                  },
+                  "name": "aws.user_activities.v1__1",
+                  "online": 1,
+                  "outputNamespace": "data",
+                  "team": "aws",
+                  "version": "1"
+                },
+                "sources": [
+                  {
+                    "events": {
+                      "query": {
+                        "selects": {
+                          "add_to_cart_event": "IF(event_type = 'add_to_cart', 1, 0)",
+                          "click_event": "IF(event_type = 'click', 1, 0)",
+                          "favorite_event": "IF(event_type = 'favorite', 1, 0)",
+                          "is_desktop": "IF(device_type = 'desktop', 1, 0)",
+                          "is_mobile": "IF(device_type = 'mobile', 1, 0)",
+                          "is_tablet": "IF(device_type = 'tablet', 1, 0)",
+                          "listing_id": "listing_id",
+                          "purchase_event": "IF(event_type = 'purchase', 1, 0)",
+                          "user_event_struct": "STRUCT(event_type, listing_id, unix_millis(TIMESTAMP(event_time_ms)) as timestamp)",
+                          "user_id": "user_id",
+                          "view_event": "IF(event_type = 'view', 1, 0)"
+                        },
+                        "timeColumn": "unix_millis(TIMESTAMP(event_time_ms))"
+                      },
+                      "table": "demo.user_activities_raw",
+                      "topic": "kinesis://user-activities/serde=glue_registry/registry_name=zipline-canary/schema_name=user-activities"
+                    }
+                  }
+                ]
+              },
+              "useLongNames": 0
+            }
+          ],
+          "left": {
+            "events": {
+              "query": {
+                "selects": {
+                  "listing_id": "listing_id",
+                  "row_id": "event_id",
+                  "ts": "event_time_ms",
+                  "user_id": "user_id"
+                },
+                "timeColumn": "event_time_ms"
+              },
+              "table": "data.aws_exports_user_activities__0"
+            }
+          },
+          "metaData": {
+            "environments": [
+              0
+            ],
+            "executionInfo": {
+              "clusterConf": {
+                "common": {
+                  "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+                }
+              },
+              "conf": {
+                "common": {
+                  "spark.chronon.coalesce.factor": "10",
+                  "spark.chronon.partition.column": "ds",
+                  "spark.chronon.partition.format": "yyyy-MM-dd",
+                  "spark.chronon.table_write.format": "iceberg",
+                  "spark.chronon.table_write.upload.format": "ion",
+                  "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                  "spark.default.parallelism": "10",
+                  "spark.driver.cores": "1",
+                  "spark.driver.memory": "1g",
+                  "spark.executor.cores": "1",
+                  "spark.executor.memory": "1g",
+                  "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                  "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                  "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                  "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                  "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                  "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                  "spark.sql.shuffle.partitions": "10",
+                  "taskmanager.memory.process.size": "4G"
+                },
+                "modeConfigs": {
+                  "backfill": {
+                    "spark.chronon.coalesce.factor": "10",
+                    "spark.chronon.partition.column": "ds",
+                    "spark.chronon.partition.format": "yyyy-MM-dd",
+                    "spark.chronon.table_write.format": "iceberg",
+                    "spark.chronon.table_write.upload.format": "ion",
+                    "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                    "spark.default.parallelism": "10",
+                    "spark.driver.cores": "1",
+                    "spark.driver.memory": "1g",
+                    "spark.executor.cores": "1",
+                    "spark.executor.memory": "1g",
+                    "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                    "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                    "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                    "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                    "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                    "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                    "spark.sql.shuffle.partitions": "10",
+                    "taskmanager.memory.process.size": "4G"
+                  }
+                }
+              },
+              "enableStatsCompute": 1,
+              "env": {
+                "common": {
+                  "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                  "AWS_REGION": "us-west-2",
+                  "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                  "CLOUD_PROVIDER": "aws",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_KINESIS": "true",
+                  "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                  "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                  "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                  "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                  "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                },
+                "modeEnvironments": {
+                  "upload": {
+                    "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                    "AWS_REGION": "us-west-2",
+                    "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                    "CLOUD_PROVIDER": "aws",
+                    "CUSTOMER_ID": "canary",
+                    "ENABLE_KINESIS": "true",
+                    "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                    "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                    "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                    "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                    "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                    "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                    "VERSION": "latest",
+                    "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                  }
+                }
+              },
+              "offlineSchedule": "@daily",
+              "onlineSchedule": "@daily",
+              "stepDays": 10
+            },
+            "name": "aws.demo.derivations_v1__2",
+            "online": 1,
+            "outputNamespace": "data",
+            "production": 0,
+            "samplePercent": 100.0,
+            "team": "aws",
+            "version": "2"
+          },
+          "rowIds": [
+            "event_id"
+          ],
+          "useLongNames": 0
+        }
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/model_transforms/aws/listing.v1__2
+++ b/python/test/canary/canary_compiled/model_transforms/aws/listing.v1__2
@@ -1,0 +1,1150 @@
+{
+  "keySchema": {
+    "kind": 13,
+    "name": "modeltransform_key_schema",
+    "params": [
+      {
+        "dataType": {
+          "kind": 7
+        },
+        "name": "listing_id_headline"
+      },
+      {
+        "dataType": {
+          "kind": 7
+        },
+        "name": "listing_id_long_description"
+      }
+    ]
+  },
+  "metaData": {
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      }
+    },
+    "name": "aws.listing.v1__2",
+    "outputNamespace": "data",
+    "sourceFile": "model_transforms/aws/listing.py",
+    "team": "aws",
+    "version": "2"
+  },
+  "models": [
+    {
+      "inferenceSpec": {
+        "modelBackend": 1,
+        "modelBackendParams": {
+          "model_name": "amazon-titan-embed-text-v1",
+          "model_type": "bedrock"
+        }
+      },
+      "inputMapping": {
+        "instance": "named_struct('content', concat_ws('; ', listing_id_headline, listing_id_long_description))"
+      },
+      "metaData": {
+        "environments": [
+          0
+        ],
+        "executionInfo": {
+          "clusterConf": {
+            "common": {
+              "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+            }
+          },
+          "conf": {
+            "common": {
+              "spark.chronon.coalesce.factor": "10",
+              "spark.chronon.partition.column": "ds",
+              "spark.chronon.partition.format": "yyyy-MM-dd",
+              "spark.chronon.table_write.format": "iceberg",
+              "spark.chronon.table_write.upload.format": "ion",
+              "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+              "spark.default.parallelism": "10",
+              "spark.driver.cores": "1",
+              "spark.driver.memory": "1g",
+              "spark.executor.cores": "1",
+              "spark.executor.memory": "1g",
+              "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+              "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+              "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+              "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+              "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+              "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+              "spark.sql.shuffle.partitions": "10",
+              "taskmanager.memory.process.size": "4G"
+            },
+            "modeConfigs": {
+              "backfill": {
+                "spark.chronon.coalesce.factor": "10",
+                "spark.chronon.partition.column": "ds",
+                "spark.chronon.partition.format": "yyyy-MM-dd",
+                "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.table_write.upload.format": "ion",
+                "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                "spark.default.parallelism": "10",
+                "spark.driver.cores": "1",
+                "spark.driver.memory": "1g",
+                "spark.executor.cores": "1",
+                "spark.executor.memory": "1g",
+                "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                "spark.sql.shuffle.partitions": "10",
+                "taskmanager.memory.process.size": "4G"
+              }
+            }
+          },
+          "env": {
+            "common": {
+              "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+              "AWS_REGION": "us-west-2",
+              "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+              "CLOUD_PROVIDER": "aws",
+              "CUSTOMER_ID": "canary",
+              "ENABLE_KINESIS": "true",
+              "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+              "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+              "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+              "FRONTEND_URL": "https://canary-aws.zipline.ai",
+              "HUB_URL": "https://canary-orch-aws.zipline.ai",
+              "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+              "VERSION": "latest",
+              "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+            },
+            "modeEnvironments": {
+              "upload": {
+                "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                "AWS_REGION": "us-west-2",
+                "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                "CLOUD_PROVIDER": "aws",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_KINESIS": "true",
+                "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+              }
+            }
+          }
+        },
+        "name": "aws.listing.item_description_model__1",
+        "outputNamespace": "data",
+        "team": "aws",
+        "version": "1"
+      },
+      "outputMapping": {
+        "item_embedding": "aws_listing_item_description_model__1__embeddings.values"
+      },
+      "valueSchema": {
+        "kind": 13,
+        "name": "model_value_schema",
+        "params": [
+          {
+            "dataType": {
+              "kind": 13,
+              "name": "embeddings",
+              "params": [
+                {
+                  "dataType": {
+                    "kind": 13,
+                    "name": "statistics",
+                    "params": [
+                      {
+                        "dataType": {
+                          "kind": 0
+                        },
+                        "name": "truncated"
+                      },
+                      {
+                        "dataType": {
+                          "kind": 3
+                        },
+                        "name": "token_count"
+                      }
+                    ]
+                  },
+                  "name": "statistics"
+                },
+                {
+                  "dataType": {
+                    "kind": 12,
+                    "params": [
+                      {
+                        "dataType": {
+                          "kind": 6
+                        },
+                        "name": "elem"
+                      }
+                    ]
+                  },
+                  "name": "values"
+                }
+              ]
+            },
+            "name": "embeddings"
+          }
+        ]
+      }
+    }
+  ],
+  "passthroughFields": [
+    "user_id",
+    "listing_id",
+    "listing_id_is_active"
+  ],
+  "sources": [
+    {
+      "joinSource": {
+        "join": {
+          "joinParts": [
+            {
+              "groupBy": {
+                "aggregations": [
+                  {
+                    "argMap": {},
+                    "inputColumn": "view_event",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "click_event",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "purchase_event",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "favorite_event",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "add_to_cart_event",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "view_event",
+                    "operation": 8,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "click_event",
+                    "operation": 8,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "purchase_event",
+                    "operation": 8,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "favorite_event",
+                    "operation": 8,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "add_to_cart_event",
+                    "operation": 8,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "is_mobile",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "is_desktop",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "is_tablet",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {
+                      "k": "128"
+                    },
+                    "inputColumn": "user_event_struct",
+                    "operation": 13,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  }
+                ],
+                "keyColumns": [
+                  "user_id"
+                ],
+                "metaData": {
+                  "environments": [
+                    0
+                  ],
+                  "executionInfo": {
+                    "clusterConf": {
+                      "common": {
+                        "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+                      }
+                    },
+                    "conf": {
+                      "common": {
+                        "spark.chronon.coalesce.factor": "10",
+                        "spark.chronon.partition.column": "ds",
+                        "spark.chronon.partition.format": "yyyy-MM-dd",
+                        "spark.chronon.table_write.format": "iceberg",
+                        "spark.chronon.table_write.upload.format": "ion",
+                        "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                        "spark.default.parallelism": "10",
+                        "spark.driver.cores": "1",
+                        "spark.driver.memory": "1g",
+                        "spark.executor.cores": "1",
+                        "spark.executor.memory": "1g",
+                        "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                        "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                        "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                        "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                        "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                        "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                        "spark.sql.shuffle.partitions": "10",
+                        "taskmanager.memory.process.size": "4G"
+                      },
+                      "modeConfigs": {
+                        "backfill": {
+                          "spark.chronon.coalesce.factor": "10",
+                          "spark.chronon.partition.column": "ds",
+                          "spark.chronon.partition.format": "yyyy-MM-dd",
+                          "spark.chronon.table_write.format": "iceberg",
+                          "spark.chronon.table_write.upload.format": "ion",
+                          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                          "spark.default.parallelism": "10",
+                          "spark.driver.cores": "1",
+                          "spark.driver.memory": "1g",
+                          "spark.executor.cores": "1",
+                          "spark.executor.memory": "1g",
+                          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                          "spark.sql.shuffle.partitions": "10",
+                          "taskmanager.memory.process.size": "4G"
+                        }
+                      }
+                    },
+                    "env": {
+                      "common": {
+                        "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                        "AWS_REGION": "us-west-2",
+                        "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+                        "CLOUD_PROVIDER": "aws",
+                        "CUSTOMER_ID": "canary",
+                        "ENABLE_KINESIS": "true",
+                        "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                        "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                        "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                        "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                        "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                        "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                        "VERSION": "latest",
+                        "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                      },
+                      "modeEnvironments": {
+                        "upload": {
+                          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                          "AWS_REGION": "us-west-2",
+                          "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+                          "CLOUD_PROVIDER": "aws",
+                          "CUSTOMER_ID": "canary",
+                          "ENABLE_KINESIS": "true",
+                          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                          "VERSION": "latest",
+                          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                        }
+                      }
+                    },
+                    "historicalBackfill": 0,
+                    "onlineSchedule": "@daily",
+                    "stepDays": 10
+                  },
+                  "name": "aws.user_activities.v1__1",
+                  "online": 1,
+                  "outputNamespace": "data",
+                  "team": "aws",
+                  "version": "1"
+                },
+                "sources": [
+                  {
+                    "events": {
+                      "query": {
+                        "selects": {
+                          "add_to_cart_event": "IF(event_type = 'add_to_cart', 1, 0)",
+                          "click_event": "IF(event_type = 'click', 1, 0)",
+                          "favorite_event": "IF(event_type = 'favorite', 1, 0)",
+                          "is_desktop": "IF(device_type = 'desktop', 1, 0)",
+                          "is_mobile": "IF(device_type = 'mobile', 1, 0)",
+                          "is_tablet": "IF(device_type = 'tablet', 1, 0)",
+                          "listing_id": "listing_id",
+                          "purchase_event": "IF(event_type = 'purchase', 1, 0)",
+                          "user_event_struct": "STRUCT(event_type, listing_id, unix_millis(TIMESTAMP(event_time_ms)) as timestamp)",
+                          "user_id": "user_id",
+                          "view_event": "IF(event_type = 'view', 1, 0)"
+                        },
+                        "timeColumn": "unix_millis(TIMESTAMP(event_time_ms))"
+                      },
+                      "table": "demo.user_activities_raw",
+                      "topic": "kinesis://user-activities/serde=glue_registry/registry_name=zipline-canary/schema_name=user-activities"
+                    }
+                  }
+                ]
+              },
+              "useLongNames": 0
+            },
+            {
+              "groupBy": {
+                "keyColumns": [
+                  "listing_id"
+                ],
+                "metaData": {
+                  "environments": [
+                    0
+                  ],
+                  "executionInfo": {
+                    "clusterConf": {
+                      "common": {
+                        "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+                      }
+                    },
+                    "conf": {
+                      "common": {
+                        "spark.chronon.coalesce.factor": "10",
+                        "spark.chronon.partition.column": "ds",
+                        "spark.chronon.partition.format": "yyyy-MM-dd",
+                        "spark.chronon.table_write.format": "iceberg",
+                        "spark.chronon.table_write.upload.format": "ion",
+                        "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                        "spark.default.parallelism": "10",
+                        "spark.driver.cores": "1",
+                        "spark.driver.memory": "1g",
+                        "spark.executor.cores": "1",
+                        "spark.executor.memory": "1g",
+                        "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                        "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                        "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                        "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                        "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                        "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                        "spark.sql.shuffle.partitions": "10",
+                        "taskmanager.memory.process.size": "4G"
+                      },
+                      "modeConfigs": {
+                        "backfill": {
+                          "spark.chronon.coalesce.factor": "10",
+                          "spark.chronon.partition.column": "ds",
+                          "spark.chronon.partition.format": "yyyy-MM-dd",
+                          "spark.chronon.table_write.format": "iceberg",
+                          "spark.chronon.table_write.upload.format": "ion",
+                          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                          "spark.default.parallelism": "10",
+                          "spark.driver.cores": "1",
+                          "spark.driver.memory": "1g",
+                          "spark.executor.cores": "1",
+                          "spark.executor.memory": "1g",
+                          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                          "spark.sql.shuffle.partitions": "10",
+                          "taskmanager.memory.process.size": "4G"
+                        }
+                      }
+                    },
+                    "env": {
+                      "common": {
+                        "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                        "AWS_REGION": "us-west-2",
+                        "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                        "CLOUD_PROVIDER": "aws",
+                        "CUSTOMER_ID": "canary",
+                        "ENABLE_KINESIS": "true",
+                        "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                        "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                        "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                        "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                        "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                        "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                        "VERSION": "latest",
+                        "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                      },
+                      "modeEnvironments": {
+                        "upload": {
+                          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                          "AWS_REGION": "us-west-2",
+                          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                          "CLOUD_PROVIDER": "aws",
+                          "CUSTOMER_ID": "canary",
+                          "ENABLE_KINESIS": "true",
+                          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                          "VERSION": "latest",
+                          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                        }
+                      }
+                    },
+                    "historicalBackfill": 0,
+                    "onlineSchedule": "@daily",
+                    "stepDays": 10
+                  },
+                  "name": "aws.dim_listings.v1__0",
+                  "online": 1,
+                  "outputNamespace": "data",
+                  "team": "aws",
+                  "version": "0"
+                },
+                "sources": [
+                  {
+                    "entities": {
+                      "query": {
+                        "selects": {
+                          "brief_description": "brief_description",
+                          "currency": "currency",
+                          "headline": "headline",
+                          "inventory_count": "inventory_count",
+                          "is_active": "is_active",
+                          "is_expensive": "IF(price_cents > 10000, 1, 0)",
+                          "is_in_stock": "IF(inventory_count > 0, 1, 0)",
+                          "listing_id": "listing_id",
+                          "long_description": "long_description",
+                          "main_image_path": "main_image_path",
+                          "merchant_id": "merchant_id",
+                          "price_cents": "price_cents",
+                          "primary_category": "primary_category",
+                          "secondary_image_paths": "secondary_image_paths",
+                          "tags": "tags",
+                          "weight_grams": "weight_grams"
+                        },
+                        "startPartition": "2025-01-01"
+                      },
+                      "snapshotTable": "data.aws_exports_dim_listings__0"
+                    }
+                  }
+                ]
+              },
+              "useLongNames": 0
+            },
+            {
+              "groupBy": {
+                "keyColumns": [
+                  "listing_id"
+                ],
+                "metaData": {
+                  "environments": [
+                    0
+                  ],
+                  "executionInfo": {
+                    "clusterConf": {
+                      "common": {
+                        "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+                      }
+                    },
+                    "conf": {
+                      "common": {
+                        "spark.chronon.coalesce.factor": "10",
+                        "spark.chronon.partition.column": "ds",
+                        "spark.chronon.partition.format": "yyyy-MM-dd",
+                        "spark.chronon.table_write.format": "iceberg",
+                        "spark.chronon.table_write.upload.format": "ion",
+                        "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                        "spark.default.parallelism": "10",
+                        "spark.driver.cores": "1",
+                        "spark.driver.memory": "1g",
+                        "spark.executor.cores": "1",
+                        "spark.executor.memory": "1g",
+                        "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                        "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                        "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                        "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                        "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                        "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                        "spark.sql.shuffle.partitions": "10",
+                        "taskmanager.memory.process.size": "4G"
+                      },
+                      "modeConfigs": {
+                        "backfill": {
+                          "spark.chronon.coalesce.factor": "10",
+                          "spark.chronon.partition.column": "ds",
+                          "spark.chronon.partition.format": "yyyy-MM-dd",
+                          "spark.chronon.table_write.format": "iceberg",
+                          "spark.chronon.table_write.upload.format": "ion",
+                          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                          "spark.default.parallelism": "10",
+                          "spark.driver.cores": "1",
+                          "spark.driver.memory": "1g",
+                          "spark.executor.cores": "1",
+                          "spark.executor.memory": "1g",
+                          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                          "spark.sql.shuffle.partitions": "10",
+                          "taskmanager.memory.process.size": "4G"
+                        }
+                      }
+                    },
+                    "env": {
+                      "common": {
+                        "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                        "AWS_REGION": "us-west-2",
+                        "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                        "CLOUD_PROVIDER": "aws",
+                        "CUSTOMER_ID": "canary",
+                        "ENABLE_KINESIS": "true",
+                        "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                        "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                        "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                        "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                        "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                        "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                        "VERSION": "latest",
+                        "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                      },
+                      "modeEnvironments": {
+                        "upload": {
+                          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                          "AWS_REGION": "us-west-2",
+                          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                          "CLOUD_PROVIDER": "aws",
+                          "CUSTOMER_ID": "canary",
+                          "ENABLE_KINESIS": "true",
+                          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                          "VERSION": "latest",
+                          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                        }
+                      }
+                    },
+                    "historicalBackfill": 0,
+                    "onlineSchedule": "@daily",
+                    "stepDays": 10
+                  },
+                  "name": "aws.dim_merchants.v1__0",
+                  "online": 1,
+                  "outputNamespace": "data",
+                  "team": "aws",
+                  "version": "0"
+                },
+                "sources": [
+                  {
+                    "entities": {
+                      "query": {
+                        "selects": {
+                          "listing_id": "merchant_id",
+                          "primary_category": "primary_category"
+                        },
+                        "startPartition": "2025-01-01"
+                      },
+                      "snapshotTable": "data.aws_exports_dim_merchants__0"
+                    }
+                  }
+                ]
+              },
+              "prefix": "merchant_",
+              "useLongNames": 0
+            }
+          ],
+          "left": {
+            "events": {
+              "query": {
+                "selects": {
+                  "listing_id": "listing_id",
+                  "row_id": "event_id",
+                  "ts": "event_time_ms",
+                  "user_id": "user_id"
+                },
+                "timeColumn": "event_time_ms"
+              },
+              "table": "data.aws_exports_user_activities__0"
+            }
+          },
+          "metaData": {
+            "environments": [
+              0
+            ],
+            "executionInfo": {
+              "clusterConf": {
+                "common": {
+                  "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+                }
+              },
+              "conf": {
+                "common": {
+                  "spark.chronon.coalesce.factor": "10",
+                  "spark.chronon.partition.column": "ds",
+                  "spark.chronon.partition.format": "yyyy-MM-dd",
+                  "spark.chronon.table_write.format": "iceberg",
+                  "spark.chronon.table_write.upload.format": "ion",
+                  "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                  "spark.default.parallelism": "10",
+                  "spark.driver.cores": "1",
+                  "spark.driver.memory": "1g",
+                  "spark.executor.cores": "1",
+                  "spark.executor.memory": "1g",
+                  "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                  "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                  "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                  "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                  "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                  "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                  "spark.sql.shuffle.partitions": "10",
+                  "taskmanager.memory.process.size": "4G"
+                },
+                "modeConfigs": {
+                  "backfill": {
+                    "spark.chronon.coalesce.factor": "10",
+                    "spark.chronon.partition.column": "ds",
+                    "spark.chronon.partition.format": "yyyy-MM-dd",
+                    "spark.chronon.table_write.format": "iceberg",
+                    "spark.chronon.table_write.upload.format": "ion",
+                    "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+                    "spark.default.parallelism": "10",
+                    "spark.driver.cores": "1",
+                    "spark.driver.memory": "1g",
+                    "spark.executor.cores": "1",
+                    "spark.executor.memory": "1g",
+                    "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+                    "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                    "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                    "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+                    "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                    "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                    "spark.sql.shuffle.partitions": "10",
+                    "taskmanager.memory.process.size": "4G"
+                  }
+                }
+              },
+              "enableStatsCompute": 1,
+              "env": {
+                "common": {
+                  "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                  "AWS_REGION": "us-west-2",
+                  "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                  "CLOUD_PROVIDER": "aws",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_KINESIS": "true",
+                  "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                  "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                  "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                  "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                  "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                },
+                "modeEnvironments": {
+                  "upload": {
+                    "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+                    "AWS_REGION": "us-west-2",
+                    "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+                    "CLOUD_PROVIDER": "aws",
+                    "CUSTOMER_ID": "canary",
+                    "ENABLE_KINESIS": "true",
+                    "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+                    "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+                    "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+                    "FRONTEND_URL": "https://canary-aws.zipline.ai",
+                    "HUB_URL": "https://canary-orch-aws.zipline.ai",
+                    "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+                    "VERSION": "latest",
+                    "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+                  }
+                }
+              },
+              "offlineSchedule": "@daily",
+              "onlineSchedule": "@daily",
+              "stepDays": 10
+            },
+            "name": "aws.demo.v1__1",
+            "online": 1,
+            "outputNamespace": "data",
+            "production": 0,
+            "samplePercent": 100.0,
+            "team": "aws",
+            "version": "1"
+          },
+          "rowIds": [
+            "event_id"
+          ],
+          "useLongNames": 0
+        },
+        "query": {
+          "wheres": [
+            "(listing_id_headline IS NOT NULL AND listing_id_headline != '') OR (listing_id_long_description IS NOT NULL AND listing_id_long_description != '')"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/model_transforms/gcp/ctr.v1__1
+++ b/python/test/canary/canary_compiled/model_transforms/gcp/ctr.v1__1
@@ -1,0 +1,994 @@
+{
+  "keySchema": {
+    "kind": 13,
+    "name": "modeltransform_key_schema",
+    "params": [
+      {
+        "dataType": {
+          "kind": 6
+        },
+        "name": "user_id_click_event_average_7d"
+      },
+      {
+        "dataType": {
+          "kind": 4
+        },
+        "name": "listing_id_price_cents"
+      },
+      {
+        "dataType": {
+          "kind": 6
+        },
+        "name": "price_log"
+      },
+      {
+        "dataType": {
+          "kind": 3
+        },
+        "name": "price_bucket"
+      }
+    ]
+  },
+  "metaData": {
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      }
+    },
+    "name": "gcp.ctr.v1__1",
+    "outputNamespace": "data",
+    "sourceFile": "model_transforms/gcp/ctr.py",
+    "team": "gcp",
+    "version": "1"
+  },
+  "models": [
+    {
+      "deploymentConf": {
+        "containerConfig": {
+          "image": "us-central1-docker.pkg.dev/canary-443022/canary-images/ctr-predictor:v1"
+        },
+        "endpointConfig": {
+          "endpointName": "test_ctr_model"
+        },
+        "resourceConfig": {
+          "machineType": "n1-standard-4",
+          "maxReplicaCount": 3,
+          "minReplicaCount": 1
+        },
+        "rolloutStrategy": {
+          "rolloutType": 2
+        }
+      },
+      "inferenceSpec": {
+        "modelBackend": 0,
+        "modelBackendParams": {
+          "model_name": "test_ctr_model",
+          "model_type": "custom"
+        }
+      },
+      "inputMapping": {
+        "instance": "named_struct('user_id_click_event_average_7d', user_id_click_event_average_7d, 'listing_price_cents', listing_id_price_cents, 'price_log', price_log, 'price_bucket', price_bucket)"
+      },
+      "metaData": {
+        "environments": [
+          0
+        ],
+        "executionInfo": {
+          "clusterConf": {
+            "modeClusterConfigs": {
+              "upload": {
+                "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+              }
+            }
+          },
+          "conf": {
+            "common": {
+              "spark.chronon.coalesce.factor": "10",
+              "spark.chronon.partition.column": "ds",
+              "spark.chronon.partition.format": "yyyy-MM-dd",
+              "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+              "spark.chronon.table_write.format": "iceberg",
+              "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+              "spark.default.parallelism": "10",
+              "spark.driver.cores": "1",
+              "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+              "spark.driver.memory": "512m",
+              "spark.executor.cores": "1",
+              "spark.executor.memory": "512m",
+              "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+              "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+              "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+              "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+              "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+              "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+              "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+              "spark.sql.shuffle.partitions": "10"
+            }
+          },
+          "env": {
+            "common": {
+              "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+              "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+              "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+              "CLOUD_PROVIDER": "gcp",
+              "CUSTOMER_ID": "canary",
+              "ENABLE_PUBSUB": "true",
+              "EVAL_URL": "http://localhost:3904",
+              "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+              "FRONTEND_URL": "http://localhost:3000",
+              "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+              "GCP_PROJECT_ID": "canary-443022",
+              "GCP_REGION": "us-central1",
+              "HUB_URL": "http://localhost:3903",
+              "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+              "VERSION": "latest",
+              "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+            },
+            "modeEnvironments": {
+              "upload": {
+                "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                "CLOUD_PROVIDER": "gcp",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_PUBSUB": "true",
+                "EVAL_URL": "http://localhost:3904",
+                "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "http://localhost:3000",
+                "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                "GCP_PROJECT_ID": "canary-443022",
+                "GCP_REGION": "us-central1",
+                "HUB_URL": "http://localhost:3903",
+                "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+              }
+            }
+          }
+        },
+        "name": "gcp.click_through_rate.ctr_model__1.0",
+        "outputNamespace": "data",
+        "team": "gcp",
+        "version": "1.0"
+      },
+      "modelArtifactBaseUri": "gs://zipline-warehouse-models",
+      "outputMapping": {
+        "ctr": "gcp_click_through_rate_ctr_model__1_0__score"
+      },
+      "trainingConf": {
+        "image": "us-docker.pkg.dev/vertex-ai/training/xgboost-cpu.2-1:latest",
+        "jobConfigs": {
+          "eta": "0.1",
+          "max-depth": "4",
+          "num-boost-round": "50"
+        },
+        "pythonModule": "trainer.train",
+        "resourceConfig": {
+          "machineType": "n1-standard-4",
+          "maxReplicaCount": 1,
+          "minReplicaCount": 1
+        },
+        "schedule": "@daily",
+        "trainingDataSource": {
+          "events": {
+            "query": {
+              "selects": {
+                "ds": "ds",
+                "label": "label",
+                "listing_price_cents": "listing_id_price_cents",
+                "price_bucket": "price_bucket",
+                "price_log": "price_log",
+                "user_id_click_event_average_7d": "user_id_click_event_average_7d"
+              },
+              "startPartition": "2025-07-01"
+            },
+            "table": "data.gcp_ctr_labels_v1__0"
+          }
+        },
+        "trainingDataWindow": {
+          "length": 1,
+          "timeUnit": 1
+        }
+      },
+      "valueSchema": {
+        "kind": 13,
+        "name": "model_value_schema",
+        "params": [
+          {
+            "dataType": {
+              "kind": 6
+            },
+            "name": "score"
+          }
+        ]
+      }
+    }
+  ],
+  "passthroughFields": [
+    "user_id",
+    "listing_id",
+    "user_id_click_event_average_7d",
+    "listing_id_price_cents",
+    "price_log",
+    "price_bucket"
+  ],
+  "sources": [
+    {
+      "joinSource": {
+        "join": {
+          "derivations": [
+            {
+              "expression": "IF(listing_id_weight_grams > 1000, 1, 0)",
+              "name": "is_listing_heavy"
+            },
+            {
+              "expression": "array_contains(split(listing_id_tags, ','), 'handmade')",
+              "name": "is_item_handmade"
+            },
+            {
+              "expression": "log1p(listing_id_price_cents)",
+              "name": "price_log"
+            },
+            {
+              "expression": "\n                CASE\n                    WHEN listing_id_price_cents < 1000 THEN 0\n                    WHEN listing_id_price_cents < 5000 THEN 1\n                    WHEN listing_id_price_cents < 10000 THEN 2\n                    WHEN listing_id_price_cents < 50000 THEN 3\n                    ELSE 4\n                END\n            ",
+              "name": "price_bucket"
+            },
+            {
+              "expression": "*",
+              "name": "*"
+            }
+          ],
+          "joinParts": [
+            {
+              "groupBy": {
+                "keyColumns": [
+                  "listing_id"
+                ],
+                "metaData": {
+                  "environments": [
+                    0
+                  ],
+                  "executionInfo": {
+                    "clusterConf": {
+                      "modeClusterConfigs": {
+                        "upload": {
+                          "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                          "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                        }
+                      }
+                    },
+                    "conf": {
+                      "common": {
+                        "spark.chronon.coalesce.factor": "10",
+                        "spark.chronon.partition.column": "ds",
+                        "spark.chronon.partition.format": "yyyy-MM-dd",
+                        "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+                        "spark.chronon.table_write.format": "iceberg",
+                        "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+                        "spark.default.parallelism": "10",
+                        "spark.driver.cores": "1",
+                        "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+                        "spark.driver.memory": "512m",
+                        "spark.executor.cores": "1",
+                        "spark.executor.memory": "512m",
+                        "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                        "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+                        "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+                        "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+                        "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+                        "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+                        "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                        "spark.sql.shuffle.partitions": "10"
+                      }
+                    },
+                    "env": {
+                      "common": {
+                        "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                        "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                        "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                        "CLOUD_PROVIDER": "gcp",
+                        "CUSTOMER_ID": "canary",
+                        "ENABLE_PUBSUB": "true",
+                        "EVAL_URL": "http://localhost:3904",
+                        "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                        "FRONTEND_URL": "http://localhost:3000",
+                        "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                        "GCP_PROJECT_ID": "canary-443022",
+                        "GCP_REGION": "us-central1",
+                        "HUB_URL": "http://localhost:3903",
+                        "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+                        "VERSION": "latest",
+                        "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                      },
+                      "modeEnvironments": {
+                        "upload": {
+                          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                          "CLOUD_PROVIDER": "gcp",
+                          "CUSTOMER_ID": "canary",
+                          "ENABLE_PUBSUB": "true",
+                          "EVAL_URL": "http://localhost:3904",
+                          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                          "FRONTEND_URL": "http://localhost:3000",
+                          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                          "GCP_PROJECT_ID": "canary-443022",
+                          "GCP_REGION": "us-central1",
+                          "HUB_URL": "http://localhost:3903",
+                          "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                          "VERSION": "latest",
+                          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                        }
+                      }
+                    },
+                    "historicalBackfill": 0,
+                    "onlineSchedule": "@daily"
+                  },
+                  "name": "gcp.dim_listings.v1__0",
+                  "online": 1,
+                  "outputNamespace": "data",
+                  "team": "gcp",
+                  "version": "0"
+                },
+                "sources": [
+                  {
+                    "entities": {
+                      "query": {
+                        "selects": {
+                          "brief_description": "brief_description",
+                          "currency": "currency",
+                          "headline": "headline",
+                          "inventory_count": "inventory_count",
+                          "is_active": "is_active",
+                          "is_expensive": "IF(price_cents > 10000, 1, 0)",
+                          "is_in_stock": "IF(inventory_count > 0, 1, 0)",
+                          "listing_id": "listing_id",
+                          "long_description": "long_description",
+                          "main_image_path": "main_image_path",
+                          "merchant_id": "merchant_id",
+                          "price_cents": "price_cents",
+                          "primary_category": "primary_category",
+                          "secondary_image_paths": "secondary_image_paths",
+                          "tags": "tags",
+                          "weight_grams": "weight_grams"
+                        },
+                        "startPartition": "2025-01-01"
+                      },
+                      "snapshotTable": "data.gcp_exports_dim_listings__0"
+                    }
+                  }
+                ]
+              },
+              "useLongNames": 0
+            },
+            {
+              "groupBy": {
+                "aggregations": [
+                  {
+                    "argMap": {},
+                    "inputColumn": "view_event",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "click_event",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "purchase_event",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "favorite_event",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "add_to_cart_event",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "view_event",
+                    "operation": 8,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "click_event",
+                    "operation": 8,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "purchase_event",
+                    "operation": 8,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "favorite_event",
+                    "operation": 8,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "add_to_cart_event",
+                    "operation": 8,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "is_mobile",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "is_desktop",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "is_tablet",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {
+                      "k": "128"
+                    },
+                    "inputColumn": "user_event_struct",
+                    "operation": 13,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  }
+                ],
+                "keyColumns": [
+                  "user_id"
+                ],
+                "metaData": {
+                  "environments": [
+                    0
+                  ],
+                  "executionInfo": {
+                    "clusterConf": {
+                      "modeClusterConfigs": {
+                        "upload": {
+                          "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                          "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                        }
+                      }
+                    },
+                    "conf": {
+                      "common": {
+                        "spark.chronon.coalesce.factor": "10",
+                        "spark.chronon.partition.column": "ds",
+                        "spark.chronon.partition.format": "yyyy-MM-dd",
+                        "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+                        "spark.chronon.table_write.format": "iceberg",
+                        "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+                        "spark.default.parallelism": "10",
+                        "spark.driver.cores": "1",
+                        "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+                        "spark.driver.memory": "512m",
+                        "spark.executor.cores": "1",
+                        "spark.executor.memory": "512m",
+                        "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                        "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+                        "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+                        "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+                        "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+                        "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+                        "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                        "spark.sql.shuffle.partitions": "10"
+                      }
+                    },
+                    "env": {
+                      "common": {
+                        "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                        "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                        "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+                        "CLOUD_PROVIDER": "gcp",
+                        "CUSTOMER_ID": "canary",
+                        "ENABLE_PUBSUB": "true",
+                        "EVAL_URL": "http://localhost:3904",
+                        "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                        "FRONTEND_URL": "http://localhost:3000",
+                        "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                        "GCP_PROJECT_ID": "canary-443022",
+                        "GCP_REGION": "us-central1",
+                        "HUB_URL": "http://localhost:3903",
+                        "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+                        "VERSION": "latest",
+                        "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                      },
+                      "modeEnvironments": {
+                        "upload": {
+                          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                          "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+                          "CLOUD_PROVIDER": "gcp",
+                          "CUSTOMER_ID": "canary",
+                          "ENABLE_PUBSUB": "true",
+                          "EVAL_URL": "http://localhost:3904",
+                          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                          "FRONTEND_URL": "http://localhost:3000",
+                          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                          "GCP_PROJECT_ID": "canary-443022",
+                          "GCP_REGION": "us-central1",
+                          "HUB_URL": "http://localhost:3903",
+                          "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                          "VERSION": "latest",
+                          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                        }
+                      }
+                    },
+                    "historicalBackfill": 0,
+                    "onlineSchedule": "@daily",
+                    "stepDays": 30
+                  },
+                  "name": "gcp.user_activities.v1__1",
+                  "online": 1,
+                  "outputNamespace": "data",
+                  "team": "gcp",
+                  "version": "1"
+                },
+                "sources": [
+                  {
+                    "events": {
+                      "query": {
+                        "selects": {
+                          "add_to_cart_event": "IF(event_type = 'add_to_cart', 1, 0)",
+                          "click_event": "IF(event_type = 'click', 1, 0)",
+                          "favorite_event": "IF(event_type = 'favorite', 1, 0)",
+                          "is_desktop": "IF(device_type = 'desktop', 1, 0)",
+                          "is_mobile": "IF(device_type = 'mobile', 1, 0)",
+                          "is_tablet": "IF(device_type = 'tablet', 1, 0)",
+                          "listing_id": "listing_id",
+                          "purchase_event": "IF(event_type = 'purchase', 1, 0)",
+                          "user_event_struct": "STRUCT(event_type, listing_id, unix_millis(TIMESTAMP(event_time_ms)) as timestamp)",
+                          "user_id": "user_id",
+                          "view_event": "IF(event_type = 'view', 1, 0)"
+                        },
+                        "timeColumn": "unix_millis(TIMESTAMP(event_time_ms))"
+                      },
+                      "table": "data.gcp_exports_user_activities__0",
+                      "topic": "pubsub://user-activities-v2/project=canary-443022/subscription=user-activities-v2-sub/serde=pubsub_schema/schemaId=user-activities"
+                    }
+                  }
+                ]
+              },
+              "useLongNames": 0
+            }
+          ],
+          "left": {
+            "events": {
+              "query": {
+                "selects": {
+                  "listing_id": "listing_id",
+                  "row_id": "event_id",
+                  "ts": "event_time_ms",
+                  "user_id": "user_id"
+                },
+                "timeColumn": "event_time_ms"
+              },
+              "table": "data.gcp_exports_user_activities__0"
+            }
+          },
+          "metaData": {
+            "environments": [
+              0
+            ],
+            "executionInfo": {
+              "clusterConf": {
+                "modeClusterConfigs": {
+                  "upload": {
+                    "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                    "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                  }
+                }
+              },
+              "conf": {
+                "common": {
+                  "spark.chronon.coalesce.factor": "10",
+                  "spark.chronon.partition.column": "ds",
+                  "spark.chronon.partition.format": "yyyy-MM-dd",
+                  "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+                  "spark.chronon.table_write.format": "iceberg",
+                  "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+                  "spark.default.parallelism": "10",
+                  "spark.driver.cores": "1",
+                  "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+                  "spark.driver.memory": "512m",
+                  "spark.executor.cores": "1",
+                  "spark.executor.memory": "512m",
+                  "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                  "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+                  "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+                  "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+                  "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+                  "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+                  "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                  "spark.sql.shuffle.partitions": "10"
+                }
+              },
+              "env": {
+                "common": {
+                  "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                  "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                  "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                  "CLOUD_PROVIDER": "gcp",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_PUBSUB": "true",
+                  "EVAL_URL": "http://localhost:3904",
+                  "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "http://localhost:3000",
+                  "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                  "GCP_PROJECT_ID": "canary-443022",
+                  "GCP_REGION": "us-central1",
+                  "HUB_URL": "http://localhost:3903",
+                  "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                },
+                "modeEnvironments": {
+                  "upload": {
+                    "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                    "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                    "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                    "CLOUD_PROVIDER": "gcp",
+                    "CUSTOMER_ID": "canary",
+                    "ENABLE_PUBSUB": "true",
+                    "EVAL_URL": "http://localhost:3904",
+                    "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                    "FRONTEND_URL": "http://localhost:3000",
+                    "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                    "GCP_PROJECT_ID": "canary-443022",
+                    "GCP_REGION": "us-central1",
+                    "HUB_URL": "http://localhost:3903",
+                    "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                    "VERSION": "latest",
+                    "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                  }
+                }
+              },
+              "offlineSchedule": "0 4 * * *",
+              "onlineSchedule": "0 3 * * *",
+              "stepDays": 30
+            },
+            "name": "gcp.demo.derivations_v1__2",
+            "online": 1,
+            "outputNamespace": "data",
+            "production": 0,
+            "samplePercent": 100.0,
+            "team": "gcp",
+            "version": "2"
+          },
+          "rowIds": [
+            "event_id"
+          ],
+          "useLongNames": 0
+        }
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/model_transforms/gcp/listing.v1__2
+++ b/python/test/canary/canary_compiled/model_transforms/gcp/listing.v1__2
@@ -1,0 +1,1058 @@
+{
+  "keySchema": {
+    "kind": 13,
+    "name": "modeltransform_key_schema",
+    "params": [
+      {
+        "dataType": {
+          "kind": 7
+        },
+        "name": "listing_id_headline"
+      },
+      {
+        "dataType": {
+          "kind": 7
+        },
+        "name": "listing_id_long_description"
+      }
+    ]
+  },
+  "metaData": {
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      }
+    },
+    "name": "gcp.listing.v1__2",
+    "outputNamespace": "data",
+    "sourceFile": "model_transforms/gcp/listing.py",
+    "team": "gcp",
+    "version": "2"
+  },
+  "models": [
+    {
+      "inferenceSpec": {
+        "modelBackend": 0,
+        "modelBackendParams": {
+          "model_name": "gemini-embedding-001",
+          "model_type": "publisher"
+        }
+      },
+      "inputMapping": {
+        "instance": "named_struct('content', concat_ws('; ', listing_id_headline, listing_id_long_description))"
+      },
+      "metaData": {
+        "environments": [
+          0
+        ],
+        "executionInfo": {
+          "clusterConf": {
+            "modeClusterConfigs": {
+              "upload": {
+                "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+              }
+            }
+          },
+          "conf": {
+            "common": {
+              "spark.chronon.coalesce.factor": "10",
+              "spark.chronon.partition.column": "ds",
+              "spark.chronon.partition.format": "yyyy-MM-dd",
+              "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+              "spark.chronon.table_write.format": "iceberg",
+              "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+              "spark.default.parallelism": "10",
+              "spark.driver.cores": "1",
+              "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+              "spark.driver.memory": "512m",
+              "spark.executor.cores": "1",
+              "spark.executor.memory": "512m",
+              "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+              "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+              "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+              "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+              "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+              "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+              "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+              "spark.sql.shuffle.partitions": "10"
+            }
+          },
+          "env": {
+            "common": {
+              "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+              "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+              "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+              "CLOUD_PROVIDER": "gcp",
+              "CUSTOMER_ID": "canary",
+              "ENABLE_PUBSUB": "true",
+              "EVAL_URL": "http://localhost:3904",
+              "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+              "FRONTEND_URL": "http://localhost:3000",
+              "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+              "GCP_PROJECT_ID": "canary-443022",
+              "GCP_REGION": "us-central1",
+              "HUB_URL": "http://localhost:3903",
+              "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+              "VERSION": "latest",
+              "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+            },
+            "modeEnvironments": {
+              "upload": {
+                "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                "CLOUD_PROVIDER": "gcp",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_PUBSUB": "true",
+                "EVAL_URL": "http://localhost:3904",
+                "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "http://localhost:3000",
+                "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                "GCP_PROJECT_ID": "canary-443022",
+                "GCP_REGION": "us-central1",
+                "HUB_URL": "http://localhost:3903",
+                "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+              }
+            }
+          }
+        },
+        "name": "gcp.listing.item_description_model__1",
+        "outputNamespace": "data",
+        "team": "gcp",
+        "version": "1"
+      },
+      "outputMapping": {
+        "item_embedding": "gcp_listing_item_description_model__1__embeddings.values"
+      },
+      "valueSchema": {
+        "kind": 13,
+        "name": "model_value_schema",
+        "params": [
+          {
+            "dataType": {
+              "kind": 13,
+              "name": "embeddings",
+              "params": [
+                {
+                  "dataType": {
+                    "kind": 13,
+                    "name": "statistics",
+                    "params": [
+                      {
+                        "dataType": {
+                          "kind": 0
+                        },
+                        "name": "truncated"
+                      },
+                      {
+                        "dataType": {
+                          "kind": 3
+                        },
+                        "name": "token_count"
+                      }
+                    ]
+                  },
+                  "name": "statistics"
+                },
+                {
+                  "dataType": {
+                    "kind": 12,
+                    "params": [
+                      {
+                        "dataType": {
+                          "kind": 6
+                        },
+                        "name": "elem"
+                      }
+                    ]
+                  },
+                  "name": "values"
+                }
+              ]
+            },
+            "name": "embeddings"
+          }
+        ]
+      }
+    }
+  ],
+  "passthroughFields": [
+    "user_id",
+    "listing_id",
+    "listing_id_is_active"
+  ],
+  "sources": [
+    {
+      "joinSource": {
+        "join": {
+          "joinParts": [
+            {
+              "groupBy": {
+                "aggregations": [
+                  {
+                    "argMap": {},
+                    "inputColumn": "view_event",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "click_event",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "purchase_event",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "favorite_event",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "add_to_cart_event",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "view_event",
+                    "operation": 8,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "click_event",
+                    "operation": 8,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "purchase_event",
+                    "operation": 8,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "favorite_event",
+                    "operation": 8,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "add_to_cart_event",
+                    "operation": 8,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "is_mobile",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "is_desktop",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "is_tablet",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {
+                      "k": "128"
+                    },
+                    "inputColumn": "user_event_struct",
+                    "operation": 13,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  }
+                ],
+                "keyColumns": [
+                  "user_id"
+                ],
+                "metaData": {
+                  "environments": [
+                    0
+                  ],
+                  "executionInfo": {
+                    "clusterConf": {
+                      "modeClusterConfigs": {
+                        "upload": {
+                          "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                          "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                        }
+                      }
+                    },
+                    "conf": {
+                      "common": {
+                        "spark.chronon.coalesce.factor": "10",
+                        "spark.chronon.partition.column": "ds",
+                        "spark.chronon.partition.format": "yyyy-MM-dd",
+                        "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+                        "spark.chronon.table_write.format": "iceberg",
+                        "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+                        "spark.default.parallelism": "10",
+                        "spark.driver.cores": "1",
+                        "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+                        "spark.driver.memory": "512m",
+                        "spark.executor.cores": "1",
+                        "spark.executor.memory": "512m",
+                        "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                        "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+                        "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+                        "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+                        "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+                        "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+                        "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                        "spark.sql.shuffle.partitions": "10"
+                      }
+                    },
+                    "env": {
+                      "common": {
+                        "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                        "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                        "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+                        "CLOUD_PROVIDER": "gcp",
+                        "CUSTOMER_ID": "canary",
+                        "ENABLE_PUBSUB": "true",
+                        "EVAL_URL": "http://localhost:3904",
+                        "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                        "FRONTEND_URL": "http://localhost:3000",
+                        "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                        "GCP_PROJECT_ID": "canary-443022",
+                        "GCP_REGION": "us-central1",
+                        "HUB_URL": "http://localhost:3903",
+                        "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+                        "VERSION": "latest",
+                        "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                      },
+                      "modeEnvironments": {
+                        "upload": {
+                          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                          "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+                          "CLOUD_PROVIDER": "gcp",
+                          "CUSTOMER_ID": "canary",
+                          "ENABLE_PUBSUB": "true",
+                          "EVAL_URL": "http://localhost:3904",
+                          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                          "FRONTEND_URL": "http://localhost:3000",
+                          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                          "GCP_PROJECT_ID": "canary-443022",
+                          "GCP_REGION": "us-central1",
+                          "HUB_URL": "http://localhost:3903",
+                          "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                          "VERSION": "latest",
+                          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                        }
+                      }
+                    },
+                    "historicalBackfill": 0,
+                    "onlineSchedule": "@daily",
+                    "stepDays": 30
+                  },
+                  "name": "gcp.user_activities.v1__1",
+                  "online": 1,
+                  "outputNamespace": "data",
+                  "team": "gcp",
+                  "version": "1"
+                },
+                "sources": [
+                  {
+                    "events": {
+                      "query": {
+                        "selects": {
+                          "add_to_cart_event": "IF(event_type = 'add_to_cart', 1, 0)",
+                          "click_event": "IF(event_type = 'click', 1, 0)",
+                          "favorite_event": "IF(event_type = 'favorite', 1, 0)",
+                          "is_desktop": "IF(device_type = 'desktop', 1, 0)",
+                          "is_mobile": "IF(device_type = 'mobile', 1, 0)",
+                          "is_tablet": "IF(device_type = 'tablet', 1, 0)",
+                          "listing_id": "listing_id",
+                          "purchase_event": "IF(event_type = 'purchase', 1, 0)",
+                          "user_event_struct": "STRUCT(event_type, listing_id, unix_millis(TIMESTAMP(event_time_ms)) as timestamp)",
+                          "user_id": "user_id",
+                          "view_event": "IF(event_type = 'view', 1, 0)"
+                        },
+                        "timeColumn": "unix_millis(TIMESTAMP(event_time_ms))"
+                      },
+                      "table": "data.gcp_exports_user_activities__0",
+                      "topic": "pubsub://user-activities-v2/project=canary-443022/subscription=user-activities-v2-sub/serde=pubsub_schema/schemaId=user-activities"
+                    }
+                  }
+                ]
+              },
+              "useLongNames": 0
+            },
+            {
+              "groupBy": {
+                "keyColumns": [
+                  "listing_id"
+                ],
+                "metaData": {
+                  "environments": [
+                    0
+                  ],
+                  "executionInfo": {
+                    "clusterConf": {
+                      "modeClusterConfigs": {
+                        "upload": {
+                          "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                          "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                        }
+                      }
+                    },
+                    "conf": {
+                      "common": {
+                        "spark.chronon.coalesce.factor": "10",
+                        "spark.chronon.partition.column": "ds",
+                        "spark.chronon.partition.format": "yyyy-MM-dd",
+                        "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+                        "spark.chronon.table_write.format": "iceberg",
+                        "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+                        "spark.default.parallelism": "10",
+                        "spark.driver.cores": "1",
+                        "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+                        "spark.driver.memory": "512m",
+                        "spark.executor.cores": "1",
+                        "spark.executor.memory": "512m",
+                        "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                        "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+                        "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+                        "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+                        "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+                        "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+                        "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                        "spark.sql.shuffle.partitions": "10"
+                      }
+                    },
+                    "env": {
+                      "common": {
+                        "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                        "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                        "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                        "CLOUD_PROVIDER": "gcp",
+                        "CUSTOMER_ID": "canary",
+                        "ENABLE_PUBSUB": "true",
+                        "EVAL_URL": "http://localhost:3904",
+                        "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                        "FRONTEND_URL": "http://localhost:3000",
+                        "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                        "GCP_PROJECT_ID": "canary-443022",
+                        "GCP_REGION": "us-central1",
+                        "HUB_URL": "http://localhost:3903",
+                        "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+                        "VERSION": "latest",
+                        "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                      },
+                      "modeEnvironments": {
+                        "upload": {
+                          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                          "CLOUD_PROVIDER": "gcp",
+                          "CUSTOMER_ID": "canary",
+                          "ENABLE_PUBSUB": "true",
+                          "EVAL_URL": "http://localhost:3904",
+                          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                          "FRONTEND_URL": "http://localhost:3000",
+                          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                          "GCP_PROJECT_ID": "canary-443022",
+                          "GCP_REGION": "us-central1",
+                          "HUB_URL": "http://localhost:3903",
+                          "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                          "VERSION": "latest",
+                          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                        }
+                      }
+                    },
+                    "historicalBackfill": 0,
+                    "onlineSchedule": "@daily"
+                  },
+                  "name": "gcp.dim_listings.v1__0",
+                  "online": 1,
+                  "outputNamespace": "data",
+                  "team": "gcp",
+                  "version": "0"
+                },
+                "sources": [
+                  {
+                    "entities": {
+                      "query": {
+                        "selects": {
+                          "brief_description": "brief_description",
+                          "currency": "currency",
+                          "headline": "headline",
+                          "inventory_count": "inventory_count",
+                          "is_active": "is_active",
+                          "is_expensive": "IF(price_cents > 10000, 1, 0)",
+                          "is_in_stock": "IF(inventory_count > 0, 1, 0)",
+                          "listing_id": "listing_id",
+                          "long_description": "long_description",
+                          "main_image_path": "main_image_path",
+                          "merchant_id": "merchant_id",
+                          "price_cents": "price_cents",
+                          "primary_category": "primary_category",
+                          "secondary_image_paths": "secondary_image_paths",
+                          "tags": "tags",
+                          "weight_grams": "weight_grams"
+                        },
+                        "startPartition": "2025-01-01"
+                      },
+                      "snapshotTable": "data.gcp_exports_dim_listings__0"
+                    }
+                  }
+                ]
+              },
+              "useLongNames": 0
+            },
+            {
+              "groupBy": {
+                "keyColumns": [
+                  "listing_id"
+                ],
+                "metaData": {
+                  "environments": [
+                    0
+                  ],
+                  "executionInfo": {
+                    "clusterConf": {
+                      "modeClusterConfigs": {
+                        "upload": {
+                          "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                          "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                        }
+                      }
+                    },
+                    "conf": {
+                      "common": {
+                        "spark.chronon.coalesce.factor": "10",
+                        "spark.chronon.partition.column": "ds",
+                        "spark.chronon.partition.format": "yyyy-MM-dd",
+                        "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+                        "spark.chronon.table_write.format": "iceberg",
+                        "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+                        "spark.default.parallelism": "10",
+                        "spark.driver.cores": "1",
+                        "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+                        "spark.driver.memory": "512m",
+                        "spark.executor.cores": "1",
+                        "spark.executor.memory": "512m",
+                        "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                        "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+                        "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+                        "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+                        "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+                        "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+                        "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                        "spark.sql.shuffle.partitions": "10"
+                      }
+                    },
+                    "env": {
+                      "common": {
+                        "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                        "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                        "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                        "CLOUD_PROVIDER": "gcp",
+                        "CUSTOMER_ID": "canary",
+                        "ENABLE_PUBSUB": "true",
+                        "EVAL_URL": "http://localhost:3904",
+                        "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                        "FRONTEND_URL": "http://localhost:3000",
+                        "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                        "GCP_PROJECT_ID": "canary-443022",
+                        "GCP_REGION": "us-central1",
+                        "HUB_URL": "http://localhost:3903",
+                        "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+                        "VERSION": "latest",
+                        "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                      },
+                      "modeEnvironments": {
+                        "upload": {
+                          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                          "CLOUD_PROVIDER": "gcp",
+                          "CUSTOMER_ID": "canary",
+                          "ENABLE_PUBSUB": "true",
+                          "EVAL_URL": "http://localhost:3904",
+                          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                          "FRONTEND_URL": "http://localhost:3000",
+                          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                          "GCP_PROJECT_ID": "canary-443022",
+                          "GCP_REGION": "us-central1",
+                          "HUB_URL": "http://localhost:3903",
+                          "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                          "VERSION": "latest",
+                          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                        }
+                      }
+                    },
+                    "historicalBackfill": 0,
+                    "onlineSchedule": "@daily"
+                  },
+                  "name": "gcp.dim_merchants.v1__0",
+                  "online": 1,
+                  "outputNamespace": "data",
+                  "team": "gcp",
+                  "version": "0"
+                },
+                "sources": [
+                  {
+                    "entities": {
+                      "query": {
+                        "selects": {
+                          "listing_id": "merchant_id",
+                          "primary_category": "primary_category"
+                        },
+                        "startPartition": "2025-01-01"
+                      },
+                      "snapshotTable": "data.gcp_exports_dim_merchants__0"
+                    }
+                  }
+                ]
+              },
+              "prefix": "merchant_",
+              "useLongNames": 0
+            }
+          ],
+          "left": {
+            "events": {
+              "query": {
+                "selects": {
+                  "listing_id": "listing_id",
+                  "row_id": "event_id",
+                  "ts": "event_time_ms",
+                  "user_id": "user_id"
+                },
+                "timeColumn": "event_time_ms"
+              },
+              "table": "data.gcp_exports_user_activities__0"
+            }
+          },
+          "metaData": {
+            "environments": [
+              0
+            ],
+            "executionInfo": {
+              "clusterConf": {
+                "modeClusterConfigs": {
+                  "upload": {
+                    "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                    "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                  }
+                }
+              },
+              "conf": {
+                "common": {
+                  "spark.chronon.coalesce.factor": "10",
+                  "spark.chronon.partition.column": "ds",
+                  "spark.chronon.partition.format": "yyyy-MM-dd",
+                  "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+                  "spark.chronon.table_write.format": "iceberg",
+                  "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+                  "spark.default.parallelism": "10",
+                  "spark.driver.cores": "1",
+                  "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+                  "spark.driver.memory": "512m",
+                  "spark.executor.cores": "1",
+                  "spark.executor.memory": "512m",
+                  "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                  "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+                  "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+                  "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+                  "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+                  "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+                  "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                  "spark.sql.shuffle.partitions": "10"
+                }
+              },
+              "enableStatsCompute": 1,
+              "env": {
+                "common": {
+                  "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                  "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                  "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                  "CLOUD_PROVIDER": "gcp",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_PUBSUB": "true",
+                  "EVAL_URL": "http://localhost:3904",
+                  "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "http://localhost:3000",
+                  "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                  "GCP_PROJECT_ID": "canary-443022",
+                  "GCP_REGION": "us-central1",
+                  "HUB_URL": "http://localhost:3903",
+                  "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                },
+                "modeEnvironments": {
+                  "upload": {
+                    "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                    "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                    "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                    "CLOUD_PROVIDER": "gcp",
+                    "CUSTOMER_ID": "canary",
+                    "ENABLE_PUBSUB": "true",
+                    "EVAL_URL": "http://localhost:3904",
+                    "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                    "FRONTEND_URL": "http://localhost:3000",
+                    "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                    "GCP_PROJECT_ID": "canary-443022",
+                    "GCP_REGION": "us-central1",
+                    "HUB_URL": "http://localhost:3903",
+                    "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                    "VERSION": "latest",
+                    "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                  }
+                }
+              },
+              "offlineSchedule": "@daily",
+              "onlineSchedule": "@daily",
+              "stepDays": 30
+            },
+            "name": "gcp.demo.v1__1",
+            "online": 1,
+            "outputNamespace": "data",
+            "production": 0,
+            "samplePercent": 100.0,
+            "team": "gcp",
+            "version": "1"
+          },
+          "rowIds": [
+            "event_id"
+          ],
+          "useLongNames": 0
+        },
+        "query": {
+          "wheres": [
+            "(listing_id_headline IS NOT NULL AND listing_id_headline != '') OR (listing_id_long_description IS NOT NULL AND listing_id_long_description != '')"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/model_transforms/gcp/team_default_ns_mt.v1__1
+++ b/python/test/canary/canary_compiled/model_transforms/gcp/team_default_ns_mt.v1__1
@@ -1,0 +1,994 @@
+{
+  "keySchema": {
+    "kind": 13,
+    "name": "modeltransform_key_schema",
+    "params": [
+      {
+        "dataType": {
+          "kind": 6
+        },
+        "name": "user_id_click_event_average_7d"
+      },
+      {
+        "dataType": {
+          "kind": 4
+        },
+        "name": "listing_id_price_cents"
+      },
+      {
+        "dataType": {
+          "kind": 6
+        },
+        "name": "price_log"
+      },
+      {
+        "dataType": {
+          "kind": 3
+        },
+        "name": "price_bucket"
+      }
+    ]
+  },
+  "metaData": {
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      }
+    },
+    "name": "gcp.team_default_ns_mt.v1__1",
+    "outputNamespace": "data",
+    "sourceFile": "model_transforms/gcp/team_default_ns_mt.py",
+    "team": "gcp",
+    "version": "1"
+  },
+  "models": [
+    {
+      "deploymentConf": {
+        "containerConfig": {
+          "image": "us-central1-docker.pkg.dev/canary-443022/canary-images/ctr-predictor:v1"
+        },
+        "endpointConfig": {
+          "endpointName": "test_ctr_model"
+        },
+        "resourceConfig": {
+          "machineType": "n1-standard-4",
+          "maxReplicaCount": 3,
+          "minReplicaCount": 1
+        },
+        "rolloutStrategy": {
+          "rolloutType": 2
+        }
+      },
+      "inferenceSpec": {
+        "modelBackend": 0,
+        "modelBackendParams": {
+          "model_name": "test_ctr_model",
+          "model_type": "custom"
+        }
+      },
+      "inputMapping": {
+        "instance": "named_struct('user_id_click_event_average_7d', user_id_click_event_average_7d, 'listing_price_cents', listing_id_price_cents, 'price_log', price_log, 'price_bucket', price_bucket)"
+      },
+      "metaData": {
+        "environments": [
+          0
+        ],
+        "executionInfo": {
+          "clusterConf": {
+            "modeClusterConfigs": {
+              "upload": {
+                "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+              }
+            }
+          },
+          "conf": {
+            "common": {
+              "spark.chronon.coalesce.factor": "10",
+              "spark.chronon.partition.column": "ds",
+              "spark.chronon.partition.format": "yyyy-MM-dd",
+              "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+              "spark.chronon.table_write.format": "iceberg",
+              "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+              "spark.default.parallelism": "10",
+              "spark.driver.cores": "1",
+              "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+              "spark.driver.memory": "512m",
+              "spark.executor.cores": "1",
+              "spark.executor.memory": "512m",
+              "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+              "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+              "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+              "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+              "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+              "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+              "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+              "spark.sql.shuffle.partitions": "10"
+            }
+          },
+          "env": {
+            "common": {
+              "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+              "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+              "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+              "CLOUD_PROVIDER": "gcp",
+              "CUSTOMER_ID": "canary",
+              "ENABLE_PUBSUB": "true",
+              "EVAL_URL": "http://localhost:3904",
+              "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+              "FRONTEND_URL": "http://localhost:3000",
+              "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+              "GCP_PROJECT_ID": "canary-443022",
+              "GCP_REGION": "us-central1",
+              "HUB_URL": "http://localhost:3903",
+              "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+              "VERSION": "latest",
+              "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+            },
+            "modeEnvironments": {
+              "upload": {
+                "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                "CLOUD_PROVIDER": "gcp",
+                "CUSTOMER_ID": "canary",
+                "ENABLE_PUBSUB": "true",
+                "EVAL_URL": "http://localhost:3904",
+                "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                "FRONTEND_URL": "http://localhost:3000",
+                "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                "GCP_PROJECT_ID": "canary-443022",
+                "GCP_REGION": "us-central1",
+                "HUB_URL": "http://localhost:3903",
+                "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                "VERSION": "latest",
+                "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+              }
+            }
+          }
+        },
+        "name": "gcp.click_through_rate.ctr_model__1.0",
+        "outputNamespace": "data",
+        "team": "gcp",
+        "version": "1.0"
+      },
+      "modelArtifactBaseUri": "gs://zipline-warehouse-models",
+      "outputMapping": {
+        "ctr": "gcp_click_through_rate_ctr_model__1_0__score"
+      },
+      "trainingConf": {
+        "image": "us-docker.pkg.dev/vertex-ai/training/xgboost-cpu.2-1:latest",
+        "jobConfigs": {
+          "eta": "0.1",
+          "max-depth": "4",
+          "num-boost-round": "50"
+        },
+        "pythonModule": "trainer.train",
+        "resourceConfig": {
+          "machineType": "n1-standard-4",
+          "maxReplicaCount": 1,
+          "minReplicaCount": 1
+        },
+        "schedule": "@daily",
+        "trainingDataSource": {
+          "events": {
+            "query": {
+              "selects": {
+                "ds": "ds",
+                "label": "label",
+                "listing_price_cents": "listing_id_price_cents",
+                "price_bucket": "price_bucket",
+                "price_log": "price_log",
+                "user_id_click_event_average_7d": "user_id_click_event_average_7d"
+              },
+              "startPartition": "2025-07-01"
+            },
+            "table": "data.gcp_ctr_labels_v1__0"
+          }
+        },
+        "trainingDataWindow": {
+          "length": 1,
+          "timeUnit": 1
+        }
+      },
+      "valueSchema": {
+        "kind": 13,
+        "name": "model_value_schema",
+        "params": [
+          {
+            "dataType": {
+              "kind": 6
+            },
+            "name": "score"
+          }
+        ]
+      }
+    }
+  ],
+  "passthroughFields": [
+    "user_id",
+    "listing_id",
+    "user_id_click_event_average_7d",
+    "listing_id_price_cents",
+    "price_log",
+    "price_bucket"
+  ],
+  "sources": [
+    {
+      "joinSource": {
+        "join": {
+          "derivations": [
+            {
+              "expression": "IF(listing_id_weight_grams > 1000, 1, 0)",
+              "name": "is_listing_heavy"
+            },
+            {
+              "expression": "array_contains(split(listing_id_tags, ','), 'handmade')",
+              "name": "is_item_handmade"
+            },
+            {
+              "expression": "log1p(listing_id_price_cents)",
+              "name": "price_log"
+            },
+            {
+              "expression": "\n                CASE\n                    WHEN listing_id_price_cents < 1000 THEN 0\n                    WHEN listing_id_price_cents < 5000 THEN 1\n                    WHEN listing_id_price_cents < 10000 THEN 2\n                    WHEN listing_id_price_cents < 50000 THEN 3\n                    ELSE 4\n                END\n            ",
+              "name": "price_bucket"
+            },
+            {
+              "expression": "*",
+              "name": "*"
+            }
+          ],
+          "joinParts": [
+            {
+              "groupBy": {
+                "keyColumns": [
+                  "listing_id"
+                ],
+                "metaData": {
+                  "environments": [
+                    0
+                  ],
+                  "executionInfo": {
+                    "clusterConf": {
+                      "modeClusterConfigs": {
+                        "upload": {
+                          "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                          "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                        }
+                      }
+                    },
+                    "conf": {
+                      "common": {
+                        "spark.chronon.coalesce.factor": "10",
+                        "spark.chronon.partition.column": "ds",
+                        "spark.chronon.partition.format": "yyyy-MM-dd",
+                        "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+                        "spark.chronon.table_write.format": "iceberg",
+                        "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+                        "spark.default.parallelism": "10",
+                        "spark.driver.cores": "1",
+                        "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+                        "spark.driver.memory": "512m",
+                        "spark.executor.cores": "1",
+                        "spark.executor.memory": "512m",
+                        "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                        "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+                        "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+                        "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+                        "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+                        "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+                        "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                        "spark.sql.shuffle.partitions": "10"
+                      }
+                    },
+                    "env": {
+                      "common": {
+                        "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                        "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                        "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                        "CLOUD_PROVIDER": "gcp",
+                        "CUSTOMER_ID": "canary",
+                        "ENABLE_PUBSUB": "true",
+                        "EVAL_URL": "http://localhost:3904",
+                        "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                        "FRONTEND_URL": "http://localhost:3000",
+                        "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                        "GCP_PROJECT_ID": "canary-443022",
+                        "GCP_REGION": "us-central1",
+                        "HUB_URL": "http://localhost:3903",
+                        "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+                        "VERSION": "latest",
+                        "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                      },
+                      "modeEnvironments": {
+                        "upload": {
+                          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                          "CLOUD_PROVIDER": "gcp",
+                          "CUSTOMER_ID": "canary",
+                          "ENABLE_PUBSUB": "true",
+                          "EVAL_URL": "http://localhost:3904",
+                          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                          "FRONTEND_URL": "http://localhost:3000",
+                          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                          "GCP_PROJECT_ID": "canary-443022",
+                          "GCP_REGION": "us-central1",
+                          "HUB_URL": "http://localhost:3903",
+                          "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                          "VERSION": "latest",
+                          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                        }
+                      }
+                    },
+                    "historicalBackfill": 0,
+                    "onlineSchedule": "@daily"
+                  },
+                  "name": "gcp.dim_listings.v1__0",
+                  "online": 1,
+                  "outputNamespace": "data",
+                  "team": "gcp",
+                  "version": "0"
+                },
+                "sources": [
+                  {
+                    "entities": {
+                      "query": {
+                        "selects": {
+                          "brief_description": "brief_description",
+                          "currency": "currency",
+                          "headline": "headline",
+                          "inventory_count": "inventory_count",
+                          "is_active": "is_active",
+                          "is_expensive": "IF(price_cents > 10000, 1, 0)",
+                          "is_in_stock": "IF(inventory_count > 0, 1, 0)",
+                          "listing_id": "listing_id",
+                          "long_description": "long_description",
+                          "main_image_path": "main_image_path",
+                          "merchant_id": "merchant_id",
+                          "price_cents": "price_cents",
+                          "primary_category": "primary_category",
+                          "secondary_image_paths": "secondary_image_paths",
+                          "tags": "tags",
+                          "weight_grams": "weight_grams"
+                        },
+                        "startPartition": "2025-01-01"
+                      },
+                      "snapshotTable": "data.gcp_exports_dim_listings__0"
+                    }
+                  }
+                ]
+              },
+              "useLongNames": 0
+            },
+            {
+              "groupBy": {
+                "aggregations": [
+                  {
+                    "argMap": {},
+                    "inputColumn": "view_event",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "click_event",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "purchase_event",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "favorite_event",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "add_to_cart_event",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "view_event",
+                    "operation": 8,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "click_event",
+                    "operation": 8,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "purchase_event",
+                    "operation": 8,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "favorite_event",
+                    "operation": 8,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "add_to_cart_event",
+                    "operation": 8,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "is_mobile",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "is_desktop",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {},
+                    "inputColumn": "is_tablet",
+                    "operation": 7,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  },
+                  {
+                    "argMap": {
+                      "k": "128"
+                    },
+                    "inputColumn": "user_event_struct",
+                    "operation": 13,
+                    "windows": [
+                      {
+                        "length": 1,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 7,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 14,
+                        "timeUnit": 1
+                      },
+                      {
+                        "length": 30,
+                        "timeUnit": 1
+                      }
+                    ]
+                  }
+                ],
+                "keyColumns": [
+                  "user_id"
+                ],
+                "metaData": {
+                  "environments": [
+                    0
+                  ],
+                  "executionInfo": {
+                    "clusterConf": {
+                      "modeClusterConfigs": {
+                        "upload": {
+                          "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                          "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                        }
+                      }
+                    },
+                    "conf": {
+                      "common": {
+                        "spark.chronon.coalesce.factor": "10",
+                        "spark.chronon.partition.column": "ds",
+                        "spark.chronon.partition.format": "yyyy-MM-dd",
+                        "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+                        "spark.chronon.table_write.format": "iceberg",
+                        "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+                        "spark.default.parallelism": "10",
+                        "spark.driver.cores": "1",
+                        "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+                        "spark.driver.memory": "512m",
+                        "spark.executor.cores": "1",
+                        "spark.executor.memory": "512m",
+                        "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                        "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+                        "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+                        "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+                        "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+                        "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+                        "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                        "spark.sql.shuffle.partitions": "10"
+                      }
+                    },
+                    "env": {
+                      "common": {
+                        "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                        "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                        "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+                        "CLOUD_PROVIDER": "gcp",
+                        "CUSTOMER_ID": "canary",
+                        "ENABLE_PUBSUB": "true",
+                        "EVAL_URL": "http://localhost:3904",
+                        "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                        "FRONTEND_URL": "http://localhost:3000",
+                        "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                        "GCP_PROJECT_ID": "canary-443022",
+                        "GCP_REGION": "us-central1",
+                        "HUB_URL": "http://localhost:3903",
+                        "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+                        "VERSION": "latest",
+                        "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                      },
+                      "modeEnvironments": {
+                        "upload": {
+                          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                          "CHRONON_ONLINE_ARGS": "-Ztasks=1",
+                          "CLOUD_PROVIDER": "gcp",
+                          "CUSTOMER_ID": "canary",
+                          "ENABLE_PUBSUB": "true",
+                          "EVAL_URL": "http://localhost:3904",
+                          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                          "FRONTEND_URL": "http://localhost:3000",
+                          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                          "GCP_PROJECT_ID": "canary-443022",
+                          "GCP_REGION": "us-central1",
+                          "HUB_URL": "http://localhost:3903",
+                          "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                          "VERSION": "latest",
+                          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                        }
+                      }
+                    },
+                    "historicalBackfill": 0,
+                    "onlineSchedule": "@daily",
+                    "stepDays": 30
+                  },
+                  "name": "gcp.user_activities.v1__1",
+                  "online": 1,
+                  "outputNamespace": "data",
+                  "team": "gcp",
+                  "version": "1"
+                },
+                "sources": [
+                  {
+                    "events": {
+                      "query": {
+                        "selects": {
+                          "add_to_cart_event": "IF(event_type = 'add_to_cart', 1, 0)",
+                          "click_event": "IF(event_type = 'click', 1, 0)",
+                          "favorite_event": "IF(event_type = 'favorite', 1, 0)",
+                          "is_desktop": "IF(device_type = 'desktop', 1, 0)",
+                          "is_mobile": "IF(device_type = 'mobile', 1, 0)",
+                          "is_tablet": "IF(device_type = 'tablet', 1, 0)",
+                          "listing_id": "listing_id",
+                          "purchase_event": "IF(event_type = 'purchase', 1, 0)",
+                          "user_event_struct": "STRUCT(event_type, listing_id, unix_millis(TIMESTAMP(event_time_ms)) as timestamp)",
+                          "user_id": "user_id",
+                          "view_event": "IF(event_type = 'view', 1, 0)"
+                        },
+                        "timeColumn": "unix_millis(TIMESTAMP(event_time_ms))"
+                      },
+                      "table": "data.gcp_exports_user_activities__0",
+                      "topic": "pubsub://user-activities-v2/project=canary-443022/subscription=user-activities-v2-sub/serde=pubsub_schema/schemaId=user-activities"
+                    }
+                  }
+                ]
+              },
+              "useLongNames": 0
+            }
+          ],
+          "left": {
+            "events": {
+              "query": {
+                "selects": {
+                  "listing_id": "listing_id",
+                  "row_id": "event_id",
+                  "ts": "event_time_ms",
+                  "user_id": "user_id"
+                },
+                "timeColumn": "event_time_ms"
+              },
+              "table": "data.gcp_exports_user_activities__0"
+            }
+          },
+          "metaData": {
+            "environments": [
+              0
+            ],
+            "executionInfo": {
+              "clusterConf": {
+                "modeClusterConfigs": {
+                  "upload": {
+                    "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+                    "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                  }
+                }
+              },
+              "conf": {
+                "common": {
+                  "spark.chronon.coalesce.factor": "10",
+                  "spark.chronon.partition.column": "ds",
+                  "spark.chronon.partition.format": "yyyy-MM-dd",
+                  "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+                  "spark.chronon.table_write.format": "iceberg",
+                  "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+                  "spark.default.parallelism": "10",
+                  "spark.driver.cores": "1",
+                  "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+                  "spark.driver.memory": "512m",
+                  "spark.executor.cores": "1",
+                  "spark.executor.memory": "512m",
+                  "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+                  "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+                  "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+                  "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+                  "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+                  "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+                  "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+                  "spark.sql.shuffle.partitions": "10"
+                }
+              },
+              "env": {
+                "common": {
+                  "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                  "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                  "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                  "CLOUD_PROVIDER": "gcp",
+                  "CUSTOMER_ID": "canary",
+                  "ENABLE_PUBSUB": "true",
+                  "EVAL_URL": "http://localhost:3904",
+                  "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                  "FRONTEND_URL": "http://localhost:3000",
+                  "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                  "GCP_PROJECT_ID": "canary-443022",
+                  "GCP_REGION": "us-central1",
+                  "HUB_URL": "http://localhost:3903",
+                  "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+                  "VERSION": "latest",
+                  "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                },
+                "modeEnvironments": {
+                  "upload": {
+                    "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+                    "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+                    "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+                    "CLOUD_PROVIDER": "gcp",
+                    "CUSTOMER_ID": "canary",
+                    "ENABLE_PUBSUB": "true",
+                    "EVAL_URL": "http://localhost:3904",
+                    "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+                    "FRONTEND_URL": "http://localhost:3000",
+                    "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+                    "GCP_PROJECT_ID": "canary-443022",
+                    "GCP_REGION": "us-central1",
+                    "HUB_URL": "http://localhost:3903",
+                    "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+                    "VERSION": "latest",
+                    "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+                  }
+                }
+              },
+              "offlineSchedule": "0 4 * * *",
+              "onlineSchedule": "0 3 * * *",
+              "stepDays": 30
+            },
+            "name": "gcp.demo.derivations_v1__2",
+            "online": 1,
+            "outputNamespace": "data",
+            "production": 0,
+            "samplePercent": 100.0,
+            "team": "gcp",
+            "version": "2"
+          },
+          "rowIds": [
+            "event_id"
+          ],
+          "useLongNames": 0
+        }
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/models/aws/click_through_rate.ctr_model__1.0
+++ b/python/test/canary/canary_compiled/models/aws/click_through_rate.ctr_model__1.0
@@ -1,0 +1,179 @@
+{
+  "deploymentConf": {
+    "containerConfig": {
+      "image": "763104351884.dkr.ecr.us-east-1.amazonaws.com/xgboost-inference:latest"
+    },
+    "endpointConfig": {
+      "endpointName": "test_ctr_model"
+    },
+    "resourceConfig": {
+      "machineType": "ml.m5.xlarge",
+      "maxReplicaCount": 10,
+      "minReplicaCount": 3
+    },
+    "rolloutStrategy": {
+      "rolloutType": 2
+    }
+  },
+  "inferenceSpec": {
+    "modelBackend": 1,
+    "modelBackendParams": {
+      "model_name": "test_ctr_model",
+      "model_type": "custom"
+    }
+  },
+  "inputMapping": {
+    "instance": "named_struct('user_id_click_event_average_7d', user_id_click_event_average_7d, 'listing_price_cents', listing_id_price_cents, 'price_log', price_log, 'price_bucket', price_bucket)"
+  },
+  "metaData": {
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      }
+    },
+    "name": "aws.click_through_rate.ctr_model__1.0",
+    "outputNamespace": "data",
+    "sourceFile": "models/aws/click_through_rate.py",
+    "team": "aws",
+    "version": "1.0"
+  },
+  "modelArtifactBaseUri": "s3://zipline-warehouse-models",
+  "outputMapping": {
+    "ctr": "score"
+  },
+  "trainingConf": {
+    "image": "763104351884.dkr.ecr.us-east-1.amazonaws.com/xgboost-training:latest",
+    "jobConfigs": {
+      "eta": "0.1",
+      "max-depth": "4",
+      "n-samples": "1000",
+      "num-boost-round": "50"
+    },
+    "pythonModule": "trainer.train",
+    "resourceConfig": {
+      "machineType": "ml.m5.xlarge",
+      "maxReplicaCount": 1,
+      "minReplicaCount": 1
+    },
+    "schedule": "@daily",
+    "trainingDataSource": {
+      "events": {
+        "query": {
+          "selects": {
+            "ds": "ds",
+            "label": "label",
+            "listing_price_cents": "listing_id_price_cents",
+            "price_bucket": "price_bucket",
+            "price_log": "price_log",
+            "user_id_click_event_average_7d": "user_id_click_event_average_7d"
+          },
+          "startPartition": "2025-07-01"
+        },
+        "table": "data.aws_ctr_labels_v1__0"
+      }
+    },
+    "trainingDataWindow": {
+      "length": 1,
+      "timeUnit": 1
+    }
+  },
+  "valueSchema": {
+    "kind": 13,
+    "name": "model_value_schema",
+    "params": [
+      {
+        "dataType": {
+          "kind": 6
+        },
+        "name": "score"
+      }
+    ]
+  }
+}

--- a/python/test/canary/canary_compiled/models/aws/listing.item_description_model__1
+++ b/python/test/canary/canary_compiled/models/aws/listing.item_description_model__1
@@ -1,0 +1,164 @@
+{
+  "inferenceSpec": {
+    "modelBackend": 1,
+    "modelBackendParams": {
+      "model_name": "amazon-titan-embed-text-v1",
+      "model_type": "bedrock"
+    }
+  },
+  "inputMapping": {
+    "instance": "named_struct('content', concat_ws('; ', listing_id_headline, listing_id_long_description))"
+  },
+  "metaData": {
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      }
+    },
+    "name": "aws.listing.item_description_model__1",
+    "outputNamespace": "data",
+    "sourceFile": "models/aws/listing.py",
+    "team": "aws",
+    "version": "1"
+  },
+  "outputMapping": {
+    "item_embedding": "aws_listing_item_description_model__1__embeddings.values"
+  },
+  "valueSchema": {
+    "kind": 13,
+    "name": "model_value_schema",
+    "params": [
+      {
+        "dataType": {
+          "kind": 13,
+          "name": "embeddings",
+          "params": [
+            {
+              "dataType": {
+                "kind": 13,
+                "name": "statistics",
+                "params": [
+                  {
+                    "dataType": {
+                      "kind": 0
+                    },
+                    "name": "truncated"
+                  },
+                  {
+                    "dataType": {
+                      "kind": 3
+                    },
+                    "name": "token_count"
+                  }
+                ]
+              },
+              "name": "statistics"
+            },
+            {
+              "dataType": {
+                "kind": 12,
+                "params": [
+                  {
+                    "dataType": {
+                      "kind": 6
+                    },
+                    "name": "elem"
+                  }
+                ]
+              },
+              "name": "values"
+            }
+          ]
+        },
+        "name": "embeddings"
+      }
+    ]
+  }
+}

--- a/python/test/canary/canary_compiled/models/aws/listing.item_img_model__001
+++ b/python/test/canary/canary_compiled/models/aws/listing.item_img_model__001
@@ -1,0 +1,149 @@
+{
+  "inferenceSpec": {
+    "modelBackend": 1,
+    "modelBackendParams": {
+      "dimension": "512",
+      "model_name": "amazon-multimodal-embedding",
+      "model_type": "bedrock"
+    }
+  },
+  "inputMapping": {
+    "instance": "named_struct('image', named_struct('s3Uri', listing_id_main_image_path), 'text','')"
+  },
+  "metaData": {
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      }
+    },
+    "name": "aws.listing.item_img_model__001",
+    "outputNamespace": "data",
+    "sourceFile": "models/aws/listing.py",
+    "team": "aws",
+    "version": "001"
+  },
+  "outputMapping": {
+    "image_embedding": "aws_listing_item_img_model__001__imageEmbedding"
+  },
+  "valueSchema": {
+    "kind": 13,
+    "name": "model_value_schema",
+    "params": [
+      {
+        "dataType": {
+          "kind": 12,
+          "params": [
+            {
+              "dataType": {
+                "kind": 6
+              },
+              "name": "elem"
+            }
+          ]
+        },
+        "name": "imageEmbedding"
+      },
+      {
+        "dataType": {
+          "kind": 12,
+          "params": [
+            {
+              "dataType": {
+                "kind": 6
+              },
+              "name": "elem"
+            }
+          ]
+        },
+        "name": "textEmbedding"
+      }
+    ]
+  }
+}

--- a/python/test/canary/canary_compiled/models/gcp/click_through_rate.ctr_model__1.0
+++ b/python/test/canary/canary_compiled/models/gcp/click_through_rate.ctr_model__1.0
@@ -1,0 +1,163 @@
+{
+  "deploymentConf": {
+    "containerConfig": {
+      "image": "us-central1-docker.pkg.dev/canary-443022/canary-images/ctr-predictor:v1"
+    },
+    "endpointConfig": {
+      "endpointName": "test_ctr_model"
+    },
+    "resourceConfig": {
+      "machineType": "n1-standard-4",
+      "maxReplicaCount": 3,
+      "minReplicaCount": 1
+    },
+    "rolloutStrategy": {
+      "rolloutType": 2
+    }
+  },
+  "inferenceSpec": {
+    "modelBackend": 0,
+    "modelBackendParams": {
+      "model_name": "test_ctr_model",
+      "model_type": "custom"
+    }
+  },
+  "inputMapping": {
+    "instance": "named_struct('user_id_click_event_average_7d', user_id_click_event_average_7d, 'listing_price_cents', listing_id_price_cents, 'price_log', price_log, 'price_bucket', price_bucket)"
+  },
+  "metaData": {
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      }
+    },
+    "name": "gcp.click_through_rate.ctr_model__1.0",
+    "outputNamespace": "data",
+    "sourceFile": "models/gcp/click_through_rate.py",
+    "team": "gcp",
+    "version": "1.0"
+  },
+  "modelArtifactBaseUri": "gs://zipline-warehouse-models",
+  "outputMapping": {
+    "ctr": "gcp_click_through_rate_ctr_model__1_0__score"
+  },
+  "trainingConf": {
+    "image": "us-docker.pkg.dev/vertex-ai/training/xgboost-cpu.2-1:latest",
+    "jobConfigs": {
+      "eta": "0.1",
+      "max-depth": "4",
+      "num-boost-round": "50"
+    },
+    "pythonModule": "trainer.train",
+    "resourceConfig": {
+      "machineType": "n1-standard-4",
+      "maxReplicaCount": 1,
+      "minReplicaCount": 1
+    },
+    "schedule": "@daily",
+    "trainingDataSource": {
+      "events": {
+        "query": {
+          "selects": {
+            "ds": "ds",
+            "label": "label",
+            "listing_price_cents": "listing_id_price_cents",
+            "price_bucket": "price_bucket",
+            "price_log": "price_log",
+            "user_id_click_event_average_7d": "user_id_click_event_average_7d"
+          },
+          "startPartition": "2025-07-01"
+        },
+        "table": "data.gcp_ctr_labels_v1__0"
+      }
+    },
+    "trainingDataWindow": {
+      "length": 1,
+      "timeUnit": 1
+    }
+  },
+  "valueSchema": {
+    "kind": 13,
+    "name": "model_value_schema",
+    "params": [
+      {
+        "dataType": {
+          "kind": 6
+        },
+        "name": "score"
+      }
+    ]
+  }
+}

--- a/python/test/canary/canary_compiled/models/gcp/listing.item_description_model__1
+++ b/python/test/canary/canary_compiled/models/gcp/listing.item_description_model__1
@@ -1,0 +1,149 @@
+{
+  "inferenceSpec": {
+    "modelBackend": 0,
+    "modelBackendParams": {
+      "model_name": "gemini-embedding-001",
+      "model_type": "publisher"
+    }
+  },
+  "inputMapping": {
+    "instance": "named_struct('content', concat_ws('; ', listing_id_headline, listing_id_long_description))"
+  },
+  "metaData": {
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      }
+    },
+    "name": "gcp.listing.item_description_model__1",
+    "outputNamespace": "data",
+    "sourceFile": "models/gcp/listing.py",
+    "team": "gcp",
+    "version": "1"
+  },
+  "outputMapping": {
+    "item_embedding": "gcp_listing_item_description_model__1__embeddings.values"
+  },
+  "valueSchema": {
+    "kind": 13,
+    "name": "model_value_schema",
+    "params": [
+      {
+        "dataType": {
+          "kind": 13,
+          "name": "embeddings",
+          "params": [
+            {
+              "dataType": {
+                "kind": 13,
+                "name": "statistics",
+                "params": [
+                  {
+                    "dataType": {
+                      "kind": 0
+                    },
+                    "name": "truncated"
+                  },
+                  {
+                    "dataType": {
+                      "kind": 3
+                    },
+                    "name": "token_count"
+                  }
+                ]
+              },
+              "name": "statistics"
+            },
+            {
+              "dataType": {
+                "kind": 12,
+                "params": [
+                  {
+                    "dataType": {
+                      "kind": 6
+                    },
+                    "name": "elem"
+                  }
+                ]
+              },
+              "name": "values"
+            }
+          ]
+        },
+        "name": "embeddings"
+      }
+    ]
+  }
+}

--- a/python/test/canary/canary_compiled/models/gcp/listing.item_img_model__001
+++ b/python/test/canary/canary_compiled/models/gcp/listing.item_img_model__001
@@ -1,0 +1,135 @@
+{
+  "inferenceSpec": {
+    "modelBackend": 0,
+    "modelBackendParams": {
+      "dimension": "512",
+      "model_name": "multimodalembedding",
+      "model_type": "publisher",
+      "version": "001"
+    }
+  },
+  "inputMapping": {
+    "instance": "named_struct('image', named_struct('gcsUri', listing_id_main_image_path), 'text','')"
+  },
+  "metaData": {
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      }
+    },
+    "name": "gcp.listing.item_img_model__001",
+    "outputNamespace": "data",
+    "sourceFile": "models/gcp/listing.py",
+    "team": "gcp",
+    "version": "001"
+  },
+  "outputMapping": {
+    "image_embedding": "gcp_listing_item_img_model__001__imageEmbedding"
+  },
+  "valueSchema": {
+    "kind": 13,
+    "name": "model_value_schema",
+    "params": [
+      {
+        "dataType": {
+          "kind": 12,
+          "params": [
+            {
+              "dataType": {
+                "kind": 6
+              },
+              "name": "elem"
+            }
+          ]
+        },
+        "name": "imageEmbedding"
+      },
+      {
+        "dataType": {
+          "kind": 12,
+          "params": [
+            {
+              "dataType": {
+                "kind": 6
+              },
+              "name": "elem"
+            }
+          ]
+        },
+        "name": "textEmbedding"
+      }
+    ]
+  }
+}

--- a/python/test/canary/canary_compiled/staging_queries/aws/ctr_labels.v1__0
+++ b/python/test/canary/canary_compiled/staging_queries/aws/ctr_labels.v1__0
@@ -1,0 +1,124 @@
+{
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_demo_derivations_v1__2_with_offset_0\", \"spec\": \"data.aws_demo_derivations_v1__2/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily"
+    },
+    "name": "aws.ctr_labels.v1__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/aws/ctr_labels.py",
+    "team": "aws",
+    "version": "0"
+  },
+  "query": "\nSELECT\n    *,\n    case when rand() < 0.5 then 0 else 1 end as label\nFROM data.aws_demo_derivations_v1__2\nWHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.aws_demo_derivations_v1__2"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/aws/cutoff_example.downstream__0
+++ b/python/test/canary/canary_compiled/staging_queries/aws/cutoff_example.downstream__0
@@ -1,0 +1,141 @@
+{
+  "engineType": 0,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_cutoff_example_export_a__0_with_offset_0\", \"spec\": \"data.aws_cutoff_example_export_a__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_aws_cutoff_example_export_b__0_with_offset_0\", \"spec\": \"data.aws_cutoff_example_export_b__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "aws.cutoff_example.downstream__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/aws/cutoff_example.py",
+    "team": "aws",
+    "version": "0"
+  },
+  "query": "\n    SELECT\n        a.ds AS ds,\n        a.listing_id AS listing_id,\n        a.merchant_id AS merchant_id\n    FROM data.aws_cutoff_example_export_a__0 a\n    JOIN data.aws_cutoff_example_export_b__0 b USING (ds, merchant_id)\n    WHERE a.ds BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.aws_cutoff_example_export_a__0"
+      }
+    },
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startCutOff": "2026-02-25",
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.aws_cutoff_example_export_b__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/aws/cutoff_example.export_a__0
+++ b/python/test/canary/canary_compiled/staging_queries/aws/cutoff_example.export_a__0
@@ -1,0 +1,126 @@
+{
+  "engineType": 0,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo_dim_listings_with_offset_0\", \"spec\": \"demo.dim_listings/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "aws.cutoff_example.export_a__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/aws/cutoff_example.py",
+    "team": "aws",
+    "version": "0"
+  },
+  "query": "\n    SELECT *\n    FROM demo.dim_listings\n    WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "demo.dim_listings"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/aws/cutoff_example.export_b__0
+++ b/python/test/canary/canary_compiled/staging_queries/aws/cutoff_example.export_b__0
@@ -1,0 +1,126 @@
+{
+  "engineType": 0,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo_dim_merchants_with_offset_0\", \"spec\": \"demo.dim_merchants/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "aws.cutoff_example.export_b__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/aws/cutoff_example.py",
+    "team": "aws",
+    "version": "0"
+  },
+  "query": "\n    SELECT *\n    FROM demo.dim_merchants\n    WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "demo.dim_merchants"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/aws/demo.v1_s__0
+++ b/python/test/canary/canary_compiled/staging_queries/aws/demo.v1_s__0
@@ -1,0 +1,124 @@
+{
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_demo_derivations_v1__2_with_offset_0\", \"spec\": \"data.aws_demo_derivations_v1__2/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily"
+    },
+    "name": "aws.demo.v1_s__0",
+    "outputNamespace": "data",
+    "sourceFile": "joins/aws/demo.py",
+    "team": "aws",
+    "version": "0"
+  },
+  "query": "\nSELECT\n    *,\n    case when rand() < 0.5 then 0 else 1 end as label\nFROM data.aws_demo_derivations_v1__2\nWHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.aws_demo_derivations_v1__2"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/aws/exports.checkouts__0
+++ b/python/test/canary/canary_compiled/staging_queries/aws/exports.checkouts__0
@@ -1,0 +1,126 @@
+{
+  "engineType": 0,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo_checkouts_with_offset_0\", \"spec\": \"demo.checkouts/ts={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 10
+    },
+    "name": "aws.exports.checkouts__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/aws/exports.py",
+    "team": "aws",
+    "version": "0"
+  },
+  "query": "\n    SELECT\n        *,\n        DATE_FORMAT(ts, 'yyyy-MM-dd') as ds\n    FROM demo.checkouts\n    WHERE\n    ts BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ts",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "demo.checkouts"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/aws/exports.dim_listings__0
+++ b/python/test/canary/canary_compiled/staging_queries/aws/exports.dim_listings__0
@@ -1,0 +1,126 @@
+{
+  "engineType": 0,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo_dim_listings_with_offset_0\", \"spec\": \"demo.dim_listings/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 10
+    },
+    "name": "aws.exports.dim_listings__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/aws/exports.py",
+    "team": "aws",
+    "version": "0"
+  },
+  "query": "\n    SELECT\n        *\n    FROM demo.dim_listings\n    WHERE\n    ds BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "demo.dim_listings"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/aws/exports.dim_merchants__0
+++ b/python/test/canary/canary_compiled/staging_queries/aws/exports.dim_merchants__0
@@ -1,0 +1,126 @@
+{
+  "engineType": 0,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo_dim_merchants_with_offset_0\", \"spec\": \"demo.dim_merchants/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 10
+    },
+    "name": "aws.exports.dim_merchants__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/aws/exports.py",
+    "team": "aws",
+    "version": "0"
+  },
+  "query": "\n    SELECT\n        *\n    FROM demo.dim_merchants\n    WHERE\n    ds BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "demo.dim_merchants"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/aws/exports.dim_users__0
+++ b/python/test/canary/canary_compiled/staging_queries/aws/exports.dim_users__0
@@ -1,0 +1,126 @@
+{
+  "engineType": 0,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo_dim_users_with_offset_0\", \"spec\": \"demo.dim_users/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 10
+    },
+    "name": "aws.exports.dim_users__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/aws/exports.py",
+    "team": "aws",
+    "version": "0"
+  },
+  "query": "\n    SELECT\n        *\n    FROM demo.dim_users\n    WHERE\n    ds BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "demo.dim_users"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/aws/exports.user_activities__0
+++ b/python/test/canary/canary_compiled/staging_queries/aws/exports.user_activities__0
@@ -1,0 +1,126 @@
+{
+  "engineType": 0,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo_user_activities_with_offset_0\", \"spec\": \"demo.user_activities/event_time={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 10
+    },
+    "name": "aws.exports.user_activities__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/aws/exports.py",
+    "team": "aws",
+    "version": "0"
+  },
+  "query": "\n    SELECT\n        *,\n        DATE_FORMAT(event_time, 'yyyy-MM-dd') as ds\n    FROM demo.user_activities\n    WHERE\n    event_time BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "event_time",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "demo.user_activities"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/aws/partitioned_logging.v0__2
+++ b/python/test/canary/canary_compiled/staging_queries/aws/partitioned_logging.v0__2
@@ -1,0 +1,123 @@
+{
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": []}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily"
+    },
+    "name": "aws.partitioned_logging.v0__2",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/aws/partitioned_logging.py",
+    "team": "aws",
+    "version": "2"
+  },
+  "query": "\n      SELECT\n        DATE(TIMESTAMP_MILLIS(tsMillis)) AS ds\n        , tsMillis as ts_millis\n        , BASE64(keyBytes) as key_base64\n        , BASE64(valueBytes) as value_base64\n        , joinName as name\n        , schemaHash as schema_hash\n        , keyBytes\n        , valueBytes\n      FROM data.loggable_response\n      WHERE DATE(TIMESTAMP_MILLIS(tsMillis)) BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.loggable_response"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/aws/sample_staging_query.cart__0
+++ b/python/test/canary/canary_compiled/staging_queries/aws/sample_staging_query.cart__0
@@ -1,0 +1,128 @@
+{
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_training_set_v1_test__0_with_offset_1\", \"spec\": \"data.aws_training_set_v1_test__0/ds={{ macros.ds_add(ds, -1) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 10
+    },
+    "name": "aws.sample_staging_query.cart__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/aws/sample_staging_query.py",
+    "tableProperties": {
+      "sample_config_json": "{\"sample_key\": \"sample value\"}"
+    },
+    "team": "aws",
+    "version": "0"
+  },
+  "query": "\n        SELECT\n            *,\n            'cart' as category_name\n        FROM data.aws_training_set_v1_test__0\n        WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.aws_training_set_v1_test__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/aws/sample_staging_query.item__0
+++ b/python/test/canary/canary_compiled/staging_queries/aws/sample_staging_query.item__0
@@ -1,0 +1,128 @@
+{
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_training_set_v1_test__0_with_offset_1\", \"spec\": \"data.aws_training_set_v1_test__0/ds={{ macros.ds_add(ds, -1) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 10
+    },
+    "name": "aws.sample_staging_query.item__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/aws/sample_staging_query.py",
+    "tableProperties": {
+      "sample_config_json": "{\"sample_key\": \"sample value\"}"
+    },
+    "team": "aws",
+    "version": "0"
+  },
+  "query": "\n        SELECT\n            *,\n            'item' as category_name\n        FROM data.aws_training_set_v1_test__0\n        WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.aws_training_set_v1_test__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/aws/sample_staging_query.order__0
+++ b/python/test/canary/canary_compiled/staging_queries/aws/sample_staging_query.order__0
@@ -1,0 +1,128 @@
+{
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_training_set_v1_test__0_with_offset_1\", \"spec\": \"data.aws_training_set_v1_test__0/ds={{ macros.ds_add(ds, -1) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 10
+    },
+    "name": "aws.sample_staging_query.order__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/aws/sample_staging_query.py",
+    "tableProperties": {
+      "sample_config_json": "{\"sample_key\": \"sample value\"}"
+    },
+    "team": "aws",
+    "version": "0"
+  },
+  "query": "\n        SELECT\n            *,\n            'order' as category_name\n        FROM data.aws_training_set_v1_test__0\n        WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.aws_training_set_v1_test__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/aws/sample_staging_query.payment__0
+++ b/python/test/canary/canary_compiled/staging_queries/aws/sample_staging_query.payment__0
@@ -1,0 +1,128 @@
+{
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_training_set_v1_test__0_with_offset_1\", \"spec\": \"data.aws_training_set_v1_test__0/ds={{ macros.ds_add(ds, -1) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 10
+    },
+    "name": "aws.sample_staging_query.payment__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/aws/sample_staging_query.py",
+    "tableProperties": {
+      "sample_config_json": "{\"sample_key\": \"sample value\"}"
+    },
+    "team": "aws",
+    "version": "0"
+  },
+  "query": "\n        SELECT\n            *,\n            'payment' as category_name\n        FROM data.aws_training_set_v1_test__0\n        WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.aws_training_set_v1_test__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/aws/sample_staging_query.purchases_labels__0
+++ b/python/test/canary/canary_compiled/staging_queries/aws/sample_staging_query.purchases_labels__0
@@ -1,0 +1,128 @@
+{
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_training_set_v1_test__0_with_offset_0\", \"spec\": \"data.aws_training_set_v1_test__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 10
+    },
+    "name": "aws.sample_staging_query.purchases_labels__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/aws/sample_staging_query.py",
+    "tableProperties": {
+      "sample_config_json": "{\"sample_key\": \"sample value\"}"
+    },
+    "team": "aws",
+    "version": "0"
+  },
+  "query": "\nSELECT\n    *,\n    case when rand() < 0.5 then 0 else 1 end as label\nFROM data.aws_training_set_v1_test__0\nWHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.aws_training_set_v1_test__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/aws/sample_staging_query.shipping__0
+++ b/python/test/canary/canary_compiled/staging_queries/aws/sample_staging_query.shipping__0
@@ -1,0 +1,128 @@
+{
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_training_set_v1_test__0_with_offset_1\", \"spec\": \"data.aws_training_set_v1_test__0/ds={{ macros.ds_add(ds, -1) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 10
+    },
+    "name": "aws.sample_staging_query.shipping__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/aws/sample_staging_query.py",
+    "tableProperties": {
+      "sample_config_json": "{\"sample_key\": \"sample value\"}"
+    },
+    "team": "aws",
+    "version": "0"
+  },
+  "query": "\n        SELECT\n            *,\n            'shipping' as category_name\n        FROM data.aws_training_set_v1_test__0\n        WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.aws_training_set_v1_test__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/aws/sample_staging_query.terminal__0
+++ b/python/test/canary/canary_compiled/staging_queries/aws/sample_staging_query.terminal__0
@@ -1,0 +1,218 @@
+{
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_sample_staging_query_cart__0_with_offset_1\", \"spec\": \"data.aws_sample_staging_query_cart__0/ds={{ macros.ds_add(ds, -1) }}\"}, {\"name\": \"wf_data_aws_sample_staging_query_user__0_with_offset_1\", \"spec\": \"data.aws_sample_staging_query_user__0/ds={{ macros.ds_add(ds, -1) }}\"}, {\"name\": \"wf_data_aws_sample_staging_query_item__0_with_offset_1\", \"spec\": \"data.aws_sample_staging_query_item__0/ds={{ macros.ds_add(ds, -1) }}\"}, {\"name\": \"wf_data_aws_sample_staging_query_order__0_with_offset_1\", \"spec\": \"data.aws_sample_staging_query_order__0/ds={{ macros.ds_add(ds, -1) }}\"}, {\"name\": \"wf_data_aws_sample_staging_query_payment__0_with_offset_1\", \"spec\": \"data.aws_sample_staging_query_payment__0/ds={{ macros.ds_add(ds, -1) }}\"}, {\"name\": \"wf_data_aws_sample_staging_query_shipping__0_with_offset_1\", \"spec\": \"data.aws_sample_staging_query_shipping__0/ds={{ macros.ds_add(ds, -1) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 10
+    },
+    "name": "aws.sample_staging_query.terminal__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/aws/sample_staging_query.py",
+    "tableProperties": {
+      "sample_config_json": "{\"sample_key\": \"sample value\"}"
+    },
+    "team": "aws",
+    "version": "0"
+  },
+  "query": "SELECT\n                *\n            FROM data.aws_sample_staging_query_cart__0\n            WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\nUNION ALL\nSELECT\n                *\n            FROM data.aws_sample_staging_query_user__0\n            WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\nUNION ALL\nSELECT\n                *\n            FROM data.aws_sample_staging_query_item__0\n            WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\nUNION ALL\nSELECT\n                *\n            FROM data.aws_sample_staging_query_order__0\n            WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\nUNION ALL\nSELECT\n                *\n            FROM data.aws_sample_staging_query_payment__0\n            WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\nUNION ALL\nSELECT\n                *\n            FROM data.aws_sample_staging_query_shipping__0\n            WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.aws_sample_staging_query_cart__0"
+      }
+    },
+    {
+      "endOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.aws_sample_staging_query_user__0"
+      }
+    },
+    {
+      "endOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.aws_sample_staging_query_item__0"
+      }
+    },
+    {
+      "endOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.aws_sample_staging_query_order__0"
+      }
+    },
+    {
+      "endOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.aws_sample_staging_query_payment__0"
+      }
+    },
+    {
+      "endOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.aws_sample_staging_query_shipping__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/aws/sample_staging_query.user__0
+++ b/python/test/canary/canary_compiled/staging_queries/aws/sample_staging_query.user__0
@@ -1,0 +1,128 @@
+{
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_training_set_v1_test__0_with_offset_1\", \"spec\": \"data.aws_training_set_v1_test__0/ds={{ macros.ds_add(ds, -1) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 10
+    },
+    "name": "aws.sample_staging_query.user__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/aws/sample_staging_query.py",
+    "tableProperties": {
+      "sample_config_json": "{\"sample_key\": \"sample value\"}"
+    },
+    "team": "aws",
+    "version": "0"
+  },
+  "query": "\n        SELECT\n            *,\n            'user' as category_name\n        FROM data.aws_training_set_v1_test__0\n        WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.aws_training_set_v1_test__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/aws/sample_staging_query.v1_bigquery_import__0
+++ b/python/test/canary/canary_compiled/staging_queries/aws/sample_staging_query.v1_bigquery_import__0
@@ -1,0 +1,126 @@
+{
+  "engineType": 1,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_training_set_v1_hub__0_with_offset_0\", \"spec\": \"data.aws_training_set_v1_hub__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 10
+    },
+    "name": "aws.sample_staging_query.v1_bigquery_import__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/aws/sample_staging_query.py",
+    "team": "aws",
+    "version": "0"
+  },
+  "query": "\nSELECT\n    *\nFROM data.aws_training_set_v1_hub__0\nWHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.aws_training_set_v1_hub__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/aws/sample_staging_query.v1_hub__0
+++ b/python/test/canary/canary_compiled/staging_queries/aws/sample_staging_query.v1_hub__0
@@ -1,0 +1,128 @@
+{
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_training_set_v1_hub__0_with_offset_1\", \"spec\": \"data.aws_training_set_v1_hub__0/ds={{ macros.ds_add(ds, -1) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "common": {
+          "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        },
+        "modeConfigs": {
+          "backfill": {
+            "spark.chronon.coalesce.factor": "10",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+            "spark.default.parallelism": "10",
+            "spark.driver.cores": "1",
+            "spark.driver.memory": "1g",
+            "spark.executor.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+            "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+            "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.shuffle.partitions": "10",
+            "taskmanager.memory.process.size": "4G"
+          }
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "AWS_REGION": "us-west-2",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 10
+    },
+    "name": "aws.sample_staging_query.v1_hub__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/aws/sample_staging_query.py",
+    "tableProperties": {
+      "sample_config_json": "{\"sample_key\": \"sample value\"}"
+    },
+    "team": "aws",
+    "version": "0"
+  },
+  "query": "\nSELECT\n    *\nFROM data.aws_training_set_v1_hub__0\nWHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.aws_training_set_v1_hub__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/aws_databricks/exports.dim_listings__0
+++ b/python/test/canary/canary_compiled/staging_queries/aws_databricks/exports.dim_listings__0
@@ -1,0 +1,51 @@
+{
+  "engineType": 0,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_workspace_poc_dim_listings_with_offset_0\", \"spec\": \"workspace.poc.dim_listings/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "offlineSchedule": "@daily"
+    },
+    "name": "aws_databricks.exports.dim_listings__0",
+    "outputNamespace": "workspace_iceberg.poc",
+    "sourceFile": "staging_queries/aws_databricks/exports.py",
+    "team": "aws_databricks",
+    "version": "0"
+  },
+  "query": "\n    SELECT\n        *\n    FROM workspace.poc.dim_listings\n    WHERE\n    ds BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "workspace.poc.dim_listings"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/aws_databricks/exports.dim_listings_non_partitioned__0
+++ b/python/test/canary/canary_compiled/staging_queries/aws_databricks/exports.dim_listings_non_partitioned__0
@@ -1,0 +1,52 @@
+{
+  "engineType": 0,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_workspace_poc_dim_listings_nop_with_offset_0\", \"spec\": \"workspace.poc.dim_listings_nop/updated_at_ts={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "offlineSchedule": "@daily"
+    },
+    "name": "aws_databricks.exports.dim_listings_non_partitioned__0",
+    "outputNamespace": "workspace_iceberg.poc",
+    "sourceFile": "staging_queries/aws_databricks/exports.py",
+    "team": "aws_databricks",
+    "version": "0"
+  },
+  "query": "\n    SELECT\n        *, DATE_FORMAT(updated_at_ts, 'yyyy-MM-dd') AS ds\n    FROM workspace.poc.dim_listings_nop\n    WHERE\n    DATE_FORMAT(updated_at_ts, 'yyyy-MM-dd') BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "updated_at_ts",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "workspace.poc.dim_listings_nop",
+        "timePartitioned": 1
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/azure/claims_demo_baseline.baseline_source__0
+++ b/python/test/canary/canary_compiled/staging_queries/azure/claims_demo_baseline.baseline_source__0
@@ -1,0 +1,93 @@
+{
+  "engineType": 2,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_DEMO_CLAIMS_DEMO_CLAIMS_DEMO_BASELINE_SOURCE_with_offset_0\", \"spec\": \"DEMO.CLAIMS_DEMO.CLAIMS_DEMO_BASELINE_SOURCE/DS={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_azure.AzureFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dlog4j.configurationFile=/opt/chronon/log4j2.properties",
+          "spark.driver.memory": "4g",
+          "spark.driver.memoryOverhead": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.extraJavaOptions": "-Dlog4j.configurationFile=/opt/chronon/log4j2.properties",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkCatalog",
+          "spark.sql.catalog.spark_catalog.credential": "",
+          "spark.sql.catalog.spark_catalog.header.X-Iceberg-Access-Delegation": "",
+          "spark.sql.catalog.spark_catalog.jdbc.password": "{POSTGRES_PASSWORD}",
+          "spark.sql.catalog.spark_catalog.jdbc.user": "chronon",
+          "spark.sql.catalog.spark_catalog.scope": "",
+          "spark.sql.catalog.spark_catalog.type": "jdbc",
+          "spark.sql.catalog.spark_catalog.uri": "jdbc:postgresql://{POSTGRES_HOST}:5432/iceberg_catalog?sslmode=require",
+          "spark.sql.catalog.spark_catalog.warehouse": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/warehouse",
+          "spark.sql.defaultCatalog": "spark_catalog",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/artifacts",
+          "CLOUD_PROVIDER": "azure",
+          "CUSTOMER_ID": "claims-demo",
+          "EVAL_URL": "http://hub.claims-demo-hub.svc.cluster.local:3903",
+          "FLINK_STATE_URI": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/flink-state",
+          "FRONTEND_URL": "http://hub.claims-demo-hub.svc.cluster.local:3903",
+          "HUB_URL": "http://hub.claims-demo-hub.svc.cluster.local:3903",
+          "K8S_NAMESPACE": "claims-demo-hub",
+          "OC_CREDENTIAL_VAULT_URI": "",
+          "POSTGRES_HOST": "crucible-claims-pg-westus.postgres.database.azure.com",
+          "POSTGRES_PASSWORD_VAULT_URI": "https://crucible-azure-kv.vault.azure.net/secrets/postgres-password",
+          "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=CLAIMS_DEMO&warehouse=demo_wh",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SPARK_CLUSTER_NAME": "http://crucible.crucible-system.svc.cluster.local:8080",
+          "SPARK_EVENT_LOG_DIR": "abfss://crucible@ziplineai2.dfs.core.windows.net/spark-events",
+          "SPARK_EVENT_LOG_ENABLED": "true",
+          "SPARK_HISTORY_SERVER_URL": "http://spark-history-server.crucible-system.svc.cluster.local:18080",
+          "SPARK_IMAGE": "ziplinecanary.azurecr.io/chronon-spark-azure:latest",
+          "SPARK_SERVICE_ACCOUNT": "spark",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/warehouse"
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "azure.claims_demo_baseline.baseline_source__0",
+    "outputNamespace": "claims_demo",
+    "sourceFile": "staging_queries/azure/claims_demo_baseline.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "query": "\n    SELECT\n        * EXCLUDE (DS),\n        DATE_TRUNC('DAY', DS)::DATE AS ds\n    FROM DEMO.CLAIMS_DEMO.CLAIMS_DEMO_BASELINE_SOURCE\n    WHERE DATE_TRUNC('DAY', DS)::DATE BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "DS",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "DEMO.CLAIMS_DEMO.CLAIMS_DEMO_BASELINE_SOURCE"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/azure/crucible_stress_fanout.segment_000__0
+++ b/python/test/canary/canary_compiled/staging_queries/azure/crucible_stress_fanout.segment_000__0
@@ -1,0 +1,93 @@
+{
+  "engineType": 0,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_claims_demo_azure_crucible_stress_training_set__0_with_offset_0\", \"spec\": \"claims_demo.azure_crucible_stress_training_set__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_azure.AzureFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dlog4j.configurationFile=/opt/chronon/log4j2.properties",
+          "spark.driver.memory": "4g",
+          "spark.driver.memoryOverhead": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.extraJavaOptions": "-Dlog4j.configurationFile=/opt/chronon/log4j2.properties",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkCatalog",
+          "spark.sql.catalog.spark_catalog.credential": "",
+          "spark.sql.catalog.spark_catalog.header.X-Iceberg-Access-Delegation": "",
+          "spark.sql.catalog.spark_catalog.jdbc.password": "{POSTGRES_PASSWORD}",
+          "spark.sql.catalog.spark_catalog.jdbc.user": "chronon",
+          "spark.sql.catalog.spark_catalog.scope": "",
+          "spark.sql.catalog.spark_catalog.type": "jdbc",
+          "spark.sql.catalog.spark_catalog.uri": "jdbc:postgresql://{POSTGRES_HOST}:5432/iceberg_catalog?sslmode=require",
+          "spark.sql.catalog.spark_catalog.warehouse": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/warehouse",
+          "spark.sql.defaultCatalog": "spark_catalog",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/artifacts",
+          "CLOUD_PROVIDER": "azure",
+          "CUSTOMER_ID": "claims-demo",
+          "EVAL_URL": "http://hub.claims-demo-hub.svc.cluster.local:3903",
+          "FLINK_STATE_URI": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/flink-state",
+          "FRONTEND_URL": "http://hub.claims-demo-hub.svc.cluster.local:3903",
+          "HUB_URL": "http://hub.claims-demo-hub.svc.cluster.local:3903",
+          "K8S_NAMESPACE": "claims-demo-hub",
+          "OC_CREDENTIAL_VAULT_URI": "",
+          "POSTGRES_HOST": "crucible-claims-pg-westus.postgres.database.azure.com",
+          "POSTGRES_PASSWORD_VAULT_URI": "https://crucible-azure-kv.vault.azure.net/secrets/postgres-password",
+          "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=CLAIMS_DEMO&warehouse=demo_wh",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SPARK_CLUSTER_NAME": "http://crucible.crucible-system.svc.cluster.local:8080",
+          "SPARK_EVENT_LOG_DIR": "abfss://crucible@ziplineai2.dfs.core.windows.net/spark-events",
+          "SPARK_EVENT_LOG_ENABLED": "true",
+          "SPARK_HISTORY_SERVER_URL": "http://spark-history-server.crucible-system.svc.cluster.local:18080",
+          "SPARK_IMAGE": "ziplinecanary.azurecr.io/chronon-spark-azure:latest",
+          "SPARK_SERVICE_ACCOUNT": "spark",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/warehouse"
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 1
+    },
+    "name": "azure.crucible_stress_fanout.segment_000__0",
+    "outputNamespace": "claims_demo",
+    "sourceFile": "staging_queries/azure/crucible_stress_fanout.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "query": "\n        SELECT\n            *,\n            0 AS stress_segment\n        FROM claims_demo.azure_crucible_stress_training_set__0\n        WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n          AND pmod(abs(hash(CAST(checkout_id AS STRING))), 4) = 0\n        ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "claims_demo.azure_crucible_stress_training_set__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/azure/crucible_stress_fanout.segment_001__0
+++ b/python/test/canary/canary_compiled/staging_queries/azure/crucible_stress_fanout.segment_001__0
@@ -1,0 +1,93 @@
+{
+  "engineType": 0,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_claims_demo_azure_crucible_stress_training_set__0_with_offset_0\", \"spec\": \"claims_demo.azure_crucible_stress_training_set__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_azure.AzureFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dlog4j.configurationFile=/opt/chronon/log4j2.properties",
+          "spark.driver.memory": "4g",
+          "spark.driver.memoryOverhead": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.extraJavaOptions": "-Dlog4j.configurationFile=/opt/chronon/log4j2.properties",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkCatalog",
+          "spark.sql.catalog.spark_catalog.credential": "",
+          "spark.sql.catalog.spark_catalog.header.X-Iceberg-Access-Delegation": "",
+          "spark.sql.catalog.spark_catalog.jdbc.password": "{POSTGRES_PASSWORD}",
+          "spark.sql.catalog.spark_catalog.jdbc.user": "chronon",
+          "spark.sql.catalog.spark_catalog.scope": "",
+          "spark.sql.catalog.spark_catalog.type": "jdbc",
+          "spark.sql.catalog.spark_catalog.uri": "jdbc:postgresql://{POSTGRES_HOST}:5432/iceberg_catalog?sslmode=require",
+          "spark.sql.catalog.spark_catalog.warehouse": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/warehouse",
+          "spark.sql.defaultCatalog": "spark_catalog",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/artifacts",
+          "CLOUD_PROVIDER": "azure",
+          "CUSTOMER_ID": "claims-demo",
+          "EVAL_URL": "http://hub.claims-demo-hub.svc.cluster.local:3903",
+          "FLINK_STATE_URI": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/flink-state",
+          "FRONTEND_URL": "http://hub.claims-demo-hub.svc.cluster.local:3903",
+          "HUB_URL": "http://hub.claims-demo-hub.svc.cluster.local:3903",
+          "K8S_NAMESPACE": "claims-demo-hub",
+          "OC_CREDENTIAL_VAULT_URI": "",
+          "POSTGRES_HOST": "crucible-claims-pg-westus.postgres.database.azure.com",
+          "POSTGRES_PASSWORD_VAULT_URI": "https://crucible-azure-kv.vault.azure.net/secrets/postgres-password",
+          "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=CLAIMS_DEMO&warehouse=demo_wh",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SPARK_CLUSTER_NAME": "http://crucible.crucible-system.svc.cluster.local:8080",
+          "SPARK_EVENT_LOG_DIR": "abfss://crucible@ziplineai2.dfs.core.windows.net/spark-events",
+          "SPARK_EVENT_LOG_ENABLED": "true",
+          "SPARK_HISTORY_SERVER_URL": "http://spark-history-server.crucible-system.svc.cluster.local:18080",
+          "SPARK_IMAGE": "ziplinecanary.azurecr.io/chronon-spark-azure:latest",
+          "SPARK_SERVICE_ACCOUNT": "spark",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/warehouse"
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 1
+    },
+    "name": "azure.crucible_stress_fanout.segment_001__0",
+    "outputNamespace": "claims_demo",
+    "sourceFile": "staging_queries/azure/crucible_stress_fanout.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "query": "\n        SELECT\n            *,\n            1 AS stress_segment\n        FROM claims_demo.azure_crucible_stress_training_set__0\n        WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n          AND pmod(abs(hash(CAST(checkout_id AS STRING))), 4) = 1\n        ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "claims_demo.azure_crucible_stress_training_set__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/azure/crucible_stress_fanout.segment_002__0
+++ b/python/test/canary/canary_compiled/staging_queries/azure/crucible_stress_fanout.segment_002__0
@@ -1,0 +1,93 @@
+{
+  "engineType": 0,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_claims_demo_azure_crucible_stress_training_set__0_with_offset_0\", \"spec\": \"claims_demo.azure_crucible_stress_training_set__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_azure.AzureFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dlog4j.configurationFile=/opt/chronon/log4j2.properties",
+          "spark.driver.memory": "4g",
+          "spark.driver.memoryOverhead": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.extraJavaOptions": "-Dlog4j.configurationFile=/opt/chronon/log4j2.properties",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkCatalog",
+          "spark.sql.catalog.spark_catalog.credential": "",
+          "spark.sql.catalog.spark_catalog.header.X-Iceberg-Access-Delegation": "",
+          "spark.sql.catalog.spark_catalog.jdbc.password": "{POSTGRES_PASSWORD}",
+          "spark.sql.catalog.spark_catalog.jdbc.user": "chronon",
+          "spark.sql.catalog.spark_catalog.scope": "",
+          "spark.sql.catalog.spark_catalog.type": "jdbc",
+          "spark.sql.catalog.spark_catalog.uri": "jdbc:postgresql://{POSTGRES_HOST}:5432/iceberg_catalog?sslmode=require",
+          "spark.sql.catalog.spark_catalog.warehouse": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/warehouse",
+          "spark.sql.defaultCatalog": "spark_catalog",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/artifacts",
+          "CLOUD_PROVIDER": "azure",
+          "CUSTOMER_ID": "claims-demo",
+          "EVAL_URL": "http://hub.claims-demo-hub.svc.cluster.local:3903",
+          "FLINK_STATE_URI": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/flink-state",
+          "FRONTEND_URL": "http://hub.claims-demo-hub.svc.cluster.local:3903",
+          "HUB_URL": "http://hub.claims-demo-hub.svc.cluster.local:3903",
+          "K8S_NAMESPACE": "claims-demo-hub",
+          "OC_CREDENTIAL_VAULT_URI": "",
+          "POSTGRES_HOST": "crucible-claims-pg-westus.postgres.database.azure.com",
+          "POSTGRES_PASSWORD_VAULT_URI": "https://crucible-azure-kv.vault.azure.net/secrets/postgres-password",
+          "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=CLAIMS_DEMO&warehouse=demo_wh",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SPARK_CLUSTER_NAME": "http://crucible.crucible-system.svc.cluster.local:8080",
+          "SPARK_EVENT_LOG_DIR": "abfss://crucible@ziplineai2.dfs.core.windows.net/spark-events",
+          "SPARK_EVENT_LOG_ENABLED": "true",
+          "SPARK_HISTORY_SERVER_URL": "http://spark-history-server.crucible-system.svc.cluster.local:18080",
+          "SPARK_IMAGE": "ziplinecanary.azurecr.io/chronon-spark-azure:latest",
+          "SPARK_SERVICE_ACCOUNT": "spark",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/warehouse"
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 1
+    },
+    "name": "azure.crucible_stress_fanout.segment_002__0",
+    "outputNamespace": "claims_demo",
+    "sourceFile": "staging_queries/azure/crucible_stress_fanout.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "query": "\n        SELECT\n            *,\n            2 AS stress_segment\n        FROM claims_demo.azure_crucible_stress_training_set__0\n        WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n          AND pmod(abs(hash(CAST(checkout_id AS STRING))), 4) = 2\n        ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "claims_demo.azure_crucible_stress_training_set__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/azure/crucible_stress_fanout.segment_003__0
+++ b/python/test/canary/canary_compiled/staging_queries/azure/crucible_stress_fanout.segment_003__0
@@ -1,0 +1,93 @@
+{
+  "engineType": 0,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_claims_demo_azure_crucible_stress_training_set__0_with_offset_0\", \"spec\": \"claims_demo.azure_crucible_stress_training_set__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_azure.AzureFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dlog4j.configurationFile=/opt/chronon/log4j2.properties",
+          "spark.driver.memory": "4g",
+          "spark.driver.memoryOverhead": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.extraJavaOptions": "-Dlog4j.configurationFile=/opt/chronon/log4j2.properties",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkCatalog",
+          "spark.sql.catalog.spark_catalog.credential": "",
+          "spark.sql.catalog.spark_catalog.header.X-Iceberg-Access-Delegation": "",
+          "spark.sql.catalog.spark_catalog.jdbc.password": "{POSTGRES_PASSWORD}",
+          "spark.sql.catalog.spark_catalog.jdbc.user": "chronon",
+          "spark.sql.catalog.spark_catalog.scope": "",
+          "spark.sql.catalog.spark_catalog.type": "jdbc",
+          "spark.sql.catalog.spark_catalog.uri": "jdbc:postgresql://{POSTGRES_HOST}:5432/iceberg_catalog?sslmode=require",
+          "spark.sql.catalog.spark_catalog.warehouse": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/warehouse",
+          "spark.sql.defaultCatalog": "spark_catalog",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/artifacts",
+          "CLOUD_PROVIDER": "azure",
+          "CUSTOMER_ID": "claims-demo",
+          "EVAL_URL": "http://hub.claims-demo-hub.svc.cluster.local:3903",
+          "FLINK_STATE_URI": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/flink-state",
+          "FRONTEND_URL": "http://hub.claims-demo-hub.svc.cluster.local:3903",
+          "HUB_URL": "http://hub.claims-demo-hub.svc.cluster.local:3903",
+          "K8S_NAMESPACE": "claims-demo-hub",
+          "OC_CREDENTIAL_VAULT_URI": "",
+          "POSTGRES_HOST": "crucible-claims-pg-westus.postgres.database.azure.com",
+          "POSTGRES_PASSWORD_VAULT_URI": "https://crucible-azure-kv.vault.azure.net/secrets/postgres-password",
+          "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=CLAIMS_DEMO&warehouse=demo_wh",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SPARK_CLUSTER_NAME": "http://crucible.crucible-system.svc.cluster.local:8080",
+          "SPARK_EVENT_LOG_DIR": "abfss://crucible@ziplineai2.dfs.core.windows.net/spark-events",
+          "SPARK_EVENT_LOG_ENABLED": "true",
+          "SPARK_HISTORY_SERVER_URL": "http://spark-history-server.crucible-system.svc.cluster.local:18080",
+          "SPARK_IMAGE": "ziplinecanary.azurecr.io/chronon-spark-azure:latest",
+          "SPARK_SERVICE_ACCOUNT": "spark",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/warehouse"
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 1
+    },
+    "name": "azure.crucible_stress_fanout.segment_003__0",
+    "outputNamespace": "claims_demo",
+    "sourceFile": "staging_queries/azure/crucible_stress_fanout.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "query": "\n        SELECT\n            *,\n            3 AS stress_segment\n        FROM claims_demo.azure_crucible_stress_training_set__0\n        WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n          AND pmod(abs(hash(CAST(checkout_id AS STRING))), 4) = 3\n        ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "claims_demo.azure_crucible_stress_training_set__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/azure/crucible_stress_fanout.terminal__0
+++ b/python/test/canary/canary_compiled/staging_queries/azure/crucible_stress_fanout.terminal__0
@@ -1,0 +1,147 @@
+{
+  "engineType": 0,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_claims_demo_azure_crucible_stress_fanout_segment_000__0_with_offset_0\", \"spec\": \"claims_demo.azure_crucible_stress_fanout_segment_000__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_claims_demo_azure_crucible_stress_fanout_segment_001__0_with_offset_0\", \"spec\": \"claims_demo.azure_crucible_stress_fanout_segment_001__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_claims_demo_azure_crucible_stress_fanout_segment_002__0_with_offset_0\", \"spec\": \"claims_demo.azure_crucible_stress_fanout_segment_002__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_claims_demo_azure_crucible_stress_fanout_segment_003__0_with_offset_0\", \"spec\": \"claims_demo.azure_crucible_stress_fanout_segment_003__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_azure.AzureFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dlog4j.configurationFile=/opt/chronon/log4j2.properties",
+          "spark.driver.memory": "4g",
+          "spark.driver.memoryOverhead": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.extraJavaOptions": "-Dlog4j.configurationFile=/opt/chronon/log4j2.properties",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkCatalog",
+          "spark.sql.catalog.spark_catalog.credential": "",
+          "spark.sql.catalog.spark_catalog.header.X-Iceberg-Access-Delegation": "",
+          "spark.sql.catalog.spark_catalog.jdbc.password": "{POSTGRES_PASSWORD}",
+          "spark.sql.catalog.spark_catalog.jdbc.user": "chronon",
+          "spark.sql.catalog.spark_catalog.scope": "",
+          "spark.sql.catalog.spark_catalog.type": "jdbc",
+          "spark.sql.catalog.spark_catalog.uri": "jdbc:postgresql://{POSTGRES_HOST}:5432/iceberg_catalog?sslmode=require",
+          "spark.sql.catalog.spark_catalog.warehouse": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/warehouse",
+          "spark.sql.defaultCatalog": "spark_catalog",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/artifacts",
+          "CLOUD_PROVIDER": "azure",
+          "CUSTOMER_ID": "claims-demo",
+          "EVAL_URL": "http://hub.claims-demo-hub.svc.cluster.local:3903",
+          "FLINK_STATE_URI": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/flink-state",
+          "FRONTEND_URL": "http://hub.claims-demo-hub.svc.cluster.local:3903",
+          "HUB_URL": "http://hub.claims-demo-hub.svc.cluster.local:3903",
+          "K8S_NAMESPACE": "claims-demo-hub",
+          "OC_CREDENTIAL_VAULT_URI": "",
+          "POSTGRES_HOST": "crucible-claims-pg-westus.postgres.database.azure.com",
+          "POSTGRES_PASSWORD_VAULT_URI": "https://crucible-azure-kv.vault.azure.net/secrets/postgres-password",
+          "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=CLAIMS_DEMO&warehouse=demo_wh",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SPARK_CLUSTER_NAME": "http://crucible.crucible-system.svc.cluster.local:8080",
+          "SPARK_EVENT_LOG_DIR": "abfss://crucible@ziplineai2.dfs.core.windows.net/spark-events",
+          "SPARK_EVENT_LOG_ENABLED": "true",
+          "SPARK_HISTORY_SERVER_URL": "http://spark-history-server.crucible-system.svc.cluster.local:18080",
+          "SPARK_IMAGE": "ziplinecanary.azurecr.io/chronon-spark-azure:latest",
+          "SPARK_SERVICE_ACCOUNT": "spark",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/warehouse"
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 1
+    },
+    "name": "azure.crucible_stress_fanout.terminal__0",
+    "outputNamespace": "claims_demo",
+    "sourceFile": "staging_queries/azure/crucible_stress_fanout.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "query": "\n        SELECT\n            *\n        FROM claims_demo.azure_crucible_stress_fanout_segment_000__0\n        WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n        \nUNION ALL\n\n        SELECT\n            *\n        FROM claims_demo.azure_crucible_stress_fanout_segment_001__0\n        WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n        \nUNION ALL\n\n        SELECT\n            *\n        FROM claims_demo.azure_crucible_stress_fanout_segment_002__0\n        WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n        \nUNION ALL\n\n        SELECT\n            *\n        FROM claims_demo.azure_crucible_stress_fanout_segment_003__0\n        WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n        ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "claims_demo.azure_crucible_stress_fanout_segment_000__0"
+      }
+    },
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "claims_demo.azure_crucible_stress_fanout_segment_001__0"
+      }
+    },
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "claims_demo.azure_crucible_stress_fanout_segment_002__0"
+      }
+    },
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "claims_demo.azure_crucible_stress_fanout_segment_003__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/azure/crucible_stress_sources.checkouts__0
+++ b/python/test/canary/canary_compiled/staging_queries/azure/crucible_stress_sources.checkouts__0
@@ -1,0 +1,93 @@
+{
+  "engineType": 2,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_DEMO_CLAIMS_DEMO_CRUCIBLE_STRESS_CHECKOUTS_with_offset_0\", \"spec\": \"DEMO.CLAIMS_DEMO.CRUCIBLE_STRESS_CHECKOUTS/DS={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_azure.AzureFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dlog4j.configurationFile=/opt/chronon/log4j2.properties",
+          "spark.driver.memory": "4g",
+          "spark.driver.memoryOverhead": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.extraJavaOptions": "-Dlog4j.configurationFile=/opt/chronon/log4j2.properties",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkCatalog",
+          "spark.sql.catalog.spark_catalog.credential": "",
+          "spark.sql.catalog.spark_catalog.header.X-Iceberg-Access-Delegation": "",
+          "spark.sql.catalog.spark_catalog.jdbc.password": "{POSTGRES_PASSWORD}",
+          "spark.sql.catalog.spark_catalog.jdbc.user": "chronon",
+          "spark.sql.catalog.spark_catalog.scope": "",
+          "spark.sql.catalog.spark_catalog.type": "jdbc",
+          "spark.sql.catalog.spark_catalog.uri": "jdbc:postgresql://{POSTGRES_HOST}:5432/iceberg_catalog?sslmode=require",
+          "spark.sql.catalog.spark_catalog.warehouse": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/warehouse",
+          "spark.sql.defaultCatalog": "spark_catalog",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/artifacts",
+          "CLOUD_PROVIDER": "azure",
+          "CUSTOMER_ID": "claims-demo",
+          "EVAL_URL": "http://hub.claims-demo-hub.svc.cluster.local:3903",
+          "FLINK_STATE_URI": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/flink-state",
+          "FRONTEND_URL": "http://hub.claims-demo-hub.svc.cluster.local:3903",
+          "HUB_URL": "http://hub.claims-demo-hub.svc.cluster.local:3903",
+          "K8S_NAMESPACE": "claims-demo-hub",
+          "OC_CREDENTIAL_VAULT_URI": "",
+          "POSTGRES_HOST": "crucible-claims-pg-westus.postgres.database.azure.com",
+          "POSTGRES_PASSWORD_VAULT_URI": "https://crucible-azure-kv.vault.azure.net/secrets/postgres-password",
+          "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=CLAIMS_DEMO&warehouse=demo_wh",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SPARK_CLUSTER_NAME": "http://crucible.crucible-system.svc.cluster.local:8080",
+          "SPARK_EVENT_LOG_DIR": "abfss://crucible@ziplineai2.dfs.core.windows.net/spark-events",
+          "SPARK_EVENT_LOG_ENABLED": "true",
+          "SPARK_HISTORY_SERVER_URL": "http://spark-history-server.crucible-system.svc.cluster.local:18080",
+          "SPARK_IMAGE": "ziplinecanary.azurecr.io/chronon-spark-azure:latest",
+          "SPARK_SERVICE_ACCOUNT": "spark",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/warehouse"
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 1
+    },
+    "name": "azure.crucible_stress_sources.checkouts__0",
+    "outputNamespace": "claims_demo",
+    "sourceFile": "staging_queries/azure/crucible_stress_sources.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "query": "\n        SELECT\n            \n            CHECKOUT_ID AS checkout_id,\n            USER_ID AS user_id,\n            TS AS ts\n    ,\n            DATE_TRUNC('DAY', DS)::DATE AS ds\n        FROM DEMO.CLAIMS_DEMO.CRUCIBLE_STRESS_CHECKOUTS\n        WHERE DATE_TRUNC('DAY', DS)::DATE BETWEEN {{ start_date }} AND {{ end_date }}\n        ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "DS",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "DEMO.CLAIMS_DEMO.CRUCIBLE_STRESS_CHECKOUTS"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/azure/crucible_stress_sources.purchases__0
+++ b/python/test/canary/canary_compiled/staging_queries/azure/crucible_stress_sources.purchases__0
@@ -1,0 +1,93 @@
+{
+  "engineType": 2,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_DEMO_CLAIMS_DEMO_CRUCIBLE_STRESS_PURCHASES_with_offset_0\", \"spec\": \"DEMO.CLAIMS_DEMO.CRUCIBLE_STRESS_PURCHASES/DS={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_azure.AzureFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dlog4j.configurationFile=/opt/chronon/log4j2.properties",
+          "spark.driver.memory": "4g",
+          "spark.driver.memoryOverhead": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.extraJavaOptions": "-Dlog4j.configurationFile=/opt/chronon/log4j2.properties",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkCatalog",
+          "spark.sql.catalog.spark_catalog.credential": "",
+          "spark.sql.catalog.spark_catalog.header.X-Iceberg-Access-Delegation": "",
+          "spark.sql.catalog.spark_catalog.jdbc.password": "{POSTGRES_PASSWORD}",
+          "spark.sql.catalog.spark_catalog.jdbc.user": "chronon",
+          "spark.sql.catalog.spark_catalog.scope": "",
+          "spark.sql.catalog.spark_catalog.type": "jdbc",
+          "spark.sql.catalog.spark_catalog.uri": "jdbc:postgresql://{POSTGRES_HOST}:5432/iceberg_catalog?sslmode=require",
+          "spark.sql.catalog.spark_catalog.warehouse": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/warehouse",
+          "spark.sql.defaultCatalog": "spark_catalog",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/artifacts",
+          "CLOUD_PROVIDER": "azure",
+          "CUSTOMER_ID": "claims-demo",
+          "EVAL_URL": "http://hub.claims-demo-hub.svc.cluster.local:3903",
+          "FLINK_STATE_URI": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/flink-state",
+          "FRONTEND_URL": "http://hub.claims-demo-hub.svc.cluster.local:3903",
+          "HUB_URL": "http://hub.claims-demo-hub.svc.cluster.local:3903",
+          "K8S_NAMESPACE": "claims-demo-hub",
+          "OC_CREDENTIAL_VAULT_URI": "",
+          "POSTGRES_HOST": "crucible-claims-pg-westus.postgres.database.azure.com",
+          "POSTGRES_PASSWORD_VAULT_URI": "https://crucible-azure-kv.vault.azure.net/secrets/postgres-password",
+          "SNOWFLAKE_JDBC_URL": "jdbc:snowflake://VEJLULX-AZURE.snowflakecomputing.com/?user=demo_batch_service&db=Demo&schema=CLAIMS_DEMO&warehouse=demo_wh",
+          "SNOWFLAKE_PRIVATE_KEY_VAULT_URI": "https://demo-service-writer-pkey.vault.azure.net/secrets/snowflake-private-key",
+          "SPARK_CLUSTER_NAME": "http://crucible.crucible-system.svc.cluster.local:8080",
+          "SPARK_EVENT_LOG_DIR": "abfss://crucible@ziplineai2.dfs.core.windows.net/spark-events",
+          "SPARK_EVENT_LOG_ENABLED": "true",
+          "SPARK_HISTORY_SERVER_URL": "http://spark-history-server.crucible-system.svc.cluster.local:18080",
+          "SPARK_IMAGE": "ziplinecanary.azurecr.io/chronon-spark-azure:latest",
+          "SPARK_SERVICE_ACCOUNT": "spark",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/warehouse"
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 1
+    },
+    "name": "azure.crucible_stress_sources.purchases__0",
+    "outputNamespace": "claims_demo",
+    "sourceFile": "staging_queries/azure/crucible_stress_sources.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "query": "\n        SELECT\n            \n            USER_ID AS user_id,\n            PURCHASE_PRICE AS purchase_price,\n            TS AS ts\n    ,\n            DATE_TRUNC('DAY', DS)::DATE AS ds\n        FROM DEMO.CLAIMS_DEMO.CRUCIBLE_STRESS_PURCHASES\n        WHERE DATE_TRUNC('DAY', DS)::DATE BETWEEN {{ start_date }} AND {{ end_date }}\n        ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "DS",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "DEMO.CLAIMS_DEMO.CRUCIBLE_STRESS_PURCHASES"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/azure/ctr_labels.v1__0
+++ b/python/test/canary/canary_compiled/staging_queries/azure/ctr_labels.v1__0
@@ -1,0 +1,50 @@
+{
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_azure_demo_derivations_v3__derived_with_offset_0\", \"spec\": \"data.azure_demo_derivations_v3__derived/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "offlineSchedule": "@daily"
+    },
+    "name": "azure.ctr_labels.v1__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/azure/ctr_labels.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "query": "\nSELECT\n    *,\n    case when rand() < 0.5 then 0 else 1 end as label\nFROM data.azure_demo_derivations_v3__derived\nWHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.azure_demo_derivations_v3__derived"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/azure/cutoff_example.downstream__0
+++ b/python/test/canary/canary_compiled/staging_queries/azure/cutoff_example.downstream__0
@@ -1,0 +1,67 @@
+{
+  "engineType": 0,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_azure_cutoff_example_export_a__0_with_offset_0\", \"spec\": \"data.azure_cutoff_example_export_a__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_azure_cutoff_example_export_b__0_with_offset_0\", \"spec\": \"data.azure_cutoff_example_export_b__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "azure.cutoff_example.downstream__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/azure/cutoff_example.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "query": "\n    SELECT\n        a.ds AS ds,\n        a.listing_id AS listing_id,\n        a.merchant_id AS merchant_id\n    FROM data.azure_cutoff_example_export_a__0 a\n    JOIN data.azure_cutoff_example_export_b__0 b USING (ds, merchant_id)\n    WHERE a.ds BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.azure_cutoff_example_export_a__0"
+      }
+    },
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startCutOff": "2026-02-25",
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.azure_cutoff_example_export_b__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/azure/cutoff_example.export_a__0
+++ b/python/test/canary/canary_compiled/staging_queries/azure/cutoff_example.export_a__0
@@ -1,0 +1,52 @@
+{
+  "engineType": 2,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_dim_listings_with_offset_0\", \"spec\": \"dim_listings/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "azure.cutoff_example.export_a__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/azure/cutoff_example.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "query": "\n    SELECT *\n    FROM dim_listings\n    WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "dim_listings"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/azure/cutoff_example.export_b__0
+++ b/python/test/canary/canary_compiled/staging_queries/azure/cutoff_example.export_b__0
@@ -1,0 +1,52 @@
+{
+  "engineType": 2,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_dim_merchants_with_offset_0\", \"spec\": \"dim_merchants/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "azure.cutoff_example.export_b__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/azure/cutoff_example.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "query": "\n    SELECT *\n    FROM dim_merchants\n    WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "dim_merchants"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/azure/exports.checkouts__0
+++ b/python/test/canary/canary_compiled/staging_queries/azure/exports.checkouts__0
@@ -1,0 +1,52 @@
+{
+  "engineType": 2,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_checkouts_with_offset_0\", \"spec\": \"checkouts/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "azure.exports.checkouts__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/azure/exports.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "query": "\n    SELECT\n        *,\n        DATE_TRUNC('DAY', ds)::DATE as ds\n    FROM checkouts\n    WHERE\n    ds BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "checkouts"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/azure/exports.dim_listings__0
+++ b/python/test/canary/canary_compiled/staging_queries/azure/exports.dim_listings__0
@@ -1,0 +1,52 @@
+{
+  "engineType": 2,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_dim_listings_with_offset_0\", \"spec\": \"dim_listings/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "azure.exports.dim_listings__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/azure/exports.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "query": "\n    SELECT\n      * EXCLUDE (ds),\n       DATE_TRUNC('DAY', ds)::DATE as ds\n    FROM dim_listings\n    WHERE\n    DATE_TRUNC('DAY', ds) BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "dim_listings"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/azure/exports.dim_listings_pc__1
+++ b/python/test/canary/canary_compiled/staging_queries/azure/exports.dim_listings_pc__1
@@ -1,0 +1,53 @@
+{
+  "engineType": 2,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_dim_listings_custom_part_with_offset_0\", \"spec\": \"dim_listings_custom_part/datest={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "azure.exports.dim_listings_pc__1",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/azure/exports.py",
+    "team": "azure",
+    "version": "1"
+  },
+  "query": "\n    SELECT\n        *,\n        DATE_TRUNC('DAY', datest)::DATE as ds\n    FROM dim_listings_custom_part\n    WHERE\n    datest BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "datest",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "dim_listings_custom_part",
+        "timePartitioned": 1
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/azure/exports.dim_merchants__0
+++ b/python/test/canary/canary_compiled/staging_queries/azure/exports.dim_merchants__0
@@ -1,0 +1,52 @@
+{
+  "engineType": 2,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_dim_merchants_with_offset_0\", \"spec\": \"dim_merchants/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "azure.exports.dim_merchants__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/azure/exports.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "query": "\n    SELECT\n      * EXCLUDE (ds),\n       DATE_TRUNC('DAY', ds)::DATE as ds\n    FROM dim_merchants\n    WHERE\n    DATE_TRUNC('DAY', ds) BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "dim_merchants"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/azure/exports.dim_users__0
+++ b/python/test/canary/canary_compiled/staging_queries/azure/exports.dim_users__0
@@ -1,0 +1,52 @@
+{
+  "engineType": 2,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_dim_users_with_offset_0\", \"spec\": \"dim_users/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "azure.exports.dim_users__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/azure/exports.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "query": "\n    SELECT\n      * EXCLUDE (ds),\n       DATE_TRUNC('DAY', ds)::DATE as ds\n    FROM dim_users\n    WHERE\n    DATE_TRUNC('DAY', ds) BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "dim_users"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/azure/exports.user_activities__0
+++ b/python/test/canary/canary_compiled/staging_queries/azure/exports.user_activities__0
@@ -1,0 +1,36 @@
+{
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": []}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "azure.exports.user_activities__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/azure/exports.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "query": "\n    SELECT\n        parsed.event_id,\n        parsed.event_time_ms,\n        parsed.ingested_time_ms,\n        parsed.user_id,\n        parsed.session_id,\n        parsed.device_type,\n        parsed.country_code,\n        parsed.listing_id,\n        parsed.event_type,\n        to_date(from_unixtime(parsed.event_time_ms / 1000)) AS ds\n    FROM (\n        SELECT *\n          , from_json(CAST(Body AS STRING)\n          , 'event_id STRING, event_time_ms BIGINT, ingested_time_ms BIGINT,\n             user_id STRING, session_id STRING, device_type STRING,\n             country_code STRING, listing_id BIGINT, event_type STRING') AS parsed\n        FROM raw_activities\n        WHERE Body IS NOT NULL\n    )\n    WHERE parsed.event_time_ms >= CAST(to_unix_timestamp({{start_date}}, 'yyyy-MM-dd') * 1000 AS BIGINT)\n      AND parsed.event_time_ms <  CAST(to_unix_timestamp({{end_date}}, 'yyyy-MM-dd') * 1000 AS BIGINT);\n    ",
+  "setups": [
+    "ADD JAR 'abfss://demo@ziplineai2.dfs.core.windows.net/jars/spark-avro_2.12-3.5.3.jar'",
+    "\n                CREATE OR REPLACE TEMPORARY VIEW raw_activities USING avro\n                OPTIONS (\n                  path 'abfss://demo@ziplineai2.dfs.core.windows.net/zipline-demo-events/user-activities/',\n                  recursiveFileLookup 'true'\n                );"
+  ],
+  "tableDependencies": []
+}

--- a/python/test/canary/canary_compiled/staging_queries/azure/local_staging_query.simple__0
+++ b/python/test/canary/canary_compiled/staging_queries/azure/local_staging_query.simple__0
@@ -1,0 +1,51 @@
+{
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_test_connection_with_offset_0\", \"spec\": \"data.test_connection/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "azure.local_staging_query.simple__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/azure/local_staging_query.py",
+    "team": "azure",
+    "version": "0"
+  },
+  "query": "\nSELECT\n    id,\n    {{ end_date }} as ds\nFROM data.test_connection\n",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.test_connection"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/azure/partitioned_logging.v0__2
+++ b/python/test/canary/canary_compiled/staging_queries/azure/partitioned_logging.v0__2
@@ -1,0 +1,49 @@
+{
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": []}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "offlineSchedule": "@daily"
+    },
+    "name": "azure.partitioned_logging.v0__2",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/azure/partitioned_logging.py",
+    "team": "azure",
+    "version": "2"
+  },
+  "query": "\n      SELECT\n        DATE(TIMESTAMP_MILLIS(tsMillis)) AS ds\n        , tsMillis as ts_millis\n        , BASE64(keyBytes) as key_base64\n        , BASE64(valueBytes) as value_base64\n        , joinName as name\n        , schemaHash as schema_hash\n        , keyBytes\n        , valueBytes\n      FROM data.loggable_response\n      WHERE DATE(TIMESTAMP_MILLIS(tsMillis)) BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.loggable_response"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/gcp/checkouts_import.v1__0
+++ b/python/test/canary/canary_compiled/staging_queries/gcp/checkouts_import.v1__0
@@ -1,0 +1,110 @@
+{
+  "engineType": 1,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_checkouts_with_offset_0\", \"spec\": \"data.checkouts/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily"
+    },
+    "name": "gcp.checkouts_import.v1__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/gcp/checkouts_import.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "query": "SELECT * FROM data.checkouts WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.checkouts"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/gcp/checkouts_notds_import.v1__0
+++ b/python/test/canary/canary_compiled/staging_queries/gcp/checkouts_notds_import.v1__0
@@ -1,0 +1,110 @@
+{
+  "engineType": 1,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_checkouts_notds_with_offset_0\", \"spec\": \"data.checkouts_notds/notds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "notds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily"
+    },
+    "name": "gcp.checkouts_notds_import.v1__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/gcp/checkouts_notds_import.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "query": "SELECT * FROM data.checkouts_notds WHERE notds BETWEEN {{ start_date }} AND {{ end_date }}",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "notds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.checkouts_notds"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/gcp/ctr_labels.v1__0
+++ b/python/test/canary/canary_compiled/staging_queries/gcp/ctr_labels.v1__0
@@ -1,0 +1,109 @@
+{
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_demo_derivations_v1__2__derived_with_offset_0\", \"spec\": \"data.gcp_demo_derivations_v1__2__derived/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily"
+    },
+    "name": "gcp.ctr_labels.v1__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/gcp/ctr_labels.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "query": "\nSELECT \n    *,\n    case when rand() < 0.5 then 0 else 1 end as label\nFROM data.gcp_demo_derivations_v1__2__derived\nWHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.gcp_demo_derivations_v1__2__derived"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/gcp/cutoff_example.downstream__0
+++ b/python/test/canary/canary_compiled/staging_queries/gcp/cutoff_example.downstream__0
@@ -1,0 +1,126 @@
+{
+  "engineType": 1,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_cutoff_example_export_a__0_with_offset_0\", \"spec\": \"data.gcp_cutoff_example_export_a__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_gcp_cutoff_example_export_b__0_with_offset_0\", \"spec\": \"data.gcp_cutoff_example_export_b__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "gcp.cutoff_example.downstream__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/gcp/cutoff_example.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "query": "\n    SELECT\n        a.ds AS ds,\n        a.listing_id AS listing_id,\n        a.merchant_id AS merchant_id\n    FROM data.gcp_cutoff_example_export_a__0 a\n    JOIN data.gcp_cutoff_example_export_b__0 b USING (ds, merchant_id)\n    WHERE a.ds BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.gcp_cutoff_example_export_a__0"
+      }
+    },
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startCutOff": "2026-02-25",
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.gcp_cutoff_example_export_b__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/gcp/cutoff_example.export_a__0
+++ b/python/test/canary/canary_compiled/staging_queries/gcp/cutoff_example.export_a__0
@@ -1,0 +1,111 @@
+{
+  "engineType": 1,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo_dim_listings_with_offset_0\", \"spec\": \"demo.dim_listings/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "gcp.cutoff_example.export_a__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/gcp/cutoff_example.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "query": "\n    SELECT *\n    FROM demo.dim_listings\n    WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "demo.dim_listings"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/gcp/cutoff_example.export_b__0
+++ b/python/test/canary/canary_compiled/staging_queries/gcp/cutoff_example.export_b__0
@@ -1,0 +1,111 @@
+{
+  "engineType": 1,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo_dim_merchants_with_offset_0\", \"spec\": \"demo.dim_merchants/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "gcp.cutoff_example.export_b__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/gcp/cutoff_example.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "query": "\n    SELECT *\n    FROM demo.dim_merchants\n    WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "demo.dim_merchants"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/gcp/demo.may4__0
+++ b/python/test/canary/canary_compiled/staging_queries/gcp/demo.may4__0
@@ -1,0 +1,109 @@
+{
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf___derived_with_offset_0\", \"spec\": \"__derived/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily"
+    },
+    "name": "gcp.demo.may4__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/gcp/demo.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "query": "\nSELECT \n    *,\n    case when rand() < 0.5 then 0 else 1 end as label\nFROM __derived\nWHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "__derived"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/gcp/exports.checkouts__0
+++ b/python/test/canary/canary_compiled/staging_queries/gcp/exports.checkouts__0
@@ -1,0 +1,111 @@
+{
+  "engineType": 1,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo__checkouts__with_offset_0\", \"spec\": \"demo.`checkouts`/_PARTITIONTIME={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "gcp.exports.checkouts__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/gcp/exports.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "query": "\n    SELECT \n        *,\n        TIMESTAMP_TRUNC(_PARTITIONTIME, DAY) as ds\n    FROM demo.`checkouts`\n    WHERE \n    _PARTITIONTIME BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "_PARTITIONTIME",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "demo.`checkouts`"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/gcp/exports.dim_listing_mutations__0
+++ b/python/test/canary/canary_compiled/staging_queries/gcp/exports.dim_listing_mutations__0
@@ -1,0 +1,111 @@
+{
+  "engineType": 1,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo__dim_listing_mutations__with_offset_0\", \"spec\": \"demo.`dim_listing_mutations`/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "gcp.exports.dim_listing_mutations__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/gcp/exports.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "query": "\n    SELECT \n        * \n    FROM demo.`dim_listing_mutations`\n    WHERE \n    TIMESTAMP_TRUNC(ds, DAY) BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "demo.`dim_listing_mutations`"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/gcp/exports.dim_listings__0
+++ b/python/test/canary/canary_compiled/staging_queries/gcp/exports.dim_listings__0
@@ -1,0 +1,111 @@
+{
+  "engineType": 1,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo__dim_listings__with_offset_0\", \"spec\": \"demo.`dim_listings`/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "gcp.exports.dim_listings__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/gcp/exports.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "query": "\n    SELECT \n        * \n    FROM demo.`dim_listings`\n    WHERE \n    TIMESTAMP_TRUNC(ds, DAY) BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "demo.`dim_listings`"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/gcp/exports.dim_merchants__0
+++ b/python/test/canary/canary_compiled/staging_queries/gcp/exports.dim_merchants__0
@@ -1,0 +1,111 @@
+{
+  "engineType": 1,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo__dim_merchants__with_offset_0\", \"spec\": \"demo.`dim_merchants`/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "gcp.exports.dim_merchants__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/gcp/exports.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "query": "\n    SELECT \n        * \n    FROM demo.`dim_merchants`\n    WHERE \n    TIMESTAMP_TRUNC(ds, DAY) BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "demo.`dim_merchants`"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/gcp/exports.dim_users__0
+++ b/python/test/canary/canary_compiled/staging_queries/gcp/exports.dim_users__0
@@ -1,0 +1,111 @@
+{
+  "engineType": 1,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo__dim_users__with_offset_0\", \"spec\": \"demo.`dim_users`/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "gcp.exports.dim_users__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/gcp/exports.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "query": "\n    SELECT \n        * \n    FROM demo.`dim_users`\n    WHERE \n    TIMESTAMP_TRUNC(ds, DAY) BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "demo.`dim_users`"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/gcp/exports.user_activities__0
+++ b/python/test/canary/canary_compiled/staging_queries/gcp/exports.user_activities__0
@@ -1,0 +1,111 @@
+{
+  "engineType": 1,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo__user_activities__with_offset_0\", \"spec\": \"demo.`user-activities`/_PARTITIONTIME={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "gcp.exports.user_activities__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/gcp/exports.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "query": "\n    SELECT \n        *,\n        TIMESTAMP_TRUNC(_PARTITIONTIME, DAY) as ds\n    FROM demo.`user-activities`\n    WHERE \n    _PARTITIONTIME BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "_PARTITIONTIME",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "demo.`user-activities`"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/gcp/partitioned_logging.v0__2
+++ b/python/test/canary/canary_compiled/staging_queries/gcp/partitioned_logging.v0__2
@@ -1,0 +1,108 @@
+{
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": []}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily"
+    },
+    "name": "gcp.partitioned_logging.v0__2",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/gcp/partitioned_logging.py",
+    "team": "gcp",
+    "version": "2"
+  },
+  "query": "\n      SELECT\n        DATE(TIMESTAMP_MILLIS(tsMillis)) AS ds\n        , tsMillis as ts_millis\n        , BASE64(keyBytes) as key_base64\n        , BASE64(valueBytes) as value_base64\n        , joinName as name\n        , schemaHash as schema_hash\n        , keyBytes\n        , valueBytes\n      FROM data.loggable_response\n      WHERE DATE(TIMESTAMP_MILLIS(tsMillis)) BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.loggable_response"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/gcp/purchases_import.v1__0
+++ b/python/test/canary/canary_compiled/staging_queries/gcp/purchases_import.v1__0
@@ -1,0 +1,110 @@
+{
+  "engineType": 1,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily"
+    },
+    "name": "gcp.purchases_import.v1__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/gcp/purchases_import.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "query": "SELECT * FROM data.purchases WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.purchases"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/gcp/purchases_notds_import.v1__0
+++ b/python/test/canary/canary_compiled/staging_queries/gcp/purchases_notds_import.v1__0
@@ -1,0 +1,110 @@
+{
+  "engineType": 1,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_purchases_notds_with_offset_0\", \"spec\": \"data.purchases_notds/notds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "notds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily"
+    },
+    "name": "gcp.purchases_notds_import.v1__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/gcp/purchases_notds_import.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "query": "SELECT * FROM data.purchases_notds WHERE notds BETWEEN {{ start_date }} AND {{ end_date }}",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "notds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.purchases_notds"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/gcp/sample_staging_query.cart__0
+++ b/python/test/canary/canary_compiled/staging_queries/gcp/sample_staging_query.cart__0
@@ -1,0 +1,113 @@
+{
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_training_set_v1_test__0_with_offset_1\", \"spec\": \"data.gcp_training_set_v1_test__0/ds={{ macros.ds_add(ds, -1) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "gcp.sample_staging_query.cart__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/gcp/sample_staging_query.py",
+    "tableProperties": {
+      "sample_config_json": "{\"sample_key\": \"sample value\"}"
+    },
+    "team": "gcp",
+    "version": "0"
+  },
+  "query": "\n        SELECT\n            *,\n            'cart' as category_name\n        FROM data.gcp_training_set_v1_test__0\n        WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.gcp_training_set_v1_test__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/gcp/sample_staging_query.item__0
+++ b/python/test/canary/canary_compiled/staging_queries/gcp/sample_staging_query.item__0
@@ -1,0 +1,113 @@
+{
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_training_set_v1_test__0_with_offset_1\", \"spec\": \"data.gcp_training_set_v1_test__0/ds={{ macros.ds_add(ds, -1) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "gcp.sample_staging_query.item__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/gcp/sample_staging_query.py",
+    "tableProperties": {
+      "sample_config_json": "{\"sample_key\": \"sample value\"}"
+    },
+    "team": "gcp",
+    "version": "0"
+  },
+  "query": "\n        SELECT\n            *,\n            'item' as category_name\n        FROM data.gcp_training_set_v1_test__0\n        WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.gcp_training_set_v1_test__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/gcp/sample_staging_query.order__0
+++ b/python/test/canary/canary_compiled/staging_queries/gcp/sample_staging_query.order__0
@@ -1,0 +1,113 @@
+{
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_training_set_v1_test__0_with_offset_1\", \"spec\": \"data.gcp_training_set_v1_test__0/ds={{ macros.ds_add(ds, -1) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "gcp.sample_staging_query.order__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/gcp/sample_staging_query.py",
+    "tableProperties": {
+      "sample_config_json": "{\"sample_key\": \"sample value\"}"
+    },
+    "team": "gcp",
+    "version": "0"
+  },
+  "query": "\n        SELECT\n            *,\n            'order' as category_name\n        FROM data.gcp_training_set_v1_test__0\n        WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.gcp_training_set_v1_test__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/gcp/sample_staging_query.payment__0
+++ b/python/test/canary/canary_compiled/staging_queries/gcp/sample_staging_query.payment__0
@@ -1,0 +1,113 @@
+{
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_training_set_v1_test__0_with_offset_1\", \"spec\": \"data.gcp_training_set_v1_test__0/ds={{ macros.ds_add(ds, -1) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "gcp.sample_staging_query.payment__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/gcp/sample_staging_query.py",
+    "tableProperties": {
+      "sample_config_json": "{\"sample_key\": \"sample value\"}"
+    },
+    "team": "gcp",
+    "version": "0"
+  },
+  "query": "\n        SELECT\n            *,\n            'payment' as category_name\n        FROM data.gcp_training_set_v1_test__0\n        WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.gcp_training_set_v1_test__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/gcp/sample_staging_query.purchases_labels__0
+++ b/python/test/canary/canary_compiled/staging_queries/gcp/sample_staging_query.purchases_labels__0
@@ -1,0 +1,113 @@
+{
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_training_set_v1_test__0_with_offset_0\", \"spec\": \"data.gcp_training_set_v1_test__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "gcp.sample_staging_query.purchases_labels__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/gcp/sample_staging_query.py",
+    "tableProperties": {
+      "sample_config_json": "{\"sample_key\": \"sample value\"}"
+    },
+    "team": "gcp",
+    "version": "0"
+  },
+  "query": "\nSELECT\n    *,\n    case when rand() < 0.5 then 0 else 1 end as label\nFROM data.gcp_training_set_v1_test__0\nWHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.gcp_training_set_v1_test__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/gcp/sample_staging_query.shipping__0
+++ b/python/test/canary/canary_compiled/staging_queries/gcp/sample_staging_query.shipping__0
@@ -1,0 +1,113 @@
+{
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_training_set_v1_test__0_with_offset_1\", \"spec\": \"data.gcp_training_set_v1_test__0/ds={{ macros.ds_add(ds, -1) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "gcp.sample_staging_query.shipping__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/gcp/sample_staging_query.py",
+    "tableProperties": {
+      "sample_config_json": "{\"sample_key\": \"sample value\"}"
+    },
+    "team": "gcp",
+    "version": "0"
+  },
+  "query": "\n        SELECT\n            *,\n            'shipping' as category_name\n        FROM data.gcp_training_set_v1_test__0\n        WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.gcp_training_set_v1_test__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/gcp/sample_staging_query.terminal__0
+++ b/python/test/canary/canary_compiled/staging_queries/gcp/sample_staging_query.terminal__0
@@ -1,0 +1,203 @@
+{
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_sample_staging_query_cart__0_with_offset_1\", \"spec\": \"data.gcp_sample_staging_query_cart__0/ds={{ macros.ds_add(ds, -1) }}\"}, {\"name\": \"wf_data_gcp_sample_staging_query_user__0_with_offset_1\", \"spec\": \"data.gcp_sample_staging_query_user__0/ds={{ macros.ds_add(ds, -1) }}\"}, {\"name\": \"wf_data_gcp_sample_staging_query_item__0_with_offset_1\", \"spec\": \"data.gcp_sample_staging_query_item__0/ds={{ macros.ds_add(ds, -1) }}\"}, {\"name\": \"wf_data_gcp_sample_staging_query_order__0_with_offset_1\", \"spec\": \"data.gcp_sample_staging_query_order__0/ds={{ macros.ds_add(ds, -1) }}\"}, {\"name\": \"wf_data_gcp_sample_staging_query_payment__0_with_offset_1\", \"spec\": \"data.gcp_sample_staging_query_payment__0/ds={{ macros.ds_add(ds, -1) }}\"}, {\"name\": \"wf_data_gcp_sample_staging_query_shipping__0_with_offset_1\", \"spec\": \"data.gcp_sample_staging_query_shipping__0/ds={{ macros.ds_add(ds, -1) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "gcp.sample_staging_query.terminal__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/gcp/sample_staging_query.py",
+    "tableProperties": {
+      "sample_config_json": "{\"sample_key\": \"sample value\"}"
+    },
+    "team": "gcp",
+    "version": "0"
+  },
+  "query": "SELECT\n                *\n            FROM data.gcp_sample_staging_query_cart__0\n            WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\nUNION ALL\nSELECT\n                *\n            FROM data.gcp_sample_staging_query_user__0\n            WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\nUNION ALL\nSELECT\n                *\n            FROM data.gcp_sample_staging_query_item__0\n            WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\nUNION ALL\nSELECT\n                *\n            FROM data.gcp_sample_staging_query_order__0\n            WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\nUNION ALL\nSELECT\n                *\n            FROM data.gcp_sample_staging_query_payment__0\n            WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\nUNION ALL\nSELECT\n                *\n            FROM data.gcp_sample_staging_query_shipping__0\n            WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.gcp_sample_staging_query_cart__0"
+      }
+    },
+    {
+      "endOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.gcp_sample_staging_query_user__0"
+      }
+    },
+    {
+      "endOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.gcp_sample_staging_query_item__0"
+      }
+    },
+    {
+      "endOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.gcp_sample_staging_query_order__0"
+      }
+    },
+    {
+      "endOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.gcp_sample_staging_query_payment__0"
+      }
+    },
+    {
+      "endOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.gcp_sample_staging_query_shipping__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/gcp/sample_staging_query.user__0
+++ b/python/test/canary/canary_compiled/staging_queries/gcp/sample_staging_query.user__0
@@ -1,0 +1,113 @@
+{
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_training_set_v1_test__0_with_offset_1\", \"spec\": \"data.gcp_training_set_v1_test__0/ds={{ macros.ds_add(ds, -1) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "gcp.sample_staging_query.user__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/gcp/sample_staging_query.py",
+    "tableProperties": {
+      "sample_config_json": "{\"sample_key\": \"sample value\"}"
+    },
+    "team": "gcp",
+    "version": "0"
+  },
+  "query": "\n        SELECT\n            *,\n            'user' as category_name\n        FROM data.gcp_training_set_v1_test__0\n        WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.gcp_training_set_v1_test__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/gcp/sample_staging_query.v1_bigquery_import__0
+++ b/python/test/canary/canary_compiled/staging_queries/gcp/sample_staging_query.v1_bigquery_import__0
@@ -1,0 +1,111 @@
+{
+  "engineType": 1,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_training_set_v1_hub__0_with_offset_0\", \"spec\": \"data.gcp_training_set_v1_hub__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "gcp.sample_staging_query.v1_bigquery_import__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/gcp/sample_staging_query.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "query": "\nSELECT\n    *\nFROM data.gcp_training_set_v1_hub__0\nWHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.gcp_training_set_v1_hub__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/gcp/sample_staging_query.v1_hub__0
+++ b/python/test/canary/canary_compiled/staging_queries/gcp/sample_staging_query.v1_hub__0
@@ -1,0 +1,113 @@
+{
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_training_set_v1_hub__0_with_offset_1\", \"spec\": \"data.gcp_training_set_v1_hub__0/ds={{ macros.ds_add(ds, -1) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 30
+    },
+    "name": "gcp.sample_staging_query.v1_hub__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/gcp/sample_staging_query.py",
+    "tableProperties": {
+      "sample_config_json": "{\"sample_key\": \"sample value\"}"
+    },
+    "team": "gcp",
+    "version": "0"
+  },
+  "query": "\nSELECT\n    *\nFROM data.gcp_training_set_v1_hub__0\nWHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 1,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.gcp_training_set_v1_hub__0"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/gcp/team_default_ns_example.v1__0
+++ b/python/test/canary/canary_compiled/staging_queries/gcp/team_default_ns_example.v1__0
@@ -1,0 +1,110 @@
+{
+  "engineType": 1,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_checkouts_with_offset_0\", \"spec\": \"data.checkouts/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily"
+    },
+    "name": "gcp.team_default_ns_example.v1__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/gcp/team_default_ns_example.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "query": "SELECT * FROM data.checkouts WHERE ds BETWEEN {{ start_date }} AND {{ end_date }}",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "data.checkouts"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/quickstart/exports.dim_listings__0
+++ b/python/test/canary/canary_compiled/staging_queries/quickstart/exports.dim_listings__0
@@ -1,0 +1,52 @@
+{
+  "engineType": 0,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo_dim_listings_with_offset_0\", \"spec\": \"demo.dim_listings/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 20
+    },
+    "name": "quickstart.exports.dim_listings__0",
+    "outputNamespace": "quickstart",
+    "sourceFile": "staging_queries/quickstart/exports.py",
+    "team": "quickstart",
+    "version": "0"
+  },
+  "query": "\n    SELECT\n        *\n    FROM demo.dim_listings\n    WHERE\n    ds BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "demo.dim_listings"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/quickstart/exports.dim_merchants__0
+++ b/python/test/canary/canary_compiled/staging_queries/quickstart/exports.dim_merchants__0
@@ -1,0 +1,52 @@
+{
+  "engineType": 0,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo_dim_merchants_with_offset_0\", \"spec\": \"demo.dim_merchants/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 20
+    },
+    "name": "quickstart.exports.dim_merchants__0",
+    "outputNamespace": "quickstart",
+    "sourceFile": "staging_queries/quickstart/exports.py",
+    "team": "quickstart",
+    "version": "0"
+  },
+  "query": "\n    SELECT\n        *\n    FROM demo.dim_merchants\n    WHERE\n    ds BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "demo.dim_merchants"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/quickstart/exports.dim_users__0
+++ b/python/test/canary/canary_compiled/staging_queries/quickstart/exports.dim_users__0
@@ -1,0 +1,52 @@
+{
+  "engineType": 0,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo_dim_users_with_offset_0\", \"spec\": \"demo.dim_users/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 20
+    },
+    "name": "quickstart.exports.dim_users__0",
+    "outputNamespace": "quickstart",
+    "sourceFile": "staging_queries/quickstart/exports.py",
+    "team": "quickstart",
+    "version": "0"
+  },
+  "query": "\n    SELECT\n        *\n    FROM demo.dim_users\n    WHERE\n    ds BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "demo.dim_users"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/staging_queries/quickstart/exports.user_activities__0
+++ b/python/test/canary/canary_compiled/staging_queries/quickstart/exports.user_activities__0
@@ -1,0 +1,52 @@
+{
+  "engineType": 0,
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo_user_activities_with_offset_0\", \"spec\": \"demo.user_activities/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "conf": {
+        "common": {
+          "spark.chronon.partition.column": "ds"
+        }
+      },
+      "env": {
+        "common": {
+          "CUSTOMER_ID": "dev",
+          "FRONTEND_URL": "http://localhost:3000",
+          "HUB_URL": "http://localhost:3903",
+          "VERSION": "latest"
+        }
+      },
+      "offlineSchedule": "@daily",
+      "stepDays": 20
+    },
+    "name": "quickstart.exports.user_activities__0",
+    "outputNamespace": "quickstart",
+    "sourceFile": "staging_queries/quickstart/exports.py",
+    "team": "quickstart",
+    "version": "0"
+  },
+  "query": "\n    SELECT\n        *\n    FROM demo.user_activities\n    WHERE\n    ds BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "demo.user_activities"
+      }
+    }
+  ]
+}

--- a/python/test/canary/canary_compiled/teams_metadata/aws/aws_team_metadata
+++ b/python/test/canary/canary_compiled/teams_metadata/aws/aws_team_metadata
@@ -1,0 +1,91 @@
+{
+  "executionInfo": {
+    "clusterConf": {
+      "common": {
+        "emr.config": "{\"releaseLabel\": \"emr-7.12.0\", \"instanceType\": \"m5.xlarge\", \"instanceCount\": 3, \"autoTerminationPolicy\": {\"idleTimeout\": 7200}, \"subnetName\": \"zipline-canary-subnet-main\", \"securityGroupName\": \"zipline-canary-sg\"}"
+      }
+    },
+    "conf": {
+      "common": {
+        "spark.chronon.coalesce.factor": "10",
+        "spark.chronon.partition.column": "ds",
+        "spark.chronon.partition.format": "yyyy-MM-dd",
+        "spark.chronon.table_write.format": "iceberg",
+        "spark.chronon.table_write.upload.format": "ion",
+        "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+        "spark.default.parallelism": "10",
+        "spark.driver.cores": "1",
+        "spark.driver.memory": "1g",
+        "spark.executor.cores": "1",
+        "spark.executor.memory": "1g",
+        "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+        "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+        "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+        "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+        "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+        "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+        "spark.sql.shuffle.partitions": "10",
+        "taskmanager.memory.process.size": "4G"
+      },
+      "modeConfigs": {
+        "backfill": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.table_write.upload.format": "ion",
+          "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.memory": "1g",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "1g",
+          "spark.hadoop.hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+          "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+          "spark.sql.shuffle.partitions": "10",
+          "taskmanager.memory.process.size": "4G"
+        }
+      }
+    },
+    "env": {
+      "common": {
+        "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+        "AWS_REGION": "us-west-2",
+        "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+        "CLOUD_PROVIDER": "aws",
+        "CUSTOMER_ID": "canary",
+        "ENABLE_KINESIS": "true",
+        "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+        "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+        "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+        "FRONTEND_URL": "https://canary-aws.zipline.ai",
+        "HUB_URL": "https://canary-orch-aws.zipline.ai",
+        "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+        "VERSION": "latest",
+        "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+      },
+      "modeEnvironments": {
+        "upload": {
+          "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+          "AWS_REGION": "us-west-2",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+          "CLOUD_PROVIDER": "aws",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+          "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "https://canary-aws.zipline.ai",
+          "HUB_URL": "https://canary-orch-aws.zipline.ai",
+          "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary"
+        }
+      }
+    }
+  }
+}

--- a/python/test/canary/canary_compiled/teams_metadata/aws_databricks/aws_databricks_team_metadata
+++ b/python/test/canary/canary_compiled/teams_metadata/aws_databricks/aws_databricks_team_metadata
@@ -1,0 +1,17 @@
+{
+  "executionInfo": {
+    "conf": {
+      "common": {
+        "spark.chronon.partition.column": "ds"
+      }
+    },
+    "env": {
+      "common": {
+        "CUSTOMER_ID": "dev",
+        "FRONTEND_URL": "http://localhost:3000",
+        "HUB_URL": "http://localhost:3903",
+        "VERSION": "latest"
+      }
+    }
+  }
+}

--- a/python/test/canary/canary_compiled/teams_metadata/azure/azure_team_metadata
+++ b/python/test/canary/canary_compiled/teams_metadata/azure/azure_team_metadata
@@ -1,0 +1,17 @@
+{
+  "executionInfo": {
+    "conf": {
+      "common": {
+        "spark.chronon.partition.column": "ds"
+      }
+    },
+    "env": {
+      "common": {
+        "CUSTOMER_ID": "dev",
+        "FRONTEND_URL": "http://localhost:3000",
+        "HUB_URL": "http://localhost:3903",
+        "VERSION": "latest"
+      }
+    }
+  }
+}

--- a/python/test/canary/canary_compiled/teams_metadata/default/default_team_metadata
+++ b/python/test/canary/canary_compiled/teams_metadata/default/default_team_metadata
@@ -1,0 +1,17 @@
+{
+  "executionInfo": {
+    "conf": {
+      "common": {
+        "spark.chronon.partition.column": "ds"
+      }
+    },
+    "env": {
+      "common": {
+        "CUSTOMER_ID": "dev",
+        "FRONTEND_URL": "http://localhost:3000",
+        "HUB_URL": "http://localhost:3903",
+        "VERSION": "latest"
+      }
+    }
+  }
+}

--- a/python/test/canary/canary_compiled/teams_metadata/gcp/gcp_team_metadata
+++ b/python/test/canary/canary_compiled/teams_metadata/gcp/gcp_team_metadata
@@ -1,0 +1,76 @@
+{
+  "executionInfo": {
+    "clusterConf": {
+      "modeClusterConfigs": {
+        "upload": {
+          "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
+          "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+        }
+      }
+    },
+    "conf": {
+      "common": {
+        "spark.chronon.coalesce.factor": "10",
+        "spark.chronon.partition.column": "ds",
+        "spark.chronon.partition.format": "yyyy-MM-dd",
+        "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+        "spark.chronon.table_write.format": "iceberg",
+        "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
+        "spark.default.parallelism": "10",
+        "spark.driver.cores": "1",
+        "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+        "spark.driver.memory": "512m",
+        "spark.executor.cores": "1",
+        "spark.executor.memory": "512m",
+        "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+        "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+        "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+        "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+        "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+        "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+        "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+        "spark.sql.shuffle.partitions": "10"
+      }
+    },
+    "env": {
+      "common": {
+        "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+        "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+        "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+        "CLOUD_PROVIDER": "gcp",
+        "CUSTOMER_ID": "canary",
+        "ENABLE_PUBSUB": "true",
+        "EVAL_URL": "http://localhost:3904",
+        "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+        "FRONTEND_URL": "http://localhost:3000",
+        "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+        "GCP_PROJECT_ID": "canary-443022",
+        "GCP_REGION": "us-central1",
+        "HUB_URL": "http://localhost:3903",
+        "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+        "VERSION": "latest",
+        "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+      },
+      "modeEnvironments": {
+        "upload": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        }
+      }
+    }
+  }
+}

--- a/python/test/canary/canary_compiled/teams_metadata/quickstart/quickstart_team_metadata
+++ b/python/test/canary/canary_compiled/teams_metadata/quickstart/quickstart_team_metadata
@@ -1,0 +1,17 @@
+{
+  "executionInfo": {
+    "conf": {
+      "common": {
+        "spark.chronon.partition.column": "ds"
+      }
+    },
+    "env": {
+      "common": {
+        "CUSTOMER_ID": "dev",
+        "FRONTEND_URL": "http://localhost:3000",
+        "HUB_URL": "http://localhost:3903",
+        "VERSION": "latest"
+      }
+    }
+  }
+}

--- a/python/test/canary/canary_compiled/teams_metadata/test/test_team_metadata
+++ b/python/test/canary/canary_compiled/teams_metadata/test/test_team_metadata
@@ -1,0 +1,17 @@
+{
+  "executionInfo": {
+    "conf": {
+      "common": {
+        "spark.chronon.partition.column": "ds"
+      }
+    },
+    "env": {
+      "common": {
+        "CUSTOMER_ID": "dev",
+        "FRONTEND_URL": "http://localhost:3000",
+        "HUB_URL": "http://localhost:3903",
+        "VERSION": "latest"
+      }
+    }
+  }
+}

--- a/python/test/canary/compiled/group_bys/aws/dim_listings.v1__0
+++ b/python/test/canary/compiled/group_bys/aws/dim_listings.v1__0
@@ -22,6 +22,9 @@
       "weight_grams": "8b5ac3514f1c8f0db67748e07de128f4"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_exports_dim_listings__0_with_offset_0\", \"spec\": \"data.aws_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/group_bys/aws/dim_merchants.v1__0
+++ b/python/test/canary/compiled/group_bys/aws/dim_merchants.v1__0
@@ -8,6 +8,9 @@
       "primary_category": "7b4dbbd91897982b4f6672bb24202751"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_exports_dim_merchants__0_with_offset_0\", \"spec\": \"data.aws_exports_dim_merchants__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/group_bys/aws/item_event_canary.actions_v1__0
+++ b/python/test/canary/compiled/group_bys/aws/item_event_canary.actions_v1__0
@@ -57,6 +57,9 @@
       "view_sum_1d": "cc58ae369bab825653562d7cd27aa09c"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_item_events_parquet_compat_partitioned_with_offset_0\", \"spec\": \"data.item_events_parquet_compat_partitioned/_DATE={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/group_bys/aws/logging_schema.v1__2
+++ b/python/test/canary/compiled/group_bys/aws/logging_schema.v1__2
@@ -16,6 +16,9 @@
       "schema_value_last": "2533f3b6588575d6884c6375f2b28e8d"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_partitioned_logging_v0__2_with_offset_0\", \"spec\": \"data.aws_partitioned_logging_v0__2/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/group_bys/aws/purchases.v1_dev__0
+++ b/python/test/canary/compiled/group_bys/aws/purchases.v1_dev__0
@@ -83,6 +83,9 @@
       "user_id": "677635fb8fabe631108435c5cffe73ce"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/group_bys/aws/purchases.v1_test__0
+++ b/python/test/canary/compiled/group_bys/aws/purchases.v1_test__0
@@ -83,6 +83,9 @@
       "user_id": "dec6601a613992b4b6cdc50ac8014a29"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/group_bys/aws/user_activities.kafka_iam_v1__1
+++ b/python/test/canary/compiled/group_bys/aws/user_activities.kafka_iam_v1__1
@@ -389,6 +389,9 @@
       "view_event_sum_7d": "85e2a9f708b8278a695c01f60e8c1396"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo_user_activities_raw_with_offset_0\", \"spec\": \"demo.user_activities_raw/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {
@@ -449,6 +452,8 @@
           "CLOUD_PROVIDER": "aws",
           "CUSTOMER_ID": "canary",
           "ENABLE_KINESIS": "true",
+          "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+          "FETCHER_URL": "http://localhost:9000",
           "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
           "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
           "FRONTEND_URL": "https://canary-aws.zipline.ai",
@@ -465,6 +470,8 @@
             "CLOUD_PROVIDER": "aws",
             "CUSTOMER_ID": "canary",
             "ENABLE_KINESIS": "true",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "FETCHER_URL": "http://localhost:9000",
             "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
             "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
             "FRONTEND_URL": "https://canary-aws.zipline.ai",

--- a/python/test/canary/compiled/group_bys/aws/user_activities.kafka_v1__1
+++ b/python/test/canary/compiled/group_bys/aws/user_activities.kafka_v1__1
@@ -389,6 +389,9 @@
       "view_event_sum_7d": "839e077acdbd8775ed00c561b685a207"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo_user_activities_raw_with_offset_0\", \"spec\": \"demo.user_activities_raw/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/group_bys/aws/user_activities.v1__1
+++ b/python/test/canary/compiled/group_bys/aws/user_activities.v1__1
@@ -389,6 +389,9 @@
       "view_event_sum_7d": "c96e2586b4fbcb1b88553f770a5868e8"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo_user_activities_raw_with_offset_0\", \"spec\": \"demo.user_activities_raw/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/group_bys/aws/user_activities_chained.chained_user_gb__0
+++ b/python/test/canary/compiled/group_bys/aws/user_activities_chained.chained_user_gb__0
@@ -23,6 +23,9 @@
       "user_id": "96df20bb89ae17fa8229552a8afe4f3f"
     },
     "customJson": "{\"airflowDependencies\": []}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {
@@ -134,6 +137,9 @@
                   "listing_id"
                 ],
                 "metaData": {
+                  "environments": [
+                    0
+                  ],
                   "executionInfo": {
                     "clusterConf": {
                       "common": {
@@ -282,6 +288,9 @@
             }
           },
           "metaData": {
+            "environments": [
+              0
+            ],
             "executionInfo": {
               "clusterConf": {
                 "common": {

--- a/python/test/canary/compiled/group_bys/azure/crucible_stress.user_purchase_features__0
+++ b/python/test/canary/compiled/group_bys/azure/crucible_stress.user_purchase_features__0
@@ -83,6 +83,9 @@
       "user_id": "43dbce4df14238a2622226be130fb913"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_claims_demo_azure_crucible_stress_sources_purchases__0_with_offset_0\", \"spec\": \"claims_demo.azure_crucible_stress_sources_purchases__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/group_bys/azure/dim_listings.pc_v3
+++ b/python/test/canary/compiled/group_bys/azure/dim_listings.pc_v3
@@ -22,6 +22,9 @@
       "weight_grams": "f8f34e81434169852c03e62a335c20aa"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_azure_exports_dim_listings_pc__1_with_offset_0\", \"spec\": \"data.azure_exports_dim_listings_pc__1/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/group_bys/azure/dim_listings.v3
+++ b/python/test/canary/compiled/group_bys/azure/dim_listings.v3
@@ -22,6 +22,9 @@
       "weight_grams": "ac84b5b0b11dca76306214d5d2f12fa9"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_azure_exports_dim_listings__0_with_offset_0\", \"spec\": \"data.azure_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/group_bys/azure/dim_merchants.v2
+++ b/python/test/canary/compiled/group_bys/azure/dim_merchants.v2
@@ -8,6 +8,9 @@
       "primary_category": "41f7c36859f55e0908a0e2ee1cea4fb3"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_azure_exports_dim_merchants__0_with_offset_0\", \"spec\": \"data.azure_exports_dim_merchants__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/group_bys/azure/item_event_canary.actions_pubsub_v2__0
+++ b/python/test/canary/compiled/group_bys/azure/item_event_canary.actions_pubsub_v2__0
@@ -57,6 +57,9 @@
       "view_sum_1d": "10afd70aaef55fd280157c808724d63a"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_item_events_parquet_compat_partitioned_with_offset_0\", \"spec\": \"data.item_events_parquet_compat_partitioned/_DATE={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/group_bys/azure/item_event_canary.actions_v1__0
+++ b/python/test/canary/compiled/group_bys/azure/item_event_canary.actions_v1__0
@@ -57,6 +57,9 @@
       "view_sum_1d": "ace9014ad7611148a04bd9f08f557021"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_item_events_parquet_compat_partitioned_with_offset_0\", \"spec\": \"data.item_events_parquet_compat_partitioned/_DATE={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/group_bys/azure/logging_schema.v1__2
+++ b/python/test/canary/compiled/group_bys/azure/logging_schema.v1__2
@@ -16,6 +16,9 @@
       "schema_value_last": "6cddbbee834e60b87d7464daa04aceb9"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_azure_partitioned_logging_v0__2_with_offset_0\", \"spec\": \"data.azure_partitioned_logging_v0__2/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/group_bys/azure/purchases.v1_dev__0
+++ b/python/test/canary/compiled/group_bys/azure/purchases.v1_dev__0
@@ -83,6 +83,9 @@
       "user_id": "e0009a36a0838b4549d689008bac5afd"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/group_bys/azure/purchases.v1_dev_notds__0
+++ b/python/test/canary/compiled/group_bys/azure/purchases.v1_dev_notds__0
@@ -83,6 +83,9 @@
       "user_id": "5039d7bfb147f14cea3f30f7379e9d6f"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_purchases_notds_with_offset_0\", \"spec\": \"data.purchases_notds/notds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/group_bys/azure/purchases.v1_test__0
+++ b/python/test/canary/compiled/group_bys/azure/purchases.v1_test__0
@@ -83,6 +83,9 @@
       "user_id": "2a2caca3ea4afb84a2271533b1a1bae1"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/group_bys/azure/purchases.v1_test_notds__0
+++ b/python/test/canary/compiled/group_bys/azure/purchases.v1_test_notds__0
@@ -83,6 +83,9 @@
       "user_id": "81dd6ad753af4f7bb8411902a7e9b861"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_purchases_notds_with_offset_0\", \"spec\": \"data.purchases_notds/notds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/group_bys/azure/user_activities.v1__1
+++ b/python/test/canary/compiled/group_bys/azure/user_activities.v1__1
@@ -389,6 +389,9 @@
       "view_event_sum_7d": "dba8c5b21cc19fe07ceea1891fcfd226"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_azure_exports_user_activities__0_with_offset_0\", \"spec\": \"data.azure_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/group_bys/azure/user_activities_chained.chained_user_gb__0
+++ b/python/test/canary/compiled/group_bys/azure/user_activities_chained.chained_user_gb__0
@@ -23,6 +23,9 @@
       "user_id": "4ecdf09ef20508785edf01ab40f381ed"
     },
     "customJson": "{\"airflowDependencies\": []}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {
@@ -91,6 +94,9 @@
                   "listing_id"
                 ],
                 "metaData": {
+                  "environments": [
+                    0
+                  ],
                   "executionInfo": {
                     "conf": {
                       "common": {
@@ -194,6 +200,9 @@
             }
           },
           "metaData": {
+            "environments": [
+              0
+            ],
             "executionInfo": {
               "conf": {
                 "common": {

--- a/python/test/canary/compiled/group_bys/gcp/demo.fake_groupby_3__0
+++ b/python/test/canary/compiled/group_bys/gcp/demo.fake_groupby_3__0
@@ -1,0 +1,127 @@
+{
+  "aggregations": [
+    {
+      "argMap": {},
+      "inputColumn": "fake-col",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    }
+  ],
+  "keyColumns": [
+    "user_id"
+  ],
+  "metaData": {
+    "columnHashes": {
+      "fake-col_sum_7d": "c79a04aed5de4f6e47c0325320ef12b3",
+      "user_id": "9a6da6b28e68f9bc0b91421707d41660"
+    },
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_some_table_with_offset_0\", \"spec\": \"some-table/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FETCHER_URL": "http://localhost:9000",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FETCHER_URL": "http://localhost:9000",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "historicalBackfill": 0
+    },
+    "name": "gcp.demo.fake_groupby_3__0",
+    "online": 0,
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/gcp/demo.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "sources": [
+    {
+      "events": {
+        "query": {
+          "selects": {
+            "fake-col": "fake-col",
+            "listing_id": "listing_id",
+            "row_id": "event_id",
+            "user_id": "user_id"
+          },
+          "timeColumn": "event_time_ms"
+        },
+        "table": "some-table"
+      }
+    }
+  ]
+}

--- a/python/test/canary/compiled/group_bys/gcp/demo.fake_groupby__0
+++ b/python/test/canary/compiled/group_bys/gcp/demo.fake_groupby__0
@@ -21,11 +21,15 @@
       "user_id": "f9e37dd13f049bc14f9303f34a4314cc"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_exports_user_activities__0_with_offset_0\", \"spec\": \"data.gcp_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -36,8 +40,10 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
           "spark.driver.memory": "512m",
           "spark.executor.cores": "1",
           "spark.executor.memory": "512m",
@@ -66,6 +72,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -85,6 +92,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/group_bys/gcp/dim_listings.v1__0
+++ b/python/test/canary/compiled/group_bys/gcp/dim_listings.v1__0
@@ -22,11 +22,15 @@
       "weight_grams": "041362c5ebf87a340a139e6b53034b7c"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_exports_dim_listings__0_with_offset_0\", \"spec\": \"data.gcp_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -37,6 +41,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -68,6 +73,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -87,6 +93,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/group_bys/gcp/dim_listings_with_mutations.v2__0
+++ b/python/test/canary/compiled/group_bys/gcp/dim_listings_with_mutations.v2__0
@@ -100,11 +100,15 @@
       "weight_grams_last": "5b19e9ed87508482695b4e3606acfa97"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_exports_dim_listings__0_with_offset_0\", \"spec\": \"data.gcp_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_gcp_exports_dim_listing_mutations__0_with_offset_0\", \"spec\": \"data.gcp_exports_dim_listing_mutations__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -115,6 +119,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -146,6 +151,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -165,6 +171,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/group_bys/gcp/dim_merchants.v1__0
+++ b/python/test/canary/compiled/group_bys/gcp/dim_merchants.v1__0
@@ -8,11 +8,15 @@
       "primary_category": "62491a3e7c13a27a3eeb765ba460169f"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_exports_dim_merchants__0_with_offset_0\", \"spec\": \"data.gcp_exports_dim_merchants__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -23,6 +27,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -54,6 +59,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -73,6 +79,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/group_bys/gcp/item_event_canary.actions_pubsub_v2__0
+++ b/python/test/canary/compiled/group_bys/gcp/item_event_canary.actions_pubsub_v2__0
@@ -57,11 +57,15 @@
       "view_sum_1d": "d4bc995b2e1955c153a0d1d78927f07c"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_item_events_parquet_compat_partitioned_with_offset_0\", \"spec\": \"data.item_events_parquet_compat_partitioned/_DATE={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -72,6 +76,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -103,6 +108,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -122,6 +128,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/group_bys/gcp/item_event_canary.actions_v1__0
+++ b/python/test/canary/compiled/group_bys/gcp/item_event_canary.actions_v1__0
@@ -57,11 +57,15 @@
       "view_sum_1d": "cbf9c10a17d7f4669437872708303738"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_item_events_parquet_compat_partitioned_with_offset_0\", \"spec\": \"data.item_events_parquet_compat_partitioned/_DATE={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -72,6 +76,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -103,6 +108,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -122,6 +128,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/group_bys/gcp/logging_schema.v1__2
+++ b/python/test/canary/compiled/group_bys/gcp/logging_schema.v1__2
@@ -16,11 +16,15 @@
       "schema_value_last": "dd8bd8fdc7f11b58dcbbd9fafe0a957d"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_partitioned_logging_v0__2_with_offset_0\", \"spec\": \"data.gcp_partitioned_logging_v0__2/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -31,6 +35,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -62,6 +67,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -81,6 +87,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/group_bys/gcp/purchases.v1_dev__0
+++ b/python/test/canary/compiled/group_bys/gcp/purchases.v1_dev__0
@@ -83,11 +83,15 @@
       "user_id": "990d1cc2263011ec3386075d3a66b1a1"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_purchases_import_v1__0_with_offset_0\", \"spec\": \"data.gcp_purchases_import_v1__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -98,6 +102,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -129,6 +134,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -148,6 +154,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/group_bys/gcp/purchases.v1_dev_notds__0
+++ b/python/test/canary/compiled/group_bys/gcp/purchases.v1_dev_notds__0
@@ -83,11 +83,15 @@
       "user_id": "659acfa58500e1f693d923b698c6e4c9"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_purchases_notds_import_v1__0_with_offset_0\", \"spec\": \"data.gcp_purchases_notds_import_v1__0/notds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -98,6 +102,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -129,6 +134,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -148,6 +154,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/group_bys/gcp/purchases.v1_test__0
+++ b/python/test/canary/compiled/group_bys/gcp/purchases.v1_test__0
@@ -83,11 +83,15 @@
       "user_id": "a406c2de0040b2e926dba6334f299281"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_purchases_import_v1__0_with_offset_0\", \"spec\": \"data.gcp_purchases_import_v1__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -98,6 +102,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -129,6 +134,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -148,6 +154,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/group_bys/gcp/purchases.v1_test_notds__0
+++ b/python/test/canary/compiled/group_bys/gcp/purchases.v1_test_notds__0
@@ -83,11 +83,15 @@
       "user_id": "e2bd778ac7f0e189c7f627b51b0eaa13"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_purchases_notds_import_v1__0_with_offset_0\", \"spec\": \"data.gcp_purchases_notds_import_v1__0/notds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -98,6 +102,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -129,6 +134,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -148,6 +154,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/group_bys/gcp/team_default_ns_gb.v1__0
+++ b/python/test/canary/compiled/group_bys/gcp/team_default_ns_gb.v1__0
@@ -21,11 +21,15 @@
       "user_id": "b5e979370e2291cded7a3af5a33adf58"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_purchases_import_v1__0_with_offset_0\", \"spec\": \"data.gcp_purchases_import_v1__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -36,6 +40,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -67,6 +72,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -86,6 +92,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/group_bys/gcp/user_activities.v1__1
+++ b/python/test/canary/compiled/group_bys/gcp/user_activities.v1__1
@@ -389,11 +389,15 @@
       "view_event_sum_7d": "f597dd2f8e5d672fbac0445fb935469b"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_exports_user_activities__0_with_offset_0\", \"spec\": \"data.gcp_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -404,6 +408,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -435,6 +440,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -454,6 +460,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/group_bys/gcp/user_activities_chained.chained_user_gb__0
+++ b/python/test/canary/compiled/group_bys/gcp/user_activities_chained.chained_user_gb__0
@@ -23,11 +23,15 @@
       "user_id": "e3d702eb6c23558f50233c39f7718309"
     },
     "customJson": "{\"airflowDependencies\": []}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -38,6 +42,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -69,6 +74,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -88,6 +94,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -115,11 +122,15 @@
                   "listing_id"
                 ],
                 "metaData": {
+                  "environments": [
+                    0
+                  ],
                   "executionInfo": {
                     "clusterConf": {
                       "modeClusterConfigs": {
                         "upload": {
-                          "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                          "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                          "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
                         }
                       }
                     },
@@ -130,6 +141,7 @@
                         "spark.chronon.partition.format": "yyyy-MM-dd",
                         "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
                         "spark.chronon.table_write.format": "iceberg",
+                        "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
                         "spark.default.parallelism": "10",
                         "spark.driver.cores": "1",
                         "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -161,6 +173,7 @@
                         "GCP_PROJECT_ID": "canary-443022",
                         "GCP_REGION": "us-central1",
                         "HUB_URL": "http://localhost:3903",
+                        "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                         "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
                         "VERSION": "latest",
                         "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -180,6 +193,7 @@
                           "GCP_PROJECT_ID": "canary-443022",
                           "GCP_REGION": "us-central1",
                           "HUB_URL": "http://localhost:3903",
+                          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                           "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                           "VERSION": "latest",
                           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -243,11 +257,15 @@
             }
           },
           "metaData": {
+            "environments": [
+              0
+            ],
             "executionInfo": {
               "clusterConf": {
                 "modeClusterConfigs": {
                   "upload": {
-                    "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                    "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                    "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
                   }
                 }
               },
@@ -258,6 +276,7 @@
                   "spark.chronon.partition.format": "yyyy-MM-dd",
                   "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
                   "spark.chronon.table_write.format": "iceberg",
+                  "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
                   "spark.default.parallelism": "10",
                   "spark.driver.cores": "1",
                   "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -289,6 +308,7 @@
                   "GCP_PROJECT_ID": "canary-443022",
                   "GCP_REGION": "us-central1",
                   "HUB_URL": "http://localhost:3903",
+                  "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                   "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
                   "VERSION": "latest",
                   "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -308,6 +328,7 @@
                     "GCP_PROJECT_ID": "canary-443022",
                     "GCP_REGION": "us-central1",
                     "HUB_URL": "http://localhost:3903",
+                    "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                     "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                     "VERSION": "latest",
                     "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/group_bys/quickstart/dim_listings.v1__0
+++ b/python/test/canary/compiled/group_bys/quickstart/dim_listings.v1__0
@@ -22,6 +22,9 @@
       "weight_grams": "5c3e9f99cb7ec2d0aa56c9bd0e391308"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_quickstart_quickstart_exports_dim_listings__0_with_offset_0\", \"spec\": \"quickstart.quickstart_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/group_bys/quickstart/dim_merchants.v1__0
+++ b/python/test/canary/compiled/group_bys/quickstart/dim_merchants.v1__0
@@ -8,6 +8,9 @@
       "primary_category": "71dfddda1396b6f421bceff5fcc72ffb"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_quickstart_quickstart_exports_dim_merchants__0_with_offset_0\", \"spec\": \"quickstart.quickstart_exports_dim_merchants__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/group_bys/quickstart/user_activities.v1__1
+++ b/python/test/canary/compiled/group_bys/quickstart/user_activities.v1__1
@@ -389,6 +389,9 @@
       "view_event_sum_7d": "62a8793addff23c7d8079961a8a07320"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_quickstart_quickstart_exports_user_activities__0_with_offset_0\", \"spec\": \"quickstart.quickstart_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/joins/aws/demo.derivations_v1__2
+++ b/python/test/canary/compiled/joins/aws/demo.derivations_v1__2
@@ -46,6 +46,9 @@
             "tags": "b02298b5dc181fd94c357eef9f0623ca",
             "weight_grams": "8b5ac3514f1c8f0db67748e07de128f4"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "clusterConf": {
               "common": {
@@ -568,6 +571,9 @@
             "view_event_sum_30d": "c96e2586b4fbcb1b88553f770a5868e8",
             "view_event_sum_7d": "c96e2586b4fbcb1b88553f770a5868e8"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "clusterConf": {
               "common": {
@@ -794,6 +800,9 @@
       "user_id_view_event_sum_7d": "90eb1026d49d637d24bd34ba85f84781"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_exports_user_activities__0_with_offset_0\", \"spec\": \"data.aws_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_aws_exports_dim_listings__0_with_offset_0\", \"spec\": \"data.aws_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_demo_user_activities_raw_with_offset_0\", \"spec\": \"demo.user_activities_raw/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/joins/aws/demo.v1__1
+++ b/python/test/canary/compiled/joins/aws/demo.v1__1
@@ -391,6 +391,9 @@
             "view_event_sum_30d": "c96e2586b4fbcb1b88553f770a5868e8",
             "view_event_sum_7d": "c96e2586b4fbcb1b88553f770a5868e8"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "clusterConf": {
               "common": {
@@ -542,6 +545,9 @@
             "tags": "b02298b5dc181fd94c357eef9f0623ca",
             "weight_grams": "8b5ac3514f1c8f0db67748e07de128f4"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "clusterConf": {
               "common": {
@@ -683,6 +689,9 @@
             "listing_id": "d06b93d848d96f30e2870c8317667b51",
             "primary_category": "7b4dbbd91897982b4f6672bb24202751"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "clusterConf": {
               "common": {
@@ -898,6 +907,9 @@
       "user_id_view_event_sum_7d": "90eb1026d49d637d24bd34ba85f84781"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_exports_user_activities__0_with_offset_0\", \"spec\": \"data.aws_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_demo_user_activities_raw_with_offset_0\", \"spec\": \"demo.user_activities_raw/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_aws_exports_dim_listings__0_with_offset_0\", \"spec\": \"data.aws_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_aws_exports_dim_merchants__0_with_offset_0\", \"spec\": \"data.aws_exports_dim_merchants__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/joins/aws/demo_chaining.downstream_join__0
+++ b/python/test/canary/compiled/joins/aws/demo_chaining.downstream_join__0
@@ -25,6 +25,9 @@
             "price_cents_last100_7d": "5377edbf5107cc02a5f74238b3c3696e",
             "user_id": "96df20bb89ae17fa8229552a8afe4f3f"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "clusterConf": {
               "common": {
@@ -135,6 +138,9 @@
                         "listing_id"
                       ],
                       "metaData": {
+                        "environments": [
+                          0
+                        ],
                         "executionInfo": {
                           "clusterConf": {
                             "common": {
@@ -283,6 +289,9 @@
                   }
                 },
                 "metaData": {
+                  "environments": [
+                    0
+                  ],
                   "executionInfo": {
                     "clusterConf": {
                       "common": {
@@ -428,6 +437,9 @@
       "user_id_price_cents_last100_7d": "3fc813a69e5409dcb620a9173e4d1141"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_exports_user_activities__0_with_offset_0\", \"spec\": \"data.aws_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/joins/aws/demo_parent.parent_join__0
+++ b/python/test/canary/compiled/joins/aws/demo_parent.parent_join__0
@@ -24,6 +24,9 @@
             "tags": "b02298b5dc181fd94c357eef9f0623ca",
             "weight_grams": "8b5ac3514f1c8f0db67748e07de128f4"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "clusterConf": {
               "common": {
@@ -195,6 +198,9 @@
       "user_id": "dd9efd48a53433b894292d805f052703"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_exports_user_activities__0_with_offset_0\", \"spec\": \"data.aws_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_aws_exports_dim_listings__0_with_offset_0\", \"spec\": \"data.aws_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/joins/aws/item_event_join.canary_batch_v1__0
+++ b/python/test/canary/compiled/joins/aws/item_event_join.canary_batch_v1__0
@@ -85,6 +85,9 @@
             "purchase_price_sum_7d": "5814df4e6a1e2eb06b9fab89e70ea97d",
             "user_id": "dec6601a613992b4b6cdc50ac8014a29"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "clusterConf": {
               "common": {
@@ -233,6 +236,9 @@
       "user_id_purchase_price_sum_7d": "5609e04d61a47a8cafc67970785a3a59"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_item_events_parquet_compat_with_offset_0\", \"spec\": \"data.item_events_parquet_compat/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/joins/aws/item_event_join.canary_combined_v1__0
+++ b/python/test/canary/compiled/joins/aws/item_event_join.canary_combined_v1__0
@@ -59,6 +59,9 @@
             "purchase_sum_1d": "fb8cfc84fca71682f8d758092259323f",
             "view_sum_1d": "cc58ae369bab825653562d7cd27aa09c"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "clusterConf": {
               "common": {
@@ -267,6 +270,9 @@
             "purchase_price_sum_7d": "5814df4e6a1e2eb06b9fab89e70ea97d",
             "user_id": "dec6601a613992b4b6cdc50ac8014a29"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "clusterConf": {
               "common": {
@@ -419,6 +425,9 @@
       "user_id_purchase_price_sum_7d": "5609e04d61a47a8cafc67970785a3a59"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_item_events_parquet_compat_with_offset_0\", \"spec\": \"data.item_events_parquet_compat/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_item_events_parquet_compat_partitioned_with_offset_0\", \"spec\": \"data.item_events_parquet_compat_partitioned/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/joins/aws/item_event_join.canary_streaming_v1__0
+++ b/python/test/canary/compiled/joins/aws/item_event_join.canary_streaming_v1__0
@@ -59,6 +59,9 @@
             "purchase_sum_1d": "fb8cfc84fca71682f8d758092259323f",
             "view_sum_1d": "cc58ae369bab825653562d7cd27aa09c"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "clusterConf": {
               "common": {
@@ -207,6 +210,9 @@
       "user_id": "493d3df28f80664abd11b19fcd33b6e6"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_item_events_parquet_compat_with_offset_0\", \"spec\": \"data.item_events_parquet_compat/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_item_events_parquet_compat_partitioned_with_offset_0\", \"spec\": \"data.item_events_parquet_compat_partitioned/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/joins/aws/training_set.v1_dev__0
+++ b/python/test/canary/compiled/joins/aws/training_set.v1_dev__0
@@ -85,6 +85,9 @@
             "purchase_price_sum_7d": "bd4c481c4e592608ace5a2930f61d45a",
             "user_id": "677635fb8fabe631108435c5cffe73ce"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "clusterConf": {
               "common": {
@@ -231,6 +234,9 @@
       "user_id_purchase_price_sum_7d": "e3351cc3265d17cfd1b99f8da7fb083d"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_checkouts_with_offset_0\", \"spec\": \"data.checkouts/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/joins/aws/training_set.v1_hub__0
+++ b/python/test/canary/compiled/joins/aws/training_set.v1_hub__0
@@ -85,6 +85,9 @@
             "purchase_price_sum_7d": "5814df4e6a1e2eb06b9fab89e70ea97d",
             "user_id": "dec6601a613992b4b6cdc50ac8014a29"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "clusterConf": {
               "common": {
@@ -231,6 +234,9 @@
       "user_id_purchase_price_sum_7d": "e3351cc3265d17cfd1b99f8da7fb083d"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_checkouts_with_offset_0\", \"spec\": \"data.checkouts/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/joins/aws/training_set.v1_test__0
+++ b/python/test/canary/compiled/joins/aws/training_set.v1_test__0
@@ -85,6 +85,9 @@
             "purchase_price_sum_7d": "5814df4e6a1e2eb06b9fab89e70ea97d",
             "user_id": "dec6601a613992b4b6cdc50ac8014a29"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "clusterConf": {
               "common": {
@@ -231,6 +234,9 @@
       "user_id_purchase_price_sum_7d": "e3351cc3265d17cfd1b99f8da7fb083d"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_checkouts_with_offset_0\", \"spec\": \"data.checkouts/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/joins/azure/crucible_stress.training_set__0
+++ b/python/test/canary/compiled/joins/azure/crucible_stress.training_set__0
@@ -85,6 +85,9 @@
             "purchase_price_sum_7d": "8c780fb5b00f55c0545cc6e48ef21c92",
             "user_id": "43dbce4df14238a2622226be130fb913"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "conf": {
               "common": {
@@ -204,6 +207,9 @@
       "user_id_purchase_price_sum_7d": "fcc7e330b079c5fd6f94b29cd8e9fb5e"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_claims_demo_azure_crucible_stress_sources_checkouts__0_with_offset_0\", \"spec\": \"claims_demo.azure_crucible_stress_sources_checkouts__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_claims_demo_azure_crucible_stress_sources_purchases__0_with_offset_0\", \"spec\": \"claims_demo.azure_crucible_stress_sources_purchases__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/joins/azure/demo.derivations_v3
+++ b/python/test/canary/compiled/joins/azure/demo.derivations_v3
@@ -46,6 +46,9 @@
             "tags": "f9ead5f03020ff66ff14e98fec19a774",
             "weight_grams": "ac84b5b0b11dca76306214d5d2f12fa9"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "conf": {
               "common": {
@@ -175,6 +178,9 @@
       "user_id": "32bdee94577162313d260c96add2652d"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_azure_exports_user_activities__0_with_offset_0\", \"spec\": \"data.azure_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_azure_exports_dim_listings__0_with_offset_0\", \"spec\": \"data.azure_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/joins/azure/demo.pc_v2
+++ b/python/test/canary/compiled/joins/azure/demo.pc_v2
@@ -24,6 +24,9 @@
             "tags": "318519d7ab1453a331685dc7f165bb85",
             "weight_grams": "f8f34e81434169852c03e62a335c20aa"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "conf": {
               "common": {
@@ -172,6 +175,9 @@
       "weight_grams": "3563150a7e46318bf3395d3d08e7b27d"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_azure_exports_dim_listings_pc__1_with_offset_0\", \"spec\": \"data.azure_exports_dim_listings_pc__1/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/joins/azure/demo.v2
+++ b/python/test/canary/compiled/joins/azure/demo.v2
@@ -24,6 +24,9 @@
             "tags": "f9ead5f03020ff66ff14e98fec19a774",
             "weight_grams": "ac84b5b0b11dca76306214d5d2f12fa9"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "conf": {
               "common": {
@@ -120,6 +123,9 @@
             "listing_id": "ef0459db5af8e98e7b54b6dbec987680",
             "primary_category": "41f7c36859f55e0908a0e2ee1cea4fb3"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "conf": {
               "common": {
@@ -234,6 +240,9 @@
       "user_id": "32bdee94577162313d260c96add2652d"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_azure_exports_user_activities__0_with_offset_0\", \"spec\": \"data.azure_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_azure_exports_dim_listings__0_with_offset_0\", \"spec\": \"data.azure_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_azure_exports_dim_merchants__0_with_offset_0\", \"spec\": \"data.azure_exports_dim_merchants__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/joins/azure/demo_chaining.downstream_join__0
+++ b/python/test/canary/compiled/joins/azure/demo_chaining.downstream_join__0
@@ -25,6 +25,9 @@
             "price_cents_last100_7d": "8d7a1fba31093361b1675f65e53748d7",
             "user_id": "4ecdf09ef20508785edf01ab40f381ed"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "conf": {
               "common": {
@@ -92,6 +95,9 @@
                         "listing_id"
                       ],
                       "metaData": {
+                        "environments": [
+                          0
+                        ],
                         "executionInfo": {
                           "conf": {
                             "common": {
@@ -195,6 +201,9 @@
                   }
                 },
                 "metaData": {
+                  "environments": [
+                    0
+                  ],
                   "executionInfo": {
                     "conf": {
                       "common": {
@@ -297,6 +306,9 @@
       "user_id_price_cents_last100_7d": "bddd7571d888b859ebeae7da9e49f6af"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_azure_exports_user_activities__0_with_offset_0\", \"spec\": \"data.azure_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/joins/azure/demo_parent.parent_join__0
+++ b/python/test/canary/compiled/joins/azure/demo_parent.parent_join__0
@@ -24,6 +24,9 @@
             "tags": "f9ead5f03020ff66ff14e98fec19a774",
             "weight_grams": "ac84b5b0b11dca76306214d5d2f12fa9"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "conf": {
               "common": {
@@ -150,6 +153,9 @@
       "user_id": "275e18a643e12228f787cd9a9b03eaed"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_azure_exports_user_activities__0_with_offset_0\", \"spec\": \"data.azure_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_azure_exports_dim_listings__0_with_offset_0\", \"spec\": \"data.azure_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/joins/azure/item_event_join.canary_batch_v1__0
+++ b/python/test/canary/compiled/joins/azure/item_event_join.canary_batch_v1__0
@@ -85,6 +85,9 @@
             "purchase_price_sum_7d": "cb0c629ccfbaf136f5a337da31f8ba98",
             "user_id": "2a2caca3ea4afb84a2271533b1a1bae1"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "conf": {
               "common": {
@@ -190,6 +193,9 @@
       "user_id_purchase_price_sum_7d": "5609e04d61a47a8cafc67970785a3a59"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_item_events_parquet_compat_with_offset_0\", \"spec\": \"data.item_events_parquet_compat/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/joins/azure/item_event_join.canary_combined_v1__0
+++ b/python/test/canary/compiled/joins/azure/item_event_join.canary_combined_v1__0
@@ -59,6 +59,9 @@
             "purchase_sum_1d": "ae525baa20eea731a1270dd356ec611a",
             "view_sum_1d": "10afd70aaef55fd280157c808724d63a"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "conf": {
               "common": {
@@ -224,6 +227,9 @@
             "purchase_price_sum_7d": "cb0c629ccfbaf136f5a337da31f8ba98",
             "user_id": "2a2caca3ea4afb84a2271533b1a1bae1"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "conf": {
               "common": {
@@ -333,6 +339,9 @@
       "user_id_purchase_price_sum_7d": "5609e04d61a47a8cafc67970785a3a59"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_item_events_parquet_compat_with_offset_0\", \"spec\": \"data.item_events_parquet_compat/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_item_events_parquet_compat_partitioned_with_offset_0\", \"spec\": \"data.item_events_parquet_compat_partitioned/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/joins/azure/item_event_join.canary_streaming_v1__0
+++ b/python/test/canary/compiled/joins/azure/item_event_join.canary_streaming_v1__0
@@ -59,6 +59,9 @@
             "purchase_sum_1d": "ae525baa20eea731a1270dd356ec611a",
             "view_sum_1d": "10afd70aaef55fd280157c808724d63a"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "conf": {
               "common": {
@@ -164,6 +167,9 @@
       "user_id": "493d3df28f80664abd11b19fcd33b6e6"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_item_events_parquet_compat_with_offset_0\", \"spec\": \"data.item_events_parquet_compat/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_item_events_parquet_compat_partitioned_with_offset_0\", \"spec\": \"data.item_events_parquet_compat_partitioned/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/joins/azure/training_set.v1_dev__0
+++ b/python/test/canary/compiled/joins/azure/training_set.v1_dev__0
@@ -85,6 +85,9 @@
             "purchase_price_sum_7d": "3ee572f0e355659fc086d52ec43333f6",
             "user_id": "e0009a36a0838b4549d689008bac5afd"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "conf": {
               "common": {
@@ -188,6 +191,9 @@
       "user_id_purchase_price_sum_7d": "e3351cc3265d17cfd1b99f8da7fb083d"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_checkouts_with_offset_0\", \"spec\": \"data.checkouts/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/joins/azure/training_set.v1_dev_notds__0
+++ b/python/test/canary/compiled/joins/azure/training_set.v1_dev_notds__0
@@ -85,6 +85,9 @@
             "purchase_price_sum_7d": "7a943d6f94aa1c892adff82c36cc0d8a",
             "user_id": "5039d7bfb147f14cea3f30f7379e9d6f"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "conf": {
               "common": {
@@ -190,6 +193,9 @@
       "user_id_purchase_price_sum_7d": "1d85a493771d48ac9fb6581c18f186e2"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_checkouts_notds_with_offset_0\", \"spec\": \"data.checkouts_notds/notds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_purchases_notds_with_offset_0\", \"spec\": \"data.purchases_notds/notds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/joins/azure/training_set.v1_hub__0
+++ b/python/test/canary/compiled/joins/azure/training_set.v1_hub__0
@@ -85,6 +85,9 @@
             "purchase_price_sum_7d": "cb0c629ccfbaf136f5a337da31f8ba98",
             "user_id": "2a2caca3ea4afb84a2271533b1a1bae1"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "conf": {
               "common": {
@@ -188,6 +191,9 @@
       "user_id_purchase_price_sum_7d": "e3351cc3265d17cfd1b99f8da7fb083d"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_checkouts_with_offset_0\", \"spec\": \"data.checkouts/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/joins/azure/training_set.v1_test__0
+++ b/python/test/canary/compiled/joins/azure/training_set.v1_test__0
@@ -85,6 +85,9 @@
             "purchase_price_sum_7d": "cb0c629ccfbaf136f5a337da31f8ba98",
             "user_id": "2a2caca3ea4afb84a2271533b1a1bae1"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "conf": {
               "common": {
@@ -188,6 +191,9 @@
       "user_id_purchase_price_sum_7d": "e3351cc3265d17cfd1b99f8da7fb083d"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_checkouts_with_offset_0\", \"spec\": \"data.checkouts/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/joins/azure/training_set.v1_test_notds__0
+++ b/python/test/canary/compiled/joins/azure/training_set.v1_test_notds__0
@@ -85,6 +85,9 @@
             "purchase_price_sum_7d": "3b0e94ffc1c3612c36f18fc42bd080e9",
             "user_id": "81dd6ad753af4f7bb8411902a7e9b861"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "conf": {
               "common": {
@@ -190,6 +193,9 @@
       "user_id_purchase_price_sum_7d": "1d85a493771d48ac9fb6581c18f186e2"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_checkouts_notds_with_offset_0\", \"spec\": \"data.checkouts_notds/notds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_purchases_notds_with_offset_0\", \"spec\": \"data.purchases_notds/notds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/joins/gcp/demo.derivations_v1__2
+++ b/python/test/canary/compiled/joins/gcp/demo.derivations_v1__2
@@ -46,11 +46,15 @@
             "tags": "589de0914f9ffabf8c80a0fe10eaa866",
             "weight_grams": "041362c5ebf87a340a139e6b53034b7c"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "clusterConf": {
               "modeClusterConfigs": {
                 "upload": {
-                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                  "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
                 }
               }
             },
@@ -61,6 +65,7 @@
                 "spark.chronon.partition.format": "yyyy-MM-dd",
                 "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
                 "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
                 "spark.default.parallelism": "10",
                 "spark.driver.cores": "1",
                 "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -92,6 +97,7 @@
                 "GCP_PROJECT_ID": "canary-443022",
                 "GCP_REGION": "us-central1",
                 "HUB_URL": "http://localhost:3903",
+                "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                 "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
                 "VERSION": "latest",
                 "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -111,6 +117,7 @@
                   "GCP_PROJECT_ID": "canary-443022",
                   "GCP_REGION": "us-central1",
                   "HUB_URL": "http://localhost:3903",
+                  "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                   "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                   "VERSION": "latest",
                   "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -548,11 +555,15 @@
             "view_event_sum_30d": "f597dd2f8e5d672fbac0445fb935469b",
             "view_event_sum_7d": "f597dd2f8e5d672fbac0445fb935469b"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "clusterConf": {
               "modeClusterConfigs": {
                 "upload": {
-                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                  "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
                 }
               }
             },
@@ -563,6 +574,7 @@
                 "spark.chronon.partition.format": "yyyy-MM-dd",
                 "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
                 "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
                 "spark.default.parallelism": "10",
                 "spark.driver.cores": "1",
                 "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -594,6 +606,7 @@
                 "GCP_PROJECT_ID": "canary-443022",
                 "GCP_REGION": "us-central1",
                 "HUB_URL": "http://localhost:3903",
+                "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                 "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
                 "VERSION": "latest",
                 "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -613,6 +626,7 @@
                   "GCP_PROJECT_ID": "canary-443022",
                   "GCP_REGION": "us-central1",
                   "HUB_URL": "http://localhost:3903",
+                  "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                   "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                   "VERSION": "latest",
                   "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -755,11 +769,15 @@
       "user_id_view_event_sum_7d": "bcc46a7a6a6ee73aa8bebbcaaf039347"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_exports_user_activities__0_with_offset_0\", \"spec\": \"data.gcp_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_gcp_exports_dim_listings__0_with_offset_0\", \"spec\": \"data.gcp_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -770,6 +788,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -801,6 +820,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -820,6 +840,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/joins/gcp/demo.mutation_test__1
+++ b/python/test/canary/compiled/joins/gcp/demo.mutation_test__1
@@ -102,11 +102,15 @@
             "tags_last": "127ced2578a540a522f3f437101d7726",
             "weight_grams_last": "5b19e9ed87508482695b4e3606acfa97"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "clusterConf": {
               "modeClusterConfigs": {
                 "upload": {
-                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                  "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
                 }
               }
             },
@@ -117,6 +121,7 @@
                 "spark.chronon.partition.format": "yyyy-MM-dd",
                 "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
                 "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
                 "spark.default.parallelism": "10",
                 "spark.driver.cores": "1",
                 "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -148,6 +153,7 @@
                 "GCP_PROJECT_ID": "canary-443022",
                 "GCP_REGION": "us-central1",
                 "HUB_URL": "http://localhost:3903",
+                "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                 "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
                 "VERSION": "latest",
                 "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -167,6 +173,7 @@
                   "GCP_PROJECT_ID": "canary-443022",
                   "GCP_REGION": "us-central1",
                   "HUB_URL": "http://localhost:3903",
+                  "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                   "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                   "VERSION": "latest",
                   "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -252,11 +259,15 @@
       "user_id": "80c458b68b34de93d3c4c555ef2b2ddc"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_exports_user_activities__0_with_offset_0\", \"spec\": \"data.gcp_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_gcp_exports_dim_listings__0_with_offset_0\", \"spec\": \"data.gcp_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_gcp_exports_dim_listing_mutations__0_with_offset_0\", \"spec\": \"data.gcp_exports_dim_listing_mutations__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -267,6 +278,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -299,6 +311,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -318,6 +331,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/joins/gcp/demo.mutation_test_modular__2
+++ b/python/test/canary/compiled/joins/gcp/demo.mutation_test_modular__2
@@ -102,11 +102,15 @@
             "tags_last": "127ced2578a540a522f3f437101d7726",
             "weight_grams_last": "5b19e9ed87508482695b4e3606acfa97"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "clusterConf": {
               "modeClusterConfigs": {
                 "upload": {
-                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                  "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
                 }
               }
             },
@@ -117,6 +121,7 @@
                 "spark.chronon.partition.format": "yyyy-MM-dd",
                 "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
                 "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
                 "spark.default.parallelism": "10",
                 "spark.driver.cores": "1",
                 "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -148,6 +153,7 @@
                 "GCP_PROJECT_ID": "canary-443022",
                 "GCP_REGION": "us-central1",
                 "HUB_URL": "http://localhost:3903",
+                "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                 "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
                 "VERSION": "latest",
                 "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -167,6 +173,7 @@
                   "GCP_PROJECT_ID": "canary-443022",
                   "GCP_REGION": "us-central1",
                   "HUB_URL": "http://localhost:3903",
+                  "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                   "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                   "VERSION": "latest",
                   "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -605,11 +612,15 @@
             "view_event_sum_30d": "f597dd2f8e5d672fbac0445fb935469b",
             "view_event_sum_7d": "f597dd2f8e5d672fbac0445fb935469b"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "clusterConf": {
               "modeClusterConfigs": {
                 "upload": {
-                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                  "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
                 }
               }
             },
@@ -620,6 +631,7 @@
                 "spark.chronon.partition.format": "yyyy-MM-dd",
                 "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
                 "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
                 "spark.default.parallelism": "10",
                 "spark.driver.cores": "1",
                 "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -651,6 +663,7 @@
                 "GCP_PROJECT_ID": "canary-443022",
                 "GCP_REGION": "us-central1",
                 "HUB_URL": "http://localhost:3903",
+                "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                 "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
                 "VERSION": "latest",
                 "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -670,6 +683,7 @@
                   "GCP_PROJECT_ID": "canary-443022",
                   "GCP_REGION": "us-central1",
                   "HUB_URL": "http://localhost:3903",
+                  "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                   "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                   "VERSION": "latest",
                   "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -807,11 +821,15 @@
       "user_id_view_event_sum_7d": "bcc46a7a6a6ee73aa8bebbcaaf039347"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_exports_user_activities__0_with_offset_0\", \"spec\": \"data.gcp_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_gcp_exports_dim_listings__0_with_offset_0\", \"spec\": \"data.gcp_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_gcp_exports_dim_listing_mutations__0_with_offset_0\", \"spec\": \"data.gcp_exports_dim_listing_mutations__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -823,6 +841,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -855,6 +874,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -874,6 +894,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/joins/gcp/demo.v1__1
+++ b/python/test/canary/compiled/joins/gcp/demo.v1__1
@@ -391,11 +391,15 @@
             "view_event_sum_30d": "f597dd2f8e5d672fbac0445fb935469b",
             "view_event_sum_7d": "f597dd2f8e5d672fbac0445fb935469b"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "clusterConf": {
               "modeClusterConfigs": {
                 "upload": {
-                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                  "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
                 }
               }
             },
@@ -406,6 +410,7 @@
                 "spark.chronon.partition.format": "yyyy-MM-dd",
                 "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
                 "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
                 "spark.default.parallelism": "10",
                 "spark.driver.cores": "1",
                 "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -437,6 +442,7 @@
                 "GCP_PROJECT_ID": "canary-443022",
                 "GCP_REGION": "us-central1",
                 "HUB_URL": "http://localhost:3903",
+                "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                 "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
                 "VERSION": "latest",
                 "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -456,6 +462,7 @@
                   "GCP_PROJECT_ID": "canary-443022",
                   "GCP_REGION": "us-central1",
                   "HUB_URL": "http://localhost:3903",
+                  "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                   "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                   "VERSION": "latest",
                   "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -523,11 +530,15 @@
             "tags": "589de0914f9ffabf8c80a0fe10eaa866",
             "weight_grams": "041362c5ebf87a340a139e6b53034b7c"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "clusterConf": {
               "modeClusterConfigs": {
                 "upload": {
-                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                  "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
                 }
               }
             },
@@ -538,6 +549,7 @@
                 "spark.chronon.partition.format": "yyyy-MM-dd",
                 "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
                 "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
                 "spark.default.parallelism": "10",
                 "spark.driver.cores": "1",
                 "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -569,6 +581,7 @@
                 "GCP_PROJECT_ID": "canary-443022",
                 "GCP_REGION": "us-central1",
                 "HUB_URL": "http://localhost:3903",
+                "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                 "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
                 "VERSION": "latest",
                 "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -588,6 +601,7 @@
                   "GCP_PROJECT_ID": "canary-443022",
                   "GCP_REGION": "us-central1",
                   "HUB_URL": "http://localhost:3903",
+                  "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                   "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                   "VERSION": "latest",
                   "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -644,11 +658,15 @@
             "listing_id": "56b684bc2ca64fd442ccd845604e5e70",
             "primary_category": "62491a3e7c13a27a3eeb765ba460169f"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "clusterConf": {
               "modeClusterConfigs": {
                 "upload": {
-                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                  "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
                 }
               }
             },
@@ -659,6 +677,7 @@
                 "spark.chronon.partition.format": "yyyy-MM-dd",
                 "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
                 "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
                 "spark.default.parallelism": "10",
                 "spark.driver.cores": "1",
                 "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -690,6 +709,7 @@
                 "GCP_PROJECT_ID": "canary-443022",
                 "GCP_REGION": "us-central1",
                 "HUB_URL": "http://localhost:3903",
+                "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                 "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
                 "VERSION": "latest",
                 "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -709,6 +729,7 @@
                   "GCP_PROJECT_ID": "canary-443022",
                   "GCP_REGION": "us-central1",
                   "HUB_URL": "http://localhost:3903",
+                  "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                   "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                   "VERSION": "latest",
                   "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -839,11 +860,15 @@
       "user_id_view_event_sum_7d": "bcc46a7a6a6ee73aa8bebbcaaf039347"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_exports_user_activities__0_with_offset_0\", \"spec\": \"data.gcp_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_gcp_exports_dim_listings__0_with_offset_0\", \"spec\": \"data.gcp_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_gcp_exports_dim_merchants__0_with_offset_0\", \"spec\": \"data.gcp_exports_dim_merchants__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -854,6 +879,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -886,6 +912,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -905,6 +932,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/joins/gcp/demo_chaining.downstream_join__0
+++ b/python/test/canary/compiled/joins/gcp/demo_chaining.downstream_join__0
@@ -25,11 +25,15 @@
             "price_cents_last100_7d": "c4c5a4063613d69fbe6ac20408f7cc07",
             "user_id": "e3d702eb6c23558f50233c39f7718309"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "clusterConf": {
               "modeClusterConfigs": {
                 "upload": {
-                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                  "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
                 }
               }
             },
@@ -40,6 +44,7 @@
                 "spark.chronon.partition.format": "yyyy-MM-dd",
                 "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
                 "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
                 "spark.default.parallelism": "10",
                 "spark.driver.cores": "1",
                 "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -71,6 +76,7 @@
                 "GCP_PROJECT_ID": "canary-443022",
                 "GCP_REGION": "us-central1",
                 "HUB_URL": "http://localhost:3903",
+                "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                 "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
                 "VERSION": "latest",
                 "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -90,6 +96,7 @@
                   "GCP_PROJECT_ID": "canary-443022",
                   "GCP_REGION": "us-central1",
                   "HUB_URL": "http://localhost:3903",
+                  "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                   "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                   "VERSION": "latest",
                   "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -116,11 +123,15 @@
                         "listing_id"
                       ],
                       "metaData": {
+                        "environments": [
+                          0
+                        ],
                         "executionInfo": {
                           "clusterConf": {
                             "modeClusterConfigs": {
                               "upload": {
-                                "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                                "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                                "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
                               }
                             }
                           },
@@ -131,6 +142,7 @@
                               "spark.chronon.partition.format": "yyyy-MM-dd",
                               "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
                               "spark.chronon.table_write.format": "iceberg",
+                              "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
                               "spark.default.parallelism": "10",
                               "spark.driver.cores": "1",
                               "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -162,6 +174,7 @@
                               "GCP_PROJECT_ID": "canary-443022",
                               "GCP_REGION": "us-central1",
                               "HUB_URL": "http://localhost:3903",
+                              "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                               "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
                               "VERSION": "latest",
                               "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -181,6 +194,7 @@
                                 "GCP_PROJECT_ID": "canary-443022",
                                 "GCP_REGION": "us-central1",
                                 "HUB_URL": "http://localhost:3903",
+                                "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                                 "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                                 "VERSION": "latest",
                                 "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -244,11 +258,15 @@
                   }
                 },
                 "metaData": {
+                  "environments": [
+                    0
+                  ],
                   "executionInfo": {
                     "clusterConf": {
                       "modeClusterConfigs": {
                         "upload": {
-                          "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                          "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                          "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
                         }
                       }
                     },
@@ -259,6 +277,7 @@
                         "spark.chronon.partition.format": "yyyy-MM-dd",
                         "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
                         "spark.chronon.table_write.format": "iceberg",
+                        "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
                         "spark.default.parallelism": "10",
                         "spark.driver.cores": "1",
                         "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -290,6 +309,7 @@
                         "GCP_PROJECT_ID": "canary-443022",
                         "GCP_REGION": "us-central1",
                         "HUB_URL": "http://localhost:3903",
+                        "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                         "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
                         "VERSION": "latest",
                         "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -309,6 +329,7 @@
                           "GCP_PROJECT_ID": "canary-443022",
                           "GCP_REGION": "us-central1",
                           "HUB_URL": "http://localhost:3903",
+                          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                           "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                           "VERSION": "latest",
                           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -370,11 +391,15 @@
       "user_id_price_cents_last100_7d": "ac24fb3bf350137048765b535ac12587"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_exports_user_activities__0_with_offset_0\", \"spec\": \"data.gcp_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -385,6 +410,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -416,6 +442,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -435,6 +462,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/joins/gcp/demo_parent.parent_join__0
+++ b/python/test/canary/compiled/joins/gcp/demo_parent.parent_join__0
@@ -24,11 +24,15 @@
             "tags": "589de0914f9ffabf8c80a0fe10eaa866",
             "weight_grams": "041362c5ebf87a340a139e6b53034b7c"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "clusterConf": {
               "modeClusterConfigs": {
                 "upload": {
-                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                  "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
                 }
               }
             },
@@ -39,6 +43,7 @@
                 "spark.chronon.partition.format": "yyyy-MM-dd",
                 "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
                 "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
                 "spark.default.parallelism": "10",
                 "spark.driver.cores": "1",
                 "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -70,6 +75,7 @@
                 "GCP_PROJECT_ID": "canary-443022",
                 "GCP_REGION": "us-central1",
                 "HUB_URL": "http://localhost:3903",
+                "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                 "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
                 "VERSION": "latest",
                 "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -89,6 +95,7 @@
                   "GCP_PROJECT_ID": "canary-443022",
                   "GCP_REGION": "us-central1",
                   "HUB_URL": "http://localhost:3903",
+                  "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                   "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                   "VERSION": "latest",
                   "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -175,11 +182,15 @@
       "user_id": "ee0c3f74c13689caeeb88cd8971d3df2"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_exports_user_activities__0_with_offset_0\", \"spec\": \"data.gcp_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_gcp_exports_dim_listings__0_with_offset_0\", \"spec\": \"data.gcp_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -190,6 +201,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -221,6 +233,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -240,6 +253,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/joins/gcp/item_event_join.canary_batch_v1__0
+++ b/python/test/canary/compiled/joins/gcp/item_event_join.canary_batch_v1__0
@@ -85,11 +85,15 @@
             "purchase_price_sum_7d": "631fab32648531978032f3b417da5d52",
             "user_id": "a406c2de0040b2e926dba6334f299281"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "clusterConf": {
               "modeClusterConfigs": {
                 "upload": {
-                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                  "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
                 }
               }
             },
@@ -100,6 +104,7 @@
                 "spark.chronon.partition.format": "yyyy-MM-dd",
                 "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
                 "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
                 "spark.default.parallelism": "10",
                 "spark.driver.cores": "1",
                 "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -131,6 +136,7 @@
                 "GCP_PROJECT_ID": "canary-443022",
                 "GCP_REGION": "us-central1",
                 "HUB_URL": "http://localhost:3903",
+                "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                 "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
                 "VERSION": "latest",
                 "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -150,6 +156,7 @@
                   "GCP_PROJECT_ID": "canary-443022",
                   "GCP_REGION": "us-central1",
                   "HUB_URL": "http://localhost:3903",
+                  "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                   "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                   "VERSION": "latest",
                   "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -214,11 +221,15 @@
       "user_id_purchase_price_sum_7d": "0167b3659bffb8660e1ea86c541ee6f1"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_item_events_parquet_compat_with_offset_0\", \"spec\": \"data.item_events_parquet_compat/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_gcp_purchases_import_v1__0_with_offset_0\", \"spec\": \"data.gcp_purchases_import_v1__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -229,6 +240,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -260,6 +272,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -279,6 +292,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/joins/gcp/item_event_join.canary_combined_v1__0
+++ b/python/test/canary/compiled/joins/gcp/item_event_join.canary_combined_v1__0
@@ -59,11 +59,15 @@
             "purchase_sum_1d": "8461cac7c35b38bae99562beb4060578",
             "view_sum_1d": "d4bc995b2e1955c153a0d1d78927f07c"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "clusterConf": {
               "modeClusterConfigs": {
                 "upload": {
-                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                  "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
                 }
               }
             },
@@ -74,6 +78,7 @@
                 "spark.chronon.partition.format": "yyyy-MM-dd",
                 "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
                 "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
                 "spark.default.parallelism": "10",
                 "spark.driver.cores": "1",
                 "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -105,6 +110,7 @@
                 "GCP_PROJECT_ID": "canary-443022",
                 "GCP_REGION": "us-central1",
                 "HUB_URL": "http://localhost:3903",
+                "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                 "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
                 "VERSION": "latest",
                 "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -124,6 +130,7 @@
                   "GCP_PROJECT_ID": "canary-443022",
                   "GCP_REGION": "us-central1",
                   "HUB_URL": "http://localhost:3903",
+                  "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                   "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                   "VERSION": "latest",
                   "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -248,11 +255,15 @@
             "purchase_price_sum_7d": "631fab32648531978032f3b417da5d52",
             "user_id": "a406c2de0040b2e926dba6334f299281"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "clusterConf": {
               "modeClusterConfigs": {
                 "upload": {
-                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                  "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
                 }
               }
             },
@@ -263,6 +274,7 @@
                 "spark.chronon.partition.format": "yyyy-MM-dd",
                 "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
                 "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
                 "spark.default.parallelism": "10",
                 "spark.driver.cores": "1",
                 "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -294,6 +306,7 @@
                 "GCP_PROJECT_ID": "canary-443022",
                 "GCP_REGION": "us-central1",
                 "HUB_URL": "http://localhost:3903",
+                "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                 "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
                 "VERSION": "latest",
                 "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -313,6 +326,7 @@
                   "GCP_PROJECT_ID": "canary-443022",
                   "GCP_REGION": "us-central1",
                   "HUB_URL": "http://localhost:3903",
+                  "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                   "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                   "VERSION": "latest",
                   "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -381,11 +395,15 @@
       "user_id_purchase_price_sum_7d": "0167b3659bffb8660e1ea86c541ee6f1"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_item_events_parquet_compat_with_offset_0\", \"spec\": \"data.item_events_parquet_compat/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_item_events_parquet_compat_partitioned_with_offset_0\", \"spec\": \"data.item_events_parquet_compat_partitioned/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_gcp_purchases_import_v1__0_with_offset_0\", \"spec\": \"data.gcp_purchases_import_v1__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -396,6 +414,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -427,6 +446,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -446,6 +466,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/joins/gcp/item_event_join.canary_streaming_v1__0
+++ b/python/test/canary/compiled/joins/gcp/item_event_join.canary_streaming_v1__0
@@ -59,11 +59,15 @@
             "purchase_sum_1d": "8461cac7c35b38bae99562beb4060578",
             "view_sum_1d": "d4bc995b2e1955c153a0d1d78927f07c"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "clusterConf": {
               "modeClusterConfigs": {
                 "upload": {
-                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                  "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
                 }
               }
             },
@@ -74,6 +78,7 @@
                 "spark.chronon.partition.format": "yyyy-MM-dd",
                 "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
                 "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
                 "spark.default.parallelism": "10",
                 "spark.driver.cores": "1",
                 "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -105,6 +110,7 @@
                 "GCP_PROJECT_ID": "canary-443022",
                 "GCP_REGION": "us-central1",
                 "HUB_URL": "http://localhost:3903",
+                "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                 "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
                 "VERSION": "latest",
                 "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -124,6 +130,7 @@
                   "GCP_PROJECT_ID": "canary-443022",
                   "GCP_REGION": "us-central1",
                   "HUB_URL": "http://localhost:3903",
+                  "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                   "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                   "VERSION": "latest",
                   "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -188,11 +195,15 @@
       "user_id": "493d3df28f80664abd11b19fcd33b6e6"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_item_events_parquet_compat_with_offset_0\", \"spec\": \"data.item_events_parquet_compat/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_item_events_parquet_compat_partitioned_with_offset_0\", \"spec\": \"data.item_events_parquet_compat_partitioned/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -203,6 +214,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -234,6 +246,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -253,6 +266,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/joins/gcp/team_default_ns_join.v1__0
+++ b/python/test/canary/compiled/joins/gcp/team_default_ns_join.v1__0
@@ -85,11 +85,15 @@
             "purchase_price_sum_7d": "631fab32648531978032f3b417da5d52",
             "user_id": "a406c2de0040b2e926dba6334f299281"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "clusterConf": {
               "modeClusterConfigs": {
                 "upload": {
-                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                  "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
                 }
               }
             },
@@ -100,6 +104,7 @@
                 "spark.chronon.partition.format": "yyyy-MM-dd",
                 "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
                 "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
                 "spark.default.parallelism": "10",
                 "spark.driver.cores": "1",
                 "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -131,6 +136,7 @@
                 "GCP_PROJECT_ID": "canary-443022",
                 "GCP_REGION": "us-central1",
                 "HUB_URL": "http://localhost:3903",
+                "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                 "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
                 "VERSION": "latest",
                 "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -150,6 +156,7 @@
                   "GCP_PROJECT_ID": "canary-443022",
                   "GCP_REGION": "us-central1",
                   "HUB_URL": "http://localhost:3903",
+                  "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                   "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                   "VERSION": "latest",
                   "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -212,11 +219,15 @@
       "user_id_purchase_price_sum_7d": "ccfe12e5d18cc66a1d1ff3ec09a44c40"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_team_default_ns_example_v1__0_with_offset_0\", \"spec\": \"data.gcp_team_default_ns_example_v1__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_gcp_purchases_import_v1__0_with_offset_0\", \"spec\": \"data.gcp_purchases_import_v1__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -227,6 +238,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -258,6 +270,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -277,6 +290,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/joins/gcp/training_set.v1_dev__0
+++ b/python/test/canary/compiled/joins/gcp/training_set.v1_dev__0
@@ -85,11 +85,15 @@
             "purchase_price_sum_7d": "29fd3a1d4f15d0f15f3eb9f755f56a1d",
             "user_id": "990d1cc2263011ec3386075d3a66b1a1"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "clusterConf": {
               "modeClusterConfigs": {
                 "upload": {
-                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                  "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
                 }
               }
             },
@@ -100,6 +104,7 @@
                 "spark.chronon.partition.format": "yyyy-MM-dd",
                 "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
                 "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
                 "spark.default.parallelism": "10",
                 "spark.driver.cores": "1",
                 "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -131,6 +136,7 @@
                 "GCP_PROJECT_ID": "canary-443022",
                 "GCP_REGION": "us-central1",
                 "HUB_URL": "http://localhost:3903",
+                "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                 "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
                 "VERSION": "latest",
                 "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -150,6 +156,7 @@
                   "GCP_PROJECT_ID": "canary-443022",
                   "GCP_REGION": "us-central1",
                   "HUB_URL": "http://localhost:3903",
+                  "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                   "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                   "VERSION": "latest",
                   "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -212,11 +219,15 @@
       "user_id_purchase_price_sum_7d": "2e37814af181a4b0552be6c124450c6e"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_checkouts_import_v1__0_with_offset_0\", \"spec\": \"data.gcp_checkouts_import_v1__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_gcp_purchases_import_v1__0_with_offset_0\", \"spec\": \"data.gcp_purchases_import_v1__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -227,6 +238,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -258,6 +270,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -277,6 +290,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/joins/gcp/training_set.v1_dev_notds__0
+++ b/python/test/canary/compiled/joins/gcp/training_set.v1_dev_notds__0
@@ -85,11 +85,15 @@
             "purchase_price_sum_7d": "fd68ef8ce11f66fb65d9bf80e3f9ece5",
             "user_id": "659acfa58500e1f693d923b698c6e4c9"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "clusterConf": {
               "modeClusterConfigs": {
                 "upload": {
-                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                  "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
                 }
               }
             },
@@ -100,6 +104,7 @@
                 "spark.chronon.partition.format": "yyyy-MM-dd",
                 "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
                 "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
                 "spark.default.parallelism": "10",
                 "spark.driver.cores": "1",
                 "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -131,6 +136,7 @@
                 "GCP_PROJECT_ID": "canary-443022",
                 "GCP_REGION": "us-central1",
                 "HUB_URL": "http://localhost:3903",
+                "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                 "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
                 "VERSION": "latest",
                 "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -150,6 +156,7 @@
                   "GCP_PROJECT_ID": "canary-443022",
                   "GCP_REGION": "us-central1",
                   "HUB_URL": "http://localhost:3903",
+                  "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                   "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                   "VERSION": "latest",
                   "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -214,11 +221,15 @@
       "user_id_purchase_price_sum_7d": "31dfb8cbf0c4d756d1d6725d1b003466"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_checkouts_notds_import_v1__0_with_offset_0\", \"spec\": \"data.gcp_checkouts_notds_import_v1__0/notds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_gcp_purchases_notds_import_v1__0_with_offset_0\", \"spec\": \"data.gcp_purchases_notds_import_v1__0/notds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -229,6 +240,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -260,6 +272,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -279,6 +292,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/joins/gcp/training_set.v1_hub__0
+++ b/python/test/canary/compiled/joins/gcp/training_set.v1_hub__0
@@ -85,11 +85,15 @@
             "purchase_price_sum_7d": "631fab32648531978032f3b417da5d52",
             "user_id": "a406c2de0040b2e926dba6334f299281"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "clusterConf": {
               "modeClusterConfigs": {
                 "upload": {
-                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                  "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
                 }
               }
             },
@@ -100,6 +104,7 @@
                 "spark.chronon.partition.format": "yyyy-MM-dd",
                 "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
                 "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
                 "spark.default.parallelism": "10",
                 "spark.driver.cores": "1",
                 "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -131,6 +136,7 @@
                 "GCP_PROJECT_ID": "canary-443022",
                 "GCP_REGION": "us-central1",
                 "HUB_URL": "http://localhost:3903",
+                "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                 "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
                 "VERSION": "latest",
                 "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -150,6 +156,7 @@
                   "GCP_PROJECT_ID": "canary-443022",
                   "GCP_REGION": "us-central1",
                   "HUB_URL": "http://localhost:3903",
+                  "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                   "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                   "VERSION": "latest",
                   "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -212,11 +219,15 @@
       "user_id_purchase_price_sum_7d": "2e37814af181a4b0552be6c124450c6e"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_checkouts_import_v1__0_with_offset_0\", \"spec\": \"data.gcp_checkouts_import_v1__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_gcp_purchases_import_v1__0_with_offset_0\", \"spec\": \"data.gcp_purchases_import_v1__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -227,6 +238,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -258,6 +270,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -277,6 +290,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/joins/gcp/training_set.v1_test__0
+++ b/python/test/canary/compiled/joins/gcp/training_set.v1_test__0
@@ -85,11 +85,15 @@
             "purchase_price_sum_7d": "631fab32648531978032f3b417da5d52",
             "user_id": "a406c2de0040b2e926dba6334f299281"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "clusterConf": {
               "modeClusterConfigs": {
                 "upload": {
-                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                  "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
                 }
               }
             },
@@ -100,6 +104,7 @@
                 "spark.chronon.partition.format": "yyyy-MM-dd",
                 "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
                 "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
                 "spark.default.parallelism": "10",
                 "spark.driver.cores": "1",
                 "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -131,6 +136,7 @@
                 "GCP_PROJECT_ID": "canary-443022",
                 "GCP_REGION": "us-central1",
                 "HUB_URL": "http://localhost:3903",
+                "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                 "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
                 "VERSION": "latest",
                 "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -150,6 +156,7 @@
                   "GCP_PROJECT_ID": "canary-443022",
                   "GCP_REGION": "us-central1",
                   "HUB_URL": "http://localhost:3903",
+                  "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                   "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                   "VERSION": "latest",
                   "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -212,11 +219,15 @@
       "user_id_purchase_price_sum_7d": "2e37814af181a4b0552be6c124450c6e"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_checkouts_import_v1__0_with_offset_0\", \"spec\": \"data.gcp_checkouts_import_v1__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_gcp_purchases_import_v1__0_with_offset_0\", \"spec\": \"data.gcp_purchases_import_v1__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -227,6 +238,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -258,6 +270,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -277,6 +290,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/joins/gcp/training_set.v1_test_notds__0
+++ b/python/test/canary/compiled/joins/gcp/training_set.v1_test_notds__0
@@ -85,11 +85,15 @@
             "purchase_price_sum_7d": "75c7ab0be06806e6086fcdd7de7077ea",
             "user_id": "e2bd778ac7f0e189c7f627b51b0eaa13"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "clusterConf": {
               "modeClusterConfigs": {
                 "upload": {
-                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                  "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                  "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
                 }
               }
             },
@@ -100,6 +104,7 @@
                 "spark.chronon.partition.format": "yyyy-MM-dd",
                 "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
                 "spark.chronon.table_write.format": "iceberg",
+                "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
                 "spark.default.parallelism": "10",
                 "spark.driver.cores": "1",
                 "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -131,6 +136,7 @@
                 "GCP_PROJECT_ID": "canary-443022",
                 "GCP_REGION": "us-central1",
                 "HUB_URL": "http://localhost:3903",
+                "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                 "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
                 "VERSION": "latest",
                 "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -150,6 +156,7 @@
                   "GCP_PROJECT_ID": "canary-443022",
                   "GCP_REGION": "us-central1",
                   "HUB_URL": "http://localhost:3903",
+                  "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                   "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                   "VERSION": "latest",
                   "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -214,11 +221,15 @@
       "user_id_purchase_price_sum_7d": "31dfb8cbf0c4d756d1d6725d1b003466"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_checkouts_notds_import_v1__0_with_offset_0\", \"spec\": \"data.gcp_checkouts_notds_import_v1__0/notds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_gcp_purchases_notds_import_v1__0_with_offset_0\", \"spec\": \"data.gcp_purchases_notds_import_v1__0/notds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -229,6 +240,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -260,6 +272,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -279,6 +292,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/joins/quickstart/demo.derivations_v1__1
+++ b/python/test/canary/compiled/joins/quickstart/demo.derivations_v1__1
@@ -46,6 +46,9 @@
             "tags": "799675961e188b9e4a5a898d7e3f02ff",
             "weight_grams": "5c3e9f99cb7ec2d0aa56c9bd0e391308"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "conf": {
               "common": {
@@ -624,6 +627,9 @@
             "view_event_sum_30d": "62a8793addff23c7d8079961a8a07320",
             "view_event_sum_7d": "62a8793addff23c7d8079961a8a07320"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "conf": {
               "common": {
@@ -911,6 +917,9 @@
       "user_id_view_event_sum_7d": "c7ae73b92e2a8aabfb4df9d22d37d2f5"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_quickstart_quickstart_exports_user_activities__0_with_offset_0\", \"spec\": \"quickstart.quickstart_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_quickstart_quickstart_exports_dim_listings__0_with_offset_0\", \"spec\": \"quickstart.quickstart_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/joins/quickstart/demo.v1__1
+++ b/python/test/canary/compiled/joins/quickstart/demo.v1__1
@@ -391,6 +391,9 @@
             "view_event_sum_30d": "62a8793addff23c7d8079961a8a07320",
             "view_event_sum_7d": "62a8793addff23c7d8079961a8a07320"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "conf": {
               "common": {
@@ -603,6 +606,9 @@
             "tags": "799675961e188b9e4a5a898d7e3f02ff",
             "weight_grams": "5c3e9f99cb7ec2d0aa56c9bd0e391308"
           },
+          "environments": [
+            0
+          ],
           "executionInfo": {
             "conf": {
               "common": {
@@ -885,6 +891,9 @@
       "user_id_view_event_sum_7d": "c7ae73b92e2a8aabfb4df9d22d37d2f5"
     },
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_quickstart_quickstart_exports_user_activities__0_with_offset_0\", \"spec\": \"quickstart.quickstart_exports_user_activities__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_quickstart_quickstart_exports_dim_listings__0_with_offset_0\", \"spec\": \"quickstart.quickstart_exports_dim_listings__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/model_transforms/aws/ctr.v1__1
+++ b/python/test/canary/compiled/model_transforms/aws/ctr.v1__1
@@ -30,6 +30,9 @@
     ]
   },
   "metaData": {
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {
@@ -156,6 +159,9 @@
         "instance": "named_struct('user_id_click_event_average_7d', user_id_click_event_average_7d, 'listing_price_cents', listing_id_price_cents, 'price_log', price_log, 'price_bucket', price_bucket)"
       },
       "metaData": {
+        "environments": [
+          0
+        ],
         "executionInfo": {
           "clusterConf": {
             "common": {
@@ -347,6 +353,9 @@
                   "listing_id"
                 ],
                 "metaData": {
+                  "environments": [
+                    0
+                  ],
                   "executionInfo": {
                     "clusterConf": {
                       "common": {
@@ -810,6 +819,9 @@
                   "user_id"
                 ],
                 "metaData": {
+                  "environments": [
+                    0
+                  ],
                   "executionInfo": {
                     "clusterConf": {
                       "common": {
@@ -953,6 +965,9 @@
             }
           },
           "metaData": {
+            "environments": [
+              0
+            ],
             "executionInfo": {
               "clusterConf": {
                 "common": {

--- a/python/test/canary/compiled/model_transforms/aws/listing.v1__2
+++ b/python/test/canary/compiled/model_transforms/aws/listing.v1__2
@@ -18,6 +18,9 @@
     ]
   },
   "metaData": {
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {
@@ -128,6 +131,9 @@
         "instance": "named_struct('content', concat_ws('; ', listing_id_headline, listing_id_long_description))"
       },
       "metaData": {
+        "environments": [
+          0
+        ],
         "executionInfo": {
           "clusterConf": {
             "common": {
@@ -621,6 +627,9 @@
                   "user_id"
                 ],
                 "metaData": {
+                  "environments": [
+                    0
+                  ],
                   "executionInfo": {
                     "clusterConf": {
                       "common": {
@@ -754,6 +763,9 @@
                   "listing_id"
                 ],
                 "metaData": {
+                  "environments": [
+                    0
+                  ],
                   "executionInfo": {
                     "clusterConf": {
                       "common": {
@@ -891,6 +903,9 @@
                   "listing_id"
                 ],
                 "metaData": {
+                  "environments": [
+                    0
+                  ],
                   "executionInfo": {
                     "clusterConf": {
                       "common": {
@@ -1025,6 +1040,9 @@
             }
           },
           "metaData": {
+            "environments": [
+              0
+            ],
             "executionInfo": {
               "clusterConf": {
                 "common": {

--- a/python/test/canary/compiled/model_transforms/gcp/ctr.v1__1
+++ b/python/test/canary/compiled/model_transforms/gcp/ctr.v1__1
@@ -30,11 +30,15 @@
     ]
   },
   "metaData": {
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -45,6 +49,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -76,6 +81,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -95,6 +101,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -137,11 +144,15 @@
         "instance": "named_struct('user_id_click_event_average_7d', user_id_click_event_average_7d, 'listing_price_cents', listing_id_price_cents, 'price_log', price_log, 'price_bucket', price_bucket)"
       },
       "metaData": {
+        "environments": [
+          0
+        ],
         "executionInfo": {
           "clusterConf": {
             "modeClusterConfigs": {
               "upload": {
-                "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
               }
             }
           },
@@ -152,6 +163,7 @@
               "spark.chronon.partition.format": "yyyy-MM-dd",
               "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
               "spark.chronon.table_write.format": "iceberg",
+              "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
               "spark.default.parallelism": "10",
               "spark.driver.cores": "1",
               "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -183,6 +195,7 @@
               "GCP_PROJECT_ID": "canary-443022",
               "GCP_REGION": "us-central1",
               "HUB_URL": "http://localhost:3903",
+              "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
               "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
               "VERSION": "latest",
               "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -202,6 +215,7 @@
                 "GCP_PROJECT_ID": "canary-443022",
                 "GCP_REGION": "us-central1",
                 "HUB_URL": "http://localhost:3903",
+                "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                 "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                 "VERSION": "latest",
                 "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -308,11 +322,15 @@
                   "listing_id"
                 ],
                 "metaData": {
+                  "environments": [
+                    0
+                  ],
                   "executionInfo": {
                     "clusterConf": {
                       "modeClusterConfigs": {
                         "upload": {
-                          "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                          "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                          "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
                         }
                       }
                     },
@@ -323,6 +341,7 @@
                         "spark.chronon.partition.format": "yyyy-MM-dd",
                         "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
                         "spark.chronon.table_write.format": "iceberg",
+                        "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
                         "spark.default.parallelism": "10",
                         "spark.driver.cores": "1",
                         "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -354,6 +373,7 @@
                         "GCP_PROJECT_ID": "canary-443022",
                         "GCP_REGION": "us-central1",
                         "HUB_URL": "http://localhost:3903",
+                        "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                         "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
                         "VERSION": "latest",
                         "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -373,6 +393,7 @@
                           "GCP_PROJECT_ID": "canary-443022",
                           "GCP_REGION": "us-central1",
                           "HUB_URL": "http://localhost:3903",
+                          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                           "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                           "VERSION": "latest",
                           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -751,11 +772,15 @@
                   "user_id"
                 ],
                 "metaData": {
+                  "environments": [
+                    0
+                  ],
                   "executionInfo": {
                     "clusterConf": {
                       "modeClusterConfigs": {
                         "upload": {
-                          "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                          "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                          "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
                         }
                       }
                     },
@@ -766,6 +791,7 @@
                         "spark.chronon.partition.format": "yyyy-MM-dd",
                         "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
                         "spark.chronon.table_write.format": "iceberg",
+                        "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
                         "spark.default.parallelism": "10",
                         "spark.driver.cores": "1",
                         "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -797,6 +823,7 @@
                         "GCP_PROJECT_ID": "canary-443022",
                         "GCP_REGION": "us-central1",
                         "HUB_URL": "http://localhost:3903",
+                        "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                         "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
                         "VERSION": "latest",
                         "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -816,6 +843,7 @@
                           "GCP_PROJECT_ID": "canary-443022",
                           "GCP_REGION": "us-central1",
                           "HUB_URL": "http://localhost:3903",
+                          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                           "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                           "VERSION": "latest",
                           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -875,11 +903,15 @@
             }
           },
           "metaData": {
+            "environments": [
+              0
+            ],
             "executionInfo": {
               "clusterConf": {
                 "modeClusterConfigs": {
                   "upload": {
-                    "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                    "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                    "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
                   }
                 }
               },
@@ -890,6 +922,7 @@
                   "spark.chronon.partition.format": "yyyy-MM-dd",
                   "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
                   "spark.chronon.table_write.format": "iceberg",
+                  "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
                   "spark.default.parallelism": "10",
                   "spark.driver.cores": "1",
                   "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -921,6 +954,7 @@
                   "GCP_PROJECT_ID": "canary-443022",
                   "GCP_REGION": "us-central1",
                   "HUB_URL": "http://localhost:3903",
+                  "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                   "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
                   "VERSION": "latest",
                   "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -940,6 +974,7 @@
                     "GCP_PROJECT_ID": "canary-443022",
                     "GCP_REGION": "us-central1",
                     "HUB_URL": "http://localhost:3903",
+                    "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                     "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                     "VERSION": "latest",
                     "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/model_transforms/gcp/listing.v1__2
+++ b/python/test/canary/compiled/model_transforms/gcp/listing.v1__2
@@ -18,11 +18,15 @@
     ]
   },
   "metaData": {
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -33,6 +37,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -64,6 +69,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -83,6 +89,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -109,11 +116,15 @@
         "instance": "named_struct('content', concat_ws('; ', listing_id_headline, listing_id_long_description))"
       },
       "metaData": {
+        "environments": [
+          0
+        ],
         "executionInfo": {
           "clusterConf": {
             "modeClusterConfigs": {
               "upload": {
-                "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
               }
             }
           },
@@ -124,6 +135,7 @@
               "spark.chronon.partition.format": "yyyy-MM-dd",
               "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
               "spark.chronon.table_write.format": "iceberg",
+              "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
               "spark.default.parallelism": "10",
               "spark.driver.cores": "1",
               "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -155,6 +167,7 @@
               "GCP_PROJECT_ID": "canary-443022",
               "GCP_REGION": "us-central1",
               "HUB_URL": "http://localhost:3903",
+              "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
               "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
               "VERSION": "latest",
               "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -174,6 +187,7 @@
                 "GCP_PROJECT_ID": "canary-443022",
                 "GCP_REGION": "us-central1",
                 "HUB_URL": "http://localhost:3903",
+                "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                 "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                 "VERSION": "latest",
                 "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -583,11 +597,15 @@
                   "user_id"
                 ],
                 "metaData": {
+                  "environments": [
+                    0
+                  ],
                   "executionInfo": {
                     "clusterConf": {
                       "modeClusterConfigs": {
                         "upload": {
-                          "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                          "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                          "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
                         }
                       }
                     },
@@ -598,6 +616,7 @@
                         "spark.chronon.partition.format": "yyyy-MM-dd",
                         "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
                         "spark.chronon.table_write.format": "iceberg",
+                        "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
                         "spark.default.parallelism": "10",
                         "spark.driver.cores": "1",
                         "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -629,6 +648,7 @@
                         "GCP_PROJECT_ID": "canary-443022",
                         "GCP_REGION": "us-central1",
                         "HUB_URL": "http://localhost:3903",
+                        "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                         "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
                         "VERSION": "latest",
                         "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -648,6 +668,7 @@
                           "GCP_PROJECT_ID": "canary-443022",
                           "GCP_REGION": "us-central1",
                           "HUB_URL": "http://localhost:3903",
+                          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                           "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                           "VERSION": "latest",
                           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -697,11 +718,15 @@
                   "listing_id"
                 ],
                 "metaData": {
+                  "environments": [
+                    0
+                  ],
                   "executionInfo": {
                     "clusterConf": {
                       "modeClusterConfigs": {
                         "upload": {
-                          "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                          "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                          "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
                         }
                       }
                     },
@@ -712,6 +737,7 @@
                         "spark.chronon.partition.format": "yyyy-MM-dd",
                         "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
                         "spark.chronon.table_write.format": "iceberg",
+                        "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
                         "spark.default.parallelism": "10",
                         "spark.driver.cores": "1",
                         "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -743,6 +769,7 @@
                         "GCP_PROJECT_ID": "canary-443022",
                         "GCP_REGION": "us-central1",
                         "HUB_URL": "http://localhost:3903",
+                        "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                         "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
                         "VERSION": "latest",
                         "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -762,6 +789,7 @@
                           "GCP_PROJECT_ID": "canary-443022",
                           "GCP_REGION": "us-central1",
                           "HUB_URL": "http://localhost:3903",
+                          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                           "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                           "VERSION": "latest",
                           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -814,11 +842,15 @@
                   "listing_id"
                 ],
                 "metaData": {
+                  "environments": [
+                    0
+                  ],
                   "executionInfo": {
                     "clusterConf": {
                       "modeClusterConfigs": {
                         "upload": {
-                          "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                          "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                          "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
                         }
                       }
                     },
@@ -829,6 +861,7 @@
                         "spark.chronon.partition.format": "yyyy-MM-dd",
                         "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
                         "spark.chronon.table_write.format": "iceberg",
+                        "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
                         "spark.default.parallelism": "10",
                         "spark.driver.cores": "1",
                         "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -860,6 +893,7 @@
                         "GCP_PROJECT_ID": "canary-443022",
                         "GCP_REGION": "us-central1",
                         "HUB_URL": "http://localhost:3903",
+                        "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                         "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
                         "VERSION": "latest",
                         "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -879,6 +913,7 @@
                           "GCP_PROJECT_ID": "canary-443022",
                           "GCP_REGION": "us-central1",
                           "HUB_URL": "http://localhost:3903",
+                          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                           "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                           "VERSION": "latest",
                           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -928,11 +963,15 @@
             }
           },
           "metaData": {
+            "environments": [
+              0
+            ],
             "executionInfo": {
               "clusterConf": {
                 "modeClusterConfigs": {
                   "upload": {
-                    "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                    "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                    "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
                   }
                 }
               },
@@ -943,6 +982,7 @@
                   "spark.chronon.partition.format": "yyyy-MM-dd",
                   "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
                   "spark.chronon.table_write.format": "iceberg",
+                  "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
                   "spark.default.parallelism": "10",
                   "spark.driver.cores": "1",
                   "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -975,6 +1015,7 @@
                   "GCP_PROJECT_ID": "canary-443022",
                   "GCP_REGION": "us-central1",
                   "HUB_URL": "http://localhost:3903",
+                  "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                   "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
                   "VERSION": "latest",
                   "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -994,6 +1035,7 @@
                     "GCP_PROJECT_ID": "canary-443022",
                     "GCP_REGION": "us-central1",
                     "HUB_URL": "http://localhost:3903",
+                    "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                     "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                     "VERSION": "latest",
                     "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/model_transforms/gcp/team_default_ns_mt.v1__1
+++ b/python/test/canary/compiled/model_transforms/gcp/team_default_ns_mt.v1__1
@@ -30,11 +30,15 @@
     ]
   },
   "metaData": {
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -45,6 +49,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -76,6 +81,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -95,6 +101,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -137,11 +144,15 @@
         "instance": "named_struct('user_id_click_event_average_7d', user_id_click_event_average_7d, 'listing_price_cents', listing_id_price_cents, 'price_log', price_log, 'price_bucket', price_bucket)"
       },
       "metaData": {
+        "environments": [
+          0
+        ],
         "executionInfo": {
           "clusterConf": {
             "modeClusterConfigs": {
               "upload": {
-                "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
               }
             }
           },
@@ -152,6 +163,7 @@
               "spark.chronon.partition.format": "yyyy-MM-dd",
               "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
               "spark.chronon.table_write.format": "iceberg",
+              "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
               "spark.default.parallelism": "10",
               "spark.driver.cores": "1",
               "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -183,6 +195,7 @@
               "GCP_PROJECT_ID": "canary-443022",
               "GCP_REGION": "us-central1",
               "HUB_URL": "http://localhost:3903",
+              "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
               "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
               "VERSION": "latest",
               "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -202,6 +215,7 @@
                 "GCP_PROJECT_ID": "canary-443022",
                 "GCP_REGION": "us-central1",
                 "HUB_URL": "http://localhost:3903",
+                "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                 "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                 "VERSION": "latest",
                 "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -308,11 +322,15 @@
                   "listing_id"
                 ],
                 "metaData": {
+                  "environments": [
+                    0
+                  ],
                   "executionInfo": {
                     "clusterConf": {
                       "modeClusterConfigs": {
                         "upload": {
-                          "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                          "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                          "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
                         }
                       }
                     },
@@ -323,6 +341,7 @@
                         "spark.chronon.partition.format": "yyyy-MM-dd",
                         "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
                         "spark.chronon.table_write.format": "iceberg",
+                        "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
                         "spark.default.parallelism": "10",
                         "spark.driver.cores": "1",
                         "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -354,6 +373,7 @@
                         "GCP_PROJECT_ID": "canary-443022",
                         "GCP_REGION": "us-central1",
                         "HUB_URL": "http://localhost:3903",
+                        "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                         "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
                         "VERSION": "latest",
                         "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -373,6 +393,7 @@
                           "GCP_PROJECT_ID": "canary-443022",
                           "GCP_REGION": "us-central1",
                           "HUB_URL": "http://localhost:3903",
+                          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                           "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                           "VERSION": "latest",
                           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -751,11 +772,15 @@
                   "user_id"
                 ],
                 "metaData": {
+                  "environments": [
+                    0
+                  ],
                   "executionInfo": {
                     "clusterConf": {
                       "modeClusterConfigs": {
                         "upload": {
-                          "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                          "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                          "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
                         }
                       }
                     },
@@ -766,6 +791,7 @@
                         "spark.chronon.partition.format": "yyyy-MM-dd",
                         "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
                         "spark.chronon.table_write.format": "iceberg",
+                        "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
                         "spark.default.parallelism": "10",
                         "spark.driver.cores": "1",
                         "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -797,6 +823,7 @@
                         "GCP_PROJECT_ID": "canary-443022",
                         "GCP_REGION": "us-central1",
                         "HUB_URL": "http://localhost:3903",
+                        "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                         "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
                         "VERSION": "latest",
                         "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -816,6 +843,7 @@
                           "GCP_PROJECT_ID": "canary-443022",
                           "GCP_REGION": "us-central1",
                           "HUB_URL": "http://localhost:3903",
+                          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                           "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                           "VERSION": "latest",
                           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -875,11 +903,15 @@
             }
           },
           "metaData": {
+            "environments": [
+              0
+            ],
             "executionInfo": {
               "clusterConf": {
                 "modeClusterConfigs": {
                   "upload": {
-                    "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+                    "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+                    "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
                   }
                 }
               },
@@ -890,6 +922,7 @@
                   "spark.chronon.partition.format": "yyyy-MM-dd",
                   "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
                   "spark.chronon.table_write.format": "iceberg",
+                  "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
                   "spark.default.parallelism": "10",
                   "spark.driver.cores": "1",
                   "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -921,6 +954,7 @@
                   "GCP_PROJECT_ID": "canary-443022",
                   "GCP_REGION": "us-central1",
                   "HUB_URL": "http://localhost:3903",
+                  "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                   "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
                   "VERSION": "latest",
                   "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -940,6 +974,7 @@
                     "GCP_PROJECT_ID": "canary-443022",
                     "GCP_REGION": "us-central1",
                     "HUB_URL": "http://localhost:3903",
+                    "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
                     "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
                     "VERSION": "latest",
                     "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/models/aws/click_through_rate.ctr_model__1.0
+++ b/python/test/canary/compiled/models/aws/click_through_rate.ctr_model__1.0
@@ -26,6 +26,9 @@
     "instance": "named_struct('user_id_click_event_average_7d', user_id_click_event_average_7d, 'listing_price_cents', listing_id_price_cents, 'price_log', price_log, 'price_bucket', price_bucket)"
   },
   "metaData": {
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/models/aws/listing.item_description_model__1
+++ b/python/test/canary/compiled/models/aws/listing.item_description_model__1
@@ -10,6 +10,9 @@
     "instance": "named_struct('content', concat_ws('; ', listing_id_headline, listing_id_long_description))"
   },
   "metaData": {
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/models/aws/listing.item_img_model__001
+++ b/python/test/canary/compiled/models/aws/listing.item_img_model__001
@@ -11,6 +11,9 @@
     "instance": "named_struct('image', named_struct('s3Uri', listing_id_main_image_path), 'text','')"
   },
   "metaData": {
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/models/gcp/click_through_rate.ctr_model__1.0
+++ b/python/test/canary/compiled/models/gcp/click_through_rate.ctr_model__1.0
@@ -26,11 +26,15 @@
     "instance": "named_struct('user_id_click_event_average_7d', user_id_click_event_average_7d, 'listing_price_cents', listing_id_price_cents, 'price_log', price_log, 'price_bucket', price_bucket)"
   },
   "metaData": {
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -41,6 +45,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -72,6 +77,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -91,6 +97,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/models/gcp/listing.item_description_model__1
+++ b/python/test/canary/compiled/models/gcp/listing.item_description_model__1
@@ -10,11 +10,15 @@
     "instance": "named_struct('content', concat_ws('; ', listing_id_headline, listing_id_long_description))"
   },
   "metaData": {
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -25,6 +29,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -56,6 +61,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -75,6 +81,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/models/gcp/listing.item_img_model__001
+++ b/python/test/canary/compiled/models/gcp/listing.item_img_model__001
@@ -12,11 +12,15 @@
     "instance": "named_struct('image', named_struct('gcsUri', listing_id_main_image_path), 'text','')"
   },
   "metaData": {
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -27,6 +31,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -58,6 +63,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -77,6 +83,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/staging_queries/aws/ctr_labels.v1__0
+++ b/python/test/canary/compiled/staging_queries/aws/ctr_labels.v1__0
@@ -1,6 +1,9 @@
 {
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_demo_derivations_v1__2_with_offset_0\", \"spec\": \"data.aws_demo_derivations_v1__2/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/aws/cutoff_example.downstream__0
+++ b/python/test/canary/compiled/staging_queries/aws/cutoff_example.downstream__0
@@ -2,6 +2,9 @@
   "engineType": 0,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_cutoff_example_export_a__0_with_offset_0\", \"spec\": \"data.aws_cutoff_example_export_a__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_aws_cutoff_example_export_b__0_with_offset_0\", \"spec\": \"data.aws_cutoff_example_export_b__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/aws/cutoff_example.export_a__0
+++ b/python/test/canary/compiled/staging_queries/aws/cutoff_example.export_a__0
@@ -2,6 +2,9 @@
   "engineType": 0,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo_dim_listings_with_offset_0\", \"spec\": \"demo.dim_listings/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/aws/cutoff_example.export_b__0
+++ b/python/test/canary/compiled/staging_queries/aws/cutoff_example.export_b__0
@@ -2,6 +2,9 @@
   "engineType": 0,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo_dim_merchants_with_offset_0\", \"spec\": \"demo.dim_merchants/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/aws/demo.v1_s__0
+++ b/python/test/canary/compiled/staging_queries/aws/demo.v1_s__0
@@ -1,6 +1,9 @@
 {
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_demo_derivations_v1__2_with_offset_0\", \"spec\": \"data.aws_demo_derivations_v1__2/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/aws/exports.checkouts__0
+++ b/python/test/canary/compiled/staging_queries/aws/exports.checkouts__0
@@ -2,6 +2,9 @@
   "engineType": 0,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo_checkouts_with_offset_0\", \"spec\": \"demo.checkouts/ts={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/aws/exports.dim_listings__0
+++ b/python/test/canary/compiled/staging_queries/aws/exports.dim_listings__0
@@ -2,6 +2,9 @@
   "engineType": 0,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo_dim_listings_with_offset_0\", \"spec\": \"demo.dim_listings/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/aws/exports.dim_merchants__0
+++ b/python/test/canary/compiled/staging_queries/aws/exports.dim_merchants__0
@@ -2,6 +2,9 @@
   "engineType": 0,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo_dim_merchants_with_offset_0\", \"spec\": \"demo.dim_merchants/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/aws/exports.dim_users__0
+++ b/python/test/canary/compiled/staging_queries/aws/exports.dim_users__0
@@ -2,6 +2,9 @@
   "engineType": 0,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo_dim_users_with_offset_0\", \"spec\": \"demo.dim_users/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/aws/exports.user_activities__0
+++ b/python/test/canary/compiled/staging_queries/aws/exports.user_activities__0
@@ -2,6 +2,9 @@
   "engineType": 0,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo_user_activities_with_offset_0\", \"spec\": \"demo.user_activities/event_time={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/aws/partitioned_logging.v0__2
+++ b/python/test/canary/compiled/staging_queries/aws/partitioned_logging.v0__2
@@ -1,6 +1,9 @@
 {
   "metaData": {
     "customJson": "{\"airflowDependencies\": []}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/aws/sample_staging_query.cart__0
+++ b/python/test/canary/compiled/staging_queries/aws/sample_staging_query.cart__0
@@ -1,6 +1,9 @@
 {
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_training_set_v1_test__0_with_offset_1\", \"spec\": \"data.aws_training_set_v1_test__0/ds={{ macros.ds_add(ds, -1) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/aws/sample_staging_query.item__0
+++ b/python/test/canary/compiled/staging_queries/aws/sample_staging_query.item__0
@@ -1,6 +1,9 @@
 {
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_training_set_v1_test__0_with_offset_1\", \"spec\": \"data.aws_training_set_v1_test__0/ds={{ macros.ds_add(ds, -1) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/aws/sample_staging_query.order__0
+++ b/python/test/canary/compiled/staging_queries/aws/sample_staging_query.order__0
@@ -1,6 +1,9 @@
 {
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_training_set_v1_test__0_with_offset_1\", \"spec\": \"data.aws_training_set_v1_test__0/ds={{ macros.ds_add(ds, -1) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/aws/sample_staging_query.payment__0
+++ b/python/test/canary/compiled/staging_queries/aws/sample_staging_query.payment__0
@@ -1,6 +1,9 @@
 {
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_training_set_v1_test__0_with_offset_1\", \"spec\": \"data.aws_training_set_v1_test__0/ds={{ macros.ds_add(ds, -1) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/aws/sample_staging_query.purchases_labels__0
+++ b/python/test/canary/compiled/staging_queries/aws/sample_staging_query.purchases_labels__0
@@ -1,6 +1,9 @@
 {
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_training_set_v1_test__0_with_offset_0\", \"spec\": \"data.aws_training_set_v1_test__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/aws/sample_staging_query.shipping__0
+++ b/python/test/canary/compiled/staging_queries/aws/sample_staging_query.shipping__0
@@ -1,6 +1,9 @@
 {
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_training_set_v1_test__0_with_offset_1\", \"spec\": \"data.aws_training_set_v1_test__0/ds={{ macros.ds_add(ds, -1) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/aws/sample_staging_query.terminal__0
+++ b/python/test/canary/compiled/staging_queries/aws/sample_staging_query.terminal__0
@@ -1,6 +1,9 @@
 {
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_sample_staging_query_cart__0_with_offset_1\", \"spec\": \"data.aws_sample_staging_query_cart__0/ds={{ macros.ds_add(ds, -1) }}\"}, {\"name\": \"wf_data_aws_sample_staging_query_user__0_with_offset_1\", \"spec\": \"data.aws_sample_staging_query_user__0/ds={{ macros.ds_add(ds, -1) }}\"}, {\"name\": \"wf_data_aws_sample_staging_query_item__0_with_offset_1\", \"spec\": \"data.aws_sample_staging_query_item__0/ds={{ macros.ds_add(ds, -1) }}\"}, {\"name\": \"wf_data_aws_sample_staging_query_order__0_with_offset_1\", \"spec\": \"data.aws_sample_staging_query_order__0/ds={{ macros.ds_add(ds, -1) }}\"}, {\"name\": \"wf_data_aws_sample_staging_query_payment__0_with_offset_1\", \"spec\": \"data.aws_sample_staging_query_payment__0/ds={{ macros.ds_add(ds, -1) }}\"}, {\"name\": \"wf_data_aws_sample_staging_query_shipping__0_with_offset_1\", \"spec\": \"data.aws_sample_staging_query_shipping__0/ds={{ macros.ds_add(ds, -1) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/aws/sample_staging_query.user__0
+++ b/python/test/canary/compiled/staging_queries/aws/sample_staging_query.user__0
@@ -1,6 +1,9 @@
 {
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_training_set_v1_test__0_with_offset_1\", \"spec\": \"data.aws_training_set_v1_test__0/ds={{ macros.ds_add(ds, -1) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/aws/sample_staging_query.v1_bigquery_import__0
+++ b/python/test/canary/compiled/staging_queries/aws/sample_staging_query.v1_bigquery_import__0
@@ -2,6 +2,9 @@
   "engineType": 1,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_training_set_v1_hub__0_with_offset_0\", \"spec\": \"data.aws_training_set_v1_hub__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/aws/sample_staging_query.v1_hub__0
+++ b/python/test/canary/compiled/staging_queries/aws/sample_staging_query.v1_hub__0
@@ -1,6 +1,9 @@
 {
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_aws_training_set_v1_hub__0_with_offset_1\", \"spec\": \"data.aws_training_set_v1_hub__0/ds={{ macros.ds_add(ds, -1) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/aws_databricks/exports.dim_listings__0
+++ b/python/test/canary/compiled/staging_queries/aws_databricks/exports.dim_listings__0
@@ -2,6 +2,9 @@
   "engineType": 0,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_workspace_poc_dim_listings_with_offset_0\", \"spec\": \"workspace.poc.dim_listings/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/aws_databricks/exports.dim_listings_non_partitioned__0
+++ b/python/test/canary/compiled/staging_queries/aws_databricks/exports.dim_listings_non_partitioned__0
@@ -2,6 +2,9 @@
   "engineType": 0,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_workspace_poc_dim_listings_nop_with_offset_0\", \"spec\": \"workspace.poc.dim_listings_nop/updated_at_ts={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/azure/claims_demo_baseline.baseline_source__0
+++ b/python/test/canary/compiled/staging_queries/azure/claims_demo_baseline.baseline_source__0
@@ -2,6 +2,9 @@
   "engineType": 2,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_DEMO_CLAIMS_DEMO_CLAIMS_DEMO_BASELINE_SOURCE_with_offset_0\", \"spec\": \"DEMO.CLAIMS_DEMO.CLAIMS_DEMO_BASELINE_SOURCE/DS={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {
@@ -41,6 +44,7 @@
           "CLOUD_PROVIDER": "azure",
           "CUSTOMER_ID": "claims-demo",
           "EVAL_URL": "http://hub.claims-demo-hub.svc.cluster.local:3903",
+          "FETCHER_URL": "http://localhost:9000",
           "FLINK_JARS_URI": "abfss://dev-zipline-artifacts@ziplineai2.dfs.core.windows.net/spark-3.5.3/libs/",
           "FLINK_SASL_JAAS_CONFIG_VAULT_URI": "https://eventhub-sasl-jaas.vault.azure.net/secrets/sasl-jass-config",
           "FLINK_STATE_URI": "abfss://crucible@ziplineai2.dfs.core.windows.net/claims-demo/flink-state",

--- a/python/test/canary/compiled/staging_queries/azure/crucible_stress_fanout.segment_000__0
+++ b/python/test/canary/compiled/staging_queries/azure/crucible_stress_fanout.segment_000__0
@@ -2,6 +2,9 @@
   "engineType": 0,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_claims_demo_azure_crucible_stress_training_set__0_with_offset_0\", \"spec\": \"claims_demo.azure_crucible_stress_training_set__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/azure/crucible_stress_fanout.segment_001__0
+++ b/python/test/canary/compiled/staging_queries/azure/crucible_stress_fanout.segment_001__0
@@ -2,6 +2,9 @@
   "engineType": 0,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_claims_demo_azure_crucible_stress_training_set__0_with_offset_0\", \"spec\": \"claims_demo.azure_crucible_stress_training_set__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/azure/crucible_stress_fanout.segment_002__0
+++ b/python/test/canary/compiled/staging_queries/azure/crucible_stress_fanout.segment_002__0
@@ -2,6 +2,9 @@
   "engineType": 0,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_claims_demo_azure_crucible_stress_training_set__0_with_offset_0\", \"spec\": \"claims_demo.azure_crucible_stress_training_set__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/azure/crucible_stress_fanout.segment_003__0
+++ b/python/test/canary/compiled/staging_queries/azure/crucible_stress_fanout.segment_003__0
@@ -2,6 +2,9 @@
   "engineType": 0,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_claims_demo_azure_crucible_stress_training_set__0_with_offset_0\", \"spec\": \"claims_demo.azure_crucible_stress_training_set__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/azure/crucible_stress_fanout.terminal__0
+++ b/python/test/canary/compiled/staging_queries/azure/crucible_stress_fanout.terminal__0
@@ -2,6 +2,9 @@
   "engineType": 0,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_claims_demo_azure_crucible_stress_fanout_segment_000__0_with_offset_0\", \"spec\": \"claims_demo.azure_crucible_stress_fanout_segment_000__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_claims_demo_azure_crucible_stress_fanout_segment_001__0_with_offset_0\", \"spec\": \"claims_demo.azure_crucible_stress_fanout_segment_001__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_claims_demo_azure_crucible_stress_fanout_segment_002__0_with_offset_0\", \"spec\": \"claims_demo.azure_crucible_stress_fanout_segment_002__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_claims_demo_azure_crucible_stress_fanout_segment_003__0_with_offset_0\", \"spec\": \"claims_demo.azure_crucible_stress_fanout_segment_003__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/azure/crucible_stress_sources.checkouts__0
+++ b/python/test/canary/compiled/staging_queries/azure/crucible_stress_sources.checkouts__0
@@ -2,6 +2,9 @@
   "engineType": 2,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_DEMO_CLAIMS_DEMO_CRUCIBLE_STRESS_CHECKOUTS_with_offset_0\", \"spec\": \"DEMO.CLAIMS_DEMO.CRUCIBLE_STRESS_CHECKOUTS/DS={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/azure/crucible_stress_sources.purchases__0
+++ b/python/test/canary/compiled/staging_queries/azure/crucible_stress_sources.purchases__0
@@ -2,6 +2,9 @@
   "engineType": 2,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_DEMO_CLAIMS_DEMO_CRUCIBLE_STRESS_PURCHASES_with_offset_0\", \"spec\": \"DEMO.CLAIMS_DEMO.CRUCIBLE_STRESS_PURCHASES/DS={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/azure/ctr_labels.v1__0
+++ b/python/test/canary/compiled/staging_queries/azure/ctr_labels.v1__0
@@ -1,6 +1,9 @@
 {
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_azure_demo_derivations_v3__derived_with_offset_0\", \"spec\": \"data.azure_demo_derivations_v3__derived/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/azure/cutoff_example.downstream__0
+++ b/python/test/canary/compiled/staging_queries/azure/cutoff_example.downstream__0
@@ -2,6 +2,9 @@
   "engineType": 0,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_azure_cutoff_example_export_a__0_with_offset_0\", \"spec\": \"data.azure_cutoff_example_export_a__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_azure_cutoff_example_export_b__0_with_offset_0\", \"spec\": \"data.azure_cutoff_example_export_b__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/azure/cutoff_example.export_a__0
+++ b/python/test/canary/compiled/staging_queries/azure/cutoff_example.export_a__0
@@ -2,6 +2,9 @@
   "engineType": 2,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_dim_listings_with_offset_0\", \"spec\": \"dim_listings/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/azure/cutoff_example.export_b__0
+++ b/python/test/canary/compiled/staging_queries/azure/cutoff_example.export_b__0
@@ -2,6 +2,9 @@
   "engineType": 2,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_dim_merchants_with_offset_0\", \"spec\": \"dim_merchants/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/azure/exports.checkouts__0
+++ b/python/test/canary/compiled/staging_queries/azure/exports.checkouts__0
@@ -2,6 +2,9 @@
   "engineType": 2,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_checkouts_with_offset_0\", \"spec\": \"checkouts/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/azure/exports.dim_listings__0
+++ b/python/test/canary/compiled/staging_queries/azure/exports.dim_listings__0
@@ -2,6 +2,9 @@
   "engineType": 2,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_dim_listings_with_offset_0\", \"spec\": \"dim_listings/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/azure/exports.dim_listings_pc__1
+++ b/python/test/canary/compiled/staging_queries/azure/exports.dim_listings_pc__1
@@ -2,6 +2,9 @@
   "engineType": 2,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_dim_listings_custom_part_with_offset_0\", \"spec\": \"dim_listings_custom_part/datest={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/azure/exports.dim_merchants__0
+++ b/python/test/canary/compiled/staging_queries/azure/exports.dim_merchants__0
@@ -2,6 +2,9 @@
   "engineType": 2,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_dim_merchants_with_offset_0\", \"spec\": \"dim_merchants/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/azure/exports.dim_users__0
+++ b/python/test/canary/compiled/staging_queries/azure/exports.dim_users__0
@@ -2,6 +2,9 @@
   "engineType": 2,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_dim_users_with_offset_0\", \"spec\": \"dim_users/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/azure/exports.user_activities__0
+++ b/python/test/canary/compiled/staging_queries/azure/exports.user_activities__0
@@ -1,6 +1,9 @@
 {
   "metaData": {
     "customJson": "{\"airflowDependencies\": []}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/azure/local_staging_query.simple__0
+++ b/python/test/canary/compiled/staging_queries/azure/local_staging_query.simple__0
@@ -1,6 +1,9 @@
 {
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_test_connection_with_offset_0\", \"spec\": \"data.test_connection/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/azure/partitioned_logging.v0__2
+++ b/python/test/canary/compiled/staging_queries/azure/partitioned_logging.v0__2
@@ -1,6 +1,9 @@
 {
   "metaData": {
     "customJson": "{\"airflowDependencies\": []}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/gcp/checkouts_import.v1__0
+++ b/python/test/canary/compiled/staging_queries/gcp/checkouts_import.v1__0
@@ -2,11 +2,15 @@
   "engineType": 1,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_checkouts_with_offset_0\", \"spec\": \"data.checkouts/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -17,6 +21,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -48,6 +53,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -67,6 +73,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/staging_queries/gcp/checkouts_notds_import.v1__0
+++ b/python/test/canary/compiled/staging_queries/gcp/checkouts_notds_import.v1__0
@@ -2,11 +2,15 @@
   "engineType": 1,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_checkouts_notds_with_offset_0\", \"spec\": \"data.checkouts_notds/notds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -17,6 +21,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -48,6 +53,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -67,6 +73,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/staging_queries/gcp/ctr_labels.v1__0
+++ b/python/test/canary/compiled/staging_queries/gcp/ctr_labels.v1__0
@@ -1,11 +1,15 @@
 {
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_demo_derivations_v1__2__derived_with_offset_0\", \"spec\": \"data.gcp_demo_derivations_v1__2__derived/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -16,6 +20,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -47,6 +52,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -66,6 +72,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/staging_queries/gcp/cutoff_example.downstream__0
+++ b/python/test/canary/compiled/staging_queries/gcp/cutoff_example.downstream__0
@@ -2,11 +2,15 @@
   "engineType": 1,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_cutoff_example_export_a__0_with_offset_0\", \"spec\": \"data.gcp_cutoff_example_export_a__0/ds={{ macros.ds_add(ds, 0) }}\"}, {\"name\": \"wf_data_gcp_cutoff_example_export_b__0_with_offset_0\", \"spec\": \"data.gcp_cutoff_example_export_b__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -17,6 +21,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -48,6 +53,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -67,6 +73,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/staging_queries/gcp/cutoff_example.export_a__0
+++ b/python/test/canary/compiled/staging_queries/gcp/cutoff_example.export_a__0
@@ -2,11 +2,15 @@
   "engineType": 1,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo_dim_listings_with_offset_0\", \"spec\": \"demo.dim_listings/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -17,6 +21,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -48,6 +53,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -67,6 +73,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/staging_queries/gcp/cutoff_example.export_b__0
+++ b/python/test/canary/compiled/staging_queries/gcp/cutoff_example.export_b__0
@@ -2,11 +2,15 @@
   "engineType": 1,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo_dim_merchants_with_offset_0\", \"spec\": \"demo.dim_merchants/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -17,6 +21,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -48,6 +53,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -67,6 +73,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/staging_queries/gcp/demo.may4__0
+++ b/python/test/canary/compiled/staging_queries/gcp/demo.may4__0
@@ -1,0 +1,111 @@
+{
+  "metaData": {
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf___derived_with_offset_0\", \"spec\": \"__derived/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
+    "executionInfo": {
+      "clusterConf": {
+        "modeClusterConfigs": {
+          "upload": {
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
+          }
+        }
+      },
+      "conf": {
+        "common": {
+          "spark.chronon.coalesce.factor": "10",
+          "spark.chronon.partition.column": "ds",
+          "spark.chronon.partition.format": "yyyy-MM-dd",
+          "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+          "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
+          "spark.default.parallelism": "10",
+          "spark.driver.cores": "1",
+          "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
+          "spark.driver.memory": "512m",
+          "spark.executor.cores": "1",
+          "spark.executor.memory": "512m",
+          "spark.sql.catalog.spark_catalog": "org.apache.iceberg.spark.SparkSessionCatalog",
+          "spark.sql.catalog.spark_catalog.catalog-impl": "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+          "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+          "spark.sql.catalog.spark_catalog.io-impl": "org.apache.iceberg.io.ResolvingFileIO",
+          "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+          "spark.sql.defaultUrlStreamHandlerFactory.enabled": "false",
+          "spark.sql.shuffle.partitions": "10"
+        }
+      },
+      "env": {
+        "common": {
+          "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+          "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+          "CLOUD_PROVIDER": "gcp",
+          "CUSTOMER_ID": "canary",
+          "ENABLE_PUBSUB": "true",
+          "EVAL_URL": "http://localhost:3904",
+          "FETCHER_URL": "http://localhost:9000",
+          "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+          "FRONTEND_URL": "http://localhost:3000",
+          "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+          "GCP_PROJECT_ID": "canary-443022",
+          "GCP_REGION": "us-central1",
+          "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
+          "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+          "VERSION": "latest",
+          "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+        },
+        "modeEnvironments": {
+          "upload": {
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "ENABLE_PUBSUB": "true",
+            "EVAL_URL": "http://localhost:3904",
+            "FETCHER_URL": "http://localhost:9000",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "FRONTEND_URL": "http://localhost:3000",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
+            "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
+            "VERSION": "latest",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
+          }
+        }
+      },
+      "offlineSchedule": "@daily"
+    },
+    "name": "gcp.demo.may4__0",
+    "outputNamespace": "data",
+    "sourceFile": "staging_queries/gcp/demo.py",
+    "team": "gcp",
+    "version": "0"
+  },
+  "query": "\nSELECT \n    *,\n    case when rand() < 0.5 then 0 else 1 end as label\nFROM __derived\nWHERE ds BETWEEN {{ start_date }} AND {{ end_date }}\n",
+  "tableDependencies": [
+    {
+      "endOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "startOffset": {
+        "length": 0,
+        "timeUnit": 1
+      },
+      "tableInfo": {
+        "partitionColumn": "ds",
+        "partitionInterval": {
+          "length": 1,
+          "timeUnit": 1
+        },
+        "table": "__derived"
+      }
+    }
+  ]
+}

--- a/python/test/canary/compiled/staging_queries/gcp/exports.checkouts__0
+++ b/python/test/canary/compiled/staging_queries/gcp/exports.checkouts__0
@@ -2,11 +2,15 @@
   "engineType": 1,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo__checkouts__with_offset_0\", \"spec\": \"demo.`checkouts`/_PARTITIONTIME={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -17,6 +21,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -48,6 +53,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -67,6 +73,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/staging_queries/gcp/exports.dim_listing_mutations__0
+++ b/python/test/canary/compiled/staging_queries/gcp/exports.dim_listing_mutations__0
@@ -2,11 +2,15 @@
   "engineType": 1,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo__dim_listing_mutations__with_offset_0\", \"spec\": \"demo.`dim_listing_mutations`/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -17,6 +21,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -48,6 +53,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -67,6 +73,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/staging_queries/gcp/exports.dim_listings__0
+++ b/python/test/canary/compiled/staging_queries/gcp/exports.dim_listings__0
@@ -2,11 +2,15 @@
   "engineType": 1,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo__dim_listings__with_offset_0\", \"spec\": \"demo.`dim_listings`/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -17,6 +21,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -48,6 +53,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -67,6 +73,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/staging_queries/gcp/exports.dim_merchants__0
+++ b/python/test/canary/compiled/staging_queries/gcp/exports.dim_merchants__0
@@ -2,11 +2,15 @@
   "engineType": 1,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo__dim_merchants__with_offset_0\", \"spec\": \"demo.`dim_merchants`/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -17,6 +21,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -48,6 +53,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -67,6 +73,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/staging_queries/gcp/exports.dim_users__0
+++ b/python/test/canary/compiled/staging_queries/gcp/exports.dim_users__0
@@ -2,11 +2,15 @@
   "engineType": 1,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo__dim_users__with_offset_0\", \"spec\": \"demo.`dim_users`/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -17,6 +21,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -48,6 +53,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -67,6 +73,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/staging_queries/gcp/exports.user_activities__0
+++ b/python/test/canary/compiled/staging_queries/gcp/exports.user_activities__0
@@ -2,11 +2,15 @@
   "engineType": 1,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo__user_activities__with_offset_0\", \"spec\": \"demo.`user-activities`/_PARTITIONTIME={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -17,6 +21,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -48,6 +53,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -67,6 +73,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/staging_queries/gcp/partitioned_logging.v0__2
+++ b/python/test/canary/compiled/staging_queries/gcp/partitioned_logging.v0__2
@@ -1,11 +1,15 @@
 {
   "metaData": {
     "customJson": "{\"airflowDependencies\": []}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -16,6 +20,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -47,6 +52,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -66,6 +72,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/staging_queries/gcp/purchases_import.v1__0
+++ b/python/test/canary/compiled/staging_queries/gcp/purchases_import.v1__0
@@ -2,11 +2,15 @@
   "engineType": 1,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_purchases_with_offset_0\", \"spec\": \"data.purchases/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -17,6 +21,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -48,6 +53,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -67,6 +73,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/staging_queries/gcp/purchases_notds_import.v1__0
+++ b/python/test/canary/compiled/staging_queries/gcp/purchases_notds_import.v1__0
@@ -2,11 +2,15 @@
   "engineType": 1,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_purchases_notds_with_offset_0\", \"spec\": \"data.purchases_notds/notds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -17,6 +21,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -48,6 +53,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -67,6 +73,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.cart__0
+++ b/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.cart__0
@@ -1,11 +1,15 @@
 {
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_training_set_v1_test__0_with_offset_1\", \"spec\": \"data.gcp_training_set_v1_test__0/ds={{ macros.ds_add(ds, -1) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -16,6 +20,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -47,6 +52,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -66,6 +72,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.item__0
+++ b/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.item__0
@@ -1,11 +1,15 @@
 {
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_training_set_v1_test__0_with_offset_1\", \"spec\": \"data.gcp_training_set_v1_test__0/ds={{ macros.ds_add(ds, -1) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -16,6 +20,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -47,6 +52,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -66,6 +72,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.order__0
+++ b/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.order__0
@@ -1,11 +1,15 @@
 {
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_training_set_v1_test__0_with_offset_1\", \"spec\": \"data.gcp_training_set_v1_test__0/ds={{ macros.ds_add(ds, -1) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -16,6 +20,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -47,6 +52,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -66,6 +72,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.payment__0
+++ b/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.payment__0
@@ -1,11 +1,15 @@
 {
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_training_set_v1_test__0_with_offset_1\", \"spec\": \"data.gcp_training_set_v1_test__0/ds={{ macros.ds_add(ds, -1) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -16,6 +20,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -47,6 +52,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -66,6 +72,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.purchases_labels__0
+++ b/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.purchases_labels__0
@@ -1,11 +1,15 @@
 {
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_training_set_v1_test__0_with_offset_0\", \"spec\": \"data.gcp_training_set_v1_test__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -16,6 +20,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -47,6 +52,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -66,6 +72,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.shipping__0
+++ b/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.shipping__0
@@ -1,11 +1,15 @@
 {
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_training_set_v1_test__0_with_offset_1\", \"spec\": \"data.gcp_training_set_v1_test__0/ds={{ macros.ds_add(ds, -1) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -16,6 +20,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -47,6 +52,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -66,6 +72,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.terminal__0
+++ b/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.terminal__0
@@ -1,11 +1,15 @@
 {
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_sample_staging_query_cart__0_with_offset_1\", \"spec\": \"data.gcp_sample_staging_query_cart__0/ds={{ macros.ds_add(ds, -1) }}\"}, {\"name\": \"wf_data_gcp_sample_staging_query_user__0_with_offset_1\", \"spec\": \"data.gcp_sample_staging_query_user__0/ds={{ macros.ds_add(ds, -1) }}\"}, {\"name\": \"wf_data_gcp_sample_staging_query_item__0_with_offset_1\", \"spec\": \"data.gcp_sample_staging_query_item__0/ds={{ macros.ds_add(ds, -1) }}\"}, {\"name\": \"wf_data_gcp_sample_staging_query_order__0_with_offset_1\", \"spec\": \"data.gcp_sample_staging_query_order__0/ds={{ macros.ds_add(ds, -1) }}\"}, {\"name\": \"wf_data_gcp_sample_staging_query_payment__0_with_offset_1\", \"spec\": \"data.gcp_sample_staging_query_payment__0/ds={{ macros.ds_add(ds, -1) }}\"}, {\"name\": \"wf_data_gcp_sample_staging_query_shipping__0_with_offset_1\", \"spec\": \"data.gcp_sample_staging_query_shipping__0/ds={{ macros.ds_add(ds, -1) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -16,6 +20,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -47,6 +52,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -66,6 +72,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.user__0
+++ b/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.user__0
@@ -1,11 +1,15 @@
 {
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_training_set_v1_test__0_with_offset_1\", \"spec\": \"data.gcp_training_set_v1_test__0/ds={{ macros.ds_add(ds, -1) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -16,6 +20,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -47,6 +52,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -66,6 +72,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.v1_bigquery_import__0
+++ b/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.v1_bigquery_import__0
@@ -2,11 +2,15 @@
   "engineType": 1,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_training_set_v1_hub__0_with_offset_0\", \"spec\": \"data.gcp_training_set_v1_hub__0/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -17,6 +21,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -48,6 +53,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -67,6 +73,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.v1_hub__0
+++ b/python/test/canary/compiled/staging_queries/gcp/sample_staging_query.v1_hub__0
@@ -1,11 +1,15 @@
 {
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_gcp_training_set_v1_hub__0_with_offset_1\", \"spec\": \"data.gcp_training_set_v1_hub__0/ds={{ macros.ds_add(ds, -1) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -16,6 +20,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -47,6 +52,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -66,6 +72,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/staging_queries/gcp/team_default_ns_example.v1__0
+++ b/python/test/canary/compiled/staging_queries/gcp/team_default_ns_example.v1__0
@@ -2,11 +2,15 @@
   "engineType": 1,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_checkouts_with_offset_0\", \"spec\": \"data.checkouts/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "clusterConf": {
         "modeClusterConfigs": {
           "upload": {
-            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+            "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+            "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
           }
         }
       },
@@ -17,6 +21,7 @@
           "spark.chronon.partition.format": "yyyy-MM-dd",
           "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
           "spark.chronon.table_write.format": "iceberg",
+          "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
           "spark.default.parallelism": "10",
           "spark.driver.cores": "1",
           "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -48,6 +53,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -67,6 +73,7 @@
             "GCP_PROJECT_ID": "canary-443022",
             "GCP_REGION": "us-central1",
             "HUB_URL": "http://localhost:3903",
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
             "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
             "VERSION": "latest",
             "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/compiled/staging_queries/quickstart/exports.dim_listings__0
+++ b/python/test/canary/compiled/staging_queries/quickstart/exports.dim_listings__0
@@ -2,6 +2,9 @@
   "engineType": 0,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo_dim_listings_with_offset_0\", \"spec\": \"demo.dim_listings/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/quickstart/exports.dim_merchants__0
+++ b/python/test/canary/compiled/staging_queries/quickstart/exports.dim_merchants__0
@@ -2,6 +2,9 @@
   "engineType": 0,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo_dim_merchants_with_offset_0\", \"spec\": \"demo.dim_merchants/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/quickstart/exports.dim_users__0
+++ b/python/test/canary/compiled/staging_queries/quickstart/exports.dim_users__0
@@ -2,6 +2,9 @@
   "engineType": 0,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo_dim_users_with_offset_0\", \"spec\": \"demo.dim_users/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/staging_queries/quickstart/exports.user_activities__0
+++ b/python/test/canary/compiled/staging_queries/quickstart/exports.user_activities__0
@@ -2,6 +2,9 @@
   "engineType": 0,
   "metaData": {
     "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_demo_user_activities_with_offset_0\", \"spec\": \"demo.user_activities/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "environments": [
+      0
+    ],
     "executionInfo": {
       "conf": {
         "common": {

--- a/python/test/canary/compiled/teams_metadata/gcp/gcp_team_metadata
+++ b/python/test/canary/compiled/teams_metadata/gcp/gcp_team_metadata
@@ -3,7 +3,8 @@
     "clusterConf": {
       "modeClusterConfigs": {
         "upload": {
-          "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}"
+          "dataproc.config": "{\"gceClusterConfig\": {\"subnetworkUri\": \"default\", \"serviceAccount\": \"dataproc@canary-443022.iam.gserviceaccount.com\", \"serviceAccountScopes\": [\"https://www.googleapis.com/auth/cloud-platform\", \"https://www.googleapis.com/auth/monitoring\", \"https://www.googleapis.com/auth/cloud.useraccounts.readonly\", \"https://www.googleapis.com/auth/devstorage.read_write\", \"https://www.googleapis.com/auth/logging.write\"], \"metadata\": {\"hive-version\": \"3.1.2\", \"SPARK_BQ_CONNECTOR_URL\": \"gs://spark-lib/bigquery/spark-3.5-bigquery-0.42.1.jar\", \"artifact_prefix\": \"gs://zipline-artifacts-canary\"}, \"tags\": []}, \"masterConfig\": {\"numInstances\": 1, \"machineTypeUri\": \"n2-highmem-8\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 1024}}, \"workerConfig\": {\"numInstances\": 2, \"machineTypeUri\": \"n2-highmem-4\", \"diskConfig\": {\"bootDiskType\": \"pd-standard\", \"bootDiskSizeGb\": 64, \"numLocalSsds\": 2}}, \"softwareConfig\": {\"imageVersion\": \"2.2.66-debian12\", \"optionalComponents\": [\"FLINK\", \"JUPYTER\"], \"properties\": {\"dataproc:dataproc.logging.stackdriver.enable\": \"true\", \"dataproc:jobs.file-backed-output.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.driver.enable\": \"true\", \"dataproc:dataproc.logging.stackdriver.job.yarn.container.enable\": \"true\"}}, \"initializationActions\": [{\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/copy_java_security.sh\"}, {\"executable_file\": \"gs://zipline-artifacts-canary/release/latest/scripts/gcp/opsagent_setup.sh\"}], \"endpointConfig\": {\"enableHttpPortAccess\": true}, \"lifecycleConfig\": {\"idleDeleteTtl\": \"7200s\"}}",
+          "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a"
         }
       }
     },
@@ -14,6 +15,7 @@
         "spark.chronon.partition.format": "yyyy-MM-dd",
         "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
         "spark.chronon.table_write.format": "iceberg",
+        "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
         "spark.default.parallelism": "10",
         "spark.driver.cores": "1",
         "spark.driver.extraJavaOptions": "-Dai.chronon.metrics.enabled=true -Dai.chronon.metrics.reader=grpc -Dai.chronon.metrics.exporter.url=http://localhost:4317",
@@ -45,6 +47,7 @@
         "GCP_PROJECT_ID": "canary-443022",
         "GCP_REGION": "us-central1",
         "HUB_URL": "http://localhost:3903",
+        "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
         "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
         "VERSION": "latest",
         "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"
@@ -64,6 +67,7 @@
           "GCP_PROJECT_ID": "canary-443022",
           "GCP_REGION": "us-central1",
           "HUB_URL": "http://localhost:3903",
+          "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
           "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster",
           "VERSION": "latest",
           "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary"

--- a/python/test/canary/teams.py
+++ b/python/test/canary/teams.py
@@ -71,6 +71,38 @@ gcp = Team(
             "FRONTEND_URL": "http://localhost:3000",
             "HUB_URL": "http://localhost:3903",
             "EVAL_URL": "http://localhost:3904",
+            # Sentinel — referenced by test_canary_compile.py to verify that the
+            # prod compile pass uses only Team.env (never Team.canaryEnv). Must
+            # not appear in any file under canary_compiled/.
+            "PROD_ONLY_SENTINEL_GCP": "prod-only-sentinel-value-9b8a7c",
+        },
+        modeEnvironments={
+            RunMode.UPLOAD: {
+                "SPARK_CLUSTER_NAME": "zipline-transient-upload-cluster"
+            }
+        }
+    ),
+    canaryEnv=EnvironmentVariables(
+        common={
+            "CLOUD_PROVIDER": "gcp",
+            "CUSTOMER_ID": "canary",
+            "VERSION": "latest",
+            "GCP_PROJECT_ID": "canary-443022",
+            "GCP_REGION": "us-central1",
+            "SPARK_CLUSTER_NAME": "zipline-canary-cluster",
+            "GCP_BIGTABLE_INSTANCE_ID": "zipline-canary-instance",
+            "ENABLE_PUBSUB": "true",
+            "ARTIFACT_PREFIX": "gs://zipline-artifacts-canary",
+            "WAREHOUSE_PREFIX": "gs://zipline-warehouse-canary",
+            "FLINK_STATE_URI": "gs://zipline-warehouse-canary/flink-state",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=4",
+            "FRONTEND_URL": "http://localhost:3000",
+            "HUB_URL": "http://localhost:3903",
+            "EVAL_URL": "http://localhost:3904",
+            # Sentinel — referenced by test_canary_compile.py to verify that the
+            # canary compile pass uses only Team.canaryEnv (never Team.env).
+            # Must not appear in any file under compiled/.
+            "CANARY_ONLY_SENTINEL_GCP": "canary-only-sentinel-value-1d2e3f",
         },
         modeEnvironments={
             RunMode.UPLOAD: {
@@ -107,6 +139,41 @@ gcp = Team(
                 "-Dai.chronon.metrics.reader=grpc",
                 "-Dai.chronon.metrics.exporter.url=http://localhost:4317",
             ]),
+            # Sentinel — prod-only conf marker for the test.
+            "spark.chronon.test.prod_only_sentinel": "prod-only-conf-sentinel-4f5a6b",
+        },
+        modeConfigs={
+        }
+    ),
+    canaryConf=ConfigProperties(
+        common={
+            **BigQueryConfiguration({
+                "spark.sql.catalog.spark_catalog.warehouse": "gs://zipline-warehouse-canary/data/tables/",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.location": "us-central1",
+                "spark.sql.catalog.spark_catalog.gcp.bigquery.project-id": "canary-443022",
+            }),
+
+            "spark.chronon.table.format_provider.class": "ai.chronon.integrations.cloud_gcp.GcpFormatProvider",
+            "spark.chronon.table_write.format": "iceberg",
+
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.partition.column": "ds",
+
+            "spark.chronon.coalesce.factor": "10",
+            "spark.default.parallelism": "10",
+            "spark.sql.shuffle.partitions": "10",
+            "spark.driver.memory": "512m",
+            "spark.driver.cores": "1",
+            "spark.executor.memory": "512m",
+            "spark.executor.cores": "1",
+
+            "spark.driver.extraJavaOptions": " ".join([
+                "-Dai.chronon.metrics.enabled=true",
+                "-Dai.chronon.metrics.reader=grpc",
+                "-Dai.chronon.metrics.exporter.url=http://localhost:4317",
+            ]),
+            # Sentinel — canary-only conf marker for the test.
+            "spark.chronon.test.canary_only_sentinel": "canary-only-conf-sentinel-7c8d9e",
         },
         modeConfigs={
         }
@@ -117,7 +184,21 @@ gcp = Team(
                 "dataproc.config": generate_dataproc_cluster_config(2, "canary-443022", "gs://zipline-artifacts-canary",
                                                                     idle_timeout="7200s",
                                                                     worker_host_type="n2-highmem-4",
-                                                                    master_host_type="n2-highmem-8")
+                                                                    master_host_type="n2-highmem-8"),
+                # Sentinel — prod-only cluster-conf marker for the test.
+                "prod_only_sentinel_cluster": "prod-only-cluster-sentinel-2e3f4a",
+            }
+        }
+    ),
+    canaryClusterConf=ClusterConfigProperties(
+        modeClusterConfigs={
+            RunMode.UPLOAD: {
+                "dataproc.config": generate_dataproc_cluster_config(2, "canary-443022", "gs://zipline-artifacts-canary",
+                                                                    idle_timeout="7200s",
+                                                                    worker_host_type="n2-highmem-4",
+                                                                    master_host_type="n2-highmem-8"),
+                # Sentinel — canary-only cluster-conf marker for the test.
+                "canary_only_sentinel_cluster": "canary-only-cluster-sentinel-5b6c7d",
             }
         }
     ),

--- a/python/test/canary/teams.py
+++ b/python/test/canary/teams.py
@@ -12,6 +12,11 @@ default = Team(
             "spark.chronon.partition.column": "ds",
         }
     ),
+    canaryConf=ConfigProperties(
+        common={
+            "spark.chronon.partition.column": "ds",
+        }
+    ),
     env=EnvironmentVariables(
         common={
             "VERSION": "latest",
@@ -20,6 +25,14 @@ default = Team(
             "HUB_URL": "http://localhost:3903",
             "EVAL_URL": "http://localhost:3904",
             "FETCHER_URL": "http://localhost:9000",
+        },
+    ),
+    canaryEnv=EnvironmentVariables(
+        common={
+            "VERSION": "latest",
+            "CUSTOMER_ID": "dev",
+            "FRONTEND_URL": "http://localhost:3000",
+            "HUB_URL": "http://localhost:3903",
         },
     ),
 )
@@ -134,6 +147,28 @@ aws = Team(
             }
         }
     ),
+    canaryEnv=EnvironmentVariables(
+        common={
+            "CLOUD_PROVIDER": "aws",
+            "CUSTOMER_ID": "canary",
+            "VERSION": "latest",
+            "AWS_REGION": "us-west-2",
+            "SPARK_CLUSTER_NAME": "zipline-emr-canary",
+            "ARTIFACT_PREFIX": "s3://zipline-artifacts-canary",
+            "WAREHOUSE_PREFIX": "s3://zipline-warehouse-canary",
+            "FLINK_STATE_URI": "s3://zipline-warehouse-canary/flink-state",
+            "CHRONON_ONLINE_ARGS": " -Ztasks=1",
+            "FRONTEND_URL": "https://canary-aws.zipline.ai",
+            "HUB_URL": "https://canary-orch-aws.zipline.ai",
+            "EVAL_URL": "https://canary-eval-aws.zipline.ai",
+            "ENABLE_KINESIS": "true",
+            "FLINK_JARS_URI": "s3://zipline-artifacts-canary/spark-3.5.3/libs/",
+        },
+        modeEnvironments={
+            RunMode.UPLOAD: {
+            }
+        }
+    ),
     conf=ConfigProperties(
         common={
             **GlueConfiguration({
@@ -159,7 +194,44 @@ aws = Team(
             }
         }
     ),
+    canaryConf=ConfigProperties(
+        common={
+            **GlueConfiguration({
+                "spark.sql.catalog.spark_catalog.warehouse": "s3://zipline-warehouse-canary/data/tables/",
+            }),
+            "spark.chronon.partition.format": "yyyy-MM-dd",
+            "spark.chronon.partition.column": "ds",
+            "spark.chronon.table_write.format": "iceberg",
+            "spark.chronon.table_write.upload.format": "ion",
+            "spark.chronon.table_write.upload.location": "s3://zipline-warehouse-canary/data/ion_uploads/",
+
+            "spark.chronon.coalesce.factor": "10",
+            "spark.default.parallelism": "10",
+            "spark.sql.shuffle.partitions": "10",
+            "spark.driver.memory": "1g",
+            "spark.driver.cores": "1",
+            "spark.executor.memory": "1g",
+            "spark.executor.cores": "1",
+            "taskmanager.memory.process.size": "4G",
+        },
+        modeConfigs={
+            RunMode.BACKFILL: {
+            }
+        }
+    ),
     clusterConf=ClusterConfigProperties(
+        common={
+            "emr.config": generate_emr_cluster_config(
+                instance_count=3,
+                subnet_name="zipline-canary-subnet-main",
+                security_group_name="zipline-canary-sg",
+                instance_type="m5.xlarge",
+                idle_timeout=7200,
+                release_label="emr-7.12.0"
+            )
+        }
+    ),
+    canaryClusterConf=ClusterConfigProperties(
         common={
             "emr.config": generate_emr_cluster_config(
                 instance_count=3,

--- a/python/test/test_canary_compile.py
+++ b/python/test/test_canary_compile.py
@@ -128,3 +128,151 @@ def test_team_default_placeholder_resolves_through_cross_config_table_refs(canar
         f"Join.left.events.table should resolve the internal placeholder against the "
         f"producer's team-default namespace, got {left_table!r}"
     )
+
+
+# Sentinel values embedded in the `gcp` Team in python/test/canary/teams.py.
+# Used by the leak-isolation tests below to verify prod and canary compile
+# passes read from disjoint Team-field sets.
+_PROD_ONLY_SENTINELS = (
+    "prod-only-sentinel-value-9b8a7c",       # env.common
+    "prod-only-conf-sentinel-4f5a6b",        # conf.common
+    "prod-only-cluster-sentinel-2e3f4a",     # clusterConf.modeClusterConfigs
+)
+_CANARY_ONLY_SENTINELS = (
+    "canary-only-sentinel-value-1d2e3f",     # canaryEnv.common
+    "canary-only-conf-sentinel-7c8d9e",      # canaryConf.common
+    "canary-only-cluster-sentinel-5b6c7d",   # canaryClusterConf.modeClusterConfigs
+)
+
+
+def _find_sentinels_in_tree(root_dir, needles):
+    """Return list of (relpath, needle) pairs for every file under `root_dir`
+    whose contents contain any needle. Walks subdirectories."""
+    hits = []
+    for dirpath, _, files in os.walk(root_dir):
+        for f in files:
+            full = os.path.join(dirpath, f)
+            with open(full) as fh:
+                contents = fh.read()
+            for needle in needles:
+                if needle in contents:
+                    hits.append((os.path.relpath(full, root_dir), needle))
+    return hits
+
+
+def test_canary_compile_emits_canary_folder(canary):
+    """A `zipline compile` invocation must produce `canary_compiled/` alongside
+    `compiled/`. The folder layout mirrors `compiled/` (per-conf-type subdirs
+    plus `teams_metadata/`)."""
+    _compile_canary(canary)
+
+    canary_compiled = os.path.join(canary, "canary_compiled")
+    assert os.path.isdir(canary_compiled), f"Expected canary_compiled/ at {canary_compiled}"
+
+    # At minimum the team-metadata folder should exist (every team writes one).
+    assert os.path.isdir(os.path.join(canary_compiled, "teams_metadata")), (
+        "canary_compiled/teams_metadata/ missing — team-metadata pass didn't run for canary"
+    )
+
+
+def test_gcp_join_compiles_to_both_folders_when_team_has_both_configs(canary):
+    """The headline scenario: a Join authored under `joins/gcp/` whose Team in
+    `teams.py` defines both prod and canary trios must land in both output
+    folders with distinct `executionInfo` reflecting the right trio."""
+    _compile_canary(canary)
+
+    relpath = "joins/gcp/training_set.v1_dev__0"
+    prod_path = os.path.join(canary, "compiled", relpath)
+    canary_path = os.path.join(canary, "canary_compiled", relpath)
+
+    assert os.path.exists(prod_path), f"Expected prod output at {prod_path}"
+    assert os.path.exists(canary_path), f"Expected canary output at {canary_path}"
+
+    prod_payload = json.loads(open(prod_path).read())
+    canary_payload = json.loads(open(canary_path).read())
+
+    prod_env = prod_payload["metaData"]["executionInfo"]["env"]["common"]
+    canary_env = canary_payload["metaData"]["executionInfo"]["env"]["common"]
+
+    # Prod env carries the prod-only sentinel; canary env carries the canary-only sentinel.
+    assert prod_env.get("PROD_ONLY_SENTINEL_GCP") == "prod-only-sentinel-value-9b8a7c", (
+        f"prod executionInfo.env should reflect Team.env, got {prod_env}"
+    )
+    assert "CANARY_ONLY_SENTINEL_GCP" not in prod_env, (
+        f"prod executionInfo.env leaked canary value: {prod_env}"
+    )
+    assert canary_env.get("CANARY_ONLY_SENTINEL_GCP") == "canary-only-sentinel-value-1d2e3f", (
+        f"canary executionInfo.env should reflect Team.canaryEnv, got {canary_env}"
+    )
+    assert "PROD_ONLY_SENTINEL_GCP" not in canary_env, (
+        f"canary executionInfo.env leaked prod value: {canary_env}"
+    )
+
+
+def test_canary_team_metadata_uses_canary_fields(canary):
+    """The gcp `_team_metadata` file in `canary_compiled/` should reflect Team.canaryEnv/
+    canaryConf/canaryClusterConf (not the prod fields)."""
+    _compile_canary(canary)
+
+    path = os.path.join(canary, "canary_compiled/teams_metadata/gcp/gcp_team_metadata")
+    assert os.path.exists(path), f"Expected canary gcp team metadata at {path}"
+
+    payload = json.loads(open(path).read())
+    env_common = payload["executionInfo"]["env"]["common"]
+    conf_common = payload["executionInfo"]["conf"]["common"]
+
+    assert env_common.get("CANARY_ONLY_SENTINEL_GCP") == "canary-only-sentinel-value-1d2e3f"
+    assert "PROD_ONLY_SENTINEL_GCP" not in env_common
+    assert conf_common.get("spark.chronon.test.canary_only_sentinel") == "canary-only-conf-sentinel-7c8d9e"
+    assert "spark.chronon.test.prod_only_sentinel" not in conf_common
+
+
+def test_canary_team_without_canary_fields_inherits_default(canary):
+    """A team that doesn't set its own canary fields still gets a team-metadata
+    file in `canary_compiled/`. Its `executionInfo` reflects only what the
+    `default` team's canary fields provide (or is empty if default has none)."""
+    _compile_canary(canary)
+
+    # `test` team in python/test/canary/teams.py has no canary fields of its own.
+    # `default` has canaryEnv with VERSION/CUSTOMER_ID/FRONTEND_URL/HUB_URL and
+    # canaryConf with spark.chronon.partition.column.
+    path = os.path.join(canary, "canary_compiled/teams_metadata/test/test_team_metadata")
+    assert os.path.exists(path), f"Expected canary test team metadata at {path}"
+
+    payload = json.loads(open(path).read())
+    exec_info = payload.get("executionInfo", {})
+    env_common = exec_info.get("env", {}).get("common", {}) if exec_info.get("env") else {}
+
+    # Inherited from default.canaryEnv but NOT carrying any gcp prod or canary sentinel.
+    assert "PROD_ONLY_SENTINEL_GCP" not in env_common
+    assert "CANARY_ONLY_SENTINEL_GCP" not in env_common
+    # Default-team canary inheritance is present.
+    assert env_common.get("VERSION") == "latest"
+
+
+def test_no_leak_prod_fields_into_canary_compiled(canary):
+    """Strict isolation: nothing under canary_compiled/ should contain any
+    prod-only sentinel value from `gcp` Team. Proves the canary compile pass
+    reads only canary trio fields."""
+    _compile_canary(canary)
+
+    canary_compiled = os.path.join(canary, "canary_compiled")
+    hits = _find_sentinels_in_tree(canary_compiled, _PROD_ONLY_SENTINELS)
+    assert not hits, (
+        "Prod-only Team values leaked into canary_compiled/:\n"
+        + "\n".join(f"  {rel} contains {needle!r}" for rel, needle in hits)
+    )
+
+
+def test_no_leak_canary_fields_into_compiled(canary):
+    """Strict isolation: nothing under compiled/ should contain any canary-only
+    sentinel value from `gcp` Team. Proves the prod compile pass reads only
+    prod trio fields."""
+    _compile_canary(canary)
+
+    compiled = os.path.join(canary, "compiled")
+    hits = _find_sentinels_in_tree(compiled, _CANARY_ONLY_SENTINELS)
+    assert not hits, (
+        "Canary-only Team values leaked into compiled/:\n"
+        + "\n".join(f"  {rel} contains {needle!r}" for rel, needle in hits)
+    )

--- a/python/test/test_compile.py
+++ b/python/test/test_compile.py
@@ -21,7 +21,7 @@ from gen_thrift.common.ttypes import ExecutionInfo
 
 from ai.chronon.cli.compile import parse_configs
 from ai.chronon.cli.compile.compile_context import CONFIG_INFOS, CompileContext
-from ai.chronon.cli.compile.parse_teams import update_metadata
+from ai.chronon.cli.compile.parse_teams import CompileMode, update_metadata
 from ai.chronon.repo.compile import __compile, compile
 from ai.chronon.utils import OUTPUT_NAMESPACE_PLACEHOLDER
 
@@ -81,6 +81,7 @@ def test_parse_configs_relative_source_file():
     mock_compile_context.validator.validate_obj.return_value = []
     mock_compile_context.compile_status = MagicMock()
     mock_compile_context.seen_obj_ids = set()
+    mock_compile_context.mode = CompileMode.PROD
 
     # Configure mocks
     with patch('ai.chronon.cli.compile.parse_configs.from_file') as mock_from_file, \

--- a/python/test/test_hub_runner.py
+++ b/python/test/test_hub_runner.py
@@ -591,7 +591,7 @@ class TestHubRunner:
             use_auth=False,
         )
 
-        mock_build_hashmap.assert_called_once_with(root_dir=canary)
+        mock_build_hashmap.assert_called_once_with(root_dir=canary, env="prod")
         mock_upload_diffs.assert_called_once()
         mock_post.assert_called_once()
         url = mock_post.call_args[0][0]

--- a/python/test/test_hub_runner.py
+++ b/python/test/test_hub_runner.py
@@ -19,6 +19,7 @@ from rich.text import Text
 
 from ai.chronon.cli.formatter import Format
 from ai.chronon.repo.hub_runner import hub, redeploy_streaming
+from gen_thrift.api.ttypes import Environment
 
 
 def _plain(text: str) -> str:
@@ -817,3 +818,484 @@ class TestHubRunner:
         assert apply_payload['user'] == "test@example.com"
         assert len(apply_payload['affectedConfs']) == 1
         assert apply_payload['affectedConfs'][0]['confName'] == "aws.my_conf.v1"
+
+    @patch('ai.chronon.repo.hub_runner.get_metadata_map')
+    @patch('ai.chronon.repo.hub_runner.get_schedule_modes')
+    @patch('ai.chronon.repo.hub_runner.hub_uploader.compute_and_upload_diffs')
+    @patch('ai.chronon.repo.hub_runner.hub_uploader.build_local_repo_hashmap')
+    @patch('ai.chronon.repo.hub_runner.get_current_branch')
+    @patch('ai.chronon.repo.hub_runner.ZiplineHub')
+    def test_schedule_all_filters_by_environment(
+        self,
+        mock_zipline_hub,
+        mock_get_current_branch,
+        mock_build_hashmap,
+        mock_compute_diffs,
+        mock_get_schedule_modes,
+        mock_get_metadata_map,
+        canary,
+    ):
+        """Test that submit_schedule_all filters confs based on environment."""
+        from ai.chronon.repo.hub_runner import (
+            ScheduleModes,
+            submit_schedule_all,
+        )
+        from gen_thrift.api.ttypes import Conf
+
+        mock_get_current_branch.return_value = "test-branch"
+        mock_build_hashmap.return_value = {}
+
+        # Create test confs: one with prod, one with canary, one with both
+        prod_conf = Conf(name="test_team.prod_join", localPath="/path/to/prod", hash="hash1")
+        canary_conf = Conf(name="test_team.canary_join", localPath="/path/to/canary", hash="hash2")
+        both_conf = Conf(name="test_team.both_join", localPath="/path/to/both", hash="hash3")
+
+        mock_compute_diffs.return_value = {
+            "test_team.prod_join": prod_conf,
+            "test_team.canary_join": canary_conf,
+            "test_team.both_join": both_conf,
+        }
+
+        # Set up environments for each conf
+        def get_metadata_side_effect(path):
+            if "prod" in path:
+                return {"environments": [Environment.PROD], "executionInfo": {"offlineSchedule": "@daily"}}
+            elif "canary" in path:
+                return {"environments": [Environment.CANARY], "executionInfo": {"offlineSchedule": "@daily"}}
+            elif "both" in path:
+                return {"environments": [Environment.PROD, Environment.CANARY], "executionInfo": {"offlineSchedule": "@daily"}}
+            return {}
+
+        mock_get_metadata_map.side_effect = get_metadata_side_effect
+
+        # Mock schedules
+        mock_get_schedule_modes.return_value = ScheduleModes(
+            offline_schedule="@daily",
+            online_schedule="None"
+        )
+
+        # Mock ZiplineHub
+        mock_hub_instance = mock_zipline_hub.return_value
+        mock_hub_instance.call_schedule_all_api.return_value = {
+            "totalCount": 2,
+            "successCount": 2,
+            "failureCount": 0,
+            "results": []
+        }
+
+        # Test with env='prod'
+        submit_schedule_all(
+            repo=canary,
+            cloud='gcp',
+            customer_id=None,
+            env='prod',
+            hub_url=None,
+            use_auth=False
+        )
+
+        # Should schedule prod_join and both_join, but not canary_join
+        call_args = mock_hub_instance.call_schedule_all_api.call_args[0][0]
+        conf_names = [conf["conf_name"] for conf in call_args]
+        assert "test_team.prod_join" in conf_names
+        assert "test_team.both_join" in conf_names
+        assert "test_team.canary_join" not in conf_names
+
+    @patch('ai.chronon.repo.hub_runner.get_metadata_map')
+    @patch('ai.chronon.repo.hub_runner.get_schedule_modes')
+    @patch('ai.chronon.repo.hub_runner.hub_uploader.compute_and_upload_diffs')
+    @patch('ai.chronon.repo.hub_runner.hub_uploader.build_local_repo_hashmap')
+    @patch('ai.chronon.repo.hub_runner.get_current_branch')
+    @patch('ai.chronon.repo.hub_runner.ZiplineHub')
+    def test_schedule_all_with_canary_environment(
+        self,
+        mock_zipline_hub,
+        mock_get_current_branch,
+        mock_build_hashmap,
+        mock_compute_diffs,
+        mock_get_schedule_modes,
+        mock_get_metadata_map,
+        canary,
+    ):
+        """Test that submit_schedule_all correctly filters for canary environment."""
+        from ai.chronon.repo.hub_runner import (
+            ScheduleModes,
+            submit_schedule_all,
+        )
+        from gen_thrift.api.ttypes import Conf
+
+        mock_get_current_branch.return_value = "test-branch"
+        mock_build_hashmap.return_value = {}
+
+        prod_conf = Conf(name="test_team.prod_join", localPath="/path/to/prod", hash="hash1")
+        canary_conf = Conf(name="test_team.canary_join", localPath="/path/to/canary", hash="hash2")
+        both_conf = Conf(name="test_team.both_join", localPath="/path/to/both", hash="hash3")
+
+        mock_compute_diffs.return_value = {
+            "test_team.prod_join": prod_conf,
+            "test_team.canary_join": canary_conf,
+            "test_team.both_join": both_conf,
+        }
+
+        def get_metadata_side_effect(path):
+            if "prod" in path:
+                return {"environments": [Environment.PROD], "executionInfo": {"offlineSchedule": "@daily"}}
+            elif "canary" in path:
+                return {"environments": [Environment.CANARY], "executionInfo": {"offlineSchedule": "@daily"}}
+            elif "both" in path:
+                return {"environments": [Environment.PROD, Environment.CANARY], "executionInfo": {"offlineSchedule": "@daily"}}
+            return {}
+
+        mock_get_metadata_map.side_effect = get_metadata_side_effect
+
+        mock_get_schedule_modes.return_value = ScheduleModes(
+            offline_schedule="@daily",
+            online_schedule="None"
+        )
+
+        mock_hub_instance = mock_zipline_hub.return_value
+        mock_hub_instance.call_schedule_all_api.return_value = {
+            "totalCount": 2,
+            "successCount": 2,
+            "failureCount": 0,
+            "results": []
+        }
+
+        # Test with env='canary'
+        submit_schedule_all(
+            repo=canary,
+            cloud='gcp',
+            customer_id=None,
+            env='canary',
+            hub_url=None,
+            use_auth=False
+        )
+
+        # Should schedule canary_join and both_join, but not prod_join
+        call_args = mock_hub_instance.call_schedule_all_api.call_args[0][0]
+        conf_names = [conf["conf_name"] for conf in call_args]
+        assert "test_team.canary_join" in conf_names
+        assert "test_team.both_join" in conf_names
+        assert "test_team.prod_join" not in conf_names
+
+    @patch('ai.chronon.repo.hub_runner.get_metadata_map')
+    @patch('ai.chronon.repo.hub_runner.get_schedule_modes')
+    @patch('ai.chronon.repo.hub_runner.hub_uploader.compute_and_upload_diffs')
+    @patch('ai.chronon.repo.hub_runner.hub_uploader.build_local_repo_hashmap')
+    @patch('ai.chronon.repo.hub_runner.get_current_branch')
+    @patch('ai.chronon.repo.hub_runner.ZiplineHub')
+    def test_schedule_all_defaults_to_prod_environment(
+        self,
+        mock_zipline_hub,
+        mock_get_current_branch,
+        mock_build_hashmap,
+        mock_compute_diffs,
+        mock_get_schedule_modes,
+        mock_get_metadata_map,
+        canary,
+    ):
+        """Test that confs without environments field default to ['prod']."""
+        from ai.chronon.repo.hub_runner import (
+            ScheduleModes,
+            submit_schedule_all,
+        )
+        from gen_thrift.api.ttypes import Conf
+
+        mock_get_current_branch.return_value = "test-branch"
+        mock_build_hashmap.return_value = {}
+
+        # Conf without environments field
+        legacy_conf = Conf(name="test_team.legacy_join", localPath="/path/to/legacy", hash="hash1")
+
+        mock_compute_diffs.return_value = {
+            "test_team.legacy_join": legacy_conf,
+        }
+
+        # Return metadata without environments field (should default to ['prod'])
+        mock_get_metadata_map.return_value = {
+            "executionInfo": {"offlineSchedule": "@daily"}
+        }
+
+        mock_get_schedule_modes.return_value = ScheduleModes(
+            offline_schedule="@daily",
+            online_schedule="None"
+        )
+
+        mock_hub_instance = mock_zipline_hub.return_value
+        mock_hub_instance.call_schedule_all_api.return_value = {
+            "totalCount": 1,
+            "successCount": 1,
+            "failureCount": 0,
+            "results": []
+        }
+
+        # Test with env='prod' (default)
+        submit_schedule_all(
+            repo=canary,
+            cloud='gcp',
+            customer_id=None,
+            env='prod',
+            hub_url=None,
+            use_auth=False
+        )
+
+        # Should schedule legacy_join since it defaults to prod
+        call_args = mock_hub_instance.call_schedule_all_api.call_args[0][0]
+        conf_names = [conf["conf_name"] for conf in call_args]
+        assert "test_team.legacy_join" in conf_names
+
+    @patch('ai.chronon.repo.hub_runner.get_metadata_map')
+    @patch('ai.chronon.repo.hub_runner.get_schedule_modes')
+    @patch('ai.chronon.repo.hub_runner.hub_uploader.compute_and_upload_diffs')
+    @patch('ai.chronon.repo.hub_runner.hub_uploader.build_local_repo_hashmap')
+    @patch('ai.chronon.repo.hub_runner.get_current_branch')
+    @patch('ai.chronon.repo.hub_runner.ZiplineHub')
+    def test_schedule_all_no_matching_environment(
+        self,
+        mock_zipline_hub,
+        mock_get_current_branch,
+        mock_build_hashmap,
+        mock_compute_diffs,
+        mock_get_schedule_modes,
+        mock_get_metadata_map,
+        canary,
+    ):
+        """Test that submit_schedule_all reports when no confs match the environment."""
+        from ai.chronon.repo.hub_runner import (
+            ScheduleModes,
+            submit_schedule_all,
+        )
+        from gen_thrift.api.ttypes import Conf
+
+        mock_get_current_branch.return_value = "test-branch"
+        mock_build_hashmap.return_value = {}
+
+        # Only prod confs
+        prod_conf = Conf(name="test_team.prod_join", localPath="/path/to/prod", hash="hash1")
+
+        mock_compute_diffs.return_value = {
+            "test_team.prod_join": prod_conf,
+        }
+
+        mock_get_metadata_map.return_value = {
+            "environments": [Environment.PROD],
+            "executionInfo": {"offlineSchedule": "@daily"}
+        }
+
+        mock_get_schedule_modes.return_value = ScheduleModes(
+            offline_schedule="@daily",
+            online_schedule="None"
+        )
+
+        mock_hub_instance = mock_zipline_hub.return_value
+
+        # Test with env='canary' (should not match any confs)
+        submit_schedule_all(
+            repo=canary,
+            cloud='gcp',
+            customer_id=None,
+            env='canary',
+            hub_url=None,
+            use_auth=False
+        )
+
+        # Should NOT call schedule API since no confs match
+        mock_hub_instance.call_schedule_all_api.assert_not_called()
+
+    @patch('ai.chronon.repo.hub_runner.submit_schedule_all')
+    @patch('ai.chronon.click_helpers.__compile')
+    def test_schedule_all_command_accepts_env_parameter(
+        self,
+        mock_compile,
+        mock_submit_schedule_all,
+        canary,
+    ):
+        """Test that schedule-all command accepts --env parameter."""
+        mock_compile.return_value = ({}, False, {"added": [], "changed": [], "deleted": []})
+
+        runner = CliRunner()
+
+        # Test with --env prod
+        result = self._run_and_print(runner, hub, [
+            'schedule-all',
+            '--repo', canary,
+            '--cloud', 'gcp',
+            '--no-use-auth',
+            '--env', 'prod',
+        ])
+        assert result.exit_code == 0
+
+        # Verify submit_schedule_all was called with env='prod'
+        call_kwargs = mock_submit_schedule_all.call_args[1]
+        assert call_kwargs['env'] == 'prod'
+
+        # Test with --env canary
+        result = self._run_and_print(runner, hub, [
+            'schedule-all',
+            '--repo', canary,
+            '--cloud', 'gcp',
+            '--no-use-auth',
+            '--env', 'canary',
+        ])
+        assert result.exit_code == 0
+
+        # Verify submit_schedule_all was called with env='canary'
+        call_kwargs = mock_submit_schedule_all.call_args[1]
+        assert call_kwargs['env'] == 'canary'
+
+    @patch('ai.chronon.repo.hub_runner.submit_schedule_all')
+    @patch('ai.chronon.click_helpers.__compile')
+    def test_schedule_all_command_rejects_invalid_env(
+        self,
+        mock_compile,
+        mock_submit_schedule_all,
+        canary,
+    ):
+        """Test that schedule-all command rejects invalid --env values."""
+        mock_compile.return_value = ({}, False, {"added": [], "changed": [], "deleted": []})
+
+        runner = CliRunner()
+
+        # Test with invalid env value
+        result = self._run_and_print(runner, hub, [
+            'schedule-all',
+            '--repo', canary,
+            '--cloud', 'gcp',
+            '--no-use-auth',
+            '--env', 'invalid',
+        ])
+
+        # Should fail with exit code 2 (invalid option)
+        assert result.exit_code == 2
+        assert "Invalid value for '--env'" in result.output or "'invalid' is not one of" in result.output
+
+        # submit_schedule_all should NOT be called
+        mock_submit_schedule_all.assert_not_called()
+
+
+class TestEnvironmentValidation:
+    """Test environment string validation in API functions."""
+
+    def test_join_accepts_valid_environments(self):
+        """Test that Join accepts 'prod' and 'canary' strings."""
+        from ai.chronon.join import Join
+        from ai.chronon.query import Query
+        from gen_thrift.api.ttypes import EventSource, Source
+
+        left = Source(events=EventSource(table="test.table", query=Query(selects={"a": "a"})))
+
+        # Should not raise for valid environments
+        join = Join(
+            left=left,
+            right_parts=[],
+            row_ids="id",
+            environments=['prod']
+        )
+        assert join.metaData.environments == [0]  # Environment.PROD
+
+        join = Join(
+            left=left,
+            right_parts=[],
+            row_ids="id",
+            environments=['canary']
+        )
+        assert join.metaData.environments == [1]  # Environment.CANARY
+
+        join = Join(
+            left=left,
+            right_parts=[],
+            row_ids="id",
+            environments=['prod', 'canary']
+        )
+        assert join.metaData.environments == [0, 1]
+
+        # Test case insensitivity
+        join = Join(
+            left=left,
+            right_parts=[],
+            row_ids="id",
+            environments=['PROD', 'Canary']
+        )
+        assert join.metaData.environments == [0, 1]
+
+    def test_join_rejects_invalid_environment(self):
+        """Test that Join raises ValueError for invalid environment strings."""
+        from ai.chronon.join import Join
+        from ai.chronon.query import Query
+        from gen_thrift.api.ttypes import EventSource, Source
+        import pytest
+
+        left = Source(events=EventSource(table="test.table", query=Query(selects={"a": "a"})))
+
+        with pytest.raises(ValueError) as exc_info:
+            Join(
+                left=left,
+                right_parts=[],
+                row_ids="id",
+                environments=['invalid']
+            )
+        assert "Invalid environment 'invalid'" in str(exc_info.value)
+        assert "Must be one of: ['prod', 'canary']" in str(exc_info.value)
+
+    def test_group_by_rejects_invalid_environment(self):
+        """Test that GroupBy raises ValueError for invalid environment strings."""
+        from ai.chronon.group_by import GroupBy
+        from ai.chronon.query import Query
+        from gen_thrift.api.ttypes import EventSource, Source
+        import pytest
+
+        source = Source(events=EventSource(table="test.table", query=Query(selects={"a": "a"})))
+
+        with pytest.raises(ValueError) as exc_info:
+            GroupBy(
+                sources=[source],
+                keys=['a'],
+                aggregations=None,
+                environments=['staging']
+            )
+        assert "Invalid environment 'staging'" in str(exc_info.value)
+
+    def test_staging_query_rejects_invalid_environment(self):
+        """Test that StagingQuery raises ValueError for invalid environment strings."""
+        from ai.chronon.staging_query import StagingQuery
+        import pytest
+
+        with pytest.raises(ValueError) as exc_info:
+            StagingQuery(
+                query="SELECT * FROM table",
+                environments=['dev']
+            )
+        assert "Invalid environment 'dev'" in str(exc_info.value)
+
+    def test_model_rejects_invalid_environment(self):
+        """Test that Model raises ValueError for invalid environment strings."""
+        from ai.chronon.model import Model
+        import pytest
+
+        with pytest.raises(ValueError) as exc_info:
+            Model(
+                version="v1",
+                environments=['test']
+            )
+        assert "Invalid environment 'test'" in str(exc_info.value)
+
+    def test_utils_convert_environments_to_enum(self):
+        """Test the shared utils.convert_environments_to_enum function."""
+        from ai.chronon.utils import convert_environments_to_enum
+        from gen_thrift.api.ttypes import Environment
+        import pytest
+
+        # Test valid inputs
+        assert convert_environments_to_enum(['prod']) == [Environment.PROD]
+        assert convert_environments_to_enum(['canary']) == [Environment.CANARY]
+        assert convert_environments_to_enum(['prod', 'canary']) == [Environment.PROD, Environment.CANARY]
+
+        # Test case insensitivity
+        assert convert_environments_to_enum(['PROD']) == [Environment.PROD]
+        assert convert_environments_to_enum(['Canary']) == [Environment.CANARY]
+        assert convert_environments_to_enum(['PrOd', 'CaNaRy']) == [Environment.PROD, Environment.CANARY]
+
+        # Test invalid input
+        with pytest.raises(ValueError) as exc_info:
+            convert_environments_to_enum(['staging'])
+        assert "Invalid environment 'staging'" in str(exc_info.value)
+        assert "Must be one of: ['prod', 'canary']" in str(exc_info.value)

--- a/thrift/api.thrift
+++ b/thrift/api.thrift
@@ -532,6 +532,10 @@ struct Team {
     20: optional common.EnvironmentVariables env
     21: optional common.ConfigProperties conf
     22: optional common.ClusterConfigProperties clusterConf
+
+    23: optional common.EnvironmentVariables canaryEnv
+    24: optional common.ConfigProperties canaryConf
+    25: optional common.ClusterConfigProperties canaryClusterConf
 }
 
 enum DataModel {

--- a/thrift/api.thrift
+++ b/thrift/api.thrift
@@ -329,6 +329,8 @@ struct MetaData {
     // users can put anything they want in here, but the compiler shouldn't
     103: optional string customJson
 
+    104: optional list<string> environments
+
     // enable job to compute consistency metrics
     200: optional bool consistencyCheck
 

--- a/thrift/api.thrift
+++ b/thrift/api.thrift
@@ -284,6 +284,11 @@ enum EngineType {
 
 }
 
+enum Environment {
+    PROD = 0,
+    CANARY = 1,
+}
+
 /**
 * contains configs params that don't change the contents of the output.
 **/
@@ -329,7 +334,7 @@ struct MetaData {
     // users can put anything they want in here, but the compiler shouldn't
     103: optional string customJson
 
-    104: optional list<string> environments
+    104: optional list<Environment> environments
 
     // enable job to compute consistency metrics
     200: optional bool consistencyCheck


### PR DESCRIPTION
## Summary

Adds end-to-end canary support for the compile pipeline and the hub CLI:

1. **Thrift / API** — adds canary trio fields on `Team` (`canaryEnv`, `canaryConf`, `canaryClusterConf`), an `Environment` enum (`PROD`/`CANARY`), and a per-conf `environments` list on `GroupBy`/`Join`/`Model`/`StagingQuery`.
2. **Compile** — one `zipline compile` invocation now produces both `<root>/compiled/` (from `Team.env/conf/clusterConf`) and `<root>/canary_compiled/` (from `Team.canaryEnv/canaryConf/canaryClusterConf`). Strict mode isolation: prod compile never reads canary fields and vice versa. Decorative BEGIN/END banners + a mode-labeled "compilation successful" log make the two passes easy to distinguish.
3. **schedule-all** — gains `--env prod|canary` which filters confs by their `environments` field at scheduling time.
4. **Hub CLI** — `cancel`, `evaluate-schema`, and `list-tables` gain matching `--env` flags. The `DEFAULT_TEAM_METADATA_CONF` constant is replaced with `default_team_metadata_conf(env)` / `team_metadata_conf(team, env)` helpers so every env-aware command reads from the right output folder. A `print_env_banner` helper loudly states the target environment at the start of each env-aware command.

### Implementation notes

- **No skip logic** in canary compile — every team's confs land in `canary_compiled/`, even teams without their own canary fields. Those teams either inherit canary settings from the `default` team or end up with an empty `executionInfo` in their canary output.
- **`merge_team_execution_info`** picks the field tuple from a `_MODE_FIELD_NAMES` table keyed by `CompileMode`. That table is the single source of truth for field-set isolation between modes.
- **Two-pass orchestration** in `compile.py.__compile`: canary pass first, then prod. Each pass owns its own `CompileContext` / `Compiler`. JSON output stays prod-only to preserve the existing external contract; canary results are recoverable from disk.
- **`_get_airflow_deps_from_source`** now skips dep generation when no partition column is resolvable (the deep assert was firing in canary mode when a team had no `canaryConf`).

## Test plan

- [x] `./mill python.test` — full python suite (600+ tests, all green)
- [x] Added 6 tests in `python/test/test_canary_compile.py`:
  - canary folder is emitted
  - gcp Join with both trios lands in both folders with distinct `executionInfo`
  - canary team metadata uses canary fields
  - team without canary fields inherits only `default.canary*`
  - **no prod-only sentinel value leaks into `canary_compiled/`**
  - **no canary-only sentinel value leaks into `compiled/`**
- [x] Extended `python/test/canary/teams.py` (`gcp` Team) with the canary trio + `PROD_ONLY_SENTINEL_*` / `CANARY_ONLY_SENTINEL_*` markers used by the isolation tests
- [x] `./mill __.compile` — full repo compiles
- [x] Manual: ran `zipline compile` against `python/test/canary/`, confirmed both `compiled/` and `canary_compiled/` are produced with the expected per-mode `executionInfo`
- [ ] Manual: end-to-end check of `schedule-all --env canary` and the new `--env` flags on `cancel` / `evaluate-schema` / `list-tables` against a real hub


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `environments` parameter to feature configurations (GroupBy, Join, Model, StagingQuery) to specify deployment targets (prod/canary).
  * Introduced canary compilation mode with separate output directory (`canary_compiled/`) for non-production deployments.
  * Added `--env` flag to CLI commands (schedule-all, cancel, eval-table, list-tables) for environment-specific operations.

* **Improvements**
  * Compilation now supports two-pass execution: canary first, then prod, enabling parallel environment management.
  * Team metadata selection is now environment-aware, using appropriate configs per deployment target.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zipline-ai/chronon/pull/1854)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->