### PR TITLE
feat(azure): enhanced stats on azure

### DIFF
--- a/cloud_azure/src/main/scala/ai/chronon/integrations/cloud_azure/AzureApiImpl.scala
+++ b/cloud_azure/src/main/scala/ai/chronon/integrations/cloud_azure/AzureApiImpl.scala
@@ -68,9 +68,51 @@ class AzureApiImpl(conf: Map[String, String]) extends Api(conf) {
     }
   }
 
-  override def genMetricsKvStore(tableBaseName: String): KVStore = null
+  override def genMetricsKvStore(tableBaseName: String): KVStore = {
+    Option(sharedMetricsKvStore.get()) match {
+      case Some(existingStore) =>
+        existingStore
+      case None =>
+        metricsKvStoreLock.synchronized {
+          Option(sharedMetricsKvStore.get()) match {
+            case Some(existingStore) => existingStore
+            case None =>
+              val kvStoreType = conf.getOrElse("kv.store.type", sys.env.getOrElse("KV_STORE_TYPE", "cosmos"))
+              val delegate = kvStoreType.toLowerCase match {
+                case "cosmos" =>
+                  logger.info("Initializing Cosmos DB metrics KV store")
+                  CosmosKVStoreFactory.createMetrics(conf)
+                case "redis" =>
+                  logger.info("Initializing Redis metrics KV store")
+                  RedisKVStoreFactory.create(conf)
+                case other =>
+                  throw new IllegalArgumentException(
+                    s"Unsupported KV store type: $other. Supported types: cosmos, redis")
+              }
+              val newStore = new AzureMetricsKVStore(delegate, tableBaseName)
+              sharedMetricsKvStore.set(newStore)
+              newStore
+          }
+        }
+    }
+  }
 
-  override def genEnhancedStatsKvStore(tableBaseName: String): KVStore = null
+  override def genEnhancedStatsKvStore(tableBaseName: String): KVStore = {
+    Option(sharedEnhancedStatsKvStore.get()) match {
+      case Some(existingStore) =>
+        existingStore
+      case None =>
+        enhancedStatsKvStoreLock.synchronized {
+          Option(sharedEnhancedStatsKvStore.get()) match {
+            case Some(existingStore) => existingStore
+            case None =>
+              val newStore = genKvStore
+              sharedEnhancedStatsKvStore.set(newStore)
+              newStore
+          }
+        }
+    }
+  }
 
   override def streamDecoder(groupByServingInfoParsed: GroupByServingInfoParsed): SerDe =
     new AvroSerDe(AvroConversions.fromChrononSchema(groupByServingInfoParsed.streamChrononSchema))

