### PR TITLE
Expose partitions and timeout_ms on dyndb ion writer as conf

### DIFF
--- a/cloud_aws/src/main/scala/ai/chronon/integrations/aws/DynamoDBKVStoreImpl.scala
+++ b/cloud_aws/src/main/scala/ai/chronon/integrations/aws/DynamoDBKVStoreImpl.scala
@@ -379,7 +379,7 @@ class DynamoDBKVStoreImpl(rawDynamoDbClient: DynamoDbAsyncClient, conf: Map[Stri
 
       logger.info(s"DynamoDB import initiated with ARN: $importArn for table: $physicalTableName")
 
-      waitForImportCompletion(importArn, physicalTableName)
+      waitForImportCompletion(importArn, physicalTableName, configuredImportTimeout)
 
       // ImportTable API does not support TTL configuration; must be applied after import completes
       if (enableTtl) {
@@ -499,8 +499,14 @@ class DynamoDBKVStoreImpl(rawDynamoDbClient: DynamoDbAsyncClient, conf: Map[Stri
       .build()
   }
 
-  private def waitForImportCompletion(importArn: String, tableName: String): Unit = {
-    val maxWaitTimeMs = 30 * 60 * 1000L // 30 minutes
+  private[aws] def configuredImportTimeout: Duration =
+    conf
+      .get(IonPathConfig.IonWriterTimeoutKey)
+      .map(timeoutMillis => Duration.ofMillis(timeoutMillis.toLong))
+      .getOrElse(DynamoImportDefaultTimeout)
+
+  private def waitForImportCompletion(importArn: String, tableName: String, timeout: Duration): Unit = {
+    val maxWaitTimeMs = timeout.toMillis
     val pollIntervalMs = 10 * 1000L // 10 seconds
     val startTime = System.currentTimeMillis()
 
@@ -550,7 +556,7 @@ class DynamoDBKVStoreImpl(rawDynamoDbClient: DynamoDbAsyncClient, conf: Map[Stri
         logger.error(diagnostics)
         throw new RuntimeException(diagnostics)
       case ImportStatus.IN_PROGRESS =>
-        throw new RuntimeException(s"DynamoDB import timed out after ${maxWaitTimeMs}ms for table: $tableName")
+        throw new RuntimeException(s"DynamoDB import timed out after $timeout for table: $tableName")
       case _ =>
         logger.warn(s"Unknown import status: $status for table: $tableName")
     }
@@ -704,6 +710,7 @@ object DynamoDBKVStoreConstants {
 
   val DataTTLSeconds = 5.days.toSeconds.toInt
   val MillisPerDay = 1.day.toMillis
+  val DynamoImportDefaultTimeout: Duration = Duration.ofMinutes(30)
 
   val BatchTableGCAgeDays = 30
   val BatchTableGCMaxDelete = 10

--- a/cloud_aws/src/test/scala/ai/chronon/integrations/aws/DynamoDBKVStoreTest.scala
+++ b/cloud_aws/src/test/scala/ai/chronon/integrations/aws/DynamoDBKVStoreTest.scala
@@ -6,6 +6,7 @@ import java.time.LocalDate
 import ai.chronon.api.TilingUtils
 import ai.chronon.integrations.aws.DynamoDBKVStoreConstants.isTimedSorted
 import ai.chronon.online.KVStore._
+import ai.chronon.spark.IonPathConfig
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.scalatest.BeforeAndAfterAll
@@ -20,6 +21,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 
 import java.net.URI
 import java.nio.charset.StandardCharsets
+import java.time.Duration
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 import scala.util.{Failure, Success, Try}
@@ -613,6 +615,14 @@ class DynamoDBKVStoreTest extends AnyFlatSpec with Matchers with BeforeAndAfterA
       software.amazon.awssdk.services.dynamodb.model.DescribeTimeToLiveRequest.builder().tableName(dataset).build()
     ).join().timeToLiveDescription()
     ttlDesc.timeToLiveStatus() shouldBe software.amazon.awssdk.services.dynamodb.model.TimeToLiveStatus.DISABLED
+  }
+
+  it should "configure DynamoDB import timeout from ion writer timeout millis" in {
+    val defaultStore = new DynamoDBKVStoreImpl(client)
+    defaultStore.configuredImportTimeout shouldBe Duration.ofMinutes(30)
+
+    val configuredStore = new DynamoDBKVStoreImpl(client, Map(IonPathConfig.IonWriterTimeoutKey -> "3600000"))
+    configuredStore.configuredImportTimeout shouldBe Duration.ofHours(1)
   }
 
   it should "gcOldBatchTables deletes tables older than the GC threshold" in {

--- a/spark/src/main/scala/ai/chronon/spark/IonWriter.scala
+++ b/spark/src/main/scala/ai/chronon/spark/IonWriter.scala
@@ -19,6 +19,8 @@ object IonPathConfig {
   val UploadFormatKey = "spark.chronon.table_write.upload.format"
   val UploadLocationKey = "spark.chronon.table_write.upload.location"
   val PartitionColumnKey = "spark.chronon.partition.column"
+  val IonWriterPartitionsKey = "spark.chronon.table_writer.ion_writer.partitions"
+  val IonWriterTimeoutKey = "spark.chronon.table_writer.ion_writer.timeout_ms"
   val DefaultPartitionColumn = "ds"
 }
 
@@ -54,8 +56,14 @@ object IonWriter {
     val keyIdx = schema.fieldIndex("key_bytes")
     val valueIdx = schema.fieldIndex("value_bytes")
     val tsIdx = schema.fieldIndex(partitionColumn)
+    val writeDf = configuredPartitions(df) match {
+      case Some(partitions) =>
+        logger.info(s"Repartitioning Ion upload for $dataSetName partition $partitionValue to $partitions partition(s)")
+        df.repartition(partitions)
+      case None => df
+    }
 
-    val written = df.rdd
+    val written = writeDf.rdd
       .mapPartitionsWithIndex((partitionId, iter) =>
         if (!iter.hasNext) Iterator.empty
         else {
@@ -169,5 +177,10 @@ object IonWriter {
       case other =>
         throw new IllegalArgumentException(s"Unsupported partition type: ${other.getClass.getName}")
     }
+  }
+
+  private def configuredPartitions(df: DataFrame): Option[Int] = {
+    val conf = df.sparkSession.conf
+    conf.getOption(IonPathConfig.IonWriterPartitionsKey).map(_.toInt)
   }
 }

--- a/spark/src/test/scala/ai/chronon/spark/upload/IonWriterTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/upload/IonWriterTest.scala
@@ -1,6 +1,6 @@
 package ai.chronon.spark.upload
 
-import ai.chronon.spark.IonWriter
+import ai.chronon.spark.{IonPathConfig, IonWriter}
 import ai.chronon.spark.utils.SparkTestBase
 import com.amazon.ion.system.IonSystemBuilder
 import com.amazon.ion.{IonBlob, IonDecimal, IonStruct}
@@ -115,6 +115,43 @@ class IonWriterTest extends SparkTestBase with Matchers {
     partitionPath.toString should include(s"ds=$partitionValue")
     val partitionDir = new File(partitionPath.toUri)
     partitionDir.listFiles().filter(_.getName.endsWith(".ion")) should not be empty
+  }
+
+  it should "honor configured ion writer partitions" in {
+    val partitionValue = "2025-10-19"
+    val dataSetName = "ion-output-partitions"
+    val rootPath = Some(new File(tmpDir, "partition-root").toURI.toString)
+
+    val schema = StructType(
+      Seq(
+        StructField("key_bytes", BinaryType, nullable = true),
+        StructField("value_bytes", BinaryType, nullable = true),
+        StructField("key_json", StringType, nullable = true),
+        StructField("value_json", StringType, nullable = true),
+        StructField("ds", DateType, nullable = false)
+      )
+    )
+
+    val rows = (0 until 30).map { idx =>
+      Row(s"k$idx".getBytes("UTF-8"),
+          s"v$idx".getBytes("UTF-8"),
+          s"k$idx-json",
+          s"""{"v":"$idx"}""",
+          LocalDate.parse(partitionValue))
+    }
+    val df = spark.createDataFrame(spark.sparkContext.parallelize(rows, numSlices = 8), schema)
+
+    spark.conf.set(IonPathConfig.IonWriterPartitionsKey, "3")
+    try {
+      val result = IonWriter.write(df, dataSetName, "ds", partitionValue, rootPath)
+      result.rowCount shouldBe rows.size
+
+      val partitionPath = IonWriter.resolvePartitionPath(dataSetName, "ds", partitionValue, rootPath)
+      val partitionDir = new File(partitionPath.toUri)
+      partitionDir.listFiles().filter(_.getName.endsWith(".ion")).length shouldBe 3
+    } finally {
+      spark.conf.unset(IonPathConfig.IonWriterPartitionsKey)
+    }
   }
 
   it should "validate root path with valid schemes" in {


### PR DESCRIPTION
## Summary

We're seeing some timeouts on large KV uploads. This PR adds two new config options:

- `spark.chronon.table_writer.ion_writer.partitions` - Lets us repartition before the upload to either split into more files (or less) as one lever on perf. 
- `spark.chronon.table_writer.ion_writer.timeout_ms` - Allows for us to extend the currently fixed to 30min timeout.

## Checklist
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * DynamoDB table import polling now uses configurable timeout instead of hardcoded limit (default: 30 minutes)
  * Ion file writing now supports configurable partition count through settings

* **Tests**
  * Added validation that DynamoDB import timeout respects configuration
  * Added verification that Ion writer honors configured partition settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->