### PR TITLE
Fix MegaTile live event rebuild to use sawtooth range

### DIFF
--- a/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
@@ -451,11 +451,17 @@ class MegaTileProcessFunction(
       case NoWatermark =>
         nextSmallWindowHop(eventTs)
       case SparseKeyLag | Live =>
-        nextSmallWindowHop(processingTs)
+        if (processingTs == floorToSmallWindowHop(processingTs)) {
+          // processor.onEvent includes retained tiles with tileStart < smallWindowAsOfTs.
+          processingTs + 1L
+        } else processingTs
     }
 
+  private def floorToSmallWindowHop(ts: Long): Long =
+    TsUtils.round(ts, processor.minSmallWindowTileSize)
+
   private def nextSmallWindowHop(ts: Long): Long =
-    TsUtils.round(ts, processor.minSmallWindowTileSize) + processor.minSmallWindowTileSize
+    floorToSmallWindowHop(ts) + processor.minSmallWindowTileSize
 
   private def scheduleEvictTimerIfNeeded(timerService: TimerService, processingTs: Long): Unit = {
     if (!hasActiveSmallWindowState) {
@@ -466,8 +472,7 @@ class MegaTileProcessFunction(
     val current = nextEvictPtTimerState.value()
     if (current != null) return
 
-    val timestamp =
-      TsUtils.round(processingTs, processor.minSmallWindowTileSize) + processor.minSmallWindowTileSize
+    val timestamp = nextSmallWindowHop(processingTs)
     timerService.registerProcessingTimeTimer(timestamp)
     nextEvictPtTimerState.update(timestamp)
   }

--- a/flink/src/test/scala/ai/chronon/flink/test/window/MegaTileProcessFunctionTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/window/MegaTileProcessFunctionTest.scala
@@ -81,6 +81,51 @@ class MegaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     }
   }
 
+  it should "Live event just after hop does not rebuild small-window cache at next hop" in {
+    withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      val key = "gen_live_after_hop"
+
+      driver.processWatermark("2025-07-21T10:30:00Z")
+      driver.setProcessingTime("2025-07-21T10:35:00Z")
+      driver.processEvent(key, "2025-07-21T10:35:00Z", "user_left_edge")
+      assertSingleOutput(
+        driver.drainNewOutputs(),
+        expectedKey = key,
+        expectedDayStart = dayStart("2025-07-21T00:00:00Z"),
+        expectedValues = windowValues(1L, 1L, 1L))
+
+      driver.processWatermark("2025-07-21T11:30:00Z")
+      driver.setProcessingTime("2025-07-21T11:35:09Z")
+      driver.drainNewOutputs().last.values shouldEqual windowValues(1L, 1L, 1L)
+
+      // If the event path rebuilt at 11:40, the live 1h start would advance to 10:40 and drop the
+      // left-edge 10:35 tile too early.
+      driver.processEvent(key, "2025-07-21T11:35:09Z", "user_current")
+      assertSingleOutput(
+        driver.drainNewOutputs(),
+        expectedKey = key,
+        expectedDayStart = dayStart("2025-07-21T00:00:00Z"),
+        expectedValues = windowValues(2L, 2L, 2L))
+    }
+  }
+
+  it should "Live event exactly on hop updates just-opened small-window tile" in {
+    withDriver(bufferingOutputTimeMillis = 0L) { driver =>
+      val key = "gen_live_exact_hop"
+
+      driver.processWatermark("2025-07-21T11:30:00Z")
+      driver.setProcessingTime("2025-07-21T11:35:00Z")
+      driver.processEvent(key, "2025-07-21T11:35:00Z", "user_exact_hop")
+
+      // processor.onEvent includes retained tiles using tileStart < smallWindowAsOfTs.
+      assertSingleOutput(
+        driver.drainNewOutputs(),
+        expectedKey = key,
+        expectedDayStart = dayStart("2025-07-21T00:00:00Z"),
+        expectedValues = windowValues(1L, 1L, 1L))
+    }
+  }
+
   it should "Live mode lifecycle: continuous events before, during, and after day transition" in {
     withDriver(bufferingOutputTimeMillis = 0L) { driver =>
       // Seed the final Jul21 tile before either PT or watermark day rollover occurs.


### PR DESCRIPTION
### context

Chronon megatile keeps a small in-memory aggregate for each key so live
events can update the latest window quickly.

For this groupby with 1-hour agg window, the smallest tile is 5 minutes.
A 1 hour window is therefore served in a sawtooth shape:

```text
at 11:35:09, the live 1h range is [10:35, 11:35:09)
at 11:39:59, the live 1h range is [10:35, 11:39:59)
at 11:40:00, the live 1h range is [10:40, 11:40:00)
```

So while we are inside a 5 minute bucket, live serving should use the
current processing time, not pretend we are already at the next 5 minute
boundary.

### problem

The Live/Sparse event path was rebuilding the small-window cache at the
next 5 minute hop.

For example, if an event arrived at 11:35:09, the old code rebuilt the
cache as if the time were already 11:40:

```text
correct live range at 11:35:09:
[10:35 | 10:40 | 10:45 | ... | 11:30 | 11:35:09)
  keep

old rebuild range:
        [10:40 | 10:45 | ... | 11:30 | 11:35 | 11:40)
  drop
```

So the wrong value comes from dropping the left-edge 5 minute tile too
early. In the example above, the 10:35-10:40 tile should still be part
of the live 1h window, but the old rebuild excluded it.

The error is bounded by one smallest-tile interval. For PCTR groupby,
that means one 5 minute tile per window:

- `sum` can be off by at most the sum inside the dropped 5 minute tile
- `num` can be off by at most the count inside the dropped 5 minute tile
- `average` / CTR is recomputed after losing that tile's numerator and
denominator, so the CTR delta depends on the tile's click rate versus
the rest of the window

This was easy to miss because the next timer/cadence (at also 5-min)
rebuild could correct the cache soon after, and the bug only showed up
clearly when we emitted during that gap.

### fix

- For live processing, rebuild the cache using the current
processing-time as-of timestamp.
- Keeps live event updates aligned with the serving range users actually
query.
- With the same example above, an event at 11:35:09 now updates the
cache for the 10:35 to 11:35:09 range, not the future 10:40 to 11:40
range.
- One small boundary adjustment: if processing time is exactly on a 5
minute boundary, the code adds 1ms. The stream processor includes tiles
using a strict `tileStart < asOf` check, so at exactly 11:35:00 we need
to use 11:35:00.001 to include the just-opened 11:35 tile.

### validation

- Added unit tests.
- `./mill --no-server flink.compile`
- `./mill --no-server flink.test.testOnly "ai.chronon.flink.test.window.MegaTileProcessFunctionTest"`