--- a/cloud_azure/src/main/scala/ai/chronon/integrations/cloud_azure/AzureApiImpl.scala
+++ b/cloud_azure/src/main/scala/ai/chronon/integrations/cloud_azure/AzureApiImpl.scala
@@ -106,7 +106,18 @@ class AzureApiImpl(conf: Map[String, String]) extends Api(conf) {
           Option(sharedEnhancedStatsKvStore.get()) match {
             case Some(existingStore) => existingStore
             case None =>
-              val newStore = genKvStore
+              val kvStoreType = conf.getOrElse("kv.store.type", sys.env.getOrElse("KV_STORE_TYPE", "cosmos"))
+              val newStore = kvStoreType.toLowerCase match {
+                case "cosmos" =>
+                  logger.info("Initializing Cosmos DB enhanced stats KV store")
+                  CosmosKVStoreFactory.create(conf)
+                case "redis" =>
+                  logger.info("Initializing Redis enhanced stats KV store")
+                  RedisKVStoreFactory.create(conf)
+                case other =>
+                  throw new IllegalArgumentException(
+                    s"Unsupported KV store type: $other. Supported types: cosmos, redis")
+              }
               sharedEnhancedStatsKvStore.set(newStore)
               newStore
           }

--- a/cloud_azure/src/main/scala/ai/chronon/integrations/cloud_azure/AzureMetricsKVStore.scala
+++ b/cloud_azure/src/main/scala/ai/chronon/integrations/cloud_azure/AzureMetricsKVStore.scala
@@ -1,0 +1,33 @@
+package ai.chronon.integrations.cloud_azure
+
+import ai.chronon.online.KVStore
+import ai.chronon.online.KVStore.{GetRequest, GetResponse, ListRequest, ListResponse, PutRequest}
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.concurrent.Future
+
+class AzureMetricsKVStore(delegate: KVStore, tableBaseName: String) extends KVStore {
+  @transient override lazy val logger: Logger = LoggerFactory.getLogger(getClass)
+
+  private[cloud_azure] def canonicalDataset(dataset: String): String =
+    if (dataset.endsWith("_STREAMING")) s"${tableBaseName}_STREAMING"
+    else s"${tableBaseName}_BATCH"
+
+  override def create(dataset: String): Unit =
+    delegate.create(canonicalDataset(dataset))
+
+  override def create(dataset: String, props: Map[String, Any]): Unit =
+    delegate.create(canonicalDataset(dataset), props)
+
+  override def multiGet(requests: Seq[GetRequest]): Future[Seq[GetResponse]] =
+    delegate.multiGet(requests.map(request => request.copy(dataset = canonicalDataset(request.dataset))))
+
+  override def multiPut(requests: Seq[PutRequest]): Future[Seq[Boolean]] =
+    delegate.multiPut(requests.map(request => request.copy(dataset = canonicalDataset(request.dataset))))
+
+  override def list(request: ListRequest): Future[ListResponse] =
+    delegate.list(request.copy(dataset = canonicalDataset(request.dataset)))
+
+  override def bulkPut(sourceOfflineTable: String, destinationOnlineDataSet: String, partition: String): Unit =
+    delegate.bulkPut(sourceOfflineTable, destinationOnlineDataSet, partition)
+}

--- a/cloud_azure/src/main/scala/ai/chronon/integrations/cloud_azure/CosmosKVStoreFactory.scala
+++ b/cloud_azure/src/main/scala/ai/chronon/integrations/cloud_azure/CosmosKVStoreFactory.scala
@@ -1,7 +1,7 @@
 package ai.chronon.integrations.cloud_azure
 
 import ai.chronon.integrations.cloud_azure.CosmosKVStoreConstants._
-import com.azure.cosmos.{ConsistencyLevel, CosmosAsyncClient, CosmosClientBuilder}
+import com.azure.cosmos.{ConsistencyLevel, CosmosAsyncClient, CosmosAsyncDatabase, CosmosClientBuilder}
 import org.slf4j.LoggerFactory
 
 import java.util.concurrent.atomic.AtomicReference
@@ -15,6 +15,14 @@ object CosmosKVStoreFactory {
   private val clientLock = new Object()
 
   def create(conf: Map[String, String]): CosmosKVStoreImpl = {
+    new CosmosKVStoreImpl(getDatabase(conf), conf)
+  }
+
+  def createMetrics(conf: Map[String, String]): CosmosMetricsKVStoreImpl = {
+    new CosmosMetricsKVStoreImpl(getDatabase(conf), conf)
+  }
+
+  private def getDatabase(conf: Map[String, String]): CosmosAsyncDatabase = {
     val endpoint = getOrElseThrow(EnvCosmosEndpoint, conf)
     val key = getOrElseThrow(EnvCosmosKey, conf)
     val databaseName = getOptional(EnvCosmosDatabase, conf).getOrElse(DefaultDatabaseName)
@@ -34,8 +42,7 @@ object CosmosKVStoreFactory {
         }
     }
 
-    val database = client.getDatabase(databaseName)
-    new CosmosKVStoreImpl(database, conf)
+    client.getDatabase(databaseName)
   }
 
   private def createCosmosClient(

--- a/cloud_azure/src/main/scala/ai/chronon/integrations/cloud_azure/CosmosMetricsKVStoreImpl.scala
+++ b/cloud_azure/src/main/scala/ai/chronon/integrations/cloud_azure/CosmosMetricsKVStoreImpl.scala
@@ -1,0 +1,282 @@
+package ai.chronon.integrations.cloud_azure
+
+import ai.chronon.integrations.cloud_azure.CosmosKVStore._
+import ai.chronon.integrations.cloud_azure.CosmosKVStoreConstants._
+import ai.chronon.online.KVStore
+import ai.chronon.online.KVStore._
+import ai.chronon.online.metrics.Metrics
+import com.azure.cosmos._
+import com.azure.cosmos.models._
+import com.azure.cosmos.util.CosmosPagedFlux
+import org.slf4j.{Logger, LoggerFactory}
+
+import java.util.UUID
+import scala.collection.concurrent.TrieMap
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future, Promise}
+import scala.jdk.CollectionConverters._
+import scala.util.{Failure, Success}
+
+/** Cosmos KV store for Iceberg partition stats.
+  *
+  * Unlike feature batch data, partition stats are raw row-key time series:
+  *   - keyBytes are strings such as <outputTable>#NULL_COUNTS or <outputTable>#schema
+  *   - timestamped metric rows must support range reads
+  *   - schema rows are stored as latest-value metadata
+  */
+class CosmosMetricsKVStoreImpl(database: CosmosAsyncDatabase, conf: Map[String, String] = Map.empty) extends KVStore {
+
+  @transient override lazy val logger: Logger = LoggerFactory.getLogger(getClass)
+
+  private val containerCache = new TrieMap[String, CosmosAsyncContainer]()
+  private val ensuredContainers = new TrieMap[String, Boolean]()
+  private val slowOperationThresholdMs = conf.getOrElse("cosmos.slow_operation_threshold_ms", "1000").toLong
+
+  protected val metricsContext: Metrics.Context =
+    Metrics.Context(Metrics.Environment.KVStore).withSuffix("cosmos_metrics")
+
+  protected val containerToContext = new TrieMap[String, Metrics.Context]()
+
+  override def create(dataset: String): Unit = create(dataset, Map.empty)
+
+  override def create(dataset: String, props: Map[String, Any]): Unit = {
+    val requestId = UUID.randomUUID().toString
+    val containerName = metricsContainerName(dataset)
+    logger.info(s"[metrics.create] [requestId=$requestId] container=$containerName, dataset=$dataset")
+
+    val isEmulator = props.get(PropEmulatorMode).exists(_.toString.toBoolean) ||
+      CosmosKVStoreConstants.isEmulator(
+        sys.env.getOrElse(CosmosKVStoreConstants.EnvCosmosEndpoint,
+                          props.getOrElse(CosmosKVStoreConstants.EnvCosmosEndpoint, "").toString)
+      )
+
+    val paths = new java.util.ArrayList[String]()
+    paths.add("/keyHash")
+    val partitionKeyDef =
+      if (isEmulator) new PartitionKeyDefinition().setPaths(paths)
+      else
+        new PartitionKeyDefinition()
+          .setPaths(paths)
+          .setVersion(PartitionKeyDefinitionVersion.V2)
+          .setKind(PartitionKind.HASH)
+
+    val containerProperties = new CosmosContainerProperties(containerName, partitionKeyDef)
+    val throughputProps = props.get(PropThroughput) match {
+      case Some(manualRU: Int) =>
+        ThroughputProperties.createManualThroughput(manualRU)
+      case _ =>
+        val maxRU = props.getOrElse(PropAutoscale, DefaultAutoscaleMaxRU).asInstanceOf[Int]
+        ThroughputProperties.createAutoscaledThroughput(maxRU)
+    }
+
+    val startTime = System.currentTimeMillis()
+    val response = Await.result(
+      monoToScalaFuture(database.createContainerIfNotExists(containerProperties, throughputProps)),
+      120.seconds
+    )
+    val duration = System.currentTimeMillis() - startTime
+    logger.info(
+      s"[metrics.create] [requestId=$requestId] Success in ${duration}ms, diagnostics=${response.getDiagnostics}")
+    ensuredContainers.put(containerName, true)
+    metricsContext.increment("create.successes")
+    metricsContext.distribution("create.latency", duration)
+  }
+
+  override def multiGet(requests: Seq[GetRequest]): Future[Seq[GetResponse]] =
+    Future.sequence(requests.zipWithIndex.map { case (request, idx) =>
+      val requestId = s"${UUID.randomUUID()}-i$idx"
+      if (request.startTsMillis.isDefined) queryTimeRange(request, requestId)
+      else readLatest(request, requestId)
+    })
+
+  override def multiPut(requests: Seq[PutRequest]): Future[Seq[Boolean]] =
+    Future.sequence(requests.zipWithIndex.map { case (request, idx) =>
+      val requestId = s"${UUID.randomUUID()}-i$idx"
+      upsertMetric(request, requestId)
+    })
+
+  override def list(request: ListRequest): Future[ListResponse] = {
+    val containerName = metricsContainerName(request.dataset)
+    val container = getOrCreateContainerRef(containerName)
+    val querySpec = new SqlQuerySpec(
+      """SELECT c.keyBytes, c.valueBytes
+        |FROM c
+        |WHERE c.dataset = @dataset""".stripMargin
+    )
+    querySpec.setParameters(new java.util.ArrayList[SqlParameter]())
+    querySpec.getParameters.add(new SqlParameter("@dataset", request.dataset))
+
+    val options = new CosmosQueryRequestOptions()
+    val flux: CosmosPagedFlux[java.util.Map[String, Object]] =
+      container.queryItems(querySpec, options, classOf[java.util.Map[String, Object]])
+
+    monoToScalaFuture(flux.collectList())
+      .map { docs =>
+        val values = docs.asScala.map { doc =>
+          ListValue(extractBytes(doc.get("keyBytes")), extractBytes(doc.get("valueBytes")))
+        }.toSeq
+        ListResponse(request, Success(values), Map.empty)
+      }
+      .recover { case e: Exception =>
+        logger.error(s"[metrics.list] Failed for dataset ${request.dataset}", e)
+        ListResponse(request, Failure(e), Map.empty)
+      }
+  }
+
+  override def bulkPut(sourceOfflineTable: String, destinationOnlineDataSet: String, partition: String): Unit =
+    throw new UnsupportedOperationException("bulkPut is not supported for CosmosMetricsKVStoreImpl")
+
+  private def upsertMetric(request: PutRequest, requestId: String): Future[Boolean] = {
+    val containerName = metricsContainerName(request.dataset)
+    val container = getOrCreateContainerRef(containerName)
+    val context = containerToContext.getOrElseUpdate(containerName, metricsContext.copy(dataset = containerName))
+    val keyHash = buildKeyHash(request.keyBytes)
+    val tsMillis = request.tsMillis.getOrElse(System.currentTimeMillis())
+    val docId = request.tsMillis match {
+      case Some(ts) => buildMetricsDocumentId(request.dataset, keyHash, ts)
+      case None     => buildMetricsLatestDocumentId(request.dataset, keyHash)
+    }
+
+    val doc = new java.util.HashMap[String, Object]()
+    doc.put("id", docId)
+    doc.put("dataset", request.dataset)
+    doc.put("keyHash", keyHash)
+    doc.put("keyBytes", request.keyBytes)
+    doc.put("valueBytes", request.valueBytes)
+    doc.put("tsMillis", tsMillis.asInstanceOf[Object])
+
+    val partitionKey = new PartitionKeyBuilder().add(keyHash).build()
+    val startTime = System.currentTimeMillis()
+    monoToScalaFuture(container.upsertItem(doc, partitionKey, new CosmosItemRequestOptions()))
+      .map { response =>
+        val duration = System.currentTimeMillis() - startTime
+        context.increment("multiPut.successes")
+        context.distribution("multiPut.latency", duration)
+        if (duration > slowOperationThresholdMs) {
+          logger.warn(
+            s"[metrics.multiPut] [requestId=$requestId] Slow upsert ${duration}ms for dataset=${request.dataset}, docId=$docId, diagnostics=${response.getDiagnostics}")
+        }
+        true
+      }
+      .recover { case e: Exception =>
+        logger.error(s"[metrics.multiPut] [requestId=$requestId] Failed for dataset=${request.dataset}, docId=$docId",
+                     e)
+        context.increment("multiPut.failures", Map("exception" -> e.getClass.getName))
+        false
+      }
+  }
+
+  private def readLatest(request: GetRequest, requestId: String): Future[GetResponse] = {
+    val containerName = metricsContainerName(request.dataset)
+    val container = getOrCreateContainerRef(containerName)
+    val keyHash = buildKeyHash(request.keyBytes)
+    val docId = buildMetricsLatestDocumentId(request.dataset, keyHash)
+    val partitionKey = new PartitionKeyBuilder().add(keyHash).build()
+
+    monoToScalaFuture(container.readItem(docId, partitionKey, classOf[java.util.Map[String, Object]]))
+      .map { response =>
+        val doc = response.getItem
+        val valueBytes = extractBytes(doc.get("valueBytes"))
+        val tsMillis = doc.get("tsMillis").asInstanceOf[Number].longValue()
+        GetResponse(request, Success(Seq(TimedValue(valueBytes, tsMillis))))
+      }
+      .recover {
+        case e: CosmosException if e.getStatusCode == 404 =>
+          logger.debug(s"[metrics.multiGet] [requestId=$requestId] Latest document not found: docId=$docId")
+          GetResponse(request, Success(Seq.empty))
+        case e: Exception =>
+          logger.error(s"[metrics.multiGet] [requestId=$requestId] Failed latest read: docId=$docId", e)
+          GetResponse(request, Failure(e))
+      }
+  }
+
+  private def queryTimeRange(request: GetRequest, requestId: String): Future[GetResponse] = {
+    val containerName = metricsContainerName(request.dataset)
+    val container = getOrCreateContainerRef(containerName)
+    val keyHash = buildKeyHash(request.keyBytes)
+    val startTs = request.startTsMillis.get
+    val endTs = request.endTsMillis.getOrElse(System.currentTimeMillis())
+
+    val querySpec = new SqlQuerySpec(
+      """SELECT c.valueBytes, c.tsMillis
+        |FROM c
+        |WHERE c.dataset = @dataset
+        |  AND c.keyHash = @keyHash
+        |  AND c.tsMillis >= @startTs
+        |  AND c.tsMillis <= @endTs""".stripMargin
+    )
+    querySpec.setParameters(new java.util.ArrayList[SqlParameter]())
+    querySpec.getParameters.add(new SqlParameter("@dataset", request.dataset))
+    querySpec.getParameters.add(new SqlParameter("@keyHash", keyHash))
+    querySpec.getParameters.add(new SqlParameter("@startTs", startTs))
+    querySpec.getParameters.add(new SqlParameter("@endTs", endTs))
+
+    val options = new CosmosQueryRequestOptions()
+    options.setPartitionKey(new PartitionKeyBuilder().add(keyHash).build())
+
+    val startTime = System.currentTimeMillis()
+    val flux: CosmosPagedFlux[java.util.Map[String, Object]] =
+      container.queryItems(querySpec, options, classOf[java.util.Map[String, Object]])
+
+    monoToScalaFuture(flux.collectList())
+      .map { docs =>
+        val duration = System.currentTimeMillis() - startTime
+        if (duration > slowOperationThresholdMs) {
+          logger.warn(
+            s"[metrics.multiGet] [requestId=$requestId] Slow range query ${duration}ms for dataset=${request.dataset}, keyHash=$keyHash")
+        }
+        val values = docs.asScala
+          .map { doc =>
+            val valueBytes = extractBytes(doc.get("valueBytes"))
+            val tsMillis = doc.get("tsMillis").asInstanceOf[Number].longValue()
+            TimedValue(valueBytes, tsMillis)
+          }
+          .toSeq
+          .sortBy(_.millis)
+        GetResponse(request, Success(values))
+      }
+      .recover { case e: Exception =>
+        logger.error(
+          s"[metrics.multiGet] [requestId=$requestId] Failed range query for dataset=${request.dataset}, keyHash=$keyHash",
+          e)
+        GetResponse(request, Failure(e))
+      }
+  }
+
+  private def getOrCreateContainerRef(containerName: String): CosmosAsyncContainer = {
+    ensuredContainers.getOrElseUpdate(containerName, {
+                                        create(containerName)
+                                        true
+                                      })
+    containerCache.getOrElseUpdate(containerName, database.getContainer(containerName))
+  }
+
+  private def monoToScalaFuture[T](mono: reactor.core.publisher.Mono[T]): Future[T] = {
+    val promise = Promise[T]()
+    mono.subscribe(
+      new reactor.core.publisher.BaseSubscriber[T]() {
+        override def hookOnNext(value: T): Unit = promise.success(value)
+        override def hookOnError(throwable: Throwable): Unit = promise.failure(throwable)
+        override def hookOnComplete(): Unit =
+          if (!promise.isCompleted)
+            promise.failure(new NoSuchElementException("Mono completed without emitting a value"))
+      }
+    )
+    promise.future
+  }
+
+  private def extractBytes(value: Any): Array[Byte] =
+    value match {
+      case bytes: Array[Byte] => bytes
+      case str: String        => java.util.Base64.getDecoder.decode(str)
+      case _                  => throw new IllegalArgumentException(s"Cannot convert ${value.getClass} to byte array")
+    }
+
+  private def metricsContainerName(dataset: String): String = dataset.toLowerCase
+
+  private def buildMetricsDocumentId(dataset: String, keyHash: String, tsMillis: Long): String =
+    s"${dataset}_${keyHash}_$tsMillis"
+
+  private def buildMetricsLatestDocumentId(dataset: String, keyHash: String): String =
+    s"${dataset}_${keyHash}_latest"
+}

--- a/cloud_azure/src/test/scala/ai/chronon/integrations/cloud_azure/AzureMetricsKVStoreTest.scala
+++ b/cloud_azure/src/test/scala/ai/chronon/integrations/cloud_azure/AzureMetricsKVStoreTest.scala
@@ -1,0 +1,69 @@
+package ai.chronon.integrations.cloud_azure
+
+import ai.chronon.online.KVStore
+import ai.chronon.online.KVStore.{GetRequest, GetResponse, ListRequest, ListResponse, PutRequest}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.concurrent.ScalaFutures
+
+import scala.concurrent.Future
+import scala.util.Success
+
+class AzureMetricsKVStoreTest extends AnyFlatSpec with Matchers with ScalaFutures {
+
+  private class RecordingKVStore extends KVStore {
+    var createdDatasets: Seq[String] = Seq.empty
+    var getDatasets: Seq[String] = Seq.empty
+    var putDatasets: Seq[String] = Seq.empty
+    var listedDatasets: Seq[String] = Seq.empty
+
+    override def create(dataset: String): Unit =
+      createdDatasets = createdDatasets :+ dataset
+
+    override def create(dataset: String, props: Map[String, Any]): Unit =
+      createdDatasets = createdDatasets :+ dataset
+
+    override def multiGet(requests: Seq[GetRequest]): Future[Seq[GetResponse]] = {
+      getDatasets = getDatasets ++ requests.map(_.dataset)
+      Future.successful(requests.map(request => GetResponse(request, Success(Seq.empty))))
+    }
+
+    override def multiPut(requests: Seq[PutRequest]): Future[Seq[Boolean]] = {
+      putDatasets = putDatasets ++ requests.map(_.dataset)
+      Future.successful(requests.map(_ => true))
+    }
+
+    override def list(request: ListRequest): Future[ListResponse] = {
+      listedDatasets = listedDatasets :+ request.dataset
+      Future.successful(ListResponse(request, Success(Seq.empty), Map.empty))
+    }
+
+    override def bulkPut(sourceOfflineTable: String, destinationOnlineDataSet: String, partition: String): Unit = {}
+  }
+
+  "AzureMetricsKVStore" should "normalize partition stats writes and reads to the configured batch dataset" in {
+    val delegate = new RecordingKVStore
+    val store = new AzureMetricsKVStore(delegate, "DATA_QUALITY_METRICS")
+
+    store.create("some_output_table_BATCH")
+    store.multiPut(Seq(PutRequest(Array[Byte](1), Array[Byte](2), "warehouse.table_BATCH"))).futureValue
+    store.multiGet(Seq(GetRequest(Array[Byte](1), "DATA_QUALITY_METRICS"))).futureValue
+    store.list(ListRequest("DATA_QUALITY_METRICS", Map.empty)).futureValue
+
+    delegate.createdDatasets shouldBe Seq("DATA_QUALITY_METRICS_BATCH")
+    delegate.putDatasets shouldBe Seq("DATA_QUALITY_METRICS_BATCH")
+    delegate.getDatasets shouldBe Seq("DATA_QUALITY_METRICS_BATCH")
+    delegate.listedDatasets shouldBe Seq("DATA_QUALITY_METRICS_BATCH")
+  }
+
+  it should "preserve streaming dataset normalization" in {
+    val delegate = new RecordingKVStore
+    val store = new AzureMetricsKVStore(delegate, "DATA_QUALITY_METRICS")
+
+    store.multiGet(Seq(GetRequest(Array[Byte](1), "anything_STREAMING"))).futureValue
+    store.multiPut(Seq(PutRequest(Array[Byte](1), Array[Byte](2), "anything_STREAMING"))).futureValue
+
+    delegate.getDatasets shouldBe Seq("DATA_QUALITY_METRICS_STREAMING")
+    delegate.putDatasets shouldBe Seq("DATA_QUALITY_METRICS_STREAMING")
+  }
+}

--- a/python/test/canary/compiled/group_bys/azure/dim_listings.pc_v3
+++ b/python/test/canary/compiled/group_bys/azure/dim_listings.pc_v3
@@ -4,24 +4,24 @@
   ],
   "metaData": {
     "columnHashes": {
-      "brief_description": "d8f700f63471993b54a19d71122ec11b",
-      "currency": "ca2881e80e9a9b877c2824d1072d337d",
-      "headline": "3336296614f6be325954fd9ba86eb0cf",
-      "inventory_count": "31547342ddbeb4a831724186b289ea87",
-      "is_active": "faf50877bb5bd0b8f8d920fa0105bd1d",
-      "is_expensive": "e637a3ddd3c42a1edf54251b574b481f",
-      "is_in_stock": "c5fc4a74834fb45b6d5af196310c0f31",
-      "listing_id": "e486882fe8630828862beed3908c72f6",
-      "long_description": "639ab6183464bef6ec2c16118a2cde83",
-      "main_image_path": "647aece2b7dd9c084a447f06db6c9078",
-      "merchant_id": "f00635e9f0582cc0a4504e90e7bc469f",
-      "price_cents": "89610b09ce4e5c7cdba038c3d9ded2ef",
-      "primary_category": "f7e610e63a0809f8b26f9d196b40d35e",
-      "secondary_image_paths": "f9194618378f2ea3855aa792c0bd9317",
-      "tags": "318519d7ab1453a331685dc7f165bb85",
-      "weight_grams": "f8f34e81434169852c03e62a335c20aa"
+      "brief_description": "3e0f2a9f08516068ffa392ac019bfd05",
+      "currency": "d4a3eb2809a50876413c1ed616392ff4",
+      "headline": "1304905ebd71b0560a7a3c27cbedde31",
+      "inventory_count": "c57d12ebe452aec73098902de4774fa8",
+      "is_active": "99949348c2be2e8e2c59102b6b395ded",
+      "is_expensive": "6d239016c7509c324cc8a211e86d22c4",
+      "is_in_stock": "bb83937923b57e801a052a4a052676a6",
+      "listing_id": "a8ce5bda04910da34810a1aa9ec6b002",
+      "long_description": "cc0bcd2c367265ccf8ca9131d5cbb07a",
+      "main_image_path": "9fbb24d0edaf13727b5d0833be5881e6",
+      "merchant_id": "d8f732c6fc9748fce927f8332bc2c8a5",
+      "price_cents": "68985594438f2a61d1617266126926e1",
+      "primary_category": "40352ee5c67eb96ff54218386be59b32",
+      "secondary_image_paths": "86a715fb49f67131b34952a1b37f2c3c",
+      "tags": "9ba51198bd9e76ff6a107e1c9f80aafd",
+      "weight_grams": "d668836776a35b3d0f7d158e1fd187dd"
     },
-    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_azure_exports_dim_listings_pc__1_with_offset_0\", \"spec\": \"data.azure_exports_dim_listings_pc__1/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_azure_exports_dim_listings_pc__3_with_offset_0\", \"spec\": \"data.azure_exports_dim_listings_pc__3/ds={{ macros.ds_add(ds, 0) }}\"}]}",
     "executionInfo": {
       "conf": {
         "common": {
@@ -101,7 +101,7 @@
           },
           "startPartition": "2025-01-01"
         },
-        "snapshotTable": "data.azure_exports_dim_listings_pc__1"
+        "snapshotTable": "data.azure_exports_dim_listings_pc__3"
       }
     }
   ]

