### PR TITLE
Extract stats for clustered iceberg tables

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/batch/iceberg/IcebergClusteredStatsExtractor.scala
+++ b/spark/src/main/scala/ai/chronon/spark/batch/iceberg/IcebergClusteredStatsExtractor.scala
@@ -1,0 +1,170 @@
+package ai.chronon.spark.batch.iceberg
+
+import ai.chronon.api.PartitionSpec
+import ai.chronon.observability.{TileSummary, TileSummaryKey}
+import org.apache.iceberg.DataFile
+import org.apache.iceberg.types.Type
+import org.slf4j.LoggerFactory
+
+import java.time.{LocalDate, ZoneOffset}
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+import scala.util.Try
+
+object IcebergClusteredStatsExtractor {
+  import IcebergPartitionStatsExtractor.PartitionKey
+
+  @transient private lazy val logger = LoggerFactory.getLogger(getClass)
+
+  def extract(fullTableName: String, table: org.apache.iceberg.Table, confName: String)(implicit
+      partitionSpec: PartitionSpec): Option[Map[TileSummaryKey, TileSummary]] = {
+    Option(table.schema()) match {
+      case None =>
+        logger.info(
+          s"Cannot extract synthetic partition stats for $fullTableName because the Iceberg schema is missing")
+        None
+      case Some(schema) =>
+        Option(schema.findField(partitionSpec.column)) match {
+          case None =>
+            logger.info(
+              s"Cannot extract synthetic partition stats for $fullTableName because column ${partitionSpec.column} is missing")
+            None
+          case Some(partitionField) =>
+            extractForPartitionField(fullTableName,
+                                     table,
+                                     confName,
+                                     schema,
+                                     partitionField.fieldId(),
+                                     partitionField.`type`())
+        }
+    }
+  }
+
+  private def extractForPartitionField(fullTableName: String,
+                                       table: org.apache.iceberg.Table,
+                                       confName: String,
+                                       schema: org.apache.iceberg.Schema,
+                                       partitionFieldId: Int,
+                                       partitionFieldType: Type)(implicit
+      partitionSpec: PartitionSpec): Option[Map[TileSummaryKey, TileSummary]] = {
+    Option(table.currentSnapshot()) match {
+      case None => Some(Map.empty)
+      case Some(_) =>
+        val tasks = table.newScan().includeColumnStats().planFiles()
+        val partitionAccumulators = mutable.Map[PartitionKey, PartitionAccumulator]()
+        var complete = true
+
+        try {
+          val iterator = tasks.iterator().asScala
+          while (iterator.hasNext && complete) {
+            val file = iterator.next().file()
+            val partitionKey = syntheticPartitionKey(file, partitionFieldId, partitionFieldType)
+            val columnStats = extractStrictColumnStats(file, schema, Set(partitionFieldId))
+
+            (partitionKey, columnStats) match {
+              case (Some(key), Some(stats)) =>
+                val accumulator = partitionAccumulators.getOrElseUpdate(
+                  key,
+                  new PartitionAccumulator(key, confName, schema)
+                )
+                accumulator.addFileStats(file.recordCount(), stats)
+              case _ =>
+                complete = false
+            }
+          }
+        } finally {
+          tasks.close()
+        }
+
+        if (complete) Some(partitionAccumulators.values.flatMap(_.toTileSummaries).toMap)
+        else None
+    }
+  }
+
+  private def syntheticPartitionKey(file: DataFile, partitionFieldId: Int, partitionFieldType: Type)(implicit
+      partitionSpec: PartitionSpec): Option[PartitionKey] = {
+    for {
+      lower <- partitionBoundValue(file.lowerBounds(), partitionFieldId, partitionFieldType)
+      upper <- partitionBoundValue(file.upperBounds(), partitionFieldId, partitionFieldType)
+      if lower == upper
+    } yield List(partitionSpec.column -> lower)
+  }
+
+  private def partitionBoundValue(bounds: java.util.Map[Integer, java.nio.ByteBuffer],
+                                  partitionFieldId: Int,
+                                  partitionFieldType: Type)(implicit partitionSpec: PartitionSpec): Option[String] =
+    Option(bounds).flatMap { values =>
+      Option(values.get(partitionFieldId)).flatMap { bound =>
+        Try(partitionValue(convertBoundValue(bound, partitionFieldType), partitionFieldType)).toOption
+      }
+    }
+
+  private def partitionValue(value: Any, fieldType: Type)(implicit partitionSpec: PartitionSpec): String =
+    fieldType.typeId() match {
+      case Type.TypeID.TIMESTAMP =>
+        partitionSpec.at(Math.floorDiv(value.asInstanceOf[java.lang.Long].longValue(), 1000L))
+      case Type.TypeID.DATE =>
+        val millis = LocalDate
+          .ofEpochDay(value.asInstanceOf[java.lang.Integer].longValue())
+          .atStartOfDay()
+          .toInstant(ZoneOffset.UTC)
+          .toEpochMilli
+        partitionSpec.at(millis)
+      case Type.TypeID.STRING =>
+        partitionSpec.at(partitionSpec.epochMillis(value.toString))
+      case other =>
+        throw new IllegalArgumentException(
+          s"Unsupported Iceberg synthetic partition bound type $other for value $value")
+    }
+
+  private[iceberg] def extractStrictColumnStats(file: DataFile,
+                                                schema: org.apache.iceberg.Schema,
+                                                excludedFieldIds: Set[Int]): Option[Map[Int, ColumnStats]] = {
+    val fieldIds = schema.columns().asScala.map(_.fieldId()).filterNot(excludedFieldIds.contains)
+    val nullCounts = Option(file.nullValueCounts()).map(
+      _.asScala
+        .map { case (fieldId, nullCount) =>
+          fieldId.toInt -> nullCount.toLong
+        }
+        .toMap)
+    val lowerBounds = extractBounds(file.lowerBounds(), schema, excludedFieldIds)
+    val upperBounds = extractBounds(file.upperBounds(), schema, excludedFieldIds)
+
+    nullCounts.flatMap { counts =>
+      if (fieldIds.forall(counts.contains)) {
+        Some(fieldIds.map { fieldId =>
+          fieldId -> ColumnStats(
+            nullCount = counts(fieldId),
+            minValue = lowerBounds.get(fieldId),
+            maxValue = upperBounds.get(fieldId)
+          )
+        }.toMap)
+      } else {
+        None
+      }
+    }
+  }
+
+  private def extractBounds(bounds: java.util.Map[Integer, java.nio.ByteBuffer],
+                            schema: org.apache.iceberg.Schema,
+                            excludedFieldIds: Set[Int]): Map[Int, Any] =
+    Option(bounds)
+      .map(
+        _.asScala
+          .filterNot { case (fieldId, _) => excludedFieldIds.contains(fieldId) }
+          .flatMap { case (fieldId, bound) =>
+            Option(schema.findField(fieldId)).flatMap { field =>
+              Option(bound).map { validBound =>
+                fieldId.toInt -> convertBoundValue(validBound, field.`type`())
+              }
+            }
+          }
+          .toMap)
+      .getOrElse(Map.empty[Int, Any])
+
+  private def convertBoundValue(bound: java.nio.ByteBuffer, fieldType: Type): Any = {
+    require(bound != null, "bound cannot be null")
+    require(fieldType != null, "fieldType cannot be null")
+    org.apache.iceberg.types.Conversions.fromByteBuffer(fieldType, bound)
+  }
+}

