### PR TITLE
handle subdaily schedules within the sensor path

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/batch/BatchNodeReadiness.scala
+++ b/spark/src/main/scala/ai/chronon/spark/batch/BatchNodeReadiness.scala
@@ -1,0 +1,224 @@
+package ai.chronon.spark.batch
+
+import ai.chronon.api.Extensions._
+import ai.chronon.api.planner.DependencyResolver
+import ai.chronon.api.{PartitionRange, PartitionSpec, TableDependency, TableInfo}
+import ai.chronon.spark.catalog.TableUtils
+import org.apache.spark.sql.types.TimestampType
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.annotation.tailrec
+import scala.util.{Failure, Success, Try}
+
+private[batch] class BatchNodeReadiness(tableUtils: TableUtils, scheduleOffsetMs: Option[Long]) {
+  import BatchNodeReadiness._
+
+  @transient private lazy val logger: Logger = LoggerFactory.getLogger(getClass)
+
+  private def isTimestampColumn(tableName: String, column: String): Boolean =
+    Try(tableUtils.getSchemaFromTable(tableName)(column).dataType == TimestampType).getOrElse(false)
+
+  private def scheduledAtMillis(range: PartitionRange): Option[Long] =
+    scheduleOffsetMs.map(offsetMs => range.partitionSpec.epochMillis(range.end) + offsetMs)
+
+  private def requiredEndMillis(range: PartitionRange, tableDependency: TableDependency): Option[Long] =
+    scheduledAtMillis(range).map { scheduledMs =>
+      val dependencySpec = tableDependency.tableInfo.partitionSpec(range.partitionSpec)
+      val offsetMs =
+        if (tableDependency.isSetEndOffset) tableDependency.getEndOffset.millis else 0L
+      val offsetRequiredMs = scheduledMs - offsetMs
+      Option(tableDependency.getEndCutOff)
+        .map(cutoff => dependencySpec.epochMillis(cutoff) + dependencySpec.spanMillis - 1)
+        .map(cutoffMs => Math.min(offsetRequiredMs, cutoffMs))
+        .getOrElse(offsetRequiredMs)
+    }
+
+  private def maxRequiredEndMillis(range: PartitionRange, deps: Iterable[TableDependency]): Option[Long] =
+    deps.flatMap(td => requiredEndMillis(range, td)).reduceOption((left, right) => Math.max(left, right))
+
+  def targetForScheduleOffset(tableName: String,
+                              tableInfo: TableInfo,
+                              range: PartitionRange,
+                              deps: Iterable[TableDependency],
+                              basePartitionSpec: PartitionSpec): Option[ReadinessTarget] = {
+    val requiredEndMs = maxRequiredEndMillis(range, deps)
+    val spec = tableInfo.partitionSpec(basePartitionSpec)
+    val partitionColumn = Option(tableInfo.partitionColumn)
+
+    for {
+      endMs <- requiredEndMs
+      column <- partitionColumn
+    } yield {
+      if (isTimestampColumn(tableName, column)) {
+        TimestampStatsTarget(column, endMs)
+      } else if (partitionSpecCoversRequiredEnd(spec, basePartitionSpec, endMs)) {
+        PartitionTarget(spec, spec.at(endMs), normalizeToBasePartitionSpec = false)
+      } else {
+        UnalignedPartitionTarget(column, endMs, spec)
+      }
+    }
+  }
+
+  private def partitionSpecCoversRequiredEnd(spec: PartitionSpec,
+                                             basePartitionSpec: PartitionSpec,
+                                             requiredEndMs: Long): Boolean =
+    spec.spanMillis >= basePartitionSpec.spanMillis || spec.epochMillis(spec.at(requiredEndMs)) == requiredEndMs
+
+  def defaultPartitionTarget(tableInfo: TableInfo,
+                             range: PartitionRange,
+                             basePartitionSpec: PartitionSpec,
+                             normalizeToBasePartitionSpec: Boolean): PartitionTarget = {
+    val spec = tableInfo.partitionSpec(basePartitionSpec)
+    PartitionTarget(spec, range.translate(spec).end, normalizeToBasePartitionSpec)
+  }
+
+  def checkTimestampStats(tableName: String, target: TimestampStatsTarget): Unit = {
+    val columnType = tableUtils.getSchemaFromTable(tableName)(target.column).dataType
+    if (columnType != TimestampType) {
+      throw new RuntimeException(
+        s"Subdaily sensor check requires timestamp partitionColumn for ${tableName}.${target.column}; found ${columnType}")
+    }
+    logger.info(
+      s"Checking stats-backed max timestamp for ${tableName} column ${target.column}; required end ms: ${target.requiredEndMs}")
+    val maxTimestampMs = tableUtils
+      .maxTimestampMillisFromStats(tableName, target.column)
+      .getOrElse(
+        throw new RuntimeException(
+          s"Subdaily sensor check is not ready: timestamp stats unavailable for ${tableName}.${target.column}"))
+
+    logger.info(s"Max timestamp from stats: ${maxTimestampMs}, required end ms: ${target.requiredEndMs}")
+    if (maxTimestampMs >= target.requiredEndMs) {
+      logger.info(s"Sensor succeeded: ${maxTimestampMs} >= ${target.requiredEndMs}")
+    } else {
+      throw new RuntimeException(
+        s"Sensor check failed: max timestamp from stats ${maxTimestampMs} < required end ms ${target.requiredEndMs}")
+    }
+  }
+
+  def checkPartition(tableName: String, partitionColumn: String, target: PartitionTarget): Unit = {
+    logger.info(s"Checking last available partition for ${tableName} column ${partitionColumn}")
+    val lastPartition = tableUtils
+      .lastAvailablePartition(tableName,
+                              tablePartitionSpec = Some(target.spec),
+                              normalizeToBasePartitionSpec = target.normalizeToBasePartitionSpec)
+      .getOrElse(throw new RuntimeException(s"Could not determine last available partition for ${tableName}"))
+
+    logger.info(s"Last available partition: ${lastPartition}, required end: ${target.requiredPartition}")
+
+    if (lastPartition >= target.requiredPartition) {
+      logger.info(s"Sensor succeeded: ${lastPartition} >= ${target.requiredPartition}")
+    } else {
+      throw new RuntimeException(
+        s"Sensor check failed: last available partition ${lastPartition} < required end ${target.requiredPartition}")
+    }
+  }
+
+  def checkSensorTarget(tableName: String,
+                        partitionColumn: String,
+                        target: ReadinessTarget,
+                        retryCount: Long,
+                        retryIntervalMin: Long): Try[Unit] =
+    retrySensorCheck(retryCount, retryIntervalMin) {
+      target match {
+        case timestampTarget: TimestampStatsTarget => checkTimestampStats(tableName, timestampTarget)
+        case target: UnalignedPartitionTarget =>
+          throw new RuntimeException(
+            s"Schedule offset ${target.requiredEndMs} does not align with partition spec " +
+              s"${target.spec.format} for ${tableName}.${target.column}; timestamp stats are required")
+        case partitionTarget: PartitionTarget => checkPartition(tableName, partitionColumn, partitionTarget)
+      }
+    }
+
+  def inputTableStatus(tableName: String,
+                       deps: Iterable[TableDependency],
+                       range: PartitionRange): Option[PartitionReadinessStatus] = {
+    targetForScheduleOffset(tableName,
+                            deps.head.tableInfo,
+                            range,
+                            deps,
+                            basePartitionSpec = tableUtils.partitionSpec) match {
+      case Some(TimestampStatsTarget(timestampColumn, maxRequiredEndMs)) =>
+        val maxTimestamp = tableUtils.maxTimestampMillisFromStats(tableName, timestampColumn)
+        Some(
+          PartitionReadinessStatus(None,
+                                   maxTimestamp.map(_.toString),
+                                   maxTimestamp.exists(_ >= maxRequiredEndMs),
+                                   maxRequiredEndMs.toString))
+      case Some(UnalignedPartitionTarget(_, requiredEndMs, _)) =>
+        Some(PartitionReadinessStatus(None, None, ready = false, requiredEndMs.toString))
+      case Some(target: PartitionTarget) =>
+        Some(partitionStatus(tableName, target))
+      case None =>
+        val inputPartitionSpec = deps.head.tableInfo.partitionSpec(tableUtils.partitionSpec)
+        dailyRequiredPartition(deps, range).map { requiredPartition =>
+          val target =
+            PartitionTarget(inputPartitionSpec, requiredPartition, normalizeToBasePartitionSpec = true)
+          partitionStatus(tableName, target)
+        }
+    }
+  }
+
+  private def dailyRequiredPartition(deps: Iterable[TableDependency], range: PartitionRange): Option[String] =
+    deps
+      .flatMap { td =>
+        DependencyResolver
+          .computeInputRange(range, td)
+          .map(_.translate(tableUtils.partitionSpec))
+          .map(_.end)
+      }
+      .toSeq
+      .sorted
+      .lastOption
+
+  private def partitionStatus(tableName: String, target: PartitionTarget): PartitionReadinessStatus = {
+    val first =
+      tableUtils.firstAvailablePartition(tableName,
+                                         partitionSpec = target.spec,
+                                         normalizeToBasePartitionSpec = target.normalizeToBasePartitionSpec)
+    val last =
+      tableUtils.lastAvailablePartition(tableName,
+                                        tablePartitionSpec = Some(target.spec),
+                                        normalizeToBasePartitionSpec = target.normalizeToBasePartitionSpec)
+    PartitionReadinessStatus(first, last, last.exists(_ >= target.requiredPartition), target.requiredPartition)
+  }
+
+  private def retrySensorCheck(retryCount: Long, retryIntervalMin: Long)(check: => Unit): Try[Unit] = {
+    @tailrec
+    def retry(attempt: Long): Try[Unit] = {
+      Try {
+        check
+      } match {
+        case Success(_) => Success(())
+        case Failure(e) if attempt < retryCount =>
+          logger.warn(s"Attempt ${attempt + 1} failed: ${e.getMessage}. Retrying in ${retryIntervalMin} minutes")
+          Thread.sleep(retryIntervalMin * 60 * 1000)
+          retry(attempt + 1)
+        case Failure(e) =>
+          Failure(
+            new RuntimeException(s"Sensor timed out after ${retryIntervalMin * attempt} minutes. ${e.getMessage}", e))
+      }
+    }
+    retry(0)
+  }
+}
+
+private[batch] object BatchNodeReadiness {
+  sealed trait ReadinessTarget {
+    def requiredEnd: String
+  }
+  case class TimestampStatsTarget(column: String, requiredEndMs: Long) extends ReadinessTarget {
+    override def requiredEnd: String = requiredEndMs.toString
+  }
+  case class UnalignedPartitionTarget(column: String, requiredEndMs: Long, spec: PartitionSpec)
+      extends ReadinessTarget {
+    override def requiredEnd: String = requiredEndMs.toString
+  }
+  case class PartitionTarget(spec: PartitionSpec, requiredPartition: String, normalizeToBasePartitionSpec: Boolean)
+      extends ReadinessTarget {
+    override def requiredEnd: String = requiredPartition
+  }
+  case class PartitionReadinessStatus(firstAvailablePartition: Option[String],
+                                      lastAvailablePartition: Option[String],
+                                      ready: Boolean,
+                                      requiredEnd: String)
+}