--- a/python/test/canary/compiled/joins/azure/demo.pc_v3
+++ b/python/test/canary/compiled/joins/azure/demo.pc_v3
@@ -7,22 +7,22 @@
         ],
         "metaData": {
           "columnHashes": {
-            "brief_description": "d8f700f63471993b54a19d71122ec11b",
-            "currency": "ca2881e80e9a9b877c2824d1072d337d",
-            "headline": "3336296614f6be325954fd9ba86eb0cf",
-            "inventory_count": "31547342ddbeb4a831724186b289ea87",
-            "is_active": "faf50877bb5bd0b8f8d920fa0105bd1d",
-            "is_expensive": "e637a3ddd3c42a1edf54251b574b481f",
-            "is_in_stock": "c5fc4a74834fb45b6d5af196310c0f31",
-            "listing_id": "e486882fe8630828862beed3908c72f6",
-            "long_description": "639ab6183464bef6ec2c16118a2cde83",
-            "main_image_path": "647aece2b7dd9c084a447f06db6c9078",
-            "merchant_id": "f00635e9f0582cc0a4504e90e7bc469f",
-            "price_cents": "89610b09ce4e5c7cdba038c3d9ded2ef",
-            "primary_category": "f7e610e63a0809f8b26f9d196b40d35e",
-            "secondary_image_paths": "f9194618378f2ea3855aa792c0bd9317",
-            "tags": "318519d7ab1453a331685dc7f165bb85",
-            "weight_grams": "f8f34e81434169852c03e62a335c20aa"
+            "brief_description": "3e0f2a9f08516068ffa392ac019bfd05",
+            "currency": "d4a3eb2809a50876413c1ed616392ff4",
+            "headline": "1304905ebd71b0560a7a3c27cbedde31",
+            "inventory_count": "c57d12ebe452aec73098902de4774fa8",
+            "is_active": "99949348c2be2e8e2c59102b6b395ded",
+            "is_expensive": "6d239016c7509c324cc8a211e86d22c4",
+            "is_in_stock": "bb83937923b57e801a052a4a052676a6",
+            "listing_id": "a8ce5bda04910da34810a1aa9ec6b002",
+            "long_description": "cc0bcd2c367265ccf8ca9131d5cbb07a",
+            "main_image_path": "9fbb24d0edaf13727b5d0833be5881e6",
+            "merchant_id": "d8f732c6fc9748fce927f8332bc2c8a5",
+            "price_cents": "68985594438f2a61d1617266126926e1",
+            "primary_category": "40352ee5c67eb96ff54218386be59b32",
+            "secondary_image_paths": "86a715fb49f67131b34952a1b37f2c3c",
+            "tags": "9ba51198bd9e76ff6a107e1c9f80aafd",
+            "weight_grams": "d668836776a35b3d0f7d158e1fd187dd"
           },
           "executionInfo": {
             "conf": {
@@ -57,6 +57,7 @@
                 "CLOUD_PROVIDER": "azure",
                 "CUSTOMER_ID": "dev",
                 "EVAL_URL": "https://dev-azure.zipline.ai/services/eval",
+                "FETCHER_URL": "http://localhost:9000",
                 "FLINK_JARS_URI": "abfss://dev-zipline-artifacts@ziplineai2.dfs.core.windows.net/spark-3.5.3/libs/",
                 "FLINK_SASL_JAAS_CONFIG_VAULT_URI": "https://eventhub-sasl-jaas.vault.azure.net/secrets/sasl-jass-config",
                 "FLINK_STATE_URI": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net/flink-state",
@@ -101,7 +102,7 @@
                 },
                 "startPartition": "2025-01-01"
               },
-              "snapshotTable": "data.azure_exports_dim_listings_pc__1"
+              "snapshotTable": "data.azure_exports_dim_listings_pc__3"
             }
           }
         ]
