### PR TITLE
Use Crucible-provided Spark history URLs

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/submission/CrucibleClient.scala
+++ b/spark/src/main/scala/ai/chronon/spark/submission/CrucibleClient.scala
@@ -10,6 +10,11 @@ import java.util.concurrent.{CompletableFuture, ExecutionException, TimeUnit, Ti
 case class CrucibleApiException(message: String, statusCode: Option[Int] = None, cause: Throwable = null)
     extends RuntimeException(message, cause)
 
+case class CrucibleJobStatus(status: String,
+                             httpCode: Int,
+                             sparkApplicationId: Option[String] = None,
+                             historyUrl: Option[String] = None)
+
 class CrucibleClient(val baseUrl: String, val namespace: String) {
   @transient lazy val logger: Logger = LoggerFactory.getLogger(getClass)
 
@@ -67,9 +72,9 @@ class CrucibleClient(val baseUrl: String, val namespace: String) {
     await(future, "submitting Crucible job")
   }
 
-  def getJobStatus(jobId: String): (String, Int) = {
+  def getJob(jobId: String): CrucibleJobStatus = {
     val uri = s"$apiBase/jobs/$jobId"
-    val future = new CompletableFuture[(String, Int)]()
+    val future = new CompletableFuture[CrucibleJobStatus]()
 
     client
       .getAbs(s"$baseUrl$uri")
@@ -82,7 +87,14 @@ class CrucibleClient(val baseUrl: String, val namespace: String) {
               val status = Option(respBody.getString("status")).filter(_.nonEmpty).getOrElse {
                 throw new IllegalStateException("Crucible status response missing required field 'status'")
               }
-              future.complete((status, 200))
+              future.complete(
+                CrucibleJobStatus(
+                  status = status,
+                  httpCode = 200,
+                  sparkApplicationId = Option(respBody.getString("sparkApplicationId")).filter(_.nonEmpty),
+                  historyUrl = Option(respBody.getString("historyUrl")).filter(_.nonEmpty)
+                )
+              )
             } catch {
               case e: Exception =>
                 val errorMsg = s"Invalid Crucible status response for job $jobId: ${e.getMessage}"
@@ -90,7 +102,7 @@ class CrucibleClient(val baseUrl: String, val namespace: String) {
                 future.completeExceptionally(CrucibleApiException(errorMsg, Some(response.statusCode()), e))
             }
           } else {
-            future.complete((statusLabel(response.statusCode()), response.statusCode()))
+            future.complete(CrucibleJobStatus(statusLabel(response.statusCode()), response.statusCode()))
           }
         } else {
           val errorMsg = s"Failed to get job status: ${ar.cause().getMessage}"
@@ -100,6 +112,11 @@ class CrucibleClient(val baseUrl: String, val namespace: String) {
       })
 
     await(future, s"getting Crucible status for job $jobId")
+  }
+
+  def getJobStatus(jobId: String): (String, Int) = {
+    val job = getJob(jobId)
+    (job.status, job.httpCode)
   }
 
   def killJob(jobId: String): Unit = {

--- a/spark/src/main/scala/ai/chronon/spark/submission/CrucibleSubmitter.scala
+++ b/spark/src/main/scala/ai/chronon/spark/submission/CrucibleSubmitter.scala
@@ -27,7 +27,8 @@ class CrucibleSubmitter(
 
   @transient override lazy val logger: Logger = LoggerFactory.getLogger(getClass)
 
-  private val client = new CrucibleClient(baseUrl.stripSuffix("/"), namespace)
+  private val normalizedBaseUrl = baseUrl.stripSuffix("/")
+  private val client = new CrucibleClient(normalizedBaseUrl, namespace)
 
   override def submit(
       jobType: JobType,
@@ -154,18 +155,26 @@ class CrucibleSubmitter(
 
   override def close(): Unit = client.close()
 
-  // Spark UI URL: the gateway translates this Crucible jobId to Spark's
-  // driver-assigned application id at click time and 302s to SHS. The
-  // submitter stays synchronous — no polling, no cache — symmetric with the
-  // other JobSubmitter implementations.
   override def getJobUrl(jobId: String): Option[String] =
-    Some(s"${baseUrl.stripSuffix("/")}/api/v1/namespaces/$namespace/jobs/$jobId")
+    Some(jobUrl(jobId))
 
-  override def getSparkUrl(jobId: String): Option[String] =
-    Some(s"${baseUrl.stripSuffix("/")}/spark/$namespace/$jobId/")
+  override def getSparkUrl(jobId: String): Option[String] = {
+    try {
+      val job = client.getJob(jobId)
+      if (job.httpCode == 200) {
+        job.historyUrl.orElse(Some(sparkUIUrl(jobId)))
+      } else {
+        Some(sparkUIUrl(jobId))
+      }
+    } catch {
+      case e: Exception =>
+        logger.warn(s"Failed to resolve Crucible Spark history URL for job $jobId; using live UI URL", e)
+        Some(sparkUIUrl(jobId))
+    }
+  }
 
   override def getFlinkUrl(jobId: String): Option[String] =
-    Some(s"${baseUrl.stripSuffix("/")}/flink/$namespace/$jobId/ui")
+    Some(flinkUIUrl(jobId))
 
   override def isClusterCreateNeeded(isLongRunning: Boolean): Boolean = false
 
@@ -209,6 +218,15 @@ class CrucibleSubmitter(
   private def localClasspathFor(jarUri: String): String =
     if (jarUri.startsWith("local://")) jarUri.stripPrefix("local://")
     else "/opt/spark/work-dir/" + jarUri.split("/").last
+
+  private def jobUrl(jobId: String): String =
+    s"$normalizedBaseUrl/api/v1/namespaces/$namespace/jobs/$jobId"
+
+  private def sparkUIUrl(jobId: String): String =
+    s"$normalizedBaseUrl/jobs/$namespace/$jobId/ui"
+
+  private def flinkUIUrl(jobId: String): String =
+    s"$normalizedBaseUrl/flink/$namespace/$jobId/ui"
 
   private def sanitizeName(name: String): String = {
     val cleaned = name.toLowerCase

--- a/spark/src/test/scala/ai/chronon/spark/submission/CrucibleSubmitterTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/submission/CrucibleSubmitterTest.scala
@@ -1,0 +1,84 @@
+package ai.chronon.spark.submission
+
+import com.sun.net.httpserver.{HttpExchange, HttpHandler, HttpServer}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.net.InetSocketAddress
+import java.nio.charset.StandardCharsets
+
+class CrucibleSubmitterTest extends AnyFlatSpec with Matchers {
+
+  it should "return Spark history URL from Crucible job status when available" in {
+    withCrucibleJobResponse(
+      """{"status":"COMPLETED","sparkApplicationId":"spark-app-1","historyUrl":"https://crucible.example.com/spark-history/history/spark-app-1/jobs/"}"""
+    ) { baseUrl =>
+      val submitter = new CrucibleSubmitter(
+        baseUrl = baseUrl,
+        namespace = "test-ns",
+        sparkImage = "spark-image",
+        flinkImage = "flink-image"
+      )
+      try {
+        submitter.getSparkUrl("job-1") shouldBe Some(
+          "https://crucible.example.com/spark-history/history/spark-app-1/jobs/")
+      } finally {
+        submitter.close()
+      }
+    }
+  }
+
+  it should "fall back to Crucible live Spark UI URL when Spark history URL is unavailable" in {
+    withCrucibleJobResponse("""{"status":"RUNNING"}""") { baseUrl =>
+      val submitter = new CrucibleSubmitter(
+        baseUrl = baseUrl,
+        namespace = "test-ns",
+        sparkImage = "spark-image",
+        flinkImage = "flink-image"
+      )
+      try {
+        submitter.getSparkUrl("job-1") shouldBe Some(s"$baseUrl/jobs/test-ns/job-1/ui")
+      } finally {
+        submitter.close()
+      }
+    }
+  }
+
+  it should "return Crucible live Flink UI URL under the configured base URL" in {
+    val submitter = new CrucibleSubmitter(
+      baseUrl = "https://crucible.example.com/spark-history",
+      namespace = "test-ns",
+      sparkImage = "spark-image",
+      flinkImage = "flink-image"
+    )
+
+    submitter.getFlinkUrl("flink-job-1") shouldBe Some(
+      "https://crucible.example.com/spark-history/flink/test-ns/flink-job-1/ui")
+  }
+
+  private def withCrucibleJobResponse(responseJson: String)(test: String => Unit): Unit = {
+    val server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
+    server.createContext(
+      "/api/v1/namespaces/test-ns/jobs/job-1",
+      new HttpHandler {
+        override def handle(exchange: HttpExchange): Unit = {
+          val response = responseJson.getBytes(StandardCharsets.UTF_8)
+          exchange.getResponseHeaders.add("Content-Type", "application/json")
+          exchange.sendResponseHeaders(200, response.length.toLong)
+          val body = exchange.getResponseBody
+          try {
+            body.write(response)
+          } finally {
+            body.close()
+          }
+        }
+      }
+    )
+    server.start()
+    try {
+      test(s"http://127.0.0.1:${server.getAddress.getPort}")
+    } finally {
+      server.stop(0)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Parse Crucible job status responses into a structured `CrucibleJobStatus`, including `sparkApplicationId` and `historyUrl`.
- Have `CrucibleSubmitter.getSparkUrl` prefer the gateway-provided `historyUrl`, falling back to the live Crucible Spark UI URL while the job is still running or unavailable.
- Keep Flink UI links under the configured Crucible base URL.

Companion Crucible PR: zipline-ai/crucible#13.

## Test plan
- [x] `./mill -i spark.test.testOnly ai.chronon.spark.submission.CrucibleSubmitterTest`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Job status tracking now includes optional Spark application IDs and history URLs for improved job navigation.
  * Spark UI links intelligently route to history URLs when available, providing better job context.

* **Tests**
  * Added comprehensive test coverage for job URL selection and formatting across different job states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zipline-ai/chronon/pull/1864?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->