### PR TITLE
feat(k8s): tag Flink pods and metrics with the GroupBy name

### DIFF
--- a/cloud_aws/src/main/scala/ai/chronon/integrations/aws/EmrServerlessSubmitter.scala
+++ b/cloud_aws/src/main/scala/ai/chronon/integrations/aws/EmrServerlessSubmitter.scala
@@ -143,6 +143,8 @@ class EmrServerlessSubmitter(
           .map(EmrServerlessSubmitter.parseNodeSelector)
           .getOrElse(Map.empty)
 
+        val groupByName = JobSubmitter.getArgValue(args.toArray, GroupByNameArgKeyword).filter(_.nonEmpty)
+
         val deploymentName = eksFlinkSubmitter
           .getOrElse(
             throw new RuntimeException("K8sFlinkSubmitter is required for Flink jobs")
@@ -160,7 +162,8 @@ class EmrServerlessSubmitter(
             serviceAccount = serviceAccount,
             namespace = namespace,
             envVars = envVars,
-            nodeSelector = nodeSelector
+            nodeSelector = nodeSelector,
+            groupByName = groupByName
           )
         s"flink:$namespace:$deploymentName"
 

--- a/cloud_aws/src/main/scala/ai/chronon/integrations/aws/EmrSubmitter.scala
+++ b/cloud_aws/src/main/scala/ai/chronon/integrations/aws/EmrSubmitter.scala
@@ -526,6 +526,8 @@ class EmrSubmitter(customerId: String,
           .map(EmrServerlessSubmitter.parseNodeSelector)
           .getOrElse(Map.empty)
 
+        val groupByName = JobSubmitter.getArgValue(args.toArray, GroupByNameArgKeyword).filter(_.nonEmpty)
+
         val deploymentName = eksFlinkSubmitter
           .getOrElse(
             throw new RuntimeException("K8sFlinkSubmitter is required for Flink jobs")
@@ -543,7 +545,8 @@ class EmrSubmitter(customerId: String,
             serviceAccount = serviceAccount,
             namespace = namespace,
             envVars = envVars,
-            nodeSelector = nodeSelector
+            nodeSelector = nodeSelector,
+            groupByName = groupByName
           )
         // Encode namespace into the job ID so status/kill can target the right namespace
         s"flink:$namespace:$deploymentName"

--- a/cloud_aws/src/test/scala/ai/chronon/integrations/aws/EmrServerlessSubmitterTest.scala
+++ b/cloud_aws/src/test/scala/ai/chronon/integrations/aws/EmrServerlessSubmitterTest.scala
@@ -944,7 +944,8 @@ class EmrServerlessSubmitterTest extends AnyFlatSpec with Matchers with MockitoS
         serviceAccount = org.mockito.ArgumentMatchers.anyString(),
         namespace = org.mockito.ArgumentMatchers.anyString(),
         envVars = org.mockito.ArgumentMatchers.any(),
-        nodeSelector = org.mockito.ArgumentMatchers.any()
+        nodeSelector = org.mockito.ArgumentMatchers.any(),
+        groupByName = org.mockito.ArgumentMatchers.any()
       )
     ).thenReturn("flink-abc123")
 
@@ -967,6 +968,96 @@ class EmrServerlessSubmitterTest extends AnyFlatSpec with Matchers with MockitoS
     )
 
     jobId shouldBe "flink:zipline-flink:flink-abc123"
+  }
+
+  it should "extract groupByName from --groupby-name arg" in {
+    val mockClient = mock[EmrServerlessClient]
+    val mockEks = mock[K8sFlinkSubmitter]
+    val groupByCaptor = org.mockito.ArgumentCaptor.forClass(classOf[Option[String]])
+    when(
+      mockEks.submit(
+        jobId = org.mockito.ArgumentMatchers.anyString(),
+        mainClass = org.mockito.ArgumentMatchers.anyString(),
+        mainJarUri = org.mockito.ArgumentMatchers.anyString(),
+        jarUris = org.mockito.ArgumentMatchers.any(),
+        flinkCheckpointUri = org.mockito.ArgumentMatchers.anyString(),
+        maybeSavepointUri = org.mockito.ArgumentMatchers.any(),
+        maybeFlinkJarsUri = org.mockito.ArgumentMatchers.any(),
+        jobProperties = org.mockito.ArgumentMatchers.any(),
+        args = org.mockito.ArgumentMatchers.any(),
+        serviceAccount = org.mockito.ArgumentMatchers.anyString(),
+        namespace = org.mockito.ArgumentMatchers.anyString(),
+        envVars = org.mockito.ArgumentMatchers.any(),
+        nodeSelector = org.mockito.ArgumentMatchers.any(),
+        groupByName = groupByCaptor.capture()
+      )
+    ).thenReturn("flink-abc123")
+
+    val submitter = createSubmitter(mockClient, eksFlinkSubmitter = Some(mockEks))
+    submitter.submit(
+      jobType = FlinkJob,
+      submissionProperties = Map(
+        JobId -> "test-job-id",
+        MainClass -> "ai.chronon.flink.FlinkJob",
+        JarURI -> "s3://bucket/cloud_aws_lib_deploy.jar",
+        FlinkMainJarURI -> "s3://bucket/flink_assembly_deploy.jar",
+        FlinkCheckpointUri -> "s3://bucket/checkpoints",
+        EksServiceAccount -> "zipline-flink-sa",
+        EksNamespace -> "zipline-flink",
+        MetadataName -> "should_be_ignored_streaming"
+      ),
+      jobProperties = Map.empty,
+      files = List.empty,
+      labels = Map.empty,
+      envVars = Map.empty,
+      "--groupby-name=ranking.user.last_n_product_saved.v1__2"
+    )
+
+    groupByCaptor.getValue shouldBe Some("ranking.user.last_n_product_saved.v1__2")
+  }
+
+  it should "pass groupByName as None when --groupby-name arg is absent" in {
+    val mockClient = mock[EmrServerlessClient]
+    val mockEks = mock[K8sFlinkSubmitter]
+    val groupByCaptor = org.mockito.ArgumentCaptor.forClass(classOf[Option[String]])
+    when(
+      mockEks.submit(
+        jobId = org.mockito.ArgumentMatchers.anyString(),
+        mainClass = org.mockito.ArgumentMatchers.anyString(),
+        mainJarUri = org.mockito.ArgumentMatchers.anyString(),
+        jarUris = org.mockito.ArgumentMatchers.any(),
+        flinkCheckpointUri = org.mockito.ArgumentMatchers.anyString(),
+        maybeSavepointUri = org.mockito.ArgumentMatchers.any(),
+        maybeFlinkJarsUri = org.mockito.ArgumentMatchers.any(),
+        jobProperties = org.mockito.ArgumentMatchers.any(),
+        args = org.mockito.ArgumentMatchers.any(),
+        serviceAccount = org.mockito.ArgumentMatchers.anyString(),
+        namespace = org.mockito.ArgumentMatchers.anyString(),
+        envVars = org.mockito.ArgumentMatchers.any(),
+        nodeSelector = org.mockito.ArgumentMatchers.any(),
+        groupByName = groupByCaptor.capture()
+      )
+    ).thenReturn("flink-abc123")
+
+    val submitter = createSubmitter(mockClient, eksFlinkSubmitter = Some(mockEks))
+    submitter.submit(
+      jobType = FlinkJob,
+      submissionProperties = Map(
+        JobId -> "test-job-id",
+        MainClass -> "ai.chronon.flink.FlinkJob",
+        JarURI -> "s3://bucket/cloud_aws_lib_deploy.jar",
+        FlinkMainJarURI -> "s3://bucket/flink_assembly_deploy.jar",
+        FlinkCheckpointUri -> "s3://bucket/checkpoints",
+        EksServiceAccount -> "zipline-flink-sa",
+        EksNamespace -> "zipline-flink"
+      ),
+      jobProperties = Map.empty,
+      files = List.empty,
+      labels = Map.empty,
+      envVars = Map.empty
+    )
+
+    groupByCaptor.getValue shouldBe None
   }
 
   // --- createSubmissionPropsMap for Flink ---