@@ -132,45 +133,45 @@
         },
         "startPartition": "2025-01-01"
       },
-      "snapshotTable": "data.azure_exports_dim_listings_pc__1"
+      "snapshotTable": "data.azure_exports_dim_listings_pc__3"
     }
   },
   "metaData": {
     "columnHashes": {
-      "brief_description": "5ae40fa9963d02d1f8afcbae02869b08",
-      "currency": "384574f30fe984988c7f736d83309a1a",
-      "headline": "000015ca5c9b191c2c9b520dcf8e0a1c",
-      "inventory_count": "6a786936e98006983e160915875e593d",
-      "is_active": "133b82620e1c926d0853614ac2002039",
-      "is_expensive": "6eaa23bf9cd94987b8905b1e861a7661",
-      "is_in_stock": "1f3cf734bfd0cf20cb656b2938b9f0cd",
-      "listing_id": "07fa41bbfe808a6524a7a16ab712fd4c",
-      "listing_id_brief_description": "31868234a42424279e00fce7f2520214",
-      "listing_id_currency": "61473201211c1afd3a1d9116fb3a9072",
-      "listing_id_headline": "9146c233c1ea889f05471ba8f3bc46d2",
-      "listing_id_inventory_count": "ff7e89d74ad170478ea1232eb5e41fb9",
-      "listing_id_is_active": "eaf3404ef754943dfa769b255fb351a0",
-      "listing_id_is_expensive": "62317488c4de93bf10d2c0cf09b8506c",
-      "listing_id_is_in_stock": "4d2f1173522465ab4bcd03aa5c5a85c7",
-      "listing_id_listing_id": "0e6bb1208bb63ccc0da0771cb4a2ab1b",
-      "listing_id_long_description": "b293571116db4c10f5f1d2ff42a57b85",
-      "listing_id_main_image_path": "fb103f1f840e9700e5bb6c67c868678e",
-      "listing_id_merchant_id": "dac397a502736222f6984f54074ecb12",
-      "listing_id_price_cents": "587f0eac8381823fb2a546f6fe1fc8b5",
-      "listing_id_primary_category": "7e08626200c9028926bf8af6462b1dd6",
-      "listing_id_secondary_image_paths": "0a44c83cfa2493c8ba715a5833475759",
-      "listing_id_tags": "5979de3fc49571d9ccec8f21e69a31e5",
-      "listing_id_weight_grams": "53700fe5e54d5350be5dacbbc9b8aa0d",
-      "long_description": "756b272483270065098e5d4e7a1e1996",
-      "main_image_path": "ee8f4253c2be3bbc3ab771aebeaff658",
-      "merchant_id": "70e7a60026c000d42380322c75cbb4d3",
-      "price_cents": "992b998ed1d9a9e72b7eec8722225f7f",
-      "primary_category": "f50570d493cbeca365386a2f9c503147",
-      "secondary_image_paths": "9ee5811f3edd43580cb230469677c955",
-      "tags": "a43e930fdfbad711713a725eccb39cbd",
-      "weight_grams": "3563150a7e46318bf3395d3d08e7b27d"
+      "brief_description": "296def455b01742325a30166e46198f2",
+      "currency": "9528336cc8c26cd11553b033485c339c",
+      "headline": "ff631ded25542aeecb2c8a0f73bfb30b",
+      "inventory_count": "9a5fdc6099e79ab95928fe06c6188c81",
+      "is_active": "2150e282aadfcf4d7085b1da1d8cc6a4",
+      "is_expensive": "2f48826fa6ad300b5891fda3c34adc90",
+      "is_in_stock": "35134e1eb4ca3d0794a376b655cab71a",
+      "listing_id": "392e992c522282dc63a2085b2e95e5c9",
+      "listing_id_brief_description": "ddc5deff0ba4f52d0cd349d24cfa8cac",
+      "listing_id_currency": "0104845d3f14da7a7e5383ee766eb537",
+      "listing_id_headline": "78f91017909dddc1620fab5aa58c9a9e",
+      "listing_id_inventory_count": "9b13623539cd91f0fde81bd16e7a3870",
+      "listing_id_is_active": "e5dc8ab2dbc2d5b369c237c1c2caef47",
+      "listing_id_is_expensive": "1b0cfea6e35fc766e63cf552d5cdf9ae",
+      "listing_id_is_in_stock": "54daf0de73d648b47b7ea3ea92b3f9a3",
+      "listing_id_listing_id": "86a1adb1d3ce8f47bc84d3827a9b7aeb",
+      "listing_id_long_description": "a1a99ca9aa020e3b32968ea898f5ee86",
+      "listing_id_main_image_path": "df5f0d210e86a96922a799d7d166698c",
+      "listing_id_merchant_id": "4127b3f0d743f994b6637f8ec483c0fb",
+      "listing_id_price_cents": "e8d78167bb0a609f18ec4f1bdcb4e7a2",
+      "listing_id_primary_category": "530a0a4d4f425082bd896f3819a42016",
+      "listing_id_secondary_image_paths": "96540433da9012999572996b653c1727",
+      "listing_id_tags": "cfbce60affd0a9f607125cfc629cc787",
+      "listing_id_weight_grams": "a3e83fc799bf798206474033d950ce57",
+      "long_description": "a20466460aac8c45c562f22a1ca13f43",
+      "main_image_path": "c2966b0a7c969c65ff5517a38089be32",
+      "merchant_id": "98b445ed1bd98517a634c8e35e5cdca3",
+      "price_cents": "1092d59bb161bf0b0922d33840922727",
+      "primary_category": "94b8b2ca55892213a35dab643b83c7a2",
+      "secondary_image_paths": "04421cec302b480246615d069b178123",
+      "tags": "686d024eded457eeaee6924bc82cdbed",
+      "weight_grams": "20cceac265a2459d48f0ba02e5eca5a9"
     },
-    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_azure_exports_dim_listings_pc__1_with_offset_0\", \"spec\": \"data.azure_exports_dim_listings_pc__1/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_azure_exports_dim_listings_pc__3_with_offset_0\", \"spec\": \"data.azure_exports_dim_listings_pc__3/ds={{ macros.ds_add(ds, 0) }}\"}]}",
     "executionInfo": {
       "conf": {
         "common": {
@@ -205,6 +206,7 @@
           "CLOUD_PROVIDER": "azure",
           "CUSTOMER_ID": "dev",
           "EVAL_URL": "https://dev-azure.zipline.ai/services/eval",
+          "FETCHER_URL": "http://localhost:9000",
           "FLINK_JARS_URI": "abfss://dev-zipline-artifacts@ziplineai2.dfs.core.windows.net/spark-3.5.3/libs/",
           "FLINK_SASL_JAAS_CONFIG_VAULT_URI": "https://eventhub-sasl-jaas.vault.azure.net/secrets/sasl-jass-config",
           "FLINK_STATE_URI": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net/flink-state",
@@ -221,7 +223,7 @@
       "offlineSchedule": "@daily",
       "stepDays": 30
     },
-    "name": "azure.demo.pc_v2",
+    "name": "azure.demo.pc_v3",
     "online": 0,
     "outputNamespace": "data",
     "production": 0,

--- a/python/test/canary/compiled/staging_queries/azure/exports.dim_listings_pc__3
+++ b/python/test/canary/compiled/staging_queries/azure/exports.dim_listings_pc__3
@@ -35,6 +35,7 @@
           "CLOUD_PROVIDER": "azure",
           "CUSTOMER_ID": "dev",
           "EVAL_URL": "https://dev-azure.zipline.ai/services/eval",
+          "FETCHER_URL": "http://localhost:9000",
           "FLINK_JARS_URI": "abfss://dev-zipline-artifacts@ziplineai2.dfs.core.windows.net/spark-3.5.3/libs/",
           "FLINK_SASL_JAAS_CONFIG_VAULT_URI": "https://eventhub-sasl-jaas.vault.azure.net/secrets/sasl-jass-config",
           "FLINK_STATE_URI": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net/flink-state",
@@ -51,11 +52,11 @@
       "offlineSchedule": "@daily",
       "stepDays": 30
     },
-    "name": "azure.exports.dim_listings_pc__1",
+    "name": "azure.exports.dim_listings_pc__3",
     "outputNamespace": "data",
     "sourceFile": "staging_queries/azure/exports.py",
     "team": "azure",
-    "version": "1"
+    "version": "3"
   },
   "query": "\n    SELECT\n        *,\n        DATE_TRUNC('DAY', datest)::DATE as ds\n    FROM dim_listings_custom_part\n    WHERE\n    datest BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
   "tableDependencies": [

--- a/python/test/canary/compiled_canary/group_bys/azure/dim_listings.pc_v3
+++ b/python/test/canary/compiled_canary/group_bys/azure/dim_listings.pc_v3
@@ -4,24 +4,24 @@
   ],
   "metaData": {
     "columnHashes": {
-      "brief_description": "d8f700f63471993b54a19d71122ec11b",
-      "currency": "ca2881e80e9a9b877c2824d1072d337d",
-      "headline": "3336296614f6be325954fd9ba86eb0cf",
-      "inventory_count": "31547342ddbeb4a831724186b289ea87",
-      "is_active": "faf50877bb5bd0b8f8d920fa0105bd1d",
-      "is_expensive": "e637a3ddd3c42a1edf54251b574b481f",
-      "is_in_stock": "c5fc4a74834fb45b6d5af196310c0f31",
-      "listing_id": "e486882fe8630828862beed3908c72f6",
-      "long_description": "639ab6183464bef6ec2c16118a2cde83",
-      "main_image_path": "647aece2b7dd9c084a447f06db6c9078",
-      "merchant_id": "f00635e9f0582cc0a4504e90e7bc469f",
-      "price_cents": "89610b09ce4e5c7cdba038c3d9ded2ef",
-      "primary_category": "f7e610e63a0809f8b26f9d196b40d35e",
-      "secondary_image_paths": "f9194618378f2ea3855aa792c0bd9317",
-      "tags": "318519d7ab1453a331685dc7f165bb85",
-      "weight_grams": "f8f34e81434169852c03e62a335c20aa"
+      "brief_description": "3e0f2a9f08516068ffa392ac019bfd05",
+      "currency": "d4a3eb2809a50876413c1ed616392ff4",
+      "headline": "1304905ebd71b0560a7a3c27cbedde31",
+      "inventory_count": "c57d12ebe452aec73098902de4774fa8",
+      "is_active": "99949348c2be2e8e2c59102b6b395ded",
+      "is_expensive": "6d239016c7509c324cc8a211e86d22c4",
+      "is_in_stock": "bb83937923b57e801a052a4a052676a6",
+      "listing_id": "a8ce5bda04910da34810a1aa9ec6b002",
+      "long_description": "cc0bcd2c367265ccf8ca9131d5cbb07a",
+      "main_image_path": "9fbb24d0edaf13727b5d0833be5881e6",
+      "merchant_id": "d8f732c6fc9748fce927f8332bc2c8a5",
+      "price_cents": "68985594438f2a61d1617266126926e1",
+      "primary_category": "40352ee5c67eb96ff54218386be59b32",
+      "secondary_image_paths": "86a715fb49f67131b34952a1b37f2c3c",
+      "tags": "9ba51198bd9e76ff6a107e1c9f80aafd",
+      "weight_grams": "d668836776a35b3d0f7d158e1fd187dd"
     },
-    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_azure_exports_dim_listings_pc__1_with_offset_0\", \"spec\": \"data.azure_exports_dim_listings_pc__1/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_azure_exports_dim_listings_pc__3_with_offset_0\", \"spec\": \"data.azure_exports_dim_listings_pc__3/ds={{ macros.ds_add(ds, 0) }}\"}]}",
     "executionInfo": {
       "conf": {
         "common": {
@@ -100,7 +100,7 @@
           },
           "startPartition": "2025-01-01"
         },
-        "snapshotTable": "data.azure_exports_dim_listings_pc__1"
+        "snapshotTable": "data.azure_exports_dim_listings_pc__3"
       }
     }
   ]