--- a/spark/src/main/scala/ai/chronon/spark/batch/BatchNodeReadiness.scala
+++ b/spark/src/main/scala/ai/chronon/spark/batch/BatchNodeReadiness.scala
@@ -49,7 +49,9 @@ private[batch] class BatchNodeReadiness(tableUtils: TableUtils, scheduleOffsetMs
       endMs <- requiredEndMs
       column <- partitionColumn
     } yield {
-      if (isTimestampColumn(tableName, column)) {
+      if (partitionSpecAlignsWithSubdailySchedule(spec, basePartitionSpec, endMs)) {
+        PartitionTarget(spec, spec.at(endMs), normalizeToBasePartitionSpec = false)
+      } else if (isTimestampColumn(tableName, column)) {
         TimestampStatsTarget(column, endMs)
       } else if (partitionSpecCoversRequiredEnd(spec, basePartitionSpec, endMs)) {
         PartitionTarget(spec, spec.at(endMs), normalizeToBasePartitionSpec = false)
@@ -58,6 +60,11 @@ private[batch] class BatchNodeReadiness(tableUtils: TableUtils, scheduleOffsetMs
       }
     }
   }
+
+  private def partitionSpecAlignsWithSubdailySchedule(spec: PartitionSpec,
+                                                      basePartitionSpec: PartitionSpec,
+                                                      requiredEndMs: Long): Boolean =
+    spec.spanMillis < basePartitionSpec.spanMillis && spec.epochMillis(spec.at(requiredEndMs)) == requiredEndMs
 
   private def partitionSpecCoversRequiredEnd(spec: PartitionSpec,
                                              basePartitionSpec: PartitionSpec,
@@ -118,15 +125,20 @@ private[batch] class BatchNodeReadiness(tableUtils: TableUtils, scheduleOffsetMs
                         target: ReadinessTarget,
                         retryCount: Long,
                         retryIntervalMin: Long): Try[Unit] =
-    retrySensorCheck(retryCount, retryIntervalMin) {
-      target match {
-        case timestampTarget: TimestampStatsTarget => checkTimestampStats(tableName, timestampTarget)
-        case target: UnalignedPartitionTarget =>
-          throw new RuntimeException(
+    target match {
+      case target: UnalignedPartitionTarget =>
+        Failure(
+          new RuntimeException(
             s"Schedule offset ${target.requiredEndMs} does not align with partition spec " +
-              s"${target.spec.format} for ${tableName}.${target.column}; timestamp stats are required")
-        case partitionTarget: PartitionTarget => checkPartition(tableName, partitionColumn, partitionTarget)
-      }
+              s"${target.spec.format} for ${tableName}.${target.column}; timestamp stats are required"))
+      case timestampTarget: TimestampStatsTarget =>
+        retrySensorCheck(retryCount, retryIntervalMin) {
+          checkTimestampStats(tableName, timestampTarget)
+        }
+      case partitionTarget: PartitionTarget =>
+        retrySensorCheck(retryCount, retryIntervalMin) {
+          checkPartition(tableName, partitionColumn, partitionTarget)
+        }
     }
 
   def inputTableStatus(tableName: String,

--- a/spark/src/main/scala/ai/chronon/spark/batch/BatchNodeRunner.scala
+++ b/spark/src/main/scala/ai/chronon/spark/batch/BatchNodeRunner.scala
@@ -2,7 +2,7 @@ package ai.chronon.spark.batch
 
 import ai.chronon.api.Extensions._
 import ai.chronon.api._
-import ai.chronon.api.planner.{DependencyResolver, NodeRunner}
+import ai.chronon.api.planner.NodeRunner
 import ai.chronon.api.secrets.SecretResolver
 import ai.chronon.observability.{TileStats, TileStatsType}
 import ai.chronon.online.{Api, KVStore}
@@ -50,11 +50,19 @@ class BatchNodeRunnerArgs(args: Array[String]) extends ScallopConf(args) {
     default = None
   )
 
+  val scheduleOffsetMs: ScallopOption[Long] = opt[Long](
+    required = false,
+    descr =
+      "Logical scheduled run offset in milliseconds from the --end-ds partition start. Enables stats-backed subdaily readiness checks."
+  )
+
   verify()
 }
 
-class BatchNodeRunner(node: Node, tableUtils: TableUtils, api: Api) extends NodeRunner {
+class BatchNodeRunner(node: Node, tableUtils: TableUtils, api: Api, scheduleOffsetMs: Option[Long] = None)
+    extends NodeRunner {
   @transient private lazy val logger: Logger = LoggerFactory.getLogger(getClass)
+  private val readiness = new BatchNodeReadiness(tableUtils, scheduleOffsetMs)
 
   // in ad-hoc flows, the jobs downstream of external tables will simply fail (albeit, with retries)
   // in scheduled flow, the jobs downstream of external sensors will be stalled by the sensor
@@ -120,40 +128,25 @@ class BatchNodeRunner(node: Node, tableUtils: TableUtils, api: Api) extends Node
       return retryTriggerExpr(0)
     }
 
+    readiness
+      .targetForScheduleOffset(tableName,
+                               tableInfo,
+                               range,
+                               Seq(conf.sourceTableDependency),
+                               basePartitionSpec = range.partitionSpec)
+      .foreach { target =>
+        return readiness.checkSensorTarget(tableName, tableInfo.partitionColumn, target, retryCount, retryIntervalMin)
+      }
+
     // Case 2: Has partition column — unified check: lastAvailablePartition >= range.end
     // Works for dense Hive, sparse Hive, Iceberg hidden partitions, timestamp columns — all the same.
     if (hasPartitionColumn) {
-      val spec = tableInfo.partitionSpec(tableUtils.partitionSpec)
-      @tailrec
-      def retry(attempt: Long): Try[Unit] = {
-        Try {
-          logger.info(s"Checking last available partition for ${tableName} column ${tableInfo.partitionColumn}")
-          val lastPartition = tableUtils
-            .lastAvailablePartition(tableName, tablePartitionSpec = Some(spec))
-            .getOrElse(throw new RuntimeException(s"Could not determine last available partition for ${tableName}"))
-
-          val requiredEnd = range.end
-          logger.info(s"Last available partition: ${lastPartition}, required end: ${requiredEnd}")
-
-          if (lastPartition >= requiredEnd) {
-            logger.info(s"Sensor succeeded: ${lastPartition} >= ${requiredEnd}")
-            ()
-          } else {
-            throw new RuntimeException(
-              s"Sensor check failed: last available partition ${lastPartition} < required end ${requiredEnd}")
-          }
-        } match {
-          case Success(_) => Success(())
-          case Failure(e) if attempt < retryCount =>
-            logger.warn(s"Attempt ${attempt + 1} failed: ${e.getMessage}. Retrying in ${retryIntervalMin} minutes")
-            Thread.sleep(retryIntervalMin * 60 * 1000)
-            retry(attempt + 1)
-          case Failure(e) =>
-            Failure(
-              new RuntimeException(s"Sensor timed out after ${retryIntervalMin * attempt} minutes. ${e.getMessage}", e))
-        }
-      }
-      return retry(0)
+      val target =
+        readiness.defaultPartitionTarget(tableInfo,
+                                         range,
+                                         tableUtils.partitionSpec,
+                                         normalizeToBasePartitionSpec = false)
+      return readiness.checkSensorTarget(tableName, tableInfo.partitionColumn, target, retryCount, retryIntervalMin)
     }
 
     // Case 3: No partition column, no trigger — just check table existence
@@ -540,6 +533,7 @@ class BatchNodeRunner(node: Node, tableUtils: TableUtils, api: Api) extends Node
       range: PartitionRange,
       tableUtils: TableUtils
   ): Iterable[TablePartitionStatus] = {
+    val inputReadiness = new BatchNodeReadiness(tableUtils, scheduleOffsetMs)
     val inputTableDependencies: Map[String, Array[TableDependency]] =
       Option(metadata.executionInfo.getTableDependencies)
         .map(_.asScala.toArray)
@@ -552,27 +546,7 @@ class BatchNodeRunner(node: Node, tableUtils: TableUtils, api: Api) extends Node
     inputTableDependencies
       .filterNot(_._2.forall(td => td.isSetIsSoftNodeDependency && td.isSoftNodeDependency))
       .flatMap { case (table, deps) =>
-        val requiredEnds = deps
-          .flatMap { td =>
-            DependencyResolver
-              .computeInputRange(range, td)
-              .map(_.translate(tableUtils.partitionSpec).end)
-          }
-          .toSeq
-          .sorted
-
-        if (requiredEnds.isEmpty) {
-          None
-        } else {
-          val inputPartitionSpec = deps.head.tableInfo.partitionSpec(tableUtils.partitionSpec)
-
-          val firstPartition =
-            tableUtils.firstAvailablePartition(table, partitionSpec = inputPartitionSpec)
-          val lastPartition = tableUtils.lastAvailablePartition(table, tablePartitionSpec = Some(inputPartitionSpec))
-          val requiredEnd = requiredEnds.last
-
-          val ready = lastPartition.exists(_ >= requiredEnd)
-
+        inputReadiness.inputTableStatus(table, deps, range).map { status =>
           // Collect semanticHash values from all dependencies for this table
           val semanticHashes = deps.flatMap { td =>
             if (td.isSetSemanticHash && td.semanticHash.nonEmpty) {
@@ -589,7 +563,12 @@ class BatchNodeRunner(node: Node, tableUtils: TableUtils, api: Api) extends Node
             semanticHashes.headOption
           }
 
-          Some(TablePartitionStatus(table, firstPartition, lastPartition, ready, requiredEnd, semanticHash))
+          TablePartitionStatus(table,
+                               status.firstAvailablePartition,
+                               status.lastAvailablePartition,
+                               status.ready,
+                               status.requiredEnd,
+                               semanticHash)
         }
       }
   }
@@ -700,7 +679,7 @@ object BatchNodeRunner {
     val node = NodeConfReader.read(batchArgs.confPath())
     val tableUtils = TableUtils(SparkSessionBuilder.build(s"batch-node-runner-${node.metaData.name}"))
     val api = instantiateApi(batchArgs.onlineClass(), batchArgs.apiProps ++ driverSecrets)
-    val runner = new BatchNodeRunner(node, tableUtils, api)
+    val runner = new BatchNodeRunner(node, tableUtils, api, batchArgs.scheduleOffsetMs.toOption)
     val exitCode =
       runner.runFromArgs(batchArgs.startDs(), batchArgs.endDs(), batchArgs.tableStatsDataset.toOption)
     tableUtils.sparkSession.stop()

--- a/spark/src/main/scala/ai/chronon/spark/catalog/DeltaLake.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/DeltaLake.scala
@@ -8,7 +8,6 @@ import org.apache.spark.sql.functions.{
   coalesce,
   col,
   count,
-  date_format,
   from_json,
   lit,
   min,
@@ -18,6 +17,7 @@ import org.apache.spark.sql.functions.{
   when
 }
 import org.apache.spark.sql.types.{DataType, DateType, MapType, StringType, StructField, StructType, TimestampType}
+import org.slf4j.{Logger, LoggerFactory}
 
 import scala.util.{Failure, Success, Try}
 
@@ -25,8 +25,6 @@ import scala.util.{Failure, Success, Try}
 // across Delta versions (e.g. 2 params in 3.2, 3 params in 3.3), so compiling against an older
 // version will cause NoSuchMethodError at runtime if the EMR-bundled Delta jar has a newer signature.
 case object DeltaLake extends Format {
-
-  private val DayMillis = 24L * 60L * 60L * 1000L
 
   override def tableTypeString: String = "delta"
 
@@ -75,6 +73,10 @@ case object DeltaLake extends Format {
       .orElse(statsLastAvailablePartition(tableName, partitionColumn, partitionSpec))
       .orElse(scanLastAvailablePartition(tableName, partitionColumn, partitionSpec))
 
+  override def maxTimestampMillisFromStats(tableName: String, timestampColumn: String)(implicit
+      sparkSession: SparkSession): Option[Long] =
+    DeltaStats.maxTimestampMillis(tableName, timestampColumn)
+
   private def statsLastAvailablePartition(tableName: String, columnName: String, partitionSpec: PartitionSpec)(implicit
       sparkSession: SparkSession): Option[String] =
     statsDateRange(tableName, columnName, partitionSpec).map { range =>
@@ -85,13 +87,23 @@ case object DeltaLake extends Format {
     }
 
   private[catalog] def statsDateRange(tableName: String, columnName: String, partitionSpec: PartitionSpec)(implicit
-      sparkSession: SparkSession): Option[StatsDateRange] = {
+      sparkSession: SparkSession): Option[StatsDateRange] =
+    DeltaStats.millisRange(tableName, columnName, partitionSpec).map(_.toDateRange(partitionSpec))
+
+  override def supportSubPartitionsFilter: Boolean = true
+}
+
+private[catalog] object DeltaStats {
+  @transient private lazy val logger: Logger = LoggerFactory.getLogger(getClass)
+
+  private val DayMillis = 24L * 60L * 60L * 1000L
+
+  def millisRange(tableName: String, columnName: String, partitionSpec: PartitionSpec)(implicit
+      sparkSession: SparkSession): Option[StatsMillisRange] = {
     import sparkSession.implicits._
 
     Try {
-      val describeResult = sparkSession.sql(s"DESCRIBE DETAIL $tableName")
-      val tablePath = describeResult.select("location").head().getString(0)
-      val activeFiles = DeltaLog.forTable(sparkSession, tablePath).update().allFiles.toDF()
+      val activeFiles = deltaActiveFiles(tableName)
       val columnType = sparkSession.read.table(tableName).schema(columnName).dataType
 
       val statsSchema = StructType(
@@ -111,20 +123,16 @@ case object DeltaLake extends Format {
         .agg(
           count(lit(1)).as("fileCount"),
           count(when(col("min_value").isNull || col("max_value").isNull, lit(1))).as("missingCount"),
-          date_format(min(statsBoundary("min_value", columnType, partitionSpec)), partitionSpec.format).as("start"),
-          date_format(max(statsBoundary("max_value", columnType, partitionSpec)), partitionSpec.format).as("end")
+          min(statsBoundaryTimestamp("min_value", columnType, partitionSpec)).as("startTimestamp"),
+          max(statsBoundaryTimestamp("max_value", columnType, partitionSpec)).as("endTimestamp")
         )
+        .as[(Long, Long, java.sql.Timestamp, java.sql.Timestamp)]
         .collect()
         .headOption
 
-      boundaries.flatMap { row =>
-        val fileCount = row.getAs[Long]("fileCount")
-        val missingCount = row.getAs[Long]("missingCount")
-        val start = row.getAs[String]("start")
-        val end = row.getAs[String]("end")
-
-        if (fileCount > 0 && missingCount == 0 && start != null && end != null) {
-          Some(StatsDateRange(start = start, end = end))
+      boundaries.flatMap { case (fileCount, missingCount, startTs, endTs) =>
+        if (fileCount > 0 && missingCount == 0 && startTs != null && endTs != null) {
+          Some(StatsMillisRange(startMillis = startTs.getTime, endMillis = endTs.getTime))
         } else {
           None
         }
@@ -132,9 +140,9 @@ case object DeltaLake extends Format {
     } match {
       case Success(result) =>
         if (result.isDefined) {
-          logger.info(s"Resolved Delta log stats boundaries for $tableName.$columnName: ${result.get}")
+          logger.info(s"Resolved Delta log stats millis boundaries for $tableName.$columnName: ${result.get}")
         } else {
-          logger.info(s"Delta log stats were incomplete for $tableName.$columnName; falling back to table scan")
+          logger.info(s"Delta log stats were incomplete for $tableName.$columnName")
         }
         result
       case Failure(e) =>
@@ -144,17 +152,65 @@ case object DeltaLake extends Format {
     }
   }
 
-  private def statsBoundary(boundaryColumn: String, columnType: DataType, partitionSpec: PartitionSpec): Column =
+  def maxTimestampMillis(tableName: String, timestampColumn: String)(implicit sparkSession: SparkSession): Option[Long] = {
+    import sparkSession.implicits._
+
+    Try {
+      val columnType = sparkSession.read.table(tableName).schema(timestampColumn).dataType
+      if (columnType != TimestampType) {
+        None
+      } else {
+        val statsSchema = StructType(
+          Seq(
+            StructField("maxValues", MapType(StringType, StringType), nullable = true)
+          ))
+
+        val maxTimestamp = deltaActiveFiles(tableName)
+          .select(from_json(col("stats"), statsSchema).as("stats"))
+          .select(col("stats.maxValues").getItem(timestampColumn).as("max_value"))
+          .agg(
+            count(lit(1)).as("fileCount"),
+            count(when(col("max_value").isNull, lit(1))).as("missingCount"),
+            max(statsBoundaryTimestamp("max_value", columnType, PartitionSpec.daily)).as("maxTimestamp")
+          )
+          .as[(Long, Long, java.sql.Timestamp)]
+          .collect()
+          .headOption
+
+        maxTimestamp.flatMap { case (fileCount, missingCount, maxTs) =>
+          if (fileCount > 0 && missingCount == 0 && maxTs != null) Some(maxTs.getTime) else None
+        }
+      }
+    } match {
+      case Success(result) =>
+        if (result.isDefined) {
+          logger.info(s"Resolved Delta log stats max timestamp for $tableName.$timestampColumn: ${result.get}")
+        } else {
+          logger.warn(s"Delta log stats max timestamp unavailable for $tableName.$timestampColumn")
+        }
+        result
+      case Failure(e) =>
+        logger.warn(
+          s"Failed to resolve Delta log stats max timestamp for $tableName.$timestampColumn: ${Option(e.getMessage).getOrElse("(no message)")}")
+        None
+    }
+  }
+
+  private def deltaActiveFiles(tableName: String)(implicit sparkSession: SparkSession) = {
+    val describeResult = sparkSession.sql(s"DESCRIBE DETAIL $tableName")
+    val tablePath = describeResult.select("location").head().getString(0)
+    DeltaLog.forTable(sparkSession, tablePath).update().allFiles.toDF()
+  }
+
+  private def statsBoundaryTimestamp(boundaryColumn: String, columnType: DataType, partitionSpec: PartitionSpec): Column =
     columnType match {
       case DateType =>
-        col(boundaryColumn).cast(DateType)
+        col(boundaryColumn).cast(DateType).cast("timestamp")
       case StringType if partitionSpec.spanMillis >= DayMillis =>
-        coalesce(to_date(col(boundaryColumn), partitionSpec.format), col(boundaryColumn).cast(DateType))
+        coalesce(to_date(col(boundaryColumn), partitionSpec.format), col(boundaryColumn).cast(DateType)).cast("timestamp")
       case StringType =>
         coalesce(to_timestamp(col(boundaryColumn), partitionSpec.format), col(boundaryColumn).cast("timestamp"))
       case _ =>
         col(boundaryColumn).cast("timestamp")
     }
-
-  override def supportSubPartitionsFilter: Boolean = true
 }

--- a/spark/src/main/scala/ai/chronon/spark/catalog/DeltaLake.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/DeltaLake.scala
@@ -4,18 +4,7 @@ import ai.chronon.api.PartitionSpec
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.delta.DeltaLog
-import org.apache.spark.sql.functions.{
-  coalesce,
-  col,
-  count,
-  from_json,
-  lit,
-  min,
-  max,
-  to_date,
-  to_timestamp,
-  when
-}
+import org.apache.spark.sql.functions.{coalesce, col, count, from_json, lit, min, max, to_date, to_timestamp, when}
 import org.apache.spark.sql.types.{DataType, DateType, MapType, StringType, StructField, StructType, TimestampType}
 import org.slf4j.{Logger, LoggerFactory}
 
@@ -152,34 +141,14 @@ private[catalog] object DeltaStats {
     }
   }
 
-  def maxTimestampMillis(tableName: String, timestampColumn: String)(implicit sparkSession: SparkSession): Option[Long] = {
-    import sparkSession.implicits._
-
+  def maxTimestampMillis(tableName: String, timestampColumn: String)(implicit
+      sparkSession: SparkSession): Option[Long] = {
     Try {
       val columnType = sparkSession.read.table(tableName).schema(timestampColumn).dataType
       if (columnType != TimestampType) {
         None
       } else {
-        val statsSchema = StructType(
-          Seq(
-            StructField("maxValues", MapType(StringType, StringType), nullable = true)
-          ))
-
-        val maxTimestamp = deltaActiveFiles(tableName)
-          .select(from_json(col("stats"), statsSchema).as("stats"))
-          .select(col("stats.maxValues").getItem(timestampColumn).as("max_value"))
-          .agg(
-            count(lit(1)).as("fileCount"),
-            count(when(col("max_value").isNull, lit(1))).as("missingCount"),
-            max(statsBoundaryTimestamp("max_value", columnType, PartitionSpec.daily)).as("maxTimestamp")
-          )
-          .as[(Long, Long, java.sql.Timestamp)]
-          .collect()
-          .headOption
-
-        maxTimestamp.flatMap { case (fileCount, missingCount, maxTs) =>
-          if (fileCount > 0 && missingCount == 0 && maxTs != null) Some(maxTs.getTime) else None
-        }
+        millisRange(tableName, timestampColumn, PartitionSpec.daily).map(_.endMillis)
       }
     } match {
       case Success(result) =>
@@ -202,12 +171,15 @@ private[catalog] object DeltaStats {
     DeltaLog.forTable(sparkSession, tablePath).update().allFiles.toDF()
   }
 
-  private def statsBoundaryTimestamp(boundaryColumn: String, columnType: DataType, partitionSpec: PartitionSpec): Column =
+  private def statsBoundaryTimestamp(boundaryColumn: String,
+                                     columnType: DataType,
+                                     partitionSpec: PartitionSpec): Column =
     columnType match {
       case DateType =>
         col(boundaryColumn).cast(DateType).cast("timestamp")
       case StringType if partitionSpec.spanMillis >= DayMillis =>
-        coalesce(to_date(col(boundaryColumn), partitionSpec.format), col(boundaryColumn).cast(DateType)).cast("timestamp")
+        coalesce(to_date(col(boundaryColumn), partitionSpec.format), col(boundaryColumn).cast(DateType))
+          .cast("timestamp")
       case StringType =>
         coalesce(to_timestamp(col(boundaryColumn), partitionSpec.format), col(boundaryColumn).cast("timestamp"))
       case _ =>

--- a/spark/src/main/scala/ai/chronon/spark/catalog/Format.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/Format.scala
@@ -293,6 +293,9 @@ private[catalog] case class StatsMillisRange(startMillis: Long, endMillis: Long)
 
 case class ResolvedTableName(catalog: String, namespace: String, table: String) {
   def toIdentifier: Identifier = Identifier.of(Array(namespace), table)
+
+  private[catalog] def quoted: String =
+    s"${QuotingUtils.quoteIdentifier(catalog)}.${QuotingUtils.quoteIdentifier(namespace)}.${QuotingUtils.quoteIdentifier(table)}"
 }
 
 object Format {

--- a/spark/src/main/scala/ai/chronon/spark/catalog/Format.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/Format.scala
@@ -213,6 +213,9 @@ trait Format {
     metadataLastAvailablePartition(tableName, partitionColumn)
       .orElse(scanLastAvailablePartition(tableName, partitionColumn, partitionSpec))
 
+  def maxTimestampMillisFromStats(tableName: String, timestampColumn: String)(implicit
+      sparkSession: SparkSession): Option[Long] = None
+
   // Unified first available partition: handles both string partition columns and timestamp/date columns.
   // For string columns that are catalog partitions, uses metadata-only lookup.
   // For timestamp/date columns, falls back to a scan.
@@ -278,6 +281,14 @@ private[catalog] case class StatsDateRange(start: String, end: String) {
   def firstAvailablePartition: String = start
 
   def lastAvailablePartition: String = end
+}
+
+private[catalog] case class StatsMillisRange(startMillis: Long, endMillis: Long) {
+  def toDateRange(partitionSpec: PartitionSpec): StatsDateRange =
+    StatsDateRange(
+      start = partitionSpec.at(startMillis),
+      end = partitionSpec.at(endMillis)
+    )
 }
 
 case class ResolvedTableName(catalog: String, namespace: String, table: String) {

--- a/spark/src/main/scala/ai/chronon/spark/catalog/Iceberg.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/Iceberg.scala
@@ -131,7 +131,7 @@ case object Iceberg extends Format {
       // Hour filter is currently buggy in iceberg. https://github.com/apache/iceberg/issues/4718
       // so we collect and then filter.
       partitionsDf
-        .select(col(s"partition.$partitionColumn"), col("partition.hr"))
+        .select(col(s"partition.$partitionColumn").cast("string"), col("partition.hr"))
         .collect()
         .filter(_.get(1) == null)
         .flatMap(row => Option(row.getString(0)))

--- a/spark/src/main/scala/ai/chronon/spark/catalog/Iceberg.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/Iceberg.scala
@@ -7,7 +7,6 @@ import org.apache.iceberg.spark.source.SparkTable
 import org.apache.iceberg.types.Type
 import org.apache.spark.sql.connector.catalog.TableCatalog
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.util.QuotingUtils
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.{StructType, TimestampType}
 import org.slf4j.{Logger, LoggerFactory}
@@ -57,7 +56,7 @@ case object Iceberg extends Format {
 
   override def partitions(tableName: String, partitionFilters: String)(implicit
       sparkSession: SparkSession): List[Map[String, String]] = {
-    val partitionsDf = sparkSession.table(s"${qualifyWithCatalog(tableName)}.partitions")
+    val partitionsDf = sparkSession.table(s"${Format.resolveTableName(tableName).quoted}.partitions")
 
     val index = partitionsDf.schema.fieldIndex("partition")
     val partitionColumnNames = partitionsDf.schema(index).dataType.asInstanceOf[StructType].fieldNames
@@ -80,7 +79,7 @@ case object Iceberg extends Format {
     * for other formats.
     */
   def partitionColumnNames(tableName: String)(implicit sparkSession: SparkSession): Array[String] = {
-    val partitionsDf = sparkSession.table(s"${qualifyWithCatalog(tableName)}.partitions")
+    val partitionsDf = sparkSession.table(s"${Format.resolveTableName(tableName).quoted}.partitions")
     val index = partitionsDf.schema.fieldIndex("partition")
     partitionsDf.schema(index).dataType.asInstanceOf[StructType].fieldNames
   }
@@ -125,7 +124,7 @@ case object Iceberg extends Format {
   private def getIcebergPartitions(tableName: String, partitionColumn: String)(implicit
       sparkSession: SparkSession): List[String] = {
 
-    val partitionsDf = sparkSession.table(s"${qualifyWithCatalog(tableName)}.partitions")
+    val partitionsDf = sparkSession.table(s"${Format.resolveTableName(tableName).quoted}.partitions")
 
     val index = partitionsDf.schema.fieldIndex("partition")
     if (partitionsDf.schema(index).dataType.asInstanceOf[StructType].fieldNames.contains("hr")) {
@@ -144,11 +143,6 @@ case object Iceberg extends Format {
         .flatMap(row => Option(row.getString(0)))
         .toList
     }
-  }
-
-  private[catalog] def qualifyWithCatalog(tableName: String)(implicit sparkSession: SparkSession): String = {
-    val resolved = Format.resolveTableName(tableName)
-    s"${QuotingUtils.quoteIdentifier(resolved.catalog)}.${QuotingUtils.quoteIdentifier(resolved.namespace)}.${QuotingUtils.quoteIdentifier(resolved.table)}"
   }
 
   override def supportSubPartitionsFilter: Boolean = false
@@ -192,17 +186,7 @@ private[catalog] object IcebergStats {
       if (columnType != TimestampType) {
         None
       } else {
-        val table = loadIcebergTable(tableName).getOrElse {
-          throw new IllegalStateException(s"Could not load Iceberg table: $tableName")
-        }
-        val field = Option(table.schema().findField(timestampColumn)).getOrElse {
-          throw new IllegalArgumentException(s"Column $timestampColumn not found in Iceberg schema for $tableName")
-        }
-        val fieldId = field.fieldId().asInstanceOf[java.lang.Integer]
-        val fieldType = field.`type`()
-        val extractor = new IcebergPartitionStatsExtractor(sparkSession)
-
-        currentDataFilesMaxMillis(table, fieldId, fieldType, extractor)
+        millisRange(tableName, timestampColumn, PartitionSpec.daily).map(_.endMillis)
       }
     } match {
       case Success(result) =>
@@ -226,43 +210,28 @@ private[catalog] object IcebergStats {
     Option(table.currentSnapshot()).flatMap { _ =>
       val tasks = table.newScan().includeColumnStats().planFiles()
       try {
-        val range = tasks.iterator().asScala.foldLeft(Some(None): Option[Option[(Long, Long)]]) {
-          case (None, _) => None
-          case (Some(acc), task) =>
-            fileMillisRange(task.file(), fieldId, fieldType, partitionSpec, extractor).map {
-              case (lowerMillis, upperMillis) =>
-                Some(acc.fold(lowerMillis -> upperMillis) { case (minMillis, maxMillis) =>
-                  Math.min(minMillis, lowerMillis) -> Math.max(maxMillis, upperMillis)
-                })
-            }
+        var range = Option.empty[(Long, Long)]
+        var statsComplete = true
+        val iterator = tasks.iterator().asScala
+
+        while (statsComplete && iterator.hasNext) {
+          fileMillisRange(iterator.next().file(), fieldId, fieldType, partitionSpec, extractor) match {
+            case Some((lowerMillis, upperMillis)) =>
+              range = Some(range.fold(lowerMillis -> upperMillis) { case (minMillis, maxMillis) =>
+                Math.min(minMillis, lowerMillis) -> Math.max(maxMillis, upperMillis)
+              })
+            case None =>
+              statsComplete = false
+          }
         }
 
-        range.flatten.map { case (minMillis, maxMillis) =>
-          StatsMillisRange(startMillis = minMillis, endMillis = maxMillis)
+        if (statsComplete) {
+          range.map { case (minMillis, maxMillis) =>
+            StatsMillisRange(startMillis = minMillis, endMillis = maxMillis)
+          }
+        } else {
+          None
         }
-      } finally {
-        tasks.close()
-      }
-    }
-
-  private def currentDataFilesMaxMillis(table: org.apache.iceberg.Table,
-                                        fieldId: java.lang.Integer,
-                                        fieldType: org.apache.iceberg.types.Type,
-                                        extractor: IcebergPartitionStatsExtractor): Option[Long] =
-    Option(table.currentSnapshot()).flatMap { _ =>
-      val tasks = table.newScan().includeColumnStats().planFiles()
-      try {
-        tasks.iterator().asScala.foldLeft(Some(None): Option[Option[Long]]) {
-          case (None, _) => None
-          case (Some(acc), task) =>
-            val upper = Option(task.file().upperBounds()).flatMap(bounds => Option(bounds.get(fieldId)))
-            upper.map { upperBound =>
-              val upperMillis = boundMillis(extractor.convertBoundValue(upperBound, fieldType),
-                                            fieldType,
-                                            PartitionSpec.daily)
-              Some(acc.fold(upperMillis)(existing => Math.max(existing, upperMillis)))
-            }
-        }.flatten
       } finally {
         tasks.close()
       }

--- a/spark/src/main/scala/ai/chronon/spark/catalog/Iceberg.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/Iceberg.scala
@@ -10,6 +10,7 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.util.QuotingUtils
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.{StructType, TimestampType}
+import org.slf4j.{Logger, LoggerFactory}
 
 import java.time.{LocalDate, ZoneOffset}
 import scala.collection.JavaConverters._
@@ -104,6 +105,10 @@ case object Iceberg extends Format {
       .orElse(statsLastAvailablePartition(tableName, partitionColumn, partitionSpec))
       .orElse(scanLastAvailablePartition(tableName, partitionColumn, partitionSpec))
 
+  override def maxTimestampMillisFromStats(tableName: String, timestampColumn: String)(implicit
+      sparkSession: SparkSession): Option[Long] =
+    IcebergStats.maxTimestampMillis(tableName, timestampColumn)
+
   private def statsLastAvailablePartition(tableName: String, columnName: String, partitionSpec: PartitionSpec)(implicit
       sparkSession: SparkSession): Option[String] =
     statsDateRange(tableName, columnName, partitionSpec).map { range =>
@@ -115,109 +120,7 @@ case object Iceberg extends Format {
 
   private[catalog] def statsDateRange(tableName: String, columnName: String, partitionSpec: PartitionSpec)(implicit
       sparkSession: SparkSession): Option[StatsDateRange] =
-    Try {
-      val table = loadIcebergTable(tableName).getOrElse {
-        throw new IllegalStateException(s"Could not load Iceberg table: $tableName")
-      }
-      val field = Option(table.schema().findField(columnName)).getOrElse {
-        throw new IllegalArgumentException(s"Column $columnName not found in Iceberg schema for $tableName")
-      }
-      val fieldId = field.fieldId().asInstanceOf[java.lang.Integer]
-      val fieldType = field.`type`()
-      val extractor = new IcebergPartitionStatsExtractor(sparkSession)
-
-      currentDataFilesDateRange(table, fieldId, fieldType, partitionSpec, extractor)
-    } match {
-      case Success(result) =>
-        if (result.isDefined) {
-          logger.info(s"Resolved Iceberg file stats boundaries for $tableName.$columnName: ${result.get}")
-        } else {
-          logger.info(s"Iceberg file stats were incomplete for $tableName.$columnName; falling back to table scan")
-        }
-        result
-      case Failure(e) =>
-        logger.warn(
-          s"Failed to resolve Iceberg file stats boundaries for $tableName.$columnName: ${Option(e.getMessage).getOrElse("(no message)")}")
-        None
-    }
-
-  private def fileDateRange(file: DataFile,
-                            fieldId: java.lang.Integer,
-                            fieldType: org.apache.iceberg.types.Type,
-                            partitionSpec: PartitionSpec,
-                            extractor: IcebergPartitionStatsExtractor): Option[(Long, Long)] = {
-    val lower = Option(file.lowerBounds()).flatMap(bounds => Option(bounds.get(fieldId)))
-    val upper = Option(file.upperBounds()).flatMap(bounds => Option(bounds.get(fieldId)))
-
-    for {
-      lowerBound <- lower
-      upperBound <- upper
-    } yield {
-      val lowerMillis = boundMillis(extractor.convertBoundValue(lowerBound, fieldType), fieldType, partitionSpec)
-      val upperMillis = boundMillis(extractor.convertBoundValue(upperBound, fieldType), fieldType, partitionSpec)
-      lowerMillis -> upperMillis
-    }
-  }
-
-  private def boundMillis(value: Any, fieldType: Type, partitionSpec: PartitionSpec): Long =
-    fieldType.typeId() match {
-      case Type.TypeID.TIMESTAMP =>
-        Math.floorDiv(value.asInstanceOf[java.lang.Long].longValue(), 1000L)
-      case Type.TypeID.DATE =>
-        LocalDate
-          .ofEpochDay(value.asInstanceOf[java.lang.Integer].longValue())
-          .atStartOfDay()
-          .toInstant(ZoneOffset.UTC)
-          .toEpochMilli
-      case Type.TypeID.STRING =>
-        partitionSpec.epochMillis(value.toString)
-      case other =>
-        throw new IllegalArgumentException(s"Unsupported Iceberg bound type $other for value $value")
-    }
-
-  private def currentDataFilesDateRange(table: org.apache.iceberg.Table,
-                                        fieldId: java.lang.Integer,
-                                        fieldType: org.apache.iceberg.types.Type,
-                                        partitionSpec: PartitionSpec,
-                                        extractor: IcebergPartitionStatsExtractor): Option[StatsDateRange] =
-    Option(table.currentSnapshot()).flatMap { _ =>
-      val tasks = table.newScan().includeColumnStats().planFiles()
-      try {
-        val range = tasks.iterator().asScala.foldLeft(Some(None): Option[Option[(Long, Long)]]) {
-          case (None, _) => None
-          case (Some(acc), task) =>
-            fileDateRange(task.file(), fieldId, fieldType, partitionSpec, extractor).map {
-              case (lowerMillis, upperMillis) =>
-                Some(acc.fold(lowerMillis -> upperMillis) { case (minMillis, maxMillis) =>
-                  Math.min(minMillis, lowerMillis) -> Math.max(maxMillis, upperMillis)
-                })
-            }
-        }
-
-        range.flatten.map { case (minMillis, maxMillis) =>
-          StatsDateRange(
-            start = partitionSpec.at(minMillis),
-            end = partitionSpec.at(maxMillis)
-          )
-        }
-      } finally {
-        tasks.close()
-      }
-    }
-
-  private def loadIcebergTable(tableName: String)(implicit
-      sparkSession: SparkSession): Option[org.apache.iceberg.Table] =
-    Try {
-      val resolved = Format.resolveTableName(tableName)
-      val catalog = sparkSession.sessionState.catalogManager
-        .catalog(resolved.catalog)
-        .asInstanceOf[TableCatalog]
-
-      catalog.loadTable(resolved.toIdentifier) match {
-        case sparkTable: SparkTable => sparkTable.table()
-        case other => throw new IllegalStateException(s"Not an Iceberg SparkTable: ${other.getClass.getName}")
-      }
-    }.toOption
+    IcebergStats.millisRange(tableName, columnName, partitionSpec).map(_.toDateRange(partitionSpec))
 
   private def getIcebergPartitions(tableName: String, partitionColumn: String)(implicit
       sparkSession: SparkSession): List[String] = {
@@ -249,4 +152,167 @@ case object Iceberg extends Format {
   }
 
   override def supportSubPartitionsFilter: Boolean = false
+}
+
+private[catalog] object IcebergStats {
+  @transient private lazy val logger: Logger = LoggerFactory.getLogger(getClass)
+
+  def millisRange(tableName: String, columnName: String, partitionSpec: PartitionSpec)(implicit
+      sparkSession: SparkSession): Option[StatsMillisRange] =
+    Try {
+      val table = loadIcebergTable(tableName).getOrElse {
+        throw new IllegalStateException(s"Could not load Iceberg table: $tableName")
+      }
+      val field = Option(table.schema().findField(columnName)).getOrElse {
+        throw new IllegalArgumentException(s"Column $columnName not found in Iceberg schema for $tableName")
+      }
+      val fieldId = field.fieldId().asInstanceOf[java.lang.Integer]
+      val fieldType = field.`type`()
+      val extractor = new IcebergPartitionStatsExtractor(sparkSession)
+
+      currentDataFilesMillisRange(table, fieldId, fieldType, partitionSpec, extractor)
+    } match {
+      case Success(result) =>
+        if (result.isDefined) {
+          logger.info(s"Resolved Iceberg file stats millis boundaries for $tableName.$columnName: ${result.get}")
+        } else {
+          logger.info(s"Iceberg file stats were incomplete for $tableName.$columnName")
+        }
+        result
+      case Failure(e) =>
+        logger.warn(
+          s"Failed to resolve Iceberg file stats boundaries for $tableName.$columnName: ${Option(e.getMessage).getOrElse("(no message)")}")
+        None
+    }
+
+  def maxTimestampMillis(tableName: String, timestampColumn: String)(implicit
+      sparkSession: SparkSession): Option[Long] =
+    Try {
+      val columnType = sparkSession.read.table(tableName).schema(timestampColumn).dataType
+      if (columnType != TimestampType) {
+        None
+      } else {
+        val table = loadIcebergTable(tableName).getOrElse {
+          throw new IllegalStateException(s"Could not load Iceberg table: $tableName")
+        }
+        val field = Option(table.schema().findField(timestampColumn)).getOrElse {
+          throw new IllegalArgumentException(s"Column $timestampColumn not found in Iceberg schema for $tableName")
+        }
+        val fieldId = field.fieldId().asInstanceOf[java.lang.Integer]
+        val fieldType = field.`type`()
+        val extractor = new IcebergPartitionStatsExtractor(sparkSession)
+
+        currentDataFilesMaxMillis(table, fieldId, fieldType, extractor)
+      }
+    } match {
+      case Success(result) =>
+        if (result.isDefined) {
+          logger.info(s"Resolved Iceberg file stats max timestamp for $tableName.$timestampColumn: ${result.get}")
+        } else {
+          logger.warn(s"Iceberg file stats max timestamp unavailable for $tableName.$timestampColumn")
+        }
+        result
+      case Failure(e) =>
+        logger.warn(
+          s"Failed to resolve Iceberg file stats max timestamp for $tableName.$timestampColumn: ${Option(e.getMessage).getOrElse("(no message)")}")
+        None
+    }
+
+  private def currentDataFilesMillisRange(table: org.apache.iceberg.Table,
+                                          fieldId: java.lang.Integer,
+                                          fieldType: org.apache.iceberg.types.Type,
+                                          partitionSpec: PartitionSpec,
+                                          extractor: IcebergPartitionStatsExtractor): Option[StatsMillisRange] =
+    Option(table.currentSnapshot()).flatMap { _ =>
+      val tasks = table.newScan().includeColumnStats().planFiles()
+      try {
+        val range = tasks.iterator().asScala.foldLeft(Some(None): Option[Option[(Long, Long)]]) {
+          case (None, _) => None
+          case (Some(acc), task) =>
+            fileMillisRange(task.file(), fieldId, fieldType, partitionSpec, extractor).map {
+              case (lowerMillis, upperMillis) =>
+                Some(acc.fold(lowerMillis -> upperMillis) { case (minMillis, maxMillis) =>
+                  Math.min(minMillis, lowerMillis) -> Math.max(maxMillis, upperMillis)
+                })
+            }
+        }
+
+        range.flatten.map { case (minMillis, maxMillis) =>
+          StatsMillisRange(startMillis = minMillis, endMillis = maxMillis)
+        }
+      } finally {
+        tasks.close()
+      }
+    }
+
+  private def currentDataFilesMaxMillis(table: org.apache.iceberg.Table,
+                                        fieldId: java.lang.Integer,
+                                        fieldType: org.apache.iceberg.types.Type,
+                                        extractor: IcebergPartitionStatsExtractor): Option[Long] =
+    Option(table.currentSnapshot()).flatMap { _ =>
+      val tasks = table.newScan().includeColumnStats().planFiles()
+      try {
+        tasks.iterator().asScala.foldLeft(Some(None): Option[Option[Long]]) {
+          case (None, _) => None
+          case (Some(acc), task) =>
+            val upper = Option(task.file().upperBounds()).flatMap(bounds => Option(bounds.get(fieldId)))
+            upper.map { upperBound =>
+              val upperMillis = boundMillis(extractor.convertBoundValue(upperBound, fieldType),
+                                            fieldType,
+                                            PartitionSpec.daily)
+              Some(acc.fold(upperMillis)(existing => Math.max(existing, upperMillis)))
+            }
+        }.flatten
+      } finally {
+        tasks.close()
+      }
+    }
+
+  private def fileMillisRange(file: DataFile,
+                              fieldId: java.lang.Integer,
+                              fieldType: org.apache.iceberg.types.Type,
+                              partitionSpec: PartitionSpec,
+                              extractor: IcebergPartitionStatsExtractor): Option[(Long, Long)] = {
+    val lower = Option(file.lowerBounds()).flatMap(bounds => Option(bounds.get(fieldId)))
+    val upper = Option(file.upperBounds()).flatMap(bounds => Option(bounds.get(fieldId)))
+
+    for {
+      lowerBound <- lower
+      upperBound <- upper
+    } yield {
+      val lowerMillis = boundMillis(extractor.convertBoundValue(lowerBound, fieldType), fieldType, partitionSpec)
+      val upperMillis = boundMillis(extractor.convertBoundValue(upperBound, fieldType), fieldType, partitionSpec)
+      lowerMillis -> upperMillis
+    }
+  }
+
+  private def boundMillis(value: Any, fieldType: Type, partitionSpec: PartitionSpec): Long =
+    fieldType.typeId() match {
+      case Type.TypeID.TIMESTAMP =>
+        Math.floorDiv(value.asInstanceOf[java.lang.Long].longValue(), 1000L)
+      case Type.TypeID.DATE =>
+        LocalDate
+          .ofEpochDay(value.asInstanceOf[java.lang.Integer].longValue())
+          .atStartOfDay()
+          .toInstant(ZoneOffset.UTC)
+          .toEpochMilli
+      case Type.TypeID.STRING =>
+        partitionSpec.epochMillis(value.toString)
+      case other =>
+        throw new IllegalArgumentException(s"Unsupported Iceberg bound type $other for value $value")
+    }
+
+  private def loadIcebergTable(tableName: String)(implicit
+      sparkSession: SparkSession): Option[org.apache.iceberg.Table] =
+    Try {
+      val resolved = Format.resolveTableName(tableName)
+      val catalog = sparkSession.sessionState.catalogManager
+        .catalog(resolved.catalog)
+        .asInstanceOf[TableCatalog]
+
+      catalog.loadTable(resolved.toIdentifier) match {
+        case sparkTable: SparkTable => sparkTable.table()
+        case other => throw new IllegalStateException(s"Not an Iceberg SparkTable: ${other.getClass.getName}")
+      }
+    }.toOption
 }

--- a/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
@@ -173,6 +173,18 @@ class TableUtils(@transient val sparkSession: SparkSession) extends Serializable
       .flatMap(_.maxTimestampDate(tableName, timestampColumn, effectiveSpec)(sparkSession))
   }
 
+  def maxTimestampMillisFromStats(tableName: String, timestampColumn: String): Option[Long] = {
+    val columnType = getSchemaFromTable(tableName)(timestampColumn).dataType
+    if (columnType != TimestampType) {
+      logger.warn(s"Column $tableName.$timestampColumn is $columnType, not timestamp; stats watermark unavailable")
+      None
+    } else {
+      tableFormatProvider
+        .readFormat(tableName)
+        .flatMap(_.maxTimestampMillisFromStats(tableName, timestampColumn)(sparkSession))
+    }
+  }
+
   def tableCoversRange(table: String, range: PartitionRange): Boolean = {
     try {
       lastAvailablePartition(table) match {

--- a/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
@@ -229,7 +229,8 @@ class TableUtils(@transient val sparkSession: SparkSession) extends Serializable
   def lastAvailablePartition(tableName: String,
                              partitionRange: Option[PartitionRange] = None,
                              subPartitionFilters: Map[String, String] = Map.empty,
-                             tablePartitionSpec: Option[PartitionSpec] = None): Option[String] = {
+                             tablePartitionSpec: Option[PartitionSpec] = None,
+                             normalizeToBasePartitionSpec: Boolean = true): Option[String] = {
     val effectiveSpec = tablePartitionSpec.getOrElse(partitionSpec)
     val effectivePartColumn = effectiveSpec.column
     if (subPartitionFilters.nonEmpty) {
@@ -240,15 +241,15 @@ class TableUtils(@transient val sparkSession: SparkSession) extends Serializable
       val result = tableFormatProvider
         .readFormat(tableName)
         .flatMap(_.lastAvailablePartition(tableName, effectivePartColumn, effectiveSpec)(sparkSession))
-      // Translate to global partitionSpec if needed
-      result.map(date => effectiveSpec.translate(date, partitionSpec))
+      if (normalizeToBasePartitionSpec) result.map(date => effectiveSpec.translate(date, partitionSpec)) else result
     }
   }
 
   def firstAvailablePartition(tableName: String,
                               partitionSpec: PartitionSpec = partitionSpec,
                               partitionRange: Option[PartitionRange] = None,
-                              subPartitionFilters: Map[String, String] = Map.empty): Option[String] = {
+                              subPartitionFilters: Map[String, String] = Map.empty,
+                              normalizeToBasePartitionSpec: Boolean = true): Option[String] = {
     if (subPartitionFilters.nonEmpty) {
       // Fall back to enumeration when sub-partition filters are needed
       Format.pickMinPartition(
@@ -263,8 +264,8 @@ class TableUtils(@transient val sparkSession: SparkSession) extends Serializable
       val result = tableFormatProvider
         .readFormat(tableName)
         .flatMap(_.firstAvailablePartition(tableName, effectivePartColumn, partitionSpec)(sparkSession))
-      // Translate to global partitionSpec if needed
-      result.map(date => partitionSpec.translate(date, this.partitionSpec))
+      if (normalizeToBasePartitionSpec) result.map(date => partitionSpec.translate(date, this.partitionSpec))
+      else result
     }
   }
 

--- a/spark/src/test/scala/ai/chronon/spark/batch/BatchNodeRunnerTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/batch/BatchNodeRunnerTest.scala
@@ -278,6 +278,8 @@ class BatchNodeRunnerTest extends SparkTestBase with Matchers with BeforeAndAfte
     spark.sql("DROP TABLE IF EXISTS test_db.tp_staging_output")
     spark.sql("DROP TABLE IF EXISTS test_db.tp_gb_output")
     spark.sql("DROP TABLE IF EXISTS test_db.time_part_sensor")
+    spark.sql("DROP TABLE IF EXISTS test_db.subdaily_stats_sensor")
+    spark.sql("DROP TABLE IF EXISTS test_db.hourly_input_table")
     spark.sql("DROP TABLE IF EXISTS test_db.yyyymmdd_events")
     spark.sql("DROP TABLE IF EXISTS test_db.yyyymmdd_gb_test")
     spark.sql("DROP TABLE IF EXISTS test_db.yyyymmdd_sq_test")
@@ -286,6 +288,55 @@ class BatchNodeRunnerTest extends SparkTestBase with Matchers with BeforeAndAfte
 
     setupTestTables()
     mockKVStore.reset()
+  }
+
+  private def createSubdailyStatsSensorTable(): Unit = {
+    spark.sql(
+      """CREATE TABLE IF NOT EXISTS test_db.subdaily_stats_sensor (
+        |  id INT,
+        |  created_at TIMESTAMP
+        |) USING iceberg
+        |TBLPROPERTIES (
+        |  'write.metadata.metrics.default' = 'full',
+        |  'write.metadata.metrics.column.created_at' = 'full'
+        |)""".stripMargin)
+    spark.sql(
+      s"""INSERT INTO test_db.subdaily_stats_sensor VALUES
+         |(1, TIMESTAMP '${yesterday} 09:00:00'),
+         |(2, TIMESTAMP '${yesterday} 12:00:00')
+         |""".stripMargin)
+  }
+
+  private def subdailySensorNode(endOffset: Option[Window] = None,
+                                 endCutOff: Option[String] = None): ExternalSourceSensorNode = {
+    val tableInfo = new TableInfo()
+      .setTable("test_db.subdaily_stats_sensor")
+      .setPartitionColumn("created_at")
+    val tableDependency = new TableDependency().setTableInfo(tableInfo)
+    endOffset.foreach(tableDependency.setEndOffset)
+    endCutOff.foreach(tableDependency.setEndCutOff)
+
+    new ExternalSourceSensorNode()
+      .setSourceTableDependency(tableDependency)
+      .setRetryCount(0L)
+      .setRetryIntervalMin(1L)
+  }
+
+  private def createHourlyInputTable(): String = {
+    val requiredHour = s"${yesterday}-12"
+    spark.sql(
+      """CREATE TABLE IF NOT EXISTS test_db.hourly_input_table (
+        |  id INT,
+        |  value STRING,
+        |  hr STRING
+        |)
+        |PARTITIONED BY (hr)
+        |""".stripMargin)
+    spark.sql(
+      s"""INSERT INTO test_db.hourly_input_table VALUES
+         |(1, 'value1', '${requiredHour}')
+         |""".stripMargin)
+    requiredHour
   }
 
   "BatchNodeRunner.runFromArgs" should "succeed for valid partition range" ignore {
@@ -414,6 +465,30 @@ class BatchNodeRunnerTest extends SparkTestBase with Matchers with BeforeAndAfte
       // Test passed
       case Failure(exception) =>
         fail(s"checkPartitions should have succeeded but failed with: ${exception.getMessage}")
+    }
+  }
+
+  it should "preserve triggerExpr checks when scheduleOffsetMs is set" in {
+    val tableInfo = new TableInfo()
+      .setTable("test_db.input_table")
+      .setPartitionColumn("ds")
+      .setTriggerExpr("MAX(ds)")
+    val tableDependency = new TableDependency().setTableInfo(tableInfo)
+    val sensorNode = new ExternalSourceSensorNode()
+      .setSourceTableDependency(tableDependency)
+      .setEngineType(EngineType.SPARK)
+      .setRetryCount(0L)
+      .setRetryIntervalMin(1L)
+
+    val metadata = createTestMetadata("test_db.input_table", "test_db.output_table")
+    val node = new Node().setMetaData(metadata)
+    val runner = new BatchNodeRunner(node, tableUtils, mockApi, Some(new Window(12, TimeUnit.HOURS).millis))
+
+    val result = runner.checkPartitions(sensorNode, PartitionRange(twoDaysAgo, twoDaysAgo)(tableUtils.partitionSpec))
+
+    result match {
+      case Success(_) => // Test passed
+      case Failure(e) => fail(s"triggerExpr check should have succeeded: ${e.getMessage}")
     }
   }
 
@@ -890,6 +965,214 @@ class BatchNodeRunnerTest extends SparkTestBase with Matchers with BeforeAndAfte
         assertTrue("Error should mention sensor",
           e.getMessage.contains("Sensor"))
     }
+  }
+
+  "BatchNodeRunner.checkPartitions with scheduleOffsetMs" should "use timestamp stats for subdaily readiness" in {
+    createSubdailyStatsSensorTable()
+
+    val maxTimestamp = tableUtils.maxTimestampMillisFromStats("test_db.subdaily_stats_sensor", "created_at").get
+    val scheduleOffsetMs = maxTimestamp - tableUtils.partitionSpec.epochMillis(yesterday) - 1000L
+    val runner = new BatchNodeRunner(new Node().setMetaData(createTestMetadata("test_db.input_table", "test_db.output_table")),
+                                     tableUtils,
+                                     mockApi,
+                                     Some(scheduleOffsetMs))
+
+    val result = runner.checkPartitions(subdailySensorNode(), PartitionRange(yesterday, yesterday)(tableUtils.partitionSpec))
+
+    result match {
+      case Success(_) => // Test passed
+      case Failure(e) => fail(s"scheduled stats check should have succeeded: ${e.getMessage}")
+    }
+  }
+
+  it should "fail subdaily readiness when timestamp stats do not reach schedule offset" in {
+    createSubdailyStatsSensorTable()
+
+    val maxTimestamp = tableUtils.maxTimestampMillisFromStats("test_db.subdaily_stats_sensor", "created_at").get
+    val scheduleOffsetMs = maxTimestamp - tableUtils.partitionSpec.epochMillis(yesterday) + 1000L
+    val runner = new BatchNodeRunner(new Node().setMetaData(createTestMetadata("test_db.input_table", "test_db.output_table")),
+                                     tableUtils,
+                                     mockApi,
+                                     Some(scheduleOffsetMs))
+
+    val result = runner.checkPartitions(subdailySensorNode(), PartitionRange(yesterday, yesterday)(tableUtils.partitionSpec))
+
+    result match {
+      case Success(_) => fail("scheduled stats check should have failed")
+      case Failure(e) => assertTrue("Error should mention max timestamp", e.getMessage.contains("max timestamp"))
+    }
+  }
+
+  it should "apply endOffset to subdaily scheduled readiness" in {
+    createSubdailyStatsSensorTable()
+
+    val maxTimestamp = tableUtils.maxTimestampMillisFromStats("test_db.subdaily_stats_sensor", "created_at").get
+    val runStartMs = maxTimestamp + new Window(3, TimeUnit.HOURS).millis
+    val scheduleOffsetMs = runStartMs - tableUtils.partitionSpec.epochMillis(yesterday)
+    val runner = new BatchNodeRunner(new Node().setMetaData(createTestMetadata("test_db.input_table", "test_db.output_table")),
+                                     tableUtils,
+                                     mockApi,
+                                     Some(scheduleOffsetMs))
+
+    val result = runner.checkPartitions(
+      subdailySensorNode(endOffset = Some(new Window(3, TimeUnit.HOURS))),
+      PartitionRange(yesterday, yesterday)(tableUtils.partitionSpec)
+    )
+
+    result match {
+      case Success(_) => // Test passed
+      case Failure(e) => fail(s"scheduled stats check should have honored endOffset: ${e.getMessage}")
+    }
+  }
+
+  it should "apply endCutOff to subdaily scheduled readiness" in {
+    createSubdailyStatsSensorTable()
+
+    val maxTimestamp = tableUtils.maxTimestampMillisFromStats("test_db.subdaily_stats_sensor", "created_at").get
+    val scheduleOffsetMs = maxTimestamp - tableUtils.partitionSpec.epochMillis(yesterday) + 1000L
+    val runner = new BatchNodeRunner(new Node().setMetaData(createTestMetadata("test_db.input_table", "test_db.output_table")),
+                                     tableUtils,
+                                     mockApi,
+                                     Some(scheduleOffsetMs))
+
+    val result = runner.checkPartitions(
+      subdailySensorNode(endCutOff = Some(twoDaysAgo)),
+      PartitionRange(yesterday, yesterday)(tableUtils.partitionSpec)
+    )
+
+    result match {
+      case Success(_) => // Test passed
+      case Failure(e) => fail(s"scheduled stats check should have honored endCutOff: ${e.getMessage}")
+    }
+  }
+
+  it should "use partition readiness for string partition sensors when scheduleOffsetMs is set" in {
+    val tableInfo = new TableInfo()
+      .setTable("test_db.input_table")
+      .setPartitionColumn("ds")
+    val tableDependency = new TableDependency().setTableInfo(tableInfo)
+    val sensorNode = new ExternalSourceSensorNode()
+      .setSourceTableDependency(tableDependency)
+      .setRetryCount(0L)
+      .setRetryIntervalMin(1L)
+    val runner = new BatchNodeRunner(new Node().setMetaData(createTestMetadata("test_db.input_table", "test_db.output_table")),
+                                     tableUtils,
+                                     mockApi,
+                                     Some(new Window(12, TimeUnit.HOURS).millis))
+
+    val result = runner.checkPartitions(sensorNode, PartitionRange(yesterday, yesterday)(tableUtils.partitionSpec))
+
+    result match {
+      case Success(_) => // Test passed
+      case Failure(e) => fail(s"scheduled partition check should have succeeded: ${e.getMessage}")
+    }
+  }
+
+  it should "use partition readiness for non-timestamp input tables when scheduleOffsetMs is set" in {
+    val metadata = createTestMetadata("test_db.input_table", "test_db.output_table")
+    val runner =
+      new BatchNodeRunner(new Node().setMetaData(metadata),
+                          tableUtils,
+                          mockApi,
+                          Some(new Window(12, TimeUnit.HOURS).millis))
+
+    val statuses = runner.computeInputTablePartitionStatuses(metadata,
+                                                             PartitionRange(twoDaysAgo, yesterday)(tableUtils.partitionSpec),
+                                                             tableUtils)
+    val status = statuses.find(_.name == "test_db.input_table")
+
+    assertTrue("Should have status for daily input table", status.isDefined)
+    assertTrue("Table should be ready from partition metadata", status.get.ready)
+    assertEquals("Required end should remain the daily dependency end", yesterday, status.get.requiredEnd)
+    assertEquals("Last available should come from partitions", Some(yesterday), status.get.lastAvailablePartition)
+  }
+
+  it should "use hourly partition readiness for hourly input tables when scheduleOffsetMs is set" in {
+    val requiredHour = createHourlyInputTable()
+    val query = new Query()
+      .setPartitionColumn("hr")
+      .setPartitionFormat("yyyy-MM-dd-HH")
+      .setPartitionInterval(new Window(1, TimeUnit.HOURS))
+    val metadata = createTestMetadata(
+      "test_db.hourly_input_table",
+      "test_db.output_table"
+    )
+    metadata.executionInfo.setTableDependencies(Seq(TableDependencies.fromTable("test_db.hourly_input_table", query)).asJava)
+    val runner =
+      new BatchNodeRunner(new Node().setMetaData(metadata),
+                          tableUtils,
+                          mockApi,
+                          Some(new Window(12, TimeUnit.HOURS).millis))
+
+    val statuses = runner.computeInputTablePartitionStatuses(metadata,
+                                                             PartitionRange(yesterday, yesterday)(tableUtils.partitionSpec),
+                                                             tableUtils)
+    val status = statuses.find(_.name == "test_db.hourly_input_table")
+
+    assertTrue("Should have status for hourly input table", status.isDefined)
+    assertTrue("Table should be ready from hourly partition metadata", status.get.ready)
+    assertEquals("Required end should be the scheduled hourly partition", requiredHour, status.get.requiredEnd)
+    assertEquals("Last available should preserve hourly partition", Some(requiredHour), status.get.lastAvailablePartition)
+  }
+
+  it should "not use hourly partition readiness when scheduleOffsetMs does not align to an hourly partition" in {
+    createHourlyInputTable()
+    val query = new Query()
+      .setPartitionColumn("hr")
+      .setPartitionFormat("yyyy-MM-dd-HH")
+      .setPartitionInterval(new Window(1, TimeUnit.HOURS))
+    val metadata = createTestMetadata(
+      "test_db.hourly_input_table",
+      "test_db.output_table"
+    )
+    metadata.executionInfo.setTableDependencies(Seq(TableDependencies.fromTable("test_db.hourly_input_table", query)).asJava)
+    val scheduleOffsetMs = new Window(12, TimeUnit.HOURS).millis + new Window(30, TimeUnit.MINUTES).millis
+    val runner =
+      new BatchNodeRunner(new Node().setMetaData(metadata),
+                          tableUtils,
+                          mockApi,
+                          Some(scheduleOffsetMs))
+
+    val statuses = runner.computeInputTablePartitionStatuses(metadata,
+                                                             PartitionRange(yesterday, yesterday)(tableUtils.partitionSpec),
+                                                             tableUtils)
+    val status = statuses.find(_.name == "test_db.hourly_input_table")
+
+    assertTrue("Should have status for hourly input table", status.isDefined)
+    assertFalse("Unaligned hourly partition should require timestamp stats", status.get.ready)
+    assertEquals("Required end should be the unaligned schedule millis",
+                 (tableUtils.partitionSpec.epochMillis(yesterday) + scheduleOffsetMs).toString,
+                 status.get.requiredEnd)
+    assertEquals("Last available should not come from hourly partition metadata",
+                 None,
+                 status.get.lastAvailablePartition)
+  }
+
+  it should "use timestamp stats in input table readiness when scheduleOffsetMs is set" in {
+    createSubdailyStatsSensorTable()
+
+    val metadata = createTestMetadata(
+      "test_db.subdaily_stats_sensor",
+      "test_db.output_table",
+      partitionColumn = "created_at"
+    )
+    val maxTimestamp = tableUtils.maxTimestampMillisFromStats("test_db.subdaily_stats_sensor", "created_at").get
+    val scheduleOffsetMs = maxTimestamp - tableUtils.partitionSpec.epochMillis(yesterday) - 1000L
+    val runner = new BatchNodeRunner(new Node().setMetaData(metadata), tableUtils, mockApi, Some(scheduleOffsetMs))
+
+    val statuses = runner.computeInputTablePartitionStatuses(metadata,
+                                                             PartitionRange(yesterday, yesterday)(tableUtils.partitionSpec),
+                                                             tableUtils)
+    val status = statuses.find(_.name == "test_db.subdaily_stats_sensor")
+
+    assertTrue("Should have status for subdaily stats table", status.isDefined)
+    assertTrue("Table should be ready from timestamp stats", status.get.ready)
+    assertEquals(
+      "Required end should be the scheduled watermark",
+      (tableUtils.partitionSpec.epochMillis(yesterday) + scheduleOffsetMs).toString,
+      status.get.requiredEnd
+    )
+    assertEquals("Last available should be max timestamp from stats", Some(maxTimestamp.toString), status.get.lastAvailablePartition)
   }
 
   private def createTimePartitionedEventsTable(): Unit = {

--- a/spark/src/test/scala/ai/chronon/spark/batch/BatchNodeRunnerTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/batch/BatchNodeRunnerTest.scala
@@ -280,6 +280,7 @@ class BatchNodeRunnerTest extends SparkTestBase with Matchers with BeforeAndAfte
     spark.sql("DROP TABLE IF EXISTS test_db.time_part_sensor")
     spark.sql("DROP TABLE IF EXISTS test_db.subdaily_stats_sensor")
     spark.sql("DROP TABLE IF EXISTS test_db.hourly_input_table")
+    spark.sql("DROP TABLE IF EXISTS test_db.hourly_timestamp_input_table")
     spark.sql("DROP TABLE IF EXISTS test_db.yyyymmdd_events")
     spark.sql("DROP TABLE IF EXISTS test_db.yyyymmdd_gb_test")
     spark.sql("DROP TABLE IF EXISTS test_db.yyyymmdd_sq_test")
@@ -1115,6 +1116,57 @@ class BatchNodeRunnerTest extends SparkTestBase with Matchers with BeforeAndAfte
     assertEquals("Last available should preserve hourly partition", Some(requiredHour), status.get.lastAvailablePartition)
   }
 
+  it should "prefer aligned hourly partition readiness for timestamp columns when scheduleOffsetMs is set" in {
+    spark.sql(
+      """CREATE TABLE IF NOT EXISTS test_db.hourly_timestamp_input_table (
+        |  id INT,
+        |  created_at TIMESTAMP
+        |)""".stripMargin)
+    val query = new Query()
+      .setPartitionColumn("created_at")
+      .setPartitionFormat("yyyy-MM-dd-HH")
+      .setPartitionInterval(new Window(1, TimeUnit.HOURS))
+    val tableDependency = TableDependencies.fromTable("test_db.hourly_timestamp_input_table", query)
+    val readiness = new BatchNodeReadiness(tableUtils, Some(new Window(12, TimeUnit.HOURS).millis))
+
+    val target = readiness
+      .targetForScheduleOffset("test_db.hourly_timestamp_input_table",
+                               tableDependency.tableInfo,
+                               PartitionRange(yesterday, yesterday)(tableUtils.partitionSpec),
+                               Seq(tableDependency),
+                               basePartitionSpec = tableUtils.partitionSpec)
+      .get
+
+    target shouldBe a[BatchNodeReadiness.PartitionTarget]
+    target.requiredEnd shouldBe s"${yesterday}-12"
+  }
+
+  it should "use timestamp stats for unaligned hourly timestamp partitions when scheduleOffsetMs is set" in {
+    spark.sql(
+      """CREATE TABLE IF NOT EXISTS test_db.hourly_timestamp_input_table (
+        |  id INT,
+        |  created_at TIMESTAMP
+        |)""".stripMargin)
+    val query = new Query()
+      .setPartitionColumn("created_at")
+      .setPartitionFormat("yyyy-MM-dd-HH")
+      .setPartitionInterval(new Window(1, TimeUnit.HOURS))
+    val tableDependency = TableDependencies.fromTable("test_db.hourly_timestamp_input_table", query)
+    val scheduleOffsetMs = new Window(12, TimeUnit.HOURS).millis + new Window(30, TimeUnit.MINUTES).millis
+    val readiness = new BatchNodeReadiness(tableUtils, Some(scheduleOffsetMs))
+
+    val target = readiness
+      .targetForScheduleOffset("test_db.hourly_timestamp_input_table",
+                               tableDependency.tableInfo,
+                               PartitionRange(yesterday, yesterday)(tableUtils.partitionSpec),
+                               Seq(tableDependency),
+                               basePartitionSpec = tableUtils.partitionSpec)
+      .get
+
+    target shouldBe a[BatchNodeReadiness.TimestampStatsTarget]
+    target.requiredEnd shouldBe (tableUtils.partitionSpec.epochMillis(yesterday) + scheduleOffsetMs).toString
+  }
+
   it should "not use hourly partition readiness when scheduleOffsetMs does not align to an hourly partition" in {
     createHourlyInputTable()
     val query = new Query()
@@ -1146,6 +1198,30 @@ class BatchNodeRunnerTest extends SparkTestBase with Matchers with BeforeAndAfte
     assertEquals("Last available should not come from hourly partition metadata",
                  None,
                  status.get.lastAvailablePartition)
+  }
+
+  it should "fail unaligned non-timestamp partition targets without retrying" in {
+    val tableInfo = new TableInfo()
+      .setTable("test_db.hourly_input_table")
+      .setPartitionColumn("hr")
+      .setPartitionFormat("yyyy-MM-dd-HH")
+      .setPartitionInterval(new Window(1, TimeUnit.HOURS))
+    val readiness = new BatchNodeReadiness(tableUtils, None)
+    val target = BatchNodeReadiness.UnalignedPartitionTarget("hr",
+                                                             tableUtils.partitionSpec.epochMillis(yesterday) +
+                                                               new Window(12, TimeUnit.HOURS).millis +
+                                                               new Window(30, TimeUnit.MINUTES).millis,
+                                                             tableInfo.partitionSpec(tableUtils.partitionSpec))
+
+    val result = readiness.checkSensorTarget("test_db.hourly_input_table", "hr", target, 0L, 1L)
+
+    result match {
+      case Success(_) => fail("unaligned partition target should fail")
+      case Failure(e) =>
+        assertTrue("Failure should describe the deterministic unaligned target",
+                   e.getMessage.startsWith("Schedule offset"))
+        assertFalse("Failure should not be wrapped by sensor retry timeout", e.getMessage.contains("Sensor timed out"))
+    }
   }
 
   it should "use timestamp stats in input table readiness when scheduleOffsetMs is set" in {

--- a/spark/src/test/scala/ai/chronon/spark/catalog/DeltaLakeTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/catalog/DeltaLakeTest.scala
@@ -9,6 +9,12 @@ import org.scalatest.matchers.should.Matchers._
 
 class DeltaLakeTest extends AnyFlatSpec with BeforeAndAfterAll {
 
+  private def toEpochMillis(value: Any): Long =
+    value match {
+      case timestamp: java.sql.Timestamp => timestamp.getTime
+      case instant: java.time.Instant    => instant.toEpochMilli
+    }
+
   private implicit lazy val spark: SparkSession =
     SparkSessionBuilder.build(
       "DeltaLakeTest",
@@ -46,6 +52,8 @@ class DeltaLakeTest extends AnyFlatSpec with BeforeAndAfterAll {
 
       DeltaLake.statsDateRange(tableName, "created_at", PartitionSpec.daily) shouldBe
         Some(StatsDateRange(start = "2024-01-01", end = "2024-01-03"))
+      DeltaLake.maxTimestampMillisFromStats(tableName, "created_at") shouldBe
+        Some(toEpochMillis(spark.table(tableName).selectExpr("MAX(created_at)").head().get(0)))
       DeltaLake.virtualPartitions(tableName, "created_at", PartitionSpec.daily) shouldBe
         List("2024-01-01", "2024-01-02", "2024-01-03")
       DeltaLake.firstAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-01-01")
@@ -197,6 +205,7 @@ class DeltaLakeTest extends AnyFlatSpec with BeforeAndAfterAll {
       """)
 
       DeltaLake.statsDateRange(tableName, "created_at", PartitionSpec.daily) shouldBe None
+      DeltaLake.maxTimestampMillisFromStats(tableName, "created_at") shouldBe None
       DeltaLake.virtualPartitions(tableName, "created_at", PartitionSpec.daily) shouldBe
         List("2024-02-01", "2024-02-02", "2024-02-03")
       DeltaLake.firstAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-02-01")

--- a/spark/src/test/scala/ai/chronon/spark/catalog/FormatTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/catalog/FormatTest.scala
@@ -189,6 +189,11 @@ class FormatTest extends SparkTestBase {
     assertEquals("tbl", resolved.table)
   }
 
+  it should "quote resolved table names" in {
+    Format.resolveTableName("`my-catalog`.`my-ns`.`my-table`").quoted shouldBe "`my-catalog`.`my-ns`.`my-table`"
+    Format.resolveTableName("`a``b`.`c``d`").quoted shouldBe "`spark_catalog`.`a``b`.`c``d`"
+  }
+
   it should "strip destination catalog in rename SQL when source and destination share a catalog" in {
     val sql = Format.renameTableSql(
       "spark_non_default_catalog.custom_test_db.src_table",

--- a/spark/src/test/scala/ai/chronon/spark/catalog/IcebergTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/catalog/IcebergTest.scala
@@ -111,6 +111,28 @@ class IcebergTest extends SparkTestBase with Matchers {
     parts shouldBe List("2024-03-01")
   }
 
+  it should "cast primary partition values before filtering null hour partitions" in {
+    val tableName = "default.iceberg_date_with_hr_partition_test"
+    spark.sql(s"DROP TABLE IF EXISTS $tableName")
+
+    spark.sql(s"""
+      CREATE TABLE $tableName (
+        id INT,
+        ds DATE,
+        hr STRING
+      ) USING iceberg
+      PARTITIONED BY (ds, hr)
+    """)
+
+    spark.sql(s"""
+      INSERT INTO $tableName VALUES
+      (1, DATE '2024-03-01', NULL),
+      (2, DATE '2024-03-02', '12')
+    """)
+
+    Iceberg.primaryPartitions(tableName, "ds", "") shouldBe List("2024-03-01")
+  }
+
   it should "derive virtual partitions from Iceberg file stats for a clustered timestamp column" in {
     val tableName = "default.iceberg_time_stats_test"
     spark.sql(s"DROP TABLE IF EXISTS $tableName")

--- a/spark/src/test/scala/ai/chronon/spark/catalog/IcebergTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/catalog/IcebergTest.scala
@@ -36,42 +36,6 @@ class IcebergTest extends SparkTestBase with Matchers {
     Iceberg.supportSubPartitionsFilter shouldBe false
   }
 
-  "qualifyWithCatalog" should "qualify a single-part name with catalog and current namespace" in {
-    val result = Iceberg.qualifyWithCatalog("my_table")
-    result shouldBe "`spark_catalog`.`default`.`my_table`"
-  }
-
-  it should "qualify a two-part name with the default catalog" in {
-    val result = Iceberg.qualifyWithCatalog("my_ns.my_table")
-    result shouldBe "`spark_catalog`.`my_ns`.`my_table`"
-  }
-
-  it should "re-quote a fully qualified three-part name" in {
-    val result = Iceberg.qualifyWithCatalog("spark_catalog.my_ns.my_table")
-    result shouldBe "`spark_catalog`.`my_ns`.`my_table`"
-  }
-
-  it should "properly quote identifiers with special characters" in {
-    val result = Iceberg.qualifyWithCatalog("`my-ns`.`my-table`")
-    result shouldBe "`spark_catalog`.`my-ns`.`my-table`"
-  }
-
-  it should "properly quote SQL reserved words" in {
-    val result = Iceberg.qualifyWithCatalog("`select`.`table`")
-    result shouldBe "`spark_catalog`.`select`.`table`"
-  }
-
-  it should "properly quote a three-part name with special characters" in {
-    val result = Iceberg.qualifyWithCatalog("`my-catalog`.`my-ns`.`my-table`")
-    result shouldBe "`my-catalog`.`my-ns`.`my-table`"
-  }
-
-  it should "handle identifiers containing backticks" in {
-    // Spark parses ``a`b`` as the identifier a`b
-    val result = Iceberg.qualifyWithCatalog("`a``b`.`c``d`")
-    result shouldBe "`spark_catalog`.`a``b`.`c``d`"
-  }
-
   "Iceberg.partitions" should "return partition values for an Iceberg table" in {
     val tableName = "default.iceberg_partitions_test"
 
@@ -96,6 +60,9 @@ class IcebergTest extends SparkTestBase with Matchers {
       Map("ds" -> "2024-01-01"),
       Map("ds" -> "2024-01-02")
     )
+
+    Iceberg.partitions("`default`.`iceberg_partitions_test`", "") should contain theSameElementsAs parts
+    Iceberg.partitions("`spark_catalog`.`default`.`iceberg_partitions_test`", "") should contain theSameElementsAs parts
   }
 
   "Iceberg.primaryPartitions" should "return primary partition values" in {

--- a/spark/src/test/scala/ai/chronon/spark/catalog/IcebergTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/catalog/IcebergTest.scala
@@ -6,6 +6,12 @@ import org.scalatest.matchers.should.Matchers
 
 class IcebergTest extends SparkTestBase with Matchers {
 
+  private def toEpochMillis(value: Any): Long =
+    value match {
+      case timestamp: java.sql.Timestamp => timestamp.getTime
+      case instant: java.time.Instant    => instant.toEpochMilli
+    }
+
   override def sparkConfs: Map[String, String] = Map(
     "spark.serializer" -> "org.apache.spark.serializer.JavaSerializer",
     "spark.sql.extensions" -> (
@@ -162,6 +168,8 @@ class IcebergTest extends SparkTestBase with Matchers {
 
     Iceberg.statsDateRange(tableName, "created_at", PartitionSpec.daily) shouldBe
       Some(StatsDateRange(start = "2024-04-01", end = "2024-04-03"))
+    Iceberg.maxTimestampMillisFromStats(tableName, "created_at") shouldBe
+      Some(toEpochMillis(spark.table(tableName).selectExpr("MAX(created_at)").head().get(0)))
     Iceberg.virtualPartitions(tableName, "created_at", PartitionSpec.daily) shouldBe
       List("2024-04-01", "2024-04-02", "2024-04-03")
     Iceberg.firstAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-04-01")
@@ -230,6 +238,7 @@ class IcebergTest extends SparkTestBase with Matchers {
     """)
 
     Iceberg.statsDateRange(tableName, "created_at", PartitionSpec.daily) shouldBe None
+    Iceberg.maxTimestampMillisFromStats(tableName, "created_at") shouldBe None
     Iceberg.virtualPartitions(tableName, "created_at", PartitionSpec.daily) shouldBe
       List("2024-05-01", "2024-05-02", "2024-05-03")
     Iceberg.firstAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-05-01")


### PR DESCRIPTION
## Summary

We want to be able to enable subdaily schedules, but that means we need to be able to check that data has landed for the correct end period. We currently do not know what the schedule is when running, 

- I added a new `--scheduled-offset-ms` that is the offset of the run from the latest ds end. I had assumed that any cron expression is valid. We can swap this to be anything that lets us derive the end ts required (could also just pass in the end ts which is maybe better). 
- Given a `scheduled-offset-ms` we want to handle the cases of:
  - We have sub-daily partitions in our table, so our checks can be checks against actual partitions. 
  - We have sub-daily partitions in our table but our schedule does not align we must then use table stats to check. 
  - We do not have sub-daily partitions in our table then we must use table stats to check.

Most changes here are an attempt to simplify the ms to partition or end conversion. Or at least make it reasonable to grok: 

- Separate out `IcebergStats` and `DeltaStats` to make the stats reuse easier. 
- We move most of the readiness checks out into `BatchNodeReadiness` because `BatchNodeRunner` because the readiness checks are getting to be a lot. 

Otherwise all existing checks should still be handled. This does not yet ungate in the python-side during compile as its not supported upstream in the orchestrator.

## Checklist
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional schedule-offset parameter for batch execution timing
  * Unified readiness checks: timestamp-backed, aligned-partition, and fallback strategies
  * Table-format support for extracting max timestamp (millis) from statistics

* **Improvements**
  * More accurate millis-based timestamp boundary computation and logging
  * Improved partition normalization and alignment handling across formats

* **Tests**
  * Expanded unit and integration tests for readiness modes and stats-based checks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->