--- a/cloud_aws/src/test/scala/ai/chronon/integrations/aws/EmrSubmitterTest.scala
+++ b/cloud_aws/src/test/scala/ai/chronon/integrations/aws/EmrSubmitterTest.scala
@@ -321,7 +321,8 @@ class EmrSubmitterTest extends AnyFlatSpec with Matchers with MockitoSugar {
         serviceAccount = org.mockito.ArgumentMatchers.anyString(),
         namespace = org.mockito.ArgumentMatchers.anyString(),
         envVars = org.mockito.ArgumentMatchers.any(),
-        nodeSelector = org.mockito.ArgumentMatchers.any()
+        nodeSelector = org.mockito.ArgumentMatchers.any(),
+        groupByName = org.mockito.ArgumentMatchers.any()
       )
     ).thenReturn("flink-abc123")
 
@@ -363,7 +364,8 @@ class EmrSubmitterTest extends AnyFlatSpec with Matchers with MockitoSugar {
         serviceAccount = org.mockito.ArgumentMatchers.anyString(),
         namespace = org.mockito.ArgumentMatchers.anyString(),
         envVars = org.mockito.ArgumentMatchers.any(),
-        nodeSelector = nodeSelectorCaptor.capture()
+        nodeSelector = nodeSelectorCaptor.capture(),
+        groupByName = org.mockito.ArgumentMatchers.any()
       )
     ).thenReturn("flink-abc123")
 