--- a/python/test/canary/compiled_canary/joins/azure/demo.pc_v3
+++ b/python/test/canary/compiled_canary/joins/azure/demo.pc_v3
@@ -7,22 +7,22 @@
         ],
         "metaData": {
           "columnHashes": {
-            "brief_description": "d8f700f63471993b54a19d71122ec11b",
-            "currency": "ca2881e80e9a9b877c2824d1072d337d",
-            "headline": "3336296614f6be325954fd9ba86eb0cf",
-            "inventory_count": "31547342ddbeb4a831724186b289ea87",
-            "is_active": "faf50877bb5bd0b8f8d920fa0105bd1d",
-            "is_expensive": "e637a3ddd3c42a1edf54251b574b481f",
-            "is_in_stock": "c5fc4a74834fb45b6d5af196310c0f31",
-            "listing_id": "e486882fe8630828862beed3908c72f6",
-            "long_description": "639ab6183464bef6ec2c16118a2cde83",
-            "main_image_path": "647aece2b7dd9c084a447f06db6c9078",
-            "merchant_id": "f00635e9f0582cc0a4504e90e7bc469f",
-            "price_cents": "89610b09ce4e5c7cdba038c3d9ded2ef",
-            "primary_category": "f7e610e63a0809f8b26f9d196b40d35e",
-            "secondary_image_paths": "f9194618378f2ea3855aa792c0bd9317",
-            "tags": "318519d7ab1453a331685dc7f165bb85",
-            "weight_grams": "f8f34e81434169852c03e62a335c20aa"
+            "brief_description": "3e0f2a9f08516068ffa392ac019bfd05",
+            "currency": "d4a3eb2809a50876413c1ed616392ff4",
+            "headline": "1304905ebd71b0560a7a3c27cbedde31",
+            "inventory_count": "c57d12ebe452aec73098902de4774fa8",
+            "is_active": "99949348c2be2e8e2c59102b6b395ded",
+            "is_expensive": "6d239016c7509c324cc8a211e86d22c4",
+            "is_in_stock": "bb83937923b57e801a052a4a052676a6",
+            "listing_id": "a8ce5bda04910da34810a1aa9ec6b002",
+            "long_description": "cc0bcd2c367265ccf8ca9131d5cbb07a",
+            "main_image_path": "9fbb24d0edaf13727b5d0833be5881e6",
+            "merchant_id": "d8f732c6fc9748fce927f8332bc2c8a5",
+            "price_cents": "68985594438f2a61d1617266126926e1",
+            "primary_category": "40352ee5c67eb96ff54218386be59b32",
+            "secondary_image_paths": "86a715fb49f67131b34952a1b37f2c3c",
+            "tags": "9ba51198bd9e76ff6a107e1c9f80aafd",
+            "weight_grams": "d668836776a35b3d0f7d158e1fd187dd"
           },
           "executionInfo": {
             "conf": {
@@ -57,7 +57,6 @@
                 "CLOUD_PROVIDER": "azure",
                 "CUSTOMER_ID": "dev",
                 "EVAL_URL": "https://dev-azure.zipline.ai/services/eval",
-                "FETCHER_URL": "http://localhost:9000",
                 "FLINK_JARS_URI": "abfss://dev-zipline-artifacts@ziplineai2.dfs.core.windows.net/spark-3.5.3/libs/",
                 "FLINK_SASL_JAAS_CONFIG_VAULT_URI": "https://eventhub-sasl-jaas.vault.azure.net/secrets/sasl-jass-config",
                 "FLINK_STATE_URI": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net/flink-state",
@@ -102,7 +101,7 @@
                 },
                 "startPartition": "2025-01-01"
               },
-              "snapshotTable": "data.azure_exports_dim_listings_pc__1"
+              "snapshotTable": "data.azure_exports_dim_listings_pc__3"
             }
           }
         ]
