### PR TITLE
Add event max timestamp to groupBy status

### DIFF
--- a/docs/source/setup/Fetcher_API.md
+++ b/docs/source/setup/Fetcher_API.md
@@ -103,6 +103,7 @@ Response fields:
 |-------|-------------|
 | `groupByName` | GroupBy metadata name. |
 | `batchEndDate` | Date through which batch upload data is available in the online KV store. |
+| `maxTs` | Max event timestamp in milliseconds included in the upload, when available. |
 
 ## CLI
 

--- a/online/src/main/java/ai/chronon/online/JavaGroupByStatusResponse.java
+++ b/online/src/main/java/ai/chronon/online/JavaGroupByStatusResponse.java
@@ -5,18 +5,21 @@ import ai.chronon.online.fetcher.Fetcher;
 public class JavaGroupByStatusResponse {
     public String groupByName;
     public String batchEndDate;
+    public Long maxTs;
 
-    public JavaGroupByStatusResponse(String groupByName, String batchEndDate) {
+    public JavaGroupByStatusResponse(String groupByName, String batchEndDate, Long maxTs) {
         this.groupByName = groupByName;
         this.batchEndDate = batchEndDate;
+        this.maxTs = maxTs;
     }
 
     public JavaGroupByStatusResponse(Fetcher.GroupByStatusResponse scalaResponse) {
         this.groupByName = scalaResponse.groupByName();
         this.batchEndDate = scalaResponse.batchEndDate();
+        this.maxTs = scalaResponse.maxTs();
     }
 
     public Fetcher.GroupByStatusResponse toScala() {
-        return new Fetcher.GroupByStatusResponse(groupByName, batchEndDate);
+        return new Fetcher.GroupByStatusResponse(groupByName, batchEndDate, maxTs);
     }
 }

--- a/online/src/main/scala/ai/chronon/online/fetcher/Fetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/Fetcher.scala
@@ -159,8 +159,9 @@ object Fetcher {
   /** Response for a groupBy status request.
     * @param groupByName - Name of the groupBy
     * @param batchEndDate - Date through which batch upload data is available in the KV store
+    * @param maxTs - Max event timestamp in milliseconds included in the upload, when available
     */
-  case class GroupByStatusResponse(groupByName: String, batchEndDate: String)
+  case class GroupByStatusResponse(groupByName: String, batchEndDate: String, maxTs: java.lang.Long)
 }
 
 private[online] case class FetcherResponseWithTs[T <: BaseResponse](responses: Seq[T], endTs: Long)
@@ -840,7 +841,8 @@ class Fetcher(val kvStore: KVStore,
         }
       }
       .map { servingInfo =>
-        val response = GroupByStatusResponse(groupByName, servingInfo.batchEndDate)
+        val maxTs = if (servingInfo.isSetMaxTs) java.lang.Long.valueOf(servingInfo.getMaxTs) else null
+        val response = GroupByStatusResponse(groupByName, servingInfo.batchEndDate, maxTs)
         ctx.distribution(Metrics.Name.LatencyMillis, System.currentTimeMillis() - startTime)
         response
       }