--- a/spark/src/main/scala/ai/chronon/spark/batch/iceberg/IcebergPartitionStatsExtractor.scala
+++ b/spark/src/main/scala/ai/chronon/spark/batch/iceberg/IcebergPartitionStatsExtractor.scala
@@ -211,8 +211,12 @@ class IcebergPartitionStatsExtractor(spark: SparkSession) {
     loadIcebergTable(fullTableName).flatMap { table =>
       val tableSpec = Option(table.spec())
 
-      if (tableSpec.isEmpty || !tableSpec.get.isPartitioned) {
+      if (tableSpec.isEmpty) {
         return None
+      }
+
+      if (!tableSpec.get.isPartitioned) {
+        return IcebergClusteredStatsExtractor.extract(fullTableName, table, confName)
       }
 
       val currentSnapshot = Option(table.currentSnapshot())

--- a/spark/src/test/scala/ai/chronon/spark/batch/iceberg/IcebergPartitionStatsExtractorTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/batch/iceberg/IcebergPartitionStatsExtractorTest.scala
@@ -10,6 +10,7 @@ import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 
 import java.nio.ByteBuffer
 import java.nio.file.Files
+import scala.collection.JavaConverters._
 
 class IcebergPartitionStatsExtractorTest
     extends AnyFlatSpec
@@ -75,6 +76,145 @@ class IcebergPartitionStatsExtractorTest
     val result = extractor.extractPartitionedStats("spark_catalog.default.test_partitioned_table", "test_conf")
 
     result should be(None)
+  }
+
+  it should "extract synthetic ds partition stats from unpartitioned table file metadata" in {
+    spark.sql("""
+      CREATE TABLE test_unpartitioned_ds_stats (
+        id BIGINT,
+        name STRING,
+        ds STRING,
+        value DOUBLE
+      ) USING iceberg
+      TBLPROPERTIES (
+        'write.metadata.metrics.default' = 'full',
+        'write.metadata.metrics.column.ds' = 'full'
+      )
+      """)
+    spark.sql("ALTER TABLE test_unpartitioned_ds_stats WRITE ORDERED BY ds")
+
+    spark.sql("""
+      INSERT INTO test_unpartitioned_ds_stats VALUES
+      (1, 'Alice', '2024-01-15', 100.0),
+      (2, NULL, '2024-01-15', 200.0)
+      """)
+    spark.sql("""
+      INSERT INTO test_unpartitioned_ds_stats VALUES
+      (3, 'Charlie', '2024-01-16', NULL)
+      """)
+
+    spark.sql("REFRESH TABLE test_unpartitioned_ds_stats")
+
+    val extractor = new IcebergPartitionStatsExtractor(spark)
+    val maybeTileSummaries =
+      extractor.extractPartitionedStats("spark_catalog.default.test_unpartitioned_ds_stats", "test_conf")
+
+    maybeTileSummaries should be(defined)
+    val tileSummaries = maybeTileSummaries.get
+    tileSummaries should not be empty
+
+    def getTileSummary(datePartition: String, column: String): Option[TileSummary] = {
+      getFieldId("test_unpartitioned_ds_stats", column).flatMap { fieldId =>
+        tileSummaries.find { case (tileKey, _) =>
+          tileKey.getColumn == fieldId && tileKey.getSlice == s"ds=$datePartition"
+        }.map(_._2)
+      }
+    }
+
+    getTileSummary("2024-01-15", "id").get.getCount should be(2)
+    getTileSummary("2024-01-15", "name").get.getNullCount should be(1)
+    getTileSummary("2024-01-15", "value").get.getNullCount should be(0)
+    getTileSummary("2024-01-16", "id").get.getCount should be(1)
+    getTileSummary("2024-01-16", "value").get.getNullCount should be(1)
+
+    val table = spark.sessionState.catalogManager
+      .catalog("spark_catalog")
+      .asInstanceOf[org.apache.spark.sql.connector.catalog.TableCatalog]
+      .loadTable(org.apache.spark.sql.connector.catalog.Identifier.of(Array("default"), "test_unpartitioned_ds_stats"))
+      .asInstanceOf[org.apache.iceberg.spark.source.SparkTable]
+      .table()
+    val schema = table.schema()
+    val dsFieldId = schema.findField("ds").fieldId()
+    val idFieldId = schema.findField("id").fieldId()
+    val valueFieldId = schema.findField("value").fieldId()
+    val tasks = table.newScan().includeColumnStats().planFiles()
+    try {
+      val firstPartitionFileStats = tasks.iterator().asScala
+        .map(_.file())
+        .find(_.recordCount() == 2L)
+        .flatMap(file => IcebergClusteredStatsExtractor.extractStrictColumnStats(file, schema, Set(dsFieldId)))
+
+      firstPartitionFileStats should be(defined)
+      firstPartitionFileStats.get(idFieldId).minValue should be(Some(1L))
+      firstPartitionFileStats.get(idFieldId).maxValue should be(Some(2L))
+      firstPartitionFileStats.get(valueFieldId).minValue should be(Some(100.0))
+      firstPartitionFileStats.get(valueFieldId).maxValue should be(Some(200.0))
+    } finally {
+      tasks.close()
+    }
+
+    tileSummaries.keys.map(_.getColumn) should not contain dsFieldId.toString
+
+    spark.sql("DROP TABLE IF EXISTS test_unpartitioned_ds_stats")
+  }
+
+  it should "return None for unpartitioned ds table when file metadata stats are missing" in {
+    spark.sql("""
+      CREATE TABLE test_unpartitioned_ds_missing_stats (
+        id BIGINT,
+        name STRING,
+        ds STRING
+      ) USING iceberg
+      TBLPROPERTIES (
+        'write.metadata.metrics.default' = 'none'
+      )
+      """)
+
+    spark.sql("""
+      INSERT INTO test_unpartitioned_ds_missing_stats VALUES
+      (1, 'Alice', '2024-01-15')
+      """)
+
+    val extractor = new IcebergPartitionStatsExtractor(spark)
+    val result =
+      extractor.extractPartitionedStats("spark_catalog.default.test_unpartitioned_ds_missing_stats", "test_conf")
+
+    result should be(None)
+
+    spark.sql("DROP TABLE IF EXISTS test_unpartitioned_ds_missing_stats")
+  }
+
+  it should "return None for unpartitioned ds table when a file spans multiple synthetic partitions" in {
+    spark.sql("""
+      CREATE TABLE test_unpartitioned_ds_multiday_file (
+        id BIGINT,
+        name STRING,
+        ds STRING
+      ) USING iceberg
+      TBLPROPERTIES (
+        'write.metadata.metrics.default' = 'full',
+        'write.metadata.metrics.column.ds' = 'full'
+      )
+      """)
+
+    val sparkSession = spark
+    import sparkSession.implicits._
+    Seq(
+      (1L, "Alice", "2024-01-15"),
+      (2L, "Bob", "2024-01-16")
+    ).toDF("id", "name", "ds")
+      .coalesce(1)
+      .write
+      .mode("append")
+      .insertInto("test_unpartitioned_ds_multiday_file")
+
+    val extractor = new IcebergPartitionStatsExtractor(spark)
+    val result =
+      extractor.extractPartitionedStats("spark_catalog.default.test_unpartitioned_ds_multiday_file", "test_conf")
+
+    result should be(None)
+
+    spark.sql("DROP TABLE IF EXISTS test_unpartitioned_ds_multiday_file")
   }
 
   it should "return empty map for empty partitioned table" in {

--- a/spark/src/test/scala/ai/chronon/spark/batch/iceberg/IcebergPartitionStatsExtractorTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/batch/iceberg/IcebergPartitionStatsExtractorTest.scala
@@ -79,142 +79,148 @@ class IcebergPartitionStatsExtractorTest
   }
 
   it should "extract synthetic ds partition stats from unpartitioned table file metadata" in {
-    spark.sql("""
-      CREATE TABLE test_unpartitioned_ds_stats (
-        id BIGINT,
-        name STRING,
-        ds STRING,
-        value DOUBLE
-      ) USING iceberg
-      TBLPROPERTIES (
-        'write.metadata.metrics.default' = 'full',
-        'write.metadata.metrics.column.ds' = 'full'
-      )
-      """)
-    spark.sql("ALTER TABLE test_unpartitioned_ds_stats WRITE ORDERED BY ds")
-
-    spark.sql("""
-      INSERT INTO test_unpartitioned_ds_stats VALUES
-      (1, 'Alice', '2024-01-15', 100.0),
-      (2, NULL, '2024-01-15', 200.0)
-      """)
-    spark.sql("""
-      INSERT INTO test_unpartitioned_ds_stats VALUES
-      (3, 'Charlie', '2024-01-16', NULL)
-      """)
-
-    spark.sql("REFRESH TABLE test_unpartitioned_ds_stats")
-
-    val extractor = new IcebergPartitionStatsExtractor(spark)
-    val maybeTileSummaries =
-      extractor.extractPartitionedStats("spark_catalog.default.test_unpartitioned_ds_stats", "test_conf")
-
-    maybeTileSummaries should be(defined)
-    val tileSummaries = maybeTileSummaries.get
-    tileSummaries should not be empty
-
-    def getTileSummary(datePartition: String, column: String): Option[TileSummary] = {
-      getFieldId("test_unpartitioned_ds_stats", column).flatMap { fieldId =>
-        tileSummaries.find { case (tileKey, _) =>
-          tileKey.getColumn == fieldId && tileKey.getSlice == s"ds=$datePartition"
-        }.map(_._2)
-      }
-    }
-
-    getTileSummary("2024-01-15", "id").get.getCount should be(2)
-    getTileSummary("2024-01-15", "name").get.getNullCount should be(1)
-    getTileSummary("2024-01-15", "value").get.getNullCount should be(0)
-    getTileSummary("2024-01-16", "id").get.getCount should be(1)
-    getTileSummary("2024-01-16", "value").get.getNullCount should be(1)
-
-    val table = spark.sessionState.catalogManager
-      .catalog("spark_catalog")
-      .asInstanceOf[org.apache.spark.sql.connector.catalog.TableCatalog]
-      .loadTable(org.apache.spark.sql.connector.catalog.Identifier.of(Array("default"), "test_unpartitioned_ds_stats"))
-      .asInstanceOf[org.apache.iceberg.spark.source.SparkTable]
-      .table()
-    val schema = table.schema()
-    val dsFieldId = schema.findField("ds").fieldId()
-    val idFieldId = schema.findField("id").fieldId()
-    val valueFieldId = schema.findField("value").fieldId()
-    val tasks = table.newScan().includeColumnStats().planFiles()
     try {
-      val firstPartitionFileStats = tasks.iterator().asScala
-        .map(_.file())
-        .find(_.recordCount() == 2L)
-        .flatMap(file => IcebergClusteredStatsExtractor.extractStrictColumnStats(file, schema, Set(dsFieldId)))
+      spark.sql("""
+        CREATE TABLE test_unpartitioned_ds_stats (
+          id BIGINT,
+          name STRING,
+          ds STRING,
+          value DOUBLE
+        ) USING iceberg
+        TBLPROPERTIES (
+          'write.metadata.metrics.default' = 'full',
+          'write.metadata.metrics.column.ds' = 'full'
+        )
+        """)
+      spark.sql("ALTER TABLE test_unpartitioned_ds_stats WRITE ORDERED BY ds")
 
-      firstPartitionFileStats should be(defined)
-      firstPartitionFileStats.get(idFieldId).minValue should be(Some(1L))
-      firstPartitionFileStats.get(idFieldId).maxValue should be(Some(2L))
-      firstPartitionFileStats.get(valueFieldId).minValue should be(Some(100.0))
-      firstPartitionFileStats.get(valueFieldId).maxValue should be(Some(200.0))
+      spark.sql("""
+        INSERT INTO test_unpartitioned_ds_stats VALUES
+        (1, 'Alice', '2024-01-15', 100.0),
+        (2, NULL, '2024-01-15', 200.0)
+        """)
+      spark.sql("""
+        INSERT INTO test_unpartitioned_ds_stats VALUES
+        (3, 'Charlie', '2024-01-16', NULL)
+        """)
+
+      spark.sql("REFRESH TABLE test_unpartitioned_ds_stats")
+
+      val extractor = new IcebergPartitionStatsExtractor(spark)
+      val maybeTileSummaries =
+        extractor.extractPartitionedStats("spark_catalog.default.test_unpartitioned_ds_stats", "test_conf")
+
+      maybeTileSummaries should be(defined)
+      val tileSummaries = maybeTileSummaries.get
+      tileSummaries should not be empty
+
+      def getTileSummary(datePartition: String, column: String): Option[TileSummary] = {
+        getFieldId("test_unpartitioned_ds_stats", column).flatMap { fieldId =>
+          tileSummaries.find { case (tileKey, _) =>
+            tileKey.getColumn == fieldId && tileKey.getSlice == s"ds=$datePartition"
+          }.map(_._2)
+        }
+      }
+
+      getTileSummary("2024-01-15", "id").get.getCount should be(2)
+      getTileSummary("2024-01-15", "name").get.getNullCount should be(1)
+      getTileSummary("2024-01-15", "value").get.getNullCount should be(0)
+      getTileSummary("2024-01-16", "id").get.getCount should be(1)
+      getTileSummary("2024-01-16", "value").get.getNullCount should be(1)
+
+      val table = spark.sessionState.catalogManager
+        .catalog("spark_catalog")
+        .asInstanceOf[org.apache.spark.sql.connector.catalog.TableCatalog]
+        .loadTable(org.apache.spark.sql.connector.catalog.Identifier.of(Array("default"), "test_unpartitioned_ds_stats"))
+        .asInstanceOf[org.apache.iceberg.spark.source.SparkTable]
+        .table()
+      val schema = table.schema()
+      val dsFieldId = schema.findField("ds").fieldId()
+      val idFieldId = schema.findField("id").fieldId()
+      val valueFieldId = schema.findField("value").fieldId()
+      val tasks = table.newScan().includeColumnStats().planFiles()
+      try {
+        val firstPartitionFileStats = tasks.iterator().asScala
+          .map(_.file())
+          .find(_.recordCount() == 2L)
+          .flatMap(file => IcebergClusteredStatsExtractor.extractStrictColumnStats(file, schema, Set(dsFieldId)))
+
+        firstPartitionFileStats should be(defined)
+        firstPartitionFileStats.get(idFieldId).minValue should be(Some(1L))
+        firstPartitionFileStats.get(idFieldId).maxValue should be(Some(2L))
+        firstPartitionFileStats.get(valueFieldId).minValue should be(Some(100.0))
+        firstPartitionFileStats.get(valueFieldId).maxValue should be(Some(200.0))
+      } finally {
+        tasks.close()
+      }
+
+      tileSummaries.keys.map(_.getColumn) should not contain dsFieldId.toString
     } finally {
-      tasks.close()
+      spark.sql("DROP TABLE IF EXISTS test_unpartitioned_ds_stats")
     }
-
-    tileSummaries.keys.map(_.getColumn) should not contain dsFieldId.toString
-
-    spark.sql("DROP TABLE IF EXISTS test_unpartitioned_ds_stats")
   }
 
   it should "return None for unpartitioned ds table when file metadata stats are missing" in {
-    spark.sql("""
-      CREATE TABLE test_unpartitioned_ds_missing_stats (
-        id BIGINT,
-        name STRING,
-        ds STRING
-      ) USING iceberg
-      TBLPROPERTIES (
-        'write.metadata.metrics.default' = 'none'
-      )
-      """)
+    try {
+      spark.sql("""
+        CREATE TABLE test_unpartitioned_ds_missing_stats (
+          id BIGINT,
+          name STRING,
+          ds STRING
+        ) USING iceberg
+        TBLPROPERTIES (
+          'write.metadata.metrics.default' = 'none'
+        )
+        """)
 
-    spark.sql("""
-      INSERT INTO test_unpartitioned_ds_missing_stats VALUES
-      (1, 'Alice', '2024-01-15')
-      """)
+      spark.sql("""
+        INSERT INTO test_unpartitioned_ds_missing_stats VALUES
+        (1, 'Alice', '2024-01-15')
+        """)
 
-    val extractor = new IcebergPartitionStatsExtractor(spark)
-    val result =
-      extractor.extractPartitionedStats("spark_catalog.default.test_unpartitioned_ds_missing_stats", "test_conf")
+      val extractor = new IcebergPartitionStatsExtractor(spark)
+      val result =
+        extractor.extractPartitionedStats("spark_catalog.default.test_unpartitioned_ds_missing_stats", "test_conf")
 
-    result should be(None)
-
-    spark.sql("DROP TABLE IF EXISTS test_unpartitioned_ds_missing_stats")
+      result should be(None)
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS test_unpartitioned_ds_missing_stats")
+    }
   }
 
   it should "return None for unpartitioned ds table when a file spans multiple synthetic partitions" in {
-    spark.sql("""
-      CREATE TABLE test_unpartitioned_ds_multiday_file (
-        id BIGINT,
-        name STRING,
-        ds STRING
-      ) USING iceberg
-      TBLPROPERTIES (
-        'write.metadata.metrics.default' = 'full',
-        'write.metadata.metrics.column.ds' = 'full'
-      )
-      """)
+    try {
+      spark.sql("""
+        CREATE TABLE test_unpartitioned_ds_multiday_file (
+          id BIGINT,
+          name STRING,
+          ds STRING
+        ) USING iceberg
+        TBLPROPERTIES (
+          'write.metadata.metrics.default' = 'full',
+          'write.metadata.metrics.column.ds' = 'full'
+        )
+        """)
 
-    val sparkSession = spark
-    import sparkSession.implicits._
-    Seq(
-      (1L, "Alice", "2024-01-15"),
-      (2L, "Bob", "2024-01-16")
-    ).toDF("id", "name", "ds")
-      .coalesce(1)
-      .write
-      .mode("append")
-      .insertInto("test_unpartitioned_ds_multiday_file")
+      val sparkSession = spark
+      import sparkSession.implicits._
+      Seq(
+        (1L, "Alice", "2024-01-15"),
+        (2L, "Bob", "2024-01-16")
+      ).toDF("id", "name", "ds")
+        .coalesce(1)
+        .write
+        .mode("append")
+        .insertInto("test_unpartitioned_ds_multiday_file")
 
-    val extractor = new IcebergPartitionStatsExtractor(spark)
-    val result =
-      extractor.extractPartitionedStats("spark_catalog.default.test_unpartitioned_ds_multiday_file", "test_conf")
+      val extractor = new IcebergPartitionStatsExtractor(spark)
+      val result =
+        extractor.extractPartitionedStats("spark_catalog.default.test_unpartitioned_ds_multiday_file", "test_conf")
 
-    result should be(None)
-
-    spark.sql("DROP TABLE IF EXISTS test_unpartitioned_ds_multiday_file")
+      result should be(None)
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS test_unpartitioned_ds_multiday_file")
+    }
   }
 
   it should "return empty map for empty partitioned table" in {


### PR DESCRIPTION
## Summary

Currently the stats extractor exits when a table is not partitioned but instead clustered over the key. We do _usually_ have sufficient (even more so after 1 new write) info on the file stats still to extract stats to collect count/min/max. This PR adds support for the non-partitioned tables to get stats for the case where the file bounds work out. 

## Checklist
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for extracting tile-level statistics from unpartitioned Iceberg tables by deriving synthetic partition slices from file metadata; returns no stats if any file lacks required metadata or spans multiple synthetic partitions.
  * Partition-handling logic now treats empty specs and truly non-partitioned tables differently, delegating non-partitioned cases to the new extractor.

* **Tests**
  * Added tests covering successful extraction, missing file metadata, and files spanning multiple synthetic partitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zipline-ai/chronon/pull/1870?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->