### PR TITLE
Handle Enum types in Avro conversion

### DIFF
--- a/online/src/main/scala/ai/chronon/online/serde/AvroConversions.scala
+++ b/online/src/main/scala/ai/chronon/online/serde/AvroConversions.scala
@@ -98,6 +98,7 @@ object AvroConversions {
       case Schema.Type.ARRAY  => ListType(toChrononSchema(schema.getElementType))
       case Schema.Type.MAP    => MapType(StringType, toChrononSchema(schema.getValueType))
       case Schema.Type.STRING => StringType
+      case Schema.Type.ENUM   => StringType
       case Schema.Type.INT
           if Option(schema.getLogicalType).map(_.getName).getOrElse("") == LogicalTypes.date().getName =>
         DateType
@@ -312,8 +313,9 @@ object AvroConversions {
           throw new RuntimeException(s"Found unknown list type in avro record: ${valueOfUnknownType.getClass.getName}")
       },
       {
-        case avString: Utf8 => avString.toString
-        case str: String    => str
+        case avString: Utf8               => avString.toString
+        case enum: GenericData.EnumSymbol => enum.toString
+        case str: String                  => str
         case other =>
           throw new IllegalArgumentException(
             s"Unexpected string type: ${other.getClass.getName}. Expected String or Utf8, got: $other"

--- a/online/src/test/scala/ai/chronon/online/test/AvroStringHandlingTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/AvroStringHandlingTest.scala
@@ -142,4 +142,37 @@ class AvroStringHandlingTest extends AnyFlatSpec with Matchers {
     result(0) shouldBe "java_string"
     result(1) shouldBe "utf8_string"
   }
+
+  it should "treat avro enums as strings" in {
+    val avroSchemaStr = """{
+      "type": "record",
+      "name": "EnumTestSchema",
+      "namespace": "ai.chronon.data",
+      "fields": [
+        {
+          "name": "status",
+          "type": ["null", {
+            "type": "enum",
+            "name": "Status",
+            "symbols": ["ACTIVE", "INACTIVE"]
+          }],
+          "default": null
+        }
+      ]
+    }"""
+
+    val avroSchema = new Schema.Parser().parse(avroSchemaStr)
+
+    val chrononSchema = AvroConversions.toChrononSchema(avroSchema).asInstanceOf[StructType]
+    chrononSchema.fields(0).fieldType shouldBe StringType
+
+    val statusSchema = avroSchema.getField("status").schema().getTypes.get(1)
+    val record = new GenericData.Record(avroSchema)
+    record.put("status", new GenericData.EnumSymbol(statusSchema, "ACTIVE"))
+
+    val converter = AvroConversions.genericRecordToChrononRowConverter(chrononSchema)
+    val result = converter(record)
+
+    result(0) shouldBe "ACTIVE"
+  }
 }


### PR DESCRIPTION
## Summary

(Avro) Events that contain enum values currently throw on `Cannot convert avro type ENUM`, we can take the string value (as happens in the [Protobuf conversion](https://github.com/zipline-ai/chronon/blob/6f69bb6f753182362ac9c070760060d2ac572b2c/online/src/main/scala/ai/chronon/online/serde/ProtobufConversions.scala#L71)) when converting. 

## Checklist
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Fixed Avro enum field handling to properly convert enum values to string type, ensuring consistent data representation and correct type inference across data processing pipelines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zipline-ai/chronon/pull/1879?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->