--- a/online/src/test/scala/ai/chronon/online/test/FetcherSchemaTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/FetcherSchemaTest.scala
@@ -49,6 +49,7 @@ class FetcherSchemaTest extends AnyFlatSpec with Matchers {
 
     val servingInfo = GroupByDerivationsTest.makeTestGroupByServingInfoParsed().groupByServingInfo
     servingInfo.groupBy.metaData.setOnline(true)
+    servingInfo.setMaxTs(1700001234567L)
     val groupByName = servingInfo.groupBy.metaData.name
     val batchDataset = new GroupByOps(servingInfo.groupBy).batchDataset
     kvStore.create(batchDataset)
@@ -61,6 +62,7 @@ class FetcherSchemaTest extends AnyFlatSpec with Matchers {
 
     response.groupByName shouldBe groupByName
     response.batchEndDate shouldBe servingInfo.batchEndDate
+    response.maxTs shouldBe servingInfo.getMaxTs
   }
 
   it should "return a user-facing status error for offline groupBys" in {

--- a/service/src/test/java/ai/chronon/service/handlers/GroupByStatusHandlerTest.java
+++ b/service/src/test/java/ai/chronon/service/handlers/GroupByStatusHandlerTest.java
@@ -69,7 +69,7 @@ public class GroupByStatusHandlerTest {
         Async async = context.async();
 
         JavaGroupByStatusResponse groupByStatusResponse =
-                new JavaGroupByStatusResponse("test_group_by", "2026-05-20");
+                new JavaGroupByStatusResponse("test_group_by", "2026-05-20", 1779256800000L);
         JTry<JavaGroupByStatusResponse> groupByStatusResponseTry = JTry.success(groupByStatusResponse);
 
         when(mockFetcher.fetchGroupByStatus(anyString())).thenReturn(groupByStatusResponseTry);
@@ -79,6 +79,7 @@ public class GroupByStatusHandlerTest {
 
             context.assertEquals(actualResponse.getString("groupByName"), "test_group_by");
             context.assertEquals(actualResponse.getString("batchEndDate"), "2026-05-20");
+            context.assertEquals(actualResponse.getLong("maxTs"), Long.valueOf(1779256800000L));
         });
 
         handler.handle(routingContext);

--- a/spark/src/main/scala/ai/chronon/spark/GroupByUpload.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupByUpload.scala
@@ -313,12 +313,13 @@ class GroupByUpload(endPartition: String, groupBy: ai.chronon.spark.GroupBy) ext
 object GroupByUpload {
   @transient lazy val logger: Logger = LoggerFactory.getLogger(getClass)
 
-  case class UploadResult(kvDf: DataFrame, nullCounts: Map[String, Long])
+  case class UploadResult(kvDf: DataFrame, nullCounts: Map[String, Long], maxTs: Option[Long] = None)
 
   // TODO - remove this if spark streaming can't reach hive tables
   private def buildServingInfo(groupByConf: api.GroupBy,
                                session: SparkSession,
-                               endDs: String): GroupByServingInfoParsed = {
+                               endDs: String,
+                               maxTs: Option[Long]): GroupByServingInfoParsed = {
     val groupByServingInfo = new GroupByServingInfo()
     val tableUtils: TableUtils = TableUtils(session)
     implicit val partitionSpec: PartitionSpec = tableUtils.partitionSpec
@@ -332,6 +333,7 @@ object GroupByUpload {
     groupByServingInfo.setKeyAvroSchema(groupBy.keySchema.toAvroSchema("Key").toString(true))
     groupByServingInfo.setSelectedAvroSchema(groupBy.preAggSchema.toAvroSchema("Value").toString(true))
     groupByServingInfo.setDateFormat(tableUtils.partitionFormat)
+    maxTs.foreach(groupByServingInfo.setMaxTs)
 
     val inputSources = groupByConf.streamingSource.toSeq ++ groupByConf.sources.toScala
     if (inputSources.nonEmpty) {
@@ -386,8 +388,26 @@ object GroupByUpload {
         |   inputSchema: ${Try(result.inputChrononSchema.catalogString)}
         |selectedSchema: ${Try(result.selectedChrononSchema.catalogString)}
         |  streamSchema: ${Try(result.streamChrononSchema.catalogString)}
+        |        maxTs: $maxTs
         |""".stripMargin)
     result
+  }
+
+  private def maxEventTs(groupBy: ai.chronon.spark.GroupBy): Option[Long] = {
+    if (!groupBy.inputDf.schema.fieldNames.contains(Constants.TimeColumn)) {
+      logger.warn(s"Cannot compute event maxTs because ${Constants.TimeColumn} is not present in the upload input.")
+      None
+    } else {
+      val maxTsRow = groupBy.inputDf
+        .agg(max(col(Constants.TimeColumn)).as("max_ts"))
+        .head()
+      Option(maxTsRow.get(0)).map {
+        case value: java.lang.Number => value.longValue()
+        case value =>
+          throw new IllegalArgumentException(
+            s"Expected ${Constants.TimeColumn} max value to be numeric, but found ${value.getClass.getName}.")
+      }
+    }
   }
 
   private[spark] def generateDf(groupByConf: api.GroupBy,
@@ -427,11 +447,19 @@ object GroupByUpload {
                    |Data Model: ${groupByConf.dataModel}
                    |""".stripMargin)
 
-    val (kvDf, nullCounts) = (groupByConf.inferredAccuracy, groupByConf.dataModel) match {
-      case (Accuracy.SNAPSHOT, DataModel.EVENTS)   => groupByUpload.snapshotEvents(jsonPercent)
-      case (Accuracy.SNAPSHOT, DataModel.ENTITIES) => groupByUpload.snapshotEntities(jsonPercent)
-      case (Accuracy.TEMPORAL, DataModel.EVENTS)   => shiftedGroupByUpload.temporalEvents(jsonPercent)
-      case (Accuracy.TEMPORAL, DataModel.ENTITIES) => otherGroupByUpload.temporalEvents(jsonPercent)
+    val (kvDf, nullCounts, maxTs) = (groupByConf.inferredAccuracy, groupByConf.dataModel) match {
+      case (Accuracy.SNAPSHOT, DataModel.EVENTS) =>
+        val (kvDf, nullCounts) = groupByUpload.snapshotEvents(jsonPercent)
+        (kvDf, nullCounts, maxEventTs(groupBy))
+      case (Accuracy.SNAPSHOT, DataModel.ENTITIES) =>
+        val (kvDf, nullCounts) = groupByUpload.snapshotEntities(jsonPercent)
+        (kvDf, nullCounts, None)
+      case (Accuracy.TEMPORAL, DataModel.EVENTS) =>
+        val (kvDf, nullCounts) = shiftedGroupByUpload.temporalEvents(jsonPercent)
+        (kvDf, nullCounts, maxEventTs(shiftedGroupBy))
+      case (Accuracy.TEMPORAL, DataModel.ENTITIES) =>
+        val (kvDf, nullCounts) = otherGroupByUpload.temporalEvents(jsonPercent)
+        (kvDf, nullCounts, None)
     }
 
     // Emit null count metrics. We force-flush the OTel meter provider afterwards because
@@ -446,7 +474,7 @@ object GroupByUpload {
       ctx.flush(Constants.ScrapeWaitSeconds.seconds.toMillis)
     }
 
-    UploadResult(kvDf, nullCounts)
+    UploadResult(kvDf, nullCounts, maxTs)
   }
 
   def run(groupByConf: api.GroupBy,
@@ -474,7 +502,8 @@ object GroupByUpload {
       kvDf.prettyPrint()
     }
 
-    val groupByServingInfo = buildServingInfo(groupByConf, session = tableUtils.sparkSession, endDs).groupByServingInfo
+    val groupByServingInfo =
+      buildServingInfo(groupByConf, session = tableUtils.sparkSession, endDs, result.maxTs).groupByServingInfo
 
     val metaRows = Seq(
       Row(

--- a/spark/src/test/scala/ai/chronon/spark/groupby/GroupByUploadTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/groupby/GroupByUploadTest.scala
@@ -98,6 +98,47 @@ class GroupByUploadTest extends SparkTestBase with Matchers {
     GroupByUpload.run(groupByConf, endDs = yesterday)
   }
 
+  it should "write max event timestamp into uploaded serving info" in {
+    val namespace = testNamespace("event_max_ts")
+    createDatabase(namespace)
+    tableUtils.sql(s"USE $namespace")
+
+    val eventsTable = s"$namespace.events_with_max_ts"
+    val eventColumns = Seq("user", "views", "ts", "ds")
+    val expectedMaxTs = TsUtils.datetimeToTs("2023-08-14 18:30:00")
+    val eventData =
+      Seq(
+        ("user1", 10, TsUtils.datetimeToTs("2023-08-14 10:00:00"), "2023-08-14"),
+        ("user1", 20, expectedMaxTs, "2023-08-14")
+      )
+
+    spark.createDataFrame(eventData).toDF(eventColumns: _*).save(eventsTable)
+
+    val groupByConf =
+      Builders.GroupBy(
+        sources = Seq(Builders.Source.events(Builders.Query(timeColumn = "ts"), table = eventsTable)),
+        keyColumns = Seq("user"),
+        aggregations = Seq(Builders.Aggregation(Operation.SUM, "views", Seq(new Window(1, TimeUnit.DAYS)))),
+        metaData = Builders.MetaData(namespace = namespace, name = "test_max_ts_upload"),
+        accuracy = Accuracy.SNAPSHOT
+      )
+
+    GroupByUpload.run(groupByConf, endDs = "2023-08-14", tableUtilsOpt = Some(tableUtils))
+
+    val metadataJson = tableUtils
+      .loadTable(groupByConf.metaData.uploadTable)
+      .where(s"key_json = '${Constants.GroupByServingInfoKey}'")
+      .select("value_json")
+      .collect()
+      .head
+      .getString(0)
+    val servingInfo =
+      ThriftJsonCodec.fromJsonStr[GroupByServingInfo](metadataJson, check = false, classOf[GroupByServingInfo])
+
+    servingInfo.isSetMaxTs shouldBe true
+    servingInfo.getMaxTs shouldBe expectedMaxTs
+  }
+
   it should "struct support" in {
     val namespace = testNamespace("struct_support")
     val today = tableUtils.partitionSpec.at(System.currentTimeMillis())

--- a/thrift/api.thrift
+++ b/thrift/api.thrift
@@ -481,6 +481,8 @@ struct GroupByServingInfo {
     //       2. batch_upload_lag = batch_upload_time - batch_data_time
     5: optional string batchEndDate
     6: optional string dateFormat
+    // Max event timestamp in milliseconds from the data included in the upload.
+    7: optional i64 maxTs
 }
 
 // DataKind + TypeParams = DataType


### PR DESCRIPTION
## Summary
- Add optional `maxTs` to `GroupByServingInfo` metadata.
- Compute the max event `ts` during event-source uploads and persist it in uploaded serving info.
- Return `maxTs` from the groupBy status API through Scala, Java, service JSON, and docs.

## Tests
- `./mill -i spark.test.testOnly ai.chronon.spark.groupby.GroupByUploadTest -- -z "write max event timestamp"`
- `./mill -i online.test.testOnly ai.chronon.online.test.FetcherSchemaTest`
- `./mill -i service.test.testOnly ai.chronon.service.handlers.GroupByStatusHandlerTest`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GroupBy status responses now include a maximum event timestamp field, indicating the latest event timestamp in the upload

* **Documentation**
  * API documentation updated to reflect new response fields

* **Tests**
  * Test coverage added to validate timestamp field propagation through the system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->