@@ -388,6 +390,95 @@ class EmrSubmitterTest extends AnyFlatSpec with Matchers with MockitoSugar {
 
     nodeSelectorCaptor.getValue shouldBe Map("sardine.ai/node-type" -> "flink")
   }
+
+  it should "extract groupByName from --groupby-name arg" in {
+    val mockEks = mock[K8sFlinkSubmitter]
+    val groupByCaptor = org.mockito.ArgumentCaptor.forClass(classOf[Option[String]])
+    when(
+      mockEks.submit(
+        jobId = org.mockito.ArgumentMatchers.anyString(),
+        mainClass = org.mockito.ArgumentMatchers.anyString(),
+        mainJarUri = org.mockito.ArgumentMatchers.anyString(),
+        jarUris = org.mockito.ArgumentMatchers.any(),
+        flinkCheckpointUri = org.mockito.ArgumentMatchers.anyString(),
+        maybeSavepointUri = org.mockito.ArgumentMatchers.any(),
+        maybeFlinkJarsUri = org.mockito.ArgumentMatchers.any(),
+        jobProperties = org.mockito.ArgumentMatchers.any(),
+        args = org.mockito.ArgumentMatchers.any(),
+        serviceAccount = org.mockito.ArgumentMatchers.anyString(),
+        namespace = org.mockito.ArgumentMatchers.anyString(),
+        envVars = org.mockito.ArgumentMatchers.any(),
+        nodeSelector = org.mockito.ArgumentMatchers.any(),
+        groupByName = groupByCaptor.capture()
+      )
+    ).thenReturn("flink-abc123")
+
+    val submitter = new EmrSubmitter("test-customer", mock[EmrClient], mock[Ec2Client], Some(mockEks))
+    submitter.submit(
+      jobType = FlinkJob,
+      submissionProperties = Map(
+        JobId -> "test-job-id",
+        MainClass -> "ai.chronon.flink.FlinkJob",
+        JarURI -> "s3://bucket/cloud_aws_lib_deploy.jar",
+        FlinkMainJarURI -> "s3://bucket/flink_assembly_deploy.jar",
+        FlinkCheckpointUri -> "s3://bucket/checkpoints",
+        EksServiceAccount -> "zipline-flink-sa",
+        EksNamespace -> "zipline-flink",
+        MetadataName -> "should_be_ignored_streaming"
+      ),
+      jobProperties = Map.empty,
+      files = List.empty,
+      labels = Map.empty,
+      envVars = Map.empty,
+      "--groupby-name=ranking.user.last_n_product_saved.v1__2"
+    )
+
+    groupByCaptor.getValue shouldBe Some("ranking.user.last_n_product_saved.v1__2")
+  }
+
+  it should "pass groupByName as None when --groupby-name arg is absent" in {
+    val mockEks = mock[K8sFlinkSubmitter]
+    val groupByCaptor = org.mockito.ArgumentCaptor.forClass(classOf[Option[String]])
+    when(
+      mockEks.submit(
+        jobId = org.mockito.ArgumentMatchers.anyString(),
+        mainClass = org.mockito.ArgumentMatchers.anyString(),
+        mainJarUri = org.mockito.ArgumentMatchers.anyString(),
+        jarUris = org.mockito.ArgumentMatchers.any(),
+        flinkCheckpointUri = org.mockito.ArgumentMatchers.anyString(),
+        maybeSavepointUri = org.mockito.ArgumentMatchers.any(),
+        maybeFlinkJarsUri = org.mockito.ArgumentMatchers.any(),
+        jobProperties = org.mockito.ArgumentMatchers.any(),
+        args = org.mockito.ArgumentMatchers.any(),
+        serviceAccount = org.mockito.ArgumentMatchers.anyString(),
+        namespace = org.mockito.ArgumentMatchers.anyString(),
+        envVars = org.mockito.ArgumentMatchers.any(),
+        nodeSelector = org.mockito.ArgumentMatchers.any(),
+        groupByName = groupByCaptor.capture()
+      )
+    ).thenReturn("flink-abc123")
+
+    val submitter = new EmrSubmitter("test-customer", mock[EmrClient], mock[Ec2Client], Some(mockEks))
+    submitter.submit(
+      jobType = FlinkJob,
+      submissionProperties = Map(
+        JobId -> "test-job-id",
+        MainClass -> "ai.chronon.flink.FlinkJob",
+        JarURI -> "s3://bucket/cloud_aws_lib_deploy.jar",
+        FlinkMainJarURI -> "s3://bucket/flink_assembly_deploy.jar",
+        FlinkCheckpointUri -> "s3://bucket/checkpoints",
+        EksServiceAccount -> "zipline-flink-sa",
+        EksNamespace -> "zipline-flink"
+      ),
+      jobProperties = Map.empty,
+      files = List.empty,
+      labels = Map.empty,
+      envVars = Map.empty
+    )
+
+    groupByCaptor.getValue shouldBe None
+  }
+
 
   it should "use single quotes for regular confs and double quotes for Databricks token confs" in {
     val stepId = "mock-step-id"

--- a/cloud_k8s/src/main/scala/ai/chronon/integrations/cloud_k8s/K8sFlinkSubmitter.scala
+++ b/cloud_k8s/src/main/scala/ai/chronon/integrations/cloud_k8s/K8sFlinkSubmitter.scala
@@ -134,6 +134,12 @@ class K8sFlinkSubmitter(
     base ++ optional
   }
 
+  // Appends the job-name pod label (sanitized GroupBy name) onto constructor-level
+  // podTemplateLabels when provided. The value is sanitized to satisfy K8s label-value
+  // constraints — without this, a long GroupBy name would make the FlinkDeployment invalid.
+  private[cloud_k8s] def buildEffectivePodLabels(groupByName: Option[String]): Map[String, String] =
+    groupByName.fold(podTemplateLabels)(name => podTemplateLabels + (JobNamePodLabel -> sanitizeLabelValue(name)))
+
   def buildFlinkConfiguration(flinkCheckpointUri: String, jobProperties: Map[String, String]): Map[String, String] = {
     val tier = parseTmMemoryTier(jobProperties)
 
@@ -276,7 +282,8 @@ class K8sFlinkSubmitter(
              serviceAccount: String,
              namespace: String,
              envVars: Map[String, String] = Map.empty,
-             nodeSelector: Map[String, String] = Map.empty): String = {
+             nodeSelector: Map[String, String] = Map.empty,
+             groupByName: Option[String] = None): String = {
 
     val deploymentName = sanitizeDeploymentName(s"flink-$jobId")
     val basePath = maybeFlinkJarsUri.getOrElse(defaultJarsBasePath)
@@ -288,6 +295,7 @@ class K8sFlinkSubmitter(
     val tier = parseTmMemoryTier(jobProperties)
 
     val flinkConfiguration = buildFlinkConfiguration(flinkCheckpointUri, jobProperties)
+    val effectivePodLabels = buildEffectivePodLabels(groupByName)
 
     val spec = new java.util.HashMap[String, Object]()
     spec.put("image", flinkImage)
@@ -333,7 +341,8 @@ class K8sFlinkSubmitter(
         allEnvVars,
         containerSpec.volumeMounts,
         containerSpec.volumes,
-        nodeSelector = nodeSelector
+        nodeSelector = nodeSelector,
+        labels = effectivePodLabels
       )
     )
     spec.put(
@@ -346,7 +355,8 @@ class K8sFlinkSubmitter(
         allEnvVars,
         containerSpec.volumeMounts,
         containerSpec.volumes,
-        nodeSelector = nodeSelector
+        nodeSelector = nodeSelector,
+        labels = effectivePodLabels
       )
     )
 
@@ -481,7 +491,8 @@ class K8sFlinkSubmitter(
       envVars: java.util.List[java.util.Map[String, String]],
       volumeMounts: java.util.List[java.util.Map[String, String]],
       volumes: java.util.List[java.util.Map[String, Object]],
-      nodeSelector: Map[String, String] = Map.empty): java.util.Map[String, Object] = {
+      nodeSelector: Map[String, String] = Map.empty,
+      labels: Map[String, String] = podTemplateLabels): java.util.Map[String, Object] = {
     val component = new java.util.HashMap[String, Object]()
 
     val resource = new java.util.HashMap[String, Object]()
@@ -518,9 +529,9 @@ class K8sFlinkSubmitter(
         m
       }
     )
-    if (podTemplateLabels.nonEmpty) {
+    if (labels.nonEmpty) {
       val labelsMap = new java.util.HashMap[String, String]()
-      podTemplateLabels.foreach { case (k, v) => labelsMap.put(k, v) }
+      labels.foreach { case (k, v) => labelsMap.put(k, v) }
       podMeta.put("labels", labelsMap)
     }
 
@@ -548,6 +559,41 @@ object K8sFlinkSubmitter {
 
   // How long a deployment may stay in a non-STABLE pending state before we declare it failed.
   val DeploymentPendingTimeout: Duration = Duration(10, TimeUnit.MINUTES)
+
+  // Pod label identifying the Flink job name (= GroupBy metadata name). Namespaced per K8s
+  // conventions; surfaced to monitoring backends via additional_pod_labels_as_tags (Datadog).
+  // Matches Flink's built-in `job_name` metric tag so dashboards can correlate infra metrics
+  // (CPU, memory — kubelet-collected, tagged via this pod label) with Flink-emitted app
+  // metrics (throughput, backpressure — already tagged with `job_name` by Flink natively).
+  val JobNamePodLabel: String = "chronon/job_name"
+
+  // K8s label-value max length (https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set).
+  val MaxLabelValueLength: Int = 63
+
+  /** Coerces an arbitrary string into a valid Kubernetes label value:
+    *   - Allowed chars: [A-Za-z0-9_]   (also safe for Prometheus label values)
+    *   - Must start/end with alphanumeric
+    *   - Length ≤ 63
+    *
+    * When the input exceeds the length limit, the tail is replaced with an 8-char hex hash
+    * of the original input so distinct long names remain distinguishable rather than
+    * collapsing to the same truncated prefix.
+    */
+  def sanitizeLabelValue(raw: String): String = {
+    require(raw.nonEmpty, "GroupBy name must be non-empty")
+    val cleaned = raw
+      .replaceAll("[^A-Za-z0-9_]", "_")
+      .replaceAll("^_+", "")
+      .replaceAll("_+$", "")
+    require(cleaned.nonEmpty, s"GroupBy name '$raw' has no alphanumeric characters")
+
+    if (cleaned.length <= MaxLabelValueLength) cleaned
+    else {
+      val hash = "%08x".format(raw.hashCode)
+      val keep = MaxLabelValueLength - hash.length - 1
+      cleaned.take(keep).replaceAll("_+$", "") + "_" + hash
+    }
+  }
 
   // Flink Kubernetes Operator enforces a 45-char limit on FlinkDeployment names.
   def sanitizeDeploymentName(raw: String): String = {

--- a/cloud_k8s/src/test/scala/ai/chronon/integrations/cloud_k8s/K8sFlinkSubmitterTest.scala
+++ b/cloud_k8s/src/test/scala/ai/chronon/integrations/cloud_k8s/K8sFlinkSubmitterTest.scala
@@ -226,16 +226,34 @@ class K8sFlinkSubmitterTest extends AnyFlatSpec {
 
   // --- buildComponentSpec: podTemplateLabels ---
 
-  private def podMeta(submitter: K8sFlinkSubmitter): java.util.Map[String, Object] = {
-    val componentSpec = submitter.buildComponentSpec(
-      memory = "4G",
-      cpu = 1.0,
-      replicas = Some(1),
-      Collections.emptyList(),
-      Collections.emptyList(),
-      Collections.emptyList(),
-      Collections.emptyList()
-    )
+  private def podMeta(submitter: K8sFlinkSubmitter,
+                      labels: Map[String, String] = Map.empty): java.util.Map[String, Object] = {
+    // When labels is empty here, buildComponentSpec falls back to its default (the submitter's
+    // podTemplateLabels), which lets us test both the constructor-level labels and the
+    // per-call override path.
+    val componentSpec =
+      if (labels.isEmpty) {
+        submitter.buildComponentSpec(
+          memory = "4G",
+          cpu = 1.0,
+          replicas = Some(1),
+          Collections.emptyList(),
+          Collections.emptyList(),
+          Collections.emptyList(),
+          Collections.emptyList()
+        )
+      } else {
+        submitter.buildComponentSpec(
+          memory = "4G",
+          cpu = 1.0,
+          replicas = Some(1),
+          Collections.emptyList(),
+          Collections.emptyList(),
+          Collections.emptyList(),
+          Collections.emptyList(),
+          labels = labels
+        )
+      }
     componentSpec.get("podTemplate")
       .asInstanceOf[java.util.Map[String, Object]]
       .get("metadata")
@@ -264,6 +282,96 @@ class K8sFlinkSubmitterTest extends AnyFlatSpec {
     val meta = podMeta(submitterWithExtra(podLabels = Map("some-label" -> "val")))
     val annotations = meta.get("annotations").asInstanceOf[java.util.Map[String, String]]
     assertEquals("true", annotations.get("prometheus.io/scrape"))
+  }
+
+  it should "use the labels override when provided, ignoring constructor podTemplateLabels" in {
+    val submitter = submitterWithExtra(podLabels = Map("constructor-label" -> "ignored"))
+    val meta: java.util.Map[String, Object] = podMeta(submitter, Map("override-label" -> "wins"))
+    val labels = meta.get("labels").asInstanceOf[java.util.Map[String, String]]
+    assertEquals("wins", labels.get("override-label"))
+    assertNull(labels.get("constructor-label"))
+  }
+
+  // --- buildEffectivePodLabels ---
+
+  "buildEffectivePodLabels" should "preserve unrelated constructor labels when groupByName is None" in {
+    val submitter = submitterWithExtra(podLabels = Map("foo" -> "bar"))
+    assertEquals(Map("foo" -> "bar"), submitter.buildEffectivePodLabels(None))
+  }
+
+  it should "merge the GroupBy label onto constructor labels when groupByName is provided" in {
+    val submitter = submitterWithExtra(podLabels = Map("foo" -> "bar"))
+    val labels = submitter.buildEffectivePodLabels(Some("ranking.user.x.v1__2"))
+    assertEquals("bar", labels("foo"))
+    assertEquals("ranking_user_x_v1__2", labels(K8sFlinkSubmitter.JobNamePodLabel))
+  }
+
+  it should "preserve the compile-version suffix in the label value" in {
+    val submitter = submitterWithExtra()
+    val labels = submitter.buildEffectivePodLabels(Some("a.b.v1__7"))
+    assertEquals("a_b_v1__7", labels(K8sFlinkSubmitter.JobNamePodLabel))
+  }
+
+  it should "let the GroupBy label win when constructor labels already have the same key" in {
+    val submitter = submitterWithExtra(
+      podLabels = Map(K8sFlinkSubmitter.JobNamePodLabel -> "stale-value")
+    )
+    val labels = submitter.buildEffectivePodLabels(Some("fresh.v1"))
+    assertEquals("fresh_v1", labels(K8sFlinkSubmitter.JobNamePodLabel))
+  }
+
+  // --- sanitizeLabelValue ---
+
+  "sanitizeLabelValue" should "leave an already-strict name unchanged" in {
+    assertEquals("a_b_v1__2", K8sFlinkSubmitter.sanitizeLabelValue("a_b_v1__2"))
+  }
+
+  it should "replace dots with underscores so the value survives Prometheus filtering" in {
+    assertEquals("a_b_v1__2", K8sFlinkSubmitter.sanitizeLabelValue("a.b.v1__2"))
+  }
+
+  it should "replace any other disallowed characters with underscore" in {
+    assertEquals("a_b_c", K8sFlinkSubmitter.sanitizeLabelValue("a/b-c"))
+  }
+
+  it should "strip leading and trailing underscores after sanitization" in {
+    assertEquals("a_b", K8sFlinkSubmitter.sanitizeLabelValue("..a.b--"))
+  }
+
+  it should "truncate names longer than 63 chars and append a hash for distinguishability" in {
+    val long = "a" * 80
+    val sanitized = K8sFlinkSubmitter.sanitizeLabelValue(long)
+    assertTrue(s"length should be <= 63, got ${sanitized.length}", sanitized.length <= 63)
+    assertTrue(s"should contain hash separator, got '$sanitized'", sanitized.contains("_"))
+  }
+
+  it should "produce different values for two distinct long names that share a prefix" in {
+    val a = "team.entity.subentity." + ("x" * 60) + ".groupbyA.v1__1"
+    val b = "team.entity.subentity." + ("x" * 60) + ".groupbyB.v1__1"
+    val sa = K8sFlinkSubmitter.sanitizeLabelValue(a)
+    val sb = K8sFlinkSubmitter.sanitizeLabelValue(b)
+    assertTrue(s"sanitized values should differ, got '$sa' and '$sb'", sa != sb)
+    assertTrue(sa.length <= 63 && sb.length <= 63)
+  }
+
+  it should "throw when input is empty or has no alphanumeric characters" in {
+    assertThrows[IllegalArgumentException](K8sFlinkSubmitter.sanitizeLabelValue(""))
+    assertThrows[IllegalArgumentException](K8sFlinkSubmitter.sanitizeLabelValue("---"))
+  }
+
+  it should "produce values that contain only [A-Za-z0-9_] (Prometheus-safe intersection)" in {
+    val sanitized = K8sFlinkSubmitter.sanitizeLabelValue("ranking.user.last_n.v1__2")
+    assertTrue(s"value should match strict pattern, got '$sanitized'", sanitized.matches("[A-Za-z0-9_]+"))
+  }
+
+  // --- buildEffectivePodLabels: sanitization ---
+
+  it should "sanitize the GroupBy label value before merging" in {
+    val submitter = submitterWithExtra()
+    val long = "team.entity." + ("x" * 80)
+    val labels = submitter.buildEffectivePodLabels(Some(long))
+    val value = labels(K8sFlinkSubmitter.JobNamePodLabel)
+    assertTrue(value.length <= 63)
   }
 
   // --- flinkEnvVars injection into JM/TM containers ---

--- a/docs/source/management_in_production/streaming_metrics.md
+++ b/docs/source/management_in_production/streaming_metrics.md
@@ -150,6 +150,12 @@ To enable streaming metrics collection, set the following Flink configuration pa
 * "metrics.reporters" = "prom",
 * "metrics.reporter.prom.factory.class" = "org.apache.flink.metrics.prometheus.PrometheusReporterFactory",
 
+## Job Identity on Flink Metrics and Pods
+
+Flink natively exposes the job name as a `job_name` tag on all emitted metrics (throughput, checkpoint duration, backpressure, etc.). Since chronon sets the Flink job name to the GroupBy metadata name (via `env.execute(groupByName)`), dashboards can group by `job_name` to identify which GroupBy a metric belongs to.
+
+For infrastructure metrics (CPU, memory, restarts) collected by kubelet-level agents — which have no access to Flink's metric scope — `K8sFlinkSubmitter` stamps a `chronon/job_name` Kubernetes pod label on both JobManager and TaskManager pods. The label value is a Kubernetes-safe sanitized representation of the same GroupBy name: restricted to `[A-Za-z0-9_]`, ≤63 characters, with an 8-char hash suffix on truncation for distinguishability. The pod label and Flink's `job_name` metric tag are intended for correlation, not necessarily exact string equality.
+
 ## Monitoring & Alerting
 
 ### Key Metrics to Monitor


### PR DESCRIPTION
## Summary

feat(k8s): stamp chronon/job_name pod label on Flink JM/TM pods

  Flink already exposes the GroupBy name as `job_name` on all emitted
  metrics. For kubelet-collected infra metrics (CPU, memory, restarts)
  which lack access to Flink's metric scope, K8sFlinkSubmitter now stamps
  a `chronon/job_name` pod label on both JM and TM pods.

  - Value sanitized to [A-Za-z0-9_], ≤63 chars, hash-suffixed on
  - The submitter owns the label key: set when groupByName is provided,
    stripped when None (prevents leaks onto opt-out jobs)
  - EmrSubmitter / EmrServerlessSubmitter extract MetadataName from
    submissionProperties and pass it through as groupByName
  - EKS only; AKS/Dataproc opt in by passing groupByName to submit()

  **EKS only for now;** AKS/Dataproc opt in by passing groupByName.

## Checklist
- [x] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested
- [x] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Jobs can now use metadata to label Kubernetes pods and scope Flink metrics for improved organization and observability.

* **Tests**
  * Added test coverage for metadata-driven label and metric configuration, including validation and sanitization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->