@@ -133,45 +132,45 @@
         },
         "startPartition": "2025-01-01"
       },
-      "snapshotTable": "data.azure_exports_dim_listings_pc__1"
+      "snapshotTable": "data.azure_exports_dim_listings_pc__3"
     }
   },
   "metaData": {
     "columnHashes": {
-      "brief_description": "5ae40fa9963d02d1f8afcbae02869b08",
-      "currency": "384574f30fe984988c7f736d83309a1a",
-      "headline": "000015ca5c9b191c2c9b520dcf8e0a1c",
-      "inventory_count": "6a786936e98006983e160915875e593d",
-      "is_active": "133b82620e1c926d0853614ac2002039",
-      "is_expensive": "6eaa23bf9cd94987b8905b1e861a7661",
-      "is_in_stock": "1f3cf734bfd0cf20cb656b2938b9f0cd",
-      "listing_id": "07fa41bbfe808a6524a7a16ab712fd4c",
-      "listing_id_brief_description": "31868234a42424279e00fce7f2520214",
-      "listing_id_currency": "61473201211c1afd3a1d9116fb3a9072",
-      "listing_id_headline": "9146c233c1ea889f05471ba8f3bc46d2",
-      "listing_id_inventory_count": "ff7e89d74ad170478ea1232eb5e41fb9",
-      "listing_id_is_active": "eaf3404ef754943dfa769b255fb351a0",
-      "listing_id_is_expensive": "62317488c4de93bf10d2c0cf09b8506c",
-      "listing_id_is_in_stock": "4d2f1173522465ab4bcd03aa5c5a85c7",
-      "listing_id_listing_id": "0e6bb1208bb63ccc0da0771cb4a2ab1b",
-      "listing_id_long_description": "b293571116db4c10f5f1d2ff42a57b85",
-      "listing_id_main_image_path": "fb103f1f840e9700e5bb6c67c868678e",
-      "listing_id_merchant_id": "dac397a502736222f6984f54074ecb12",
-      "listing_id_price_cents": "587f0eac8381823fb2a546f6fe1fc8b5",
-      "listing_id_primary_category": "7e08626200c9028926bf8af6462b1dd6",
-      "listing_id_secondary_image_paths": "0a44c83cfa2493c8ba715a5833475759",
-      "listing_id_tags": "5979de3fc49571d9ccec8f21e69a31e5",
-      "listing_id_weight_grams": "53700fe5e54d5350be5dacbbc9b8aa0d",
-      "long_description": "756b272483270065098e5d4e7a1e1996",
-      "main_image_path": "ee8f4253c2be3bbc3ab771aebeaff658",
-      "merchant_id": "70e7a60026c000d42380322c75cbb4d3",
-      "price_cents": "992b998ed1d9a9e72b7eec8722225f7f",
-      "primary_category": "f50570d493cbeca365386a2f9c503147",
-      "secondary_image_paths": "9ee5811f3edd43580cb230469677c955",
-      "tags": "a43e930fdfbad711713a725eccb39cbd",
-      "weight_grams": "3563150a7e46318bf3395d3d08e7b27d"
+      "brief_description": "296def455b01742325a30166e46198f2",
+      "currency": "9528336cc8c26cd11553b033485c339c",
+      "headline": "ff631ded25542aeecb2c8a0f73bfb30b",
+      "inventory_count": "9a5fdc6099e79ab95928fe06c6188c81",
+      "is_active": "2150e282aadfcf4d7085b1da1d8cc6a4",
+      "is_expensive": "2f48826fa6ad300b5891fda3c34adc90",
+      "is_in_stock": "35134e1eb4ca3d0794a376b655cab71a",
+      "listing_id": "392e992c522282dc63a2085b2e95e5c9",
+      "listing_id_brief_description": "ddc5deff0ba4f52d0cd349d24cfa8cac",
+      "listing_id_currency": "0104845d3f14da7a7e5383ee766eb537",
+      "listing_id_headline": "78f91017909dddc1620fab5aa58c9a9e",
+      "listing_id_inventory_count": "9b13623539cd91f0fde81bd16e7a3870",
+      "listing_id_is_active": "e5dc8ab2dbc2d5b369c237c1c2caef47",
+      "listing_id_is_expensive": "1b0cfea6e35fc766e63cf552d5cdf9ae",
+      "listing_id_is_in_stock": "54daf0de73d648b47b7ea3ea92b3f9a3",
+      "listing_id_listing_id": "86a1adb1d3ce8f47bc84d3827a9b7aeb",
+      "listing_id_long_description": "a1a99ca9aa020e3b32968ea898f5ee86",
+      "listing_id_main_image_path": "df5f0d210e86a96922a799d7d166698c",
+      "listing_id_merchant_id": "4127b3f0d743f994b6637f8ec483c0fb",
+      "listing_id_price_cents": "e8d78167bb0a609f18ec4f1bdcb4e7a2",
+      "listing_id_primary_category": "530a0a4d4f425082bd896f3819a42016",
+      "listing_id_secondary_image_paths": "96540433da9012999572996b653c1727",
+      "listing_id_tags": "cfbce60affd0a9f607125cfc629cc787",
+      "listing_id_weight_grams": "a3e83fc799bf798206474033d950ce57",
+      "long_description": "a20466460aac8c45c562f22a1ca13f43",
+      "main_image_path": "c2966b0a7c969c65ff5517a38089be32",
+      "merchant_id": "98b445ed1bd98517a634c8e35e5cdca3",
+      "price_cents": "1092d59bb161bf0b0922d33840922727",
+      "primary_category": "94b8b2ca55892213a35dab643b83c7a2",
+      "secondary_image_paths": "04421cec302b480246615d069b178123",
+      "tags": "686d024eded457eeaee6924bc82cdbed",
+      "weight_grams": "20cceac265a2459d48f0ba02e5eca5a9"
     },
-    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_azure_exports_dim_listings_pc__1_with_offset_0\", \"spec\": \"data.azure_exports_dim_listings_pc__1/ds={{ macros.ds_add(ds, 0) }}\"}]}",
+    "customJson": "{\"airflowDependencies\": [{\"name\": \"wf_data_azure_exports_dim_listings_pc__3_with_offset_0\", \"spec\": \"data.azure_exports_dim_listings_pc__3/ds={{ macros.ds_add(ds, 0) }}\"}]}",
     "executionInfo": {
       "conf": {
         "common": {
@@ -206,7 +205,6 @@
           "CLOUD_PROVIDER": "azure",
           "CUSTOMER_ID": "dev",
           "EVAL_URL": "https://dev-azure.zipline.ai/services/eval",
-          "FETCHER_URL": "http://localhost:9000",
           "FLINK_JARS_URI": "abfss://dev-zipline-artifacts@ziplineai2.dfs.core.windows.net/spark-3.5.3/libs/",
           "FLINK_SASL_JAAS_CONFIG_VAULT_URI": "https://eventhub-sasl-jaas.vault.azure.net/secrets/sasl-jass-config",
           "FLINK_STATE_URI": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net/flink-state",
@@ -223,7 +221,7 @@
       "offlineSchedule": "@daily",
       "stepDays": 30
     },
-    "name": "azure.demo.pc_v2",
+    "name": "azure.demo.pc_v3",
     "online": 0,
     "outputNamespace": "data",
     "production": 0,

--- a/python/test/canary/compiled_canary/staging_queries/azure/exports.dim_listings_pc__3
+++ b/python/test/canary/compiled_canary/staging_queries/azure/exports.dim_listings_pc__3
@@ -35,7 +35,6 @@
           "CLOUD_PROVIDER": "azure",
           "CUSTOMER_ID": "dev",
           "EVAL_URL": "https://dev-azure.zipline.ai/services/eval",
-          "FETCHER_URL": "http://localhost:9000",
           "FLINK_JARS_URI": "abfss://dev-zipline-artifacts@ziplineai2.dfs.core.windows.net/spark-3.5.3/libs/",
           "FLINK_SASL_JAAS_CONFIG_VAULT_URI": "https://eventhub-sasl-jaas.vault.azure.net/secrets/sasl-jass-config",
           "FLINK_STATE_URI": "abfss://dev-zipline-warehouse@ziplineai2.dfs.core.windows.net/flink-state",
@@ -52,11 +51,11 @@
       "offlineSchedule": "@daily",
       "stepDays": 30
     },
-    "name": "azure.exports.dim_listings_pc__1",
+    "name": "azure.exports.dim_listings_pc__3",
     "outputNamespace": "data",
     "sourceFile": "staging_queries/azure/exports.py",
     "team": "azure",
-    "version": "1"
+    "version": "3"
   },
   "query": "\n    SELECT\n        *,\n        DATE_TRUNC('DAY', datest)::DATE as ds\n    FROM dim_listings_custom_part\n    WHERE\n    datest BETWEEN {{ start_date }} AND {{ end_date }}\n    ",
   "tableDependencies": [

--- a/python/test/canary/joins/azure/demo.py
+++ b/python/test/canary/joins/azure/demo.py
@@ -104,7 +104,7 @@ derivations_v3 = Join(
     step_days=30,
 )
 
-pc_v2 = Join(
+pc_v3 = Join(
     left=dim_listings.pc_source,
     row_ids=[], # TODO -- kill this once the SPJ API change goes through
     right_parts=[

--- a/python/test/canary/staging_queries/azure/exports.py
+++ b/python/test/canary/staging_queries/azure/exports.py
@@ -89,7 +89,7 @@ def user_activities_export(version: int = 0):
 
 user_activities = user_activities_export(version=0)
 checkouts = get_native_partition_export("checkouts", "ds")
-dim_listings_pc = get_native_partition_export("dim_listings_custom_part", "datest", time_partitioned=True, version=1)
+dim_listings_pc = get_native_partition_export("dim_listings_custom_part", "datest", time_partitioned=True, version=3)
 dim_listings = get_select_star_export("dim_listings", "ds")
 dim_merchants = get_select_star_export("dim_merchants", "ds")
 dim_users = get_select_star_export("dim_users", "ds")

--- a/spark/src/main/scala/ai/chronon/spark/stats/EnhancedStatsStore.scala
+++ b/spark/src/main/scala/ai/chronon/spark/stats/EnhancedStatsStore.scala
@@ -140,7 +140,9 @@ class EnhancedStatsStore(api: Api,
       logger.info(s"Batch ${batchIdx + 1} complete: $successCount succeeded, $failureCount failed")
 
       if (failureCount > 0) {
-        logger.error(s"Some uploads failed in batch ${batchIdx + 1}")
+        throw new RuntimeException(
+          s"Failed to upload enhanced stats batch ${batchIdx + 1}/${batches.size}: " +
+            s"$failureCount of ${batch.length} writes failed")
       }
     }
 


### PR DESCRIPTION
## Summary

Updated impl in order to compute stats.
<img width="771" height="800" alt="Screenshot 2026-06-05 at 3 58 20 PM" src="https://github.com/user-attachments/assets/dbea31c0-e164-47e4-9dd8-c858d7623c38" />
<img width="1649" height="888" alt="Screenshot 2026-06-08 at 2 48 55 PM" src="https://github.com/user-attachments/assets/83f7c7f5-723a-476a-8500-75585d21b3dd" />

Tested alongside:
* https://github.com/zipline-ai/platform/pull/1093/changes
* https://github.com/zipline-ai/infra-azure-prod/pull/30

Modified demo.py for azure to enable stats compute and run. 

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [x] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Azure integration now provides cached, lazily-initialized metrics and enhanced-stats stores with Cosmos and Redis backends.
  * Metrics store normalizes dataset names for batch vs streaming use.

* **Bug Fixes**
  * Batch KV write failures now fail fast with explicit errors instead of only logging.

* **Tests**
  * Added unit tests validating dataset normalization.
  * Updated canary/compiled test configs and staging exports to reference v3 snapshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->