### PR TITLE
Fix MegaTile stale small-window cache before event updates

### DIFF
--- a/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/MegaTileProcessFunction.scala
@@ -147,6 +147,9 @@ class MegaTileProcessFunction(
   private var nextEvictPtTimerState: ValueState[java.lang.Long] = _
   private var nextEmitPtTimerState: ValueState[java.lang.Long] = _
   private var lastEventProcessingTsState: ValueState[java.lang.Long] = _
+  // The floored as-of marker for the range currently covered by the TileStore's
+  // cachedSmallWindowIr. In Flink, that cached IR is backed by megaTileIrState.
+  private var cachedSmallWindowAsOfTsState: ValueState[java.lang.Long] = _
   private var todayDirtyState: ValueState[java.lang.Boolean] = _
   private var yesterdayDirtyState: ValueState[java.lang.Boolean] = _
 
@@ -190,6 +193,8 @@ class MegaTileProcessFunction(
       new ValueStateDescriptor[java.lang.Long]("mega-tile-next-emit-pt-timer", classOf[java.lang.Long]))
     lastEventProcessingTsState = getRuntimeContext.getState(
       new ValueStateDescriptor[java.lang.Long]("mega-tile-last-event-processing-ts", classOf[java.lang.Long]))
+    cachedSmallWindowAsOfTsState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Long]("mega-tile-cached-small-window-as-of-ts", classOf[java.lang.Long]))
     todayDirtyState = getRuntimeContext.getState(
       new ValueStateDescriptor[java.lang.Boolean]("mega-tile-today-dirty", classOf[java.lang.Boolean]))
     yesterdayDirtyState = getRuntimeContext.getState(
@@ -250,8 +255,10 @@ class MegaTileProcessFunction(
 
       val mode = currentMode(processingTs, watermark)
       val smallWindowAsOfTs = smallWindowAsOfTsForEvent(mode, tsMills, processingTs, watermark)
+      rebuildCachedSmallWindowForEventIfNeeded(smallWindowAsOfTs)
       // Step 3.
       val result = processor.onEvent(row, tsMills, smallWindowAsOfTs)
+      recordCachedSmallWindowAsOfTs(smallWindowAsOfTs)
       // Step 4.
       markDirtyState(result.todayEntry != null, result.yesterdayEntry != null)
 
@@ -344,6 +351,30 @@ class MegaTileProcessFunction(
     if (hasYesterdayUpdate) yesterdayDirtyState.update(java.lang.Boolean.TRUE)
   }
 
+  private def cachedSmallWindowAsOfTs: Option[Long] =
+    Option(cachedSmallWindowAsOfTsState.value()).map(_.longValue())
+
+  private def recordCachedSmallWindowAsOfTs(asOfTs: Long): Unit = {
+    if (processor.hasSmallWindows) {
+      cachedSmallWindowAsOfTsState.update(floorToSmallWindowHop(asOfTs))
+    }
+  }
+
+  private def rebuildCachedSmallWindowForEventIfNeeded(smallWindowAsOfTs: Long): Unit = {
+    if (!processor.hasSmallWindows || !hasActiveSmallWindowState) {
+      return
+    }
+
+    val targetAsOfTs = floorToSmallWindowHop(smallWindowAsOfTs)
+    if (cachedSmallWindowAsOfTs.contains(targetAsOfTs)) {
+      return
+    }
+
+    val result = processor.onEviction(smallWindowAsOfTs)
+    recordCachedSmallWindowAsOfTs(smallWindowAsOfTs)
+    markDirtyState(result.todayEntry != null, hasYesterdayUpdate = false)
+  }
+
   private def runEvictionTimer(currentKey: java.util.List[Any],
                                timestamp: Long,
                                processingTs: Long,
@@ -355,6 +386,7 @@ class MegaTileProcessFunction(
     emitOrBufferTodayThenDayRoll(evictionTime, currentKey, processingTs, out)
 
     val result = processor.onEviction(evictionTime)
+    recordCachedSmallWindowAsOfTs(evictionTime)
     markDirtyState(result.todayEntry != null, hasYesterdayUpdate = false)
     scheduleEvictTimerIfNeeded(timerService, processingTs)
 
@@ -397,6 +429,10 @@ class MegaTileProcessFunction(
     }
 
     processor.advanceWatermark(dayTransitionTs)
+    val currentDayStart = flinkStore.getCurrentDayStart
+    if (currentDayStart != previousDayStart) {
+      recordCachedSmallWindowAsOfTs(dayTransitionTs)
+    }
   }
 
   sealed private trait Mode

--- a/flink/src/test/scala/ai/chronon/flink/test/window/MegaTileProcessFunctionTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/window/MegaTileProcessFunctionTest.scala
@@ -78,6 +78,17 @@ class MegaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
         expectedKey = "gen_catchup",
         expectedDayStart = dayStart("2025-07-21T00:00:00Z"),
         expectedValues = windowValues(2L, 3L, 3L))
+
+      // When the watermark catches up enough for Live mode, the event path must rebuild from the
+      // current live range before applying the incremental update.
+      driver.processWatermark("2025-07-21T11:29:40Z")
+      driver.setProcessingTime("2025-07-21T11:35:09Z")
+      driver.processEvent("gen_catchup", "2025-07-21T11:35:09Z", "user_after_transition")
+      assertSingleOutput(
+        driver.drainNewOutputs(),
+        expectedKey = "gen_catchup",
+        expectedDayStart = dayStart("2025-07-21T00:00:00Z"),
+        expectedValues = windowValues(2L, 4L, 4L))
     }
   }
 


