### PR TITLE
Resolve Flink runtime job id through Crucible

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/submission/CrucibleClient.scala
+++ b/spark/src/main/scala/ai/chronon/spark/submission/CrucibleClient.scala
@@ -210,8 +210,7 @@ class CrucibleClient(val baseUrl: String, val namespace: String) {
       jobObjects
         .find(job => nonEmptyString(job, "jid").isDefined && isRunning(job, "state"))
         .orElse(
-          jobObjects.find(job =>
-            nonEmptyString(job, "jid").isDefined && nonEmptyString(job, "state").isDefined)
+          jobObjects.find(job => nonEmptyString(job, "jid").isDefined && nonEmptyString(job, "state").isDefined)
         )
         .flatMap(job => nonEmptyString(job, "jid"))
         .orElse(

--- a/spark/src/main/scala/ai/chronon/spark/submission/CrucibleClient.scala
+++ b/spark/src/main/scala/ai/chronon/spark/submission/CrucibleClient.scala
@@ -1,7 +1,7 @@
 package ai.chronon.spark.submission
 
 import io.vertx.core.Vertx
-import io.vertx.core.json.JsonObject
+import io.vertx.core.json.{JsonArray, JsonObject}
 import io.vertx.ext.web.client.{WebClient, WebClientOptions}
 import org.slf4j.{Logger, LoggerFactory}
 
@@ -114,6 +114,43 @@ class CrucibleClient(val baseUrl: String, val namespace: String) {
     await(future, s"getting Crucible status for job $jobId")
   }
 
+  def getFlinkInternalJobId(jobId: String): Option[String] = {
+    val uri = s"/flink/$namespace/$jobId/ui/jobs"
+    val future = new CompletableFuture[Option[String]]()
+
+    client
+      .getAbs(s"$baseUrl$uri")
+      .send(ar => {
+        if (ar.succeeded()) {
+          val response = ar.result()
+          if (response.statusCode() == 200) {
+            try {
+              val respBody = new JsonObject(response.bodyAsString())
+              future.complete(extractFlinkJobId(respBody.getJsonArray("jobs")))
+            } catch {
+              case e: Exception =>
+                val errorMsg = s"Invalid Flink jobs response for Crucible job $jobId: ${e.getMessage}"
+                logger.error(errorMsg, e)
+                future.completeExceptionally(CrucibleApiException(errorMsg, Some(response.statusCode()), e))
+            }
+          } else if (response.statusCode() == 404) {
+            future.complete(None)
+          } else {
+            val errorMsg =
+              s"Failed to get Flink internal job id for Crucible job $jobId: HTTP ${response.statusCode()} - ${response.bodyAsString()}"
+            logger.warn(errorMsg)
+            future.complete(None)
+          }
+        } else {
+          val errorMsg = s"Failed to get Flink internal job id for Crucible job $jobId: ${ar.cause().getMessage}"
+          logger.error(errorMsg, ar.cause())
+          future.completeExceptionally(CrucibleApiException(errorMsg, cause = ar.cause()))
+        }
+      })
+
+    await(future, s"getting Flink internal job id for Crucible job $jobId")
+  }
+
   def killJob(jobId: String): Unit = {
     val uri = s"$apiBase/jobs/$jobId"
     logger.info(s"Killing job $jobId")
@@ -159,6 +196,18 @@ class CrucibleClient(val baseUrl: String, val namespace: String) {
       case code if code >= 500 && code < 600 => "SERVER_ERROR"
       case _                                 => "ERROR"
     }
+
+  private def extractFlinkJobId(jobs: JsonArray): Option[String] = {
+    if (jobs == null || jobs.isEmpty) {
+      None
+    } else {
+      val jobObjects = (0 until jobs.size()).flatMap(i => Option(jobs.getJsonObject(i)))
+      jobObjects
+        .find(job => Option(job.getString("status")).exists(_.equalsIgnoreCase("RUNNING")))
+        .orElse(jobObjects.headOption)
+        .flatMap(job => Option(job.getString("id")).filter(_.nonEmpty))
+    }
+  }
 
   def close(): Unit = {
     client.close()

--- a/spark/src/main/scala/ai/chronon/spark/submission/CrucibleClient.scala
+++ b/spark/src/main/scala/ai/chronon/spark/submission/CrucibleClient.scala
@@ -202,10 +202,24 @@ class CrucibleClient(val baseUrl: String, val namespace: String) {
       None
     } else {
       val jobObjects = (0 until jobs.size()).flatMap(i => Option(jobs.getJsonObject(i)))
+      def nonEmptyString(job: JsonObject, field: String): Option[String] =
+        Option(job.getString(field)).filter(_.nonEmpty)
+      def isRunning(job: JsonObject, field: String): Boolean =
+        nonEmptyString(job, field).exists(_.equalsIgnoreCase("RUNNING"))
+
       jobObjects
-        .find(job => Option(job.getString("status")).exists(_.equalsIgnoreCase("RUNNING")))
-        .orElse(jobObjects.headOption)
-        .flatMap(job => Option(job.getString("id")).filter(_.nonEmpty))
+        .find(job => nonEmptyString(job, "jid").isDefined && isRunning(job, "state"))
+        .orElse(
+          jobObjects.find(job =>
+            nonEmptyString(job, "jid").isDefined && nonEmptyString(job, "state").isDefined)
+        )
+        .flatMap(job => nonEmptyString(job, "jid"))
+        .orElse(
+          jobObjects
+            .find(job => isRunning(job, "status"))
+            .orElse(jobObjects.headOption)
+            .flatMap(job => nonEmptyString(job, "id"))
+        )
     }
   }
 

--- a/spark/src/main/scala/ai/chronon/spark/submission/CrucibleSubmitter.scala
+++ b/spark/src/main/scala/ai/chronon/spark/submission/CrucibleSubmitter.scala
@@ -170,6 +170,23 @@ class CrucibleSubmitter(
   override def getFlinkUrl(jobId: String): Option[String] =
     Some(flinkUIUrl(jobId))
 
+  override def getFlinkInternalJobId(jobId: String): Option[String] =
+    try {
+      val internalJobId = client.getFlinkInternalJobId(jobId)
+      internalJobId match {
+        case Some(id) => logger.info(s"Resolved Flink internal job id for Crucible job $jobId: $id")
+        case None     => logger.warn(s"Flink internal job id not yet available for Crucible job $jobId")
+      }
+      internalJobId
+    } catch {
+      case e: CrucibleApiException =>
+        logger.warn(s"Failed to resolve Flink internal job id for Crucible job $jobId: ${e.getMessage}")
+        None
+      case e: Exception =>
+        logger.warn(s"Unexpected error resolving Flink internal job id for Crucible job $jobId", e)
+        None
+    }
+
   override def isClusterCreateNeeded(isLongRunning: Boolean): Boolean = false
 
   override def ensureClusterReady(clusterName: String, clusterConf: Option[Map[String, String]])(implicit

--- a/spark/src/test/scala/ai/chronon/spark/submission/CrucibleSubmitterTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/submission/CrucibleSubmitterTest.scala
@@ -131,6 +131,25 @@ class CrucibleSubmitterTest extends AnyFlatSpec with Matchers {
     }
   }
 
+  it should "resolve Flink internal job id from jid and state fields" in {
+    withCruciblePathResponse(
+      "/flink/test-ns/flink-job-1/ui/jobs",
+      """{"jobs":[{"jid":"staging-job","state":"CREATED"},{"jid":"flink-runtime-456","state":"RUNNING"}]}"""
+    ) { baseUrl =>
+      val submitter = new CrucibleSubmitter(
+        baseUrl = baseUrl,
+        namespace = "test-ns",
+        sparkImage = "spark-image",
+        flinkImage = "flink-image"
+      )
+      try {
+        submitter.getFlinkInternalJobId("flink-job-1") shouldBe Some("flink-runtime-456")
+      } finally {
+        submitter.close()
+      }
+    }
+  }
+
   it should "expand flink dependency jar base path for crucible submissions" in {
     val jars = CrucibleSubmitter.flinkAdditionalJars(
       submissionProperties = Map(

--- a/spark/src/test/scala/ai/chronon/spark/submission/CrucibleSubmitterTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/submission/CrucibleSubmitterTest.scala
@@ -112,6 +112,25 @@ class CrucibleSubmitterTest extends AnyFlatSpec with Matchers {
       "https://crucible.example.com/spark-history/flink/test-ns/flink-job-1/ui")
   }
 
+  it should "resolve Flink internal job id through Crucible Flink REST proxy" in {
+    withCruciblePathResponse(
+      "/flink/test-ns/flink-job-1/ui/jobs",
+      """{"jobs":[{"id":"staging-job","status":"CREATED"},{"id":"flink-runtime-123","status":"RUNNING"}]}"""
+    ) { baseUrl =>
+      val submitter = new CrucibleSubmitter(
+        baseUrl = baseUrl,
+        namespace = "test-ns",
+        sparkImage = "spark-image",
+        flinkImage = "flink-image"
+      )
+      try {
+        submitter.getFlinkInternalJobId("flink-job-1") shouldBe Some("flink-runtime-123")
+      } finally {
+        submitter.close()
+      }
+    }
+  }
+
   it should "expand flink dependency jar base path for crucible submissions" in {
     val jars = CrucibleSubmitter.flinkAdditionalJars(
       submissionProperties = Map(
@@ -134,9 +153,13 @@ class CrucibleSubmitterTest extends AnyFlatSpec with Matchers {
   }
 
   private def withCrucibleJobResponse(responseJson: String)(test: String => Unit): Unit = {
+    withCruciblePathResponse("/api/v1/namespaces/test-ns/jobs/job-1", responseJson)(test)
+  }
+
+  private def withCruciblePathResponse(path: String, responseJson: String)(test: String => Unit): Unit = {
     val server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
     server.createContext(
-      "/api/v1/namespaces/test-ns/jobs/job-1",
+      path,
       new HttpHandler {
         override def handle(exchange: HttpExchange): Unit = {
           val response = responseJson.getBytes(StandardCharsets.UTF_8)


### PR DESCRIPTION
## Summary
- add Crucible client support for resolving the Flink runtime job id via the Flink REST proxy
- wire CrucibleSubmitter.getFlinkInternalJobId so orchestration can persist the runtime id and recover checkpoints without Crucible job state
- add focused submitter coverage for the Flink REST proxy lookup

## Test
- ./mill spark.test.testOnly ai.chronon.spark.submission.CrucibleSubmitterTest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retrieve internal Flink job IDs for Crucible-submitted jobs.

* **Improvements**
  * More robust resolution logic with ordered fallbacks and clearer info/warning logs when an internal ID is found or not yet available; safer handling of missing, unexpected, or error responses.

* **Tests**
  * Added tests covering internal Flink job ID resolution across multiple response formats and scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zipline-ai/chronon/pull/1866?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->