### PR DESCRIPTION
### Current:

- MegaTile keeps `cachedSmallWindowIr` so a live event can update
windows like 1h CTR immediately.
- `cachedSmallWindowIr` is only correct for the as-of range it was last
rebuilt for.
- In the happy path, a processing-time eviction timer periodically
rebuilds it as live time moves across each 5m hop. That timer normally
keeps the cache correct, but it is an asynchronous Flink callback, not a
hard barrier before every later event.

Example with 5m hops and a 1h window on _happy path_:

```text
11:30 timer eviction:
  cachedSmallWindowIr covers [10:30, 11:30)
  cache marker = 11:30

11:35 timer eviction:
  cachedSmallWindowIr should cover [10:35, 11:35)
  cache marker should become 11:35
```

### Problem:

- The old event path relied on an implicit assumption: by the time a
live event is processed, the eviction timer has already rebuilt
`cachedSmallWindowIr` for the current live range. That is usually true
in steady state, but it is not a hard invariant:
- Flink still synchronizes `processElement` (when event arrives) and
`onTimer` (our scheduled eviction timer), so they do not mutate state
concurrently.
- But synchronization does not mean "the timer always runs before every
later event."

One possible ordering when the timer callback is delayed:

```text
11:35:00 timer becomes due
         Flink enqueues: onTimer(11:35)

operator thread still has work in front of it:
  processElement(row A)
  processElement(row B)
  processElement(row C at processing time 11:35:09)
  onTimer(11:35)
```

- If the event path observes a cache that still represents the previous
range, the event gets added to stale state, leading to incorrect result.

Example with 5m hops and a 1h window:

```text
Previous timer rebuild:
  processing time = 11:30
  cache covers    = [10:30, 11:30)
  cache marker    = 11:30

Later, a row is processed:
  row event time      = 11:34:20
  row processing time = 11:35:09

Correct live range at processing time 11:35:09:
  [10:35, 11:35:09)

But if the 11:35 eviction rebuild has not run for this key yet,
old code does this:
  old [10:30, 11:30) cache + one row from event-time tile [11:30, 11:35)

That mixed cache is wrong:
  -> keeps expired 10:30-10:35 data
  -> can miss retained data that should be in the current 11:35 range
  -> can be emitted before a later timer rebuild corrects it
```

- So the bug is not that the eviction timer is always wrong. The bug is
that the event path assumed the eviction timer was always already
correct. When that assumption failed, we could publish a stale
small-window value until the next correction.

### Fix:

- Store the cache's time marker in Flink state.
- Whenever we rebuild the small-window cache, record the marker for the
range it now represents.
- Before processing an event, compare the cache marker with the event
path's target live range.
- If the marker does not match, rebuild the cache first, then apply the
row once.

```text
After this PR:
  cached marker = 11:30
  target marker = 11:35

  markers differ
  -> rebuild cache from retained tiles for [10:35, 11:35:09)
  -> record marker 11:35
  -> add the row once
```

Timer rebuilds and day-roll rebuilds also record the marker so the next
event can tell what range the cache covers.

### validation

- Added unit tests.
- `./mill --no-server flink.compile`
- `./mill --no-server flink.test.testOnly "ai.chronon.flink.test.window.MegaTileProcessFunctionTest"`
