### PR TITLE
JoinParts are not reused as no partitions are detected on clustered tables

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -1167,7 +1167,12 @@ object Driver {
           val partColumnName = spec.head._1
           val partitionSpec =
             PartitionSpec(partColumnName, tableUtils.partitionSpec.format, tableUtils.partitionSpec.spanMillis)
-          val partList = tableUtils.partitions(tbl, spec.tail.toMap, tablePartitionSpec = Option(partitionSpec))
+          val partitionRange = Some(PartitionRange(spec.head._2, spec.head._2)(partitionSpec))
+          val partList = tableUtils.partitions(tbl,
+                                               spec.tail.toMap,
+                                               partitionRange = partitionRange,
+                                               tablePartitionSpec = Option(partitionSpec),
+                                               deriveLogicalPartitions = true)
           logger.info(
             s"Checking for presence of partition: ${spec.head} for table: ${tbl} with subpartitions: ${spec.tail}")
           partList.contains(spec.head._2)

--- a/spark/src/main/scala/ai/chronon/spark/batch/ModularMonolith.scala
+++ b/spark/src/main/scala/ai/chronon/spark/batch/ModularMonolith.scala
@@ -136,7 +136,7 @@ class ModularMonolith(join: api.Join, dateRange: DateRange)(implicit tableUtils:
   }
 
   private def runJoinPartJob(joinPartNode: JoinPartNode, metaData: MetaData, nodeRange: DateRange): Unit = {
-    StepRunner(nodeRange, metaData) { stepRange =>
+    StepRunner(nodeRange, metaData, deriveLogicalPartitions = true) { stepRange =>
       // alignOutput=false: SNAPSHOT join parts write to the shifted (D-1) partition, which MergeJob reads.
       // Enabling alignOutput consistently requires MergeJob to also stop shifting its reads, which is a
       // larger change tracked separately.

--- a/spark/src/main/scala/ai/chronon/spark/batch/StepRunner.scala
+++ b/spark/src/main/scala/ai/chronon/spark/batch/StepRunner.scala
@@ -2,7 +2,7 @@ package ai.chronon.spark.batch
 
 import ai.chronon.api.Extensions.MetadataOps
 import ai.chronon.api.{DateRange, MetaData, PartitionRange, PartitionSpec}
-import ai.chronon.spark.catalog.TableUtils
+import ai.chronon.spark.catalog.{Format, TableUtils}
 import org.slf4j.{Logger, LoggerFactory}
 
 case class StepRunner(
@@ -93,20 +93,24 @@ object StepRunner {
 
     val tableName = metaData.outputTable
     val stepSize = metaData.stepSize
+    val outputPartitions: String => Seq[String] = { t =>
+      tableUtils.partitions(t, partitionRange = Some(requestedRange), deriveLogicalPartitions = deriveLogicalPartitions)
+    }
     val stepRunner = StepRunner(
       tableName,
       body,
-      { t =>
-        tableUtils.partitions(t,
-                              partitionRange = Some(requestedRange),
-                              deriveLogicalPartitions = deriveLogicalPartitions)
-      },
+      outputPartitions,
       Some(stepSize)
     )(tableUtils, tableUtils.partitionSpec)
 
     stepRunner.run(requestedRange)
 
-    val lastPartition = tableUtils.lastAvailablePartition(tableName)
+    val lastPartition =
+      if (deriveLogicalPartitions) {
+        Format.pickMaxPartition(outputPartitions(tableName))
+      } else {
+        tableUtils.lastAvailablePartition(tableName)
+      }
     lastPartition match {
       case Some(lp) if lp >= requestedRange.end =>
         logger.info(s"Output table $tableName covers requested range (last: $lp >= end: ${requestedRange.end})")

--- a/spark/src/main/scala/ai/chronon/spark/batch/StepRunner.scala
+++ b/spark/src/main/scala/ai/chronon/spark/batch/StepRunner.scala
@@ -83,7 +83,11 @@ object StepRunner {
   @transient lazy val logger: Logger = LoggerFactory.getLogger(getClass)
 
   def apply(requestedDateRange: DateRange, metaData: MetaData)(body: DateRange => Unit)(implicit
-      tableUtils: TableUtils): Unit = {
+      tableUtils: TableUtils): Unit =
+    apply(requestedDateRange, metaData, deriveLogicalPartitions = false)(body)
+
+  def apply(requestedDateRange: DateRange, metaData: MetaData, deriveLogicalPartitions: Boolean)(
+      body: DateRange => Unit)(implicit tableUtils: TableUtils): Unit = {
 
     val requestedRange = PartitionRange(requestedDateRange.startDate, requestedDateRange.endDate)(PartitionSpec.daily)
 
@@ -92,7 +96,11 @@ object StepRunner {
     val stepRunner = StepRunner(
       tableName,
       body,
-      { t => tableUtils.partitions(t) },
+      { t =>
+        tableUtils.partitions(t,
+                              partitionRange = Some(requestedRange),
+                              deriveLogicalPartitions = deriveLogicalPartitions)
+      },
       Some(stepSize)
     )(tableUtils, tableUtils.partitionSpec)
 

--- a/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
@@ -114,7 +114,8 @@ class TableUtils(@transient val sparkSession: SparkSession) extends Serializable
                  subPartitionsFilter: Map[String, String] = Map.empty,
                  partitionRange: Option[PartitionRange] = None,
                  tablePartitionSpec: Option[PartitionSpec] = None,
-                 timePartitioned: Boolean = false): List[String] = {
+                 timePartitioned: Boolean = false,
+                 deriveLogicalPartitions: Boolean = false): List[String] = {
     val rangeWheres = andPredicates(partitionRange.map(_.whereClauses).getOrElse(Seq.empty))
 
     val effectivePartColumn = tablePartitionSpec.map(_.column).getOrElse(partitionSpec.column)
@@ -123,7 +124,7 @@ class TableUtils(@transient val sparkSession: SparkSession) extends Serializable
     val partitions = tableFormatProvider
       .readFormat(tableName)
       .map((format) => {
-        if (timePartitioned) {
+        val rawPartitions = if (timePartitioned) {
           logger.info(
             s"Getting virtual partitions for time-partitioned table ${tableName} using column ${effectivePartColumn}")
           val allPartitions = format.virtualPartitions(tableName, effectivePartColumn, effectiveSpec)(sparkSession)
@@ -140,17 +141,38 @@ class TableUtils(@transient val sparkSession: SparkSession) extends Serializable
             s"Getting partitions for ${tableName} with partitionColumnName ${effectivePartColumn} and subpartitions: ${subPartitionsFilter}")
           format.primaryPartitions(tableName, effectivePartColumn, rangeWheres, subPartitionsFilter)(sparkSession)
         }
-      })
-      .map { partitions =>
-        val nonNullPartitions = Format.sanitizePartitionValues(partitions)
-        if (nonNullPartitions.isEmpty) {
-          logger.info(s"No partitions found for table: $tableName with subpartition filters ${subPartitionsFilter}")
+
+        val catalogPartitions = Format.sanitizePartitionValues(rawPartitions)
+        // Some Iceberg join-part outputs are clustered or otherwise not physically partitioned
+        // by Chronon's logical partition column. In that case the catalog partition list is
+        // empty, but StepRunner still needs exact logical ds values to decide whether to skip.
+        val shouldQueryLogicalPartitions =
+          deriveLogicalPartitions &&
+            format == Iceberg &&
+            !timePartitioned &&
+            catalogPartitions.isEmpty &&
+            subPartitionsFilter.isEmpty
+
+        val effectivePartitions =
+          if (shouldQueryLogicalPartitions) {
+            queryLogicalPartitions(tableName, effectivePartColumn, rangeWheres, effectiveSpec, format)
+          } else {
+            catalogPartitions
+          }
+
+        if (effectivePartitions.nonEmpty) {
+          if (shouldQueryLogicalPartitions) {
+            logger.info(
+              s"Found ${effectivePartitions.size} logical partitions for unpartitioned or clustered table $tableName by scanning column $effectivePartColumn")
+          } else {
+            logger.info(
+              s"Found ${effectivePartitions.size}, between (${effectivePartitions.min}, ${effectivePartitions.max}) partitions for table: $tableName")
+          }
         } else {
-          logger.info(
-            s"Found ${nonNullPartitions.size}, between (${nonNullPartitions.min}, ${nonNullPartitions.max}) partitions for table: $tableName")
+          logger.info(s"No partitions found for table: $tableName with subpartition filters ${subPartitionsFilter}")
         }
-        nonNullPartitions
-      }
+        effectivePartitions
+      })
       .getOrElse(List.empty)
 
     // if table is yyyyMMdd and global partitionSpec is yyyy-MM-dd, partitions will use yyyyMMdd
@@ -161,6 +183,44 @@ class TableUtils(@transient val sparkSession: SparkSession) extends Serializable
         .getOrElse(partitions)
     } else {
       partitions
+    }
+  }
+
+  private def queryLogicalPartitions(tableName: String,
+                                     partitionColumn: String,
+                                     partitionFilters: String,
+                                     partitionSpec: PartitionSpec,
+                                     format: Format): List[String] = {
+    Try {
+      val df = format.table(tableName, partitionFilters)(sparkSession)
+      val resolvedColumn = df.schema.fieldNames.find(_.equalsIgnoreCase(partitionColumn))
+      resolvedColumn match {
+        case None =>
+          logger.info(s"Cannot derive logical partitions for $tableName because column $partitionColumn is missing")
+          List.empty[String]
+        case Some(columnName) =>
+          val partitionExpr = df.schema(columnName).dataType match {
+            case StringType => col(QuotingUtils.quoteIdentifier(columnName)).cast(StringType)
+            case DateType | TimestampType =>
+              date_format(col(QuotingUtils.quoteIdentifier(columnName)), partitionSpec.format)
+            case _ =>
+              date_format(col(QuotingUtils.quoteIdentifier(columnName)).cast(DateType), partitionSpec.format)
+          }
+
+          import sparkSession.implicits._
+          df.select(partitionExpr.as("partitions"))
+            .filter(col("partitions").isNotNull)
+            .distinct()
+            .as[String]
+            .collect()
+            .toList
+      }
+    } match {
+      case Success(result) => Format.sanitizePartitionValues(result)
+      case Failure(e) =>
+        logger.warn(
+          s"Failed to derive logical partitions for $tableName from column $partitionColumn: ${e.getClass.getSimpleName}: ${Option(e.getMessage).getOrElse("(no message)")}")
+        List.empty
     }
   }
 
@@ -453,7 +513,7 @@ class TableUtils(@transient val sparkSession: SparkSession) extends Serializable
       if (validPartitionRange.partitionSpec == partitionSpec) validPartitionRange
       else validPartitionRange.translate(partitionSpec)
 
-    val outputExisting = partitions(outputTable)
+    val outputExisting = partitions(outputTable, partitionRange = Some(canonicalRange), deriveLogicalPartitions = true)
     // To avoid recomputing partitions removed by retention mechanisms we will not fill holes in the very beginning of the range
     // If a user fills a new partition in the newer end of the range, then we will never fill any partitions before that range.
     // We instead log a message saying why we won't fill the earliest hole.

--- a/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
@@ -519,11 +519,14 @@ class TableUtils(@transient val sparkSession: SparkSession) extends Serializable
       else validPartitionRange.translate(partitionSpec)
 
     val outputExisting = partitions(outputTable, partitionRange = Some(canonicalRange), deriveLogicalPartitions = true)
+    // The hole calculation only needs requested-range output partitions, but the retention cutoff
+    // must see the first retained output partition even when it falls outside the requested range.
+    val outputExistingForCutoff = partitions(outputTable, deriveLogicalPartitions = true)
     // To avoid recomputing partitions removed by retention mechanisms we will not fill holes in the very beginning of the range
     // If a user fills a new partition in the newer end of the range, then we will never fill any partitions before that range.
     // We instead log a message saying why we won't fill the earliest hole.
-    val cutoffPartition = if (outputExisting.nonEmpty) {
-      Format.pickMaxPartition(Seq(outputExisting.min, canonicalRange.start)).getOrElse(canonicalRange.start)
+    val cutoffPartition = if (outputExistingForCutoff.nonEmpty) {
+      Format.pickMaxPartition(Seq(outputExistingForCutoff.min, canonicalRange.start)).getOrElse(canonicalRange.start)
     } else {
       canonicalRange.start
     }

--- a/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
@@ -116,10 +116,15 @@ class TableUtils(@transient val sparkSession: SparkSession) extends Serializable
                  tablePartitionSpec: Option[PartitionSpec] = None,
                  timePartitioned: Boolean = false,
                  deriveLogicalPartitions: Boolean = false): List[String] = {
-    val rangeWheres = andPredicates(partitionRange.map(_.whereClauses).getOrElse(Seq.empty))
-
     val effectivePartColumn = tablePartitionSpec.map(_.column).getOrElse(partitionSpec.column)
     val effectiveSpec = tablePartitionSpec.getOrElse(partitionSpec)
+    val effectiveRange = partitionRange.map { range =>
+      if (range.partitionSpec == effectiveSpec) range else range.translate(effectiveSpec)
+    }
+    val rangeWheres = andPredicates(
+      effectiveRange
+        .map(range => whereClauses(range, partitionColumn = Some(effectivePartColumn)))
+        .getOrElse(Seq.empty))
 
     val partitions = tableFormatProvider
       .readFormat(tableName)

--- a/spark/src/test/scala/ai/chronon/spark/catalog/IcebergTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/catalog/IcebergTest.scala
@@ -163,6 +163,53 @@ class IcebergTest extends SparkTestBase with Matchers {
     }
   }
 
+  it should "skip Iceberg tables with timestamp logical partitions" in {
+    val tableName = "default.iceberg_step_runner_timestamp_logical_partitions_test"
+    val previousPartitionColumn = spark.conf.getOption("spark.chronon.partition.column")
+    spark.conf.set("spark.chronon.partition.column", "ts")
+    val tableUtils = TableUtils(spark)
+    spark.sql(s"DROP TABLE IF EXISTS $tableName")
+
+    try {
+      spark.sql(s"""
+        CREATE TABLE $tableName (
+          id INT,
+          value STRING,
+          ts TIMESTAMP
+        ) USING iceberg
+      """)
+
+      spark.sql(s"""
+        INSERT INTO $tableName VALUES
+        (1, 'a', TIMESTAMP '2024-02-01 12:00:00'),
+        (2, 'b', TIMESTAMP '2024-02-02 12:00:00'),
+        (3, 'c', TIMESTAMP '2024-02-03 12:00:00')
+      """)
+
+      val dateRange = new DateRange().setStartDate("2024-02-01").setEndDate("2024-02-03")
+      val metadata = new MetaData()
+        .setName("iceberg_step_runner_timestamp_logical_partitions_test")
+        .setOutputNamespace("default")
+        .setExecutionInfo(
+          new ExecutionInfo()
+            .setOutputTableInfo(new TableInfo().setTable(tableName))
+            .setStepDays(1)
+        )
+
+      var logicalPartitionRuns = 0
+      StepRunner(dateRange, metadata, deriveLogicalPartitions = true) { _ =>
+        logicalPartitionRuns += 1
+      }(tableUtils)
+      logicalPartitionRuns shouldBe 0
+    } finally {
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+      previousPartitionColumn match {
+        case Some(value) => spark.conf.set("spark.chronon.partition.column", value)
+        case None        => spark.conf.unset("spark.chronon.partition.column")
+      }
+    }
+  }
+
   "TableUtils.unfilledRanges" should "reuse unpartitioned Iceberg tables using logical partitions" in {
     val tableName = "default.iceberg_unfilled_ranges_logical_partitions_test"
     val tableUtils = TableUtils(spark)
@@ -186,6 +233,40 @@ class IcebergTest extends SparkTestBase with Matchers {
 
       val requestedRange = PartitionRange("2024-02-01", "2024-02-03")(PartitionSpec.daily)
       tableUtils.unfilledRanges(tableName, requestedRange) shouldBe None
+    } finally {
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+    }
+  }
+
+  it should "derive logical partitions from timestamp columns through the requested end date" in {
+    val tableName = "default.iceberg_timestamp_logical_partitions_test"
+    val tableUtils = TableUtils(spark)
+    val timestampPartitionSpec = PartitionSpec("ts", "yyyy-MM-dd", 24 * 60 * 60 * 1000)
+    spark.sql(s"DROP TABLE IF EXISTS $tableName")
+
+    try {
+      spark.sql(s"""
+        CREATE TABLE $tableName (
+          id INT,
+          value STRING,
+          ts TIMESTAMP
+        ) USING iceberg
+      """)
+
+      spark.sql(s"""
+        INSERT INTO $tableName VALUES
+        (1, 'a', TIMESTAMP '2024-02-01 12:00:00'),
+        (2, 'b', TIMESTAMP '2024-02-02 12:00:00'),
+        (3, 'c', TIMESTAMP '2024-02-03 12:00:00')
+      """)
+
+      val requestedRange = PartitionRange("2024-02-01", "2024-02-03")(timestampPartitionSpec)
+      tableUtils.partitions(
+        tableName,
+        partitionRange = Some(requestedRange),
+        tablePartitionSpec = Some(timestampPartitionSpec),
+        deriveLogicalPartitions = true
+      ) should contain theSameElementsAs List("2024-02-01", "2024-02-02", "2024-02-03")
     } finally {
       spark.sql(s"DROP TABLE IF EXISTS $tableName")
     }

--- a/spark/src/test/scala/ai/chronon/spark/catalog/IcebergTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/catalog/IcebergTest.scala
@@ -116,7 +116,7 @@ class IcebergTest extends SparkTestBase with Matchers {
     parts should contain theSameElementsAs List("2024-02-01", "2024-02-02", "2024-02-03")
   }
 
-  "StepRunner" should "skip Iceberg tables when logical partitions cover the requested range" in {
+  "StepRunner with Iceberg logical partitions" should "skip unpartitioned tables when logical partitions cover the requested range" in {
     val tableName = "default.iceberg_step_runner_logical_partitions_test"
     val tableUtils = TableUtils(spark)
     spark.sql(s"DROP TABLE IF EXISTS $tableName")
@@ -232,6 +232,32 @@ class IcebergTest extends SparkTestBase with Matchers {
       """)
 
       val requestedRange = PartitionRange("2024-02-01", "2024-02-03")(PartitionSpec.daily)
+      tableUtils.unfilledRanges(tableName, requestedRange) shouldBe None
+    } finally {
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+    }
+  }
+
+  it should "preserve retention cutoff for unpartitioned Iceberg tables when the requested range is empty" in {
+    val tableName = "default.iceberg_unfilled_ranges_logical_retention_test"
+    val tableUtils = TableUtils(spark)
+    spark.sql(s"DROP TABLE IF EXISTS $tableName")
+
+    try {
+      spark.sql(s"""
+        CREATE TABLE $tableName (
+          id INT,
+          value STRING,
+          ds STRING
+        ) USING iceberg
+      """)
+
+      spark.sql(s"""
+        INSERT INTO $tableName VALUES
+        (1, 'a', '2024-02-01')
+      """)
+
+      val requestedRange = PartitionRange("2024-01-01", "2024-01-03")(PartitionSpec.daily)
       tableUtils.unfilledRanges(tableName, requestedRange) shouldBe None
     } finally {
       spark.sql(s"DROP TABLE IF EXISTS $tableName")

--- a/spark/src/test/scala/ai/chronon/spark/catalog/IcebergTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/catalog/IcebergTest.scala
@@ -1,6 +1,7 @@
 package ai.chronon.spark.catalog
 
-import ai.chronon.api.PartitionSpec
+import ai.chronon.api.{DateRange, ExecutionInfo, MetaData, PartitionRange, PartitionSpec, TableInfo}
+import ai.chronon.spark.batch.StepRunner
 import ai.chronon.spark.utils.SparkTestBase
 import org.scalatest.matchers.should.Matchers
 
@@ -113,6 +114,81 @@ class IcebergTest extends SparkTestBase with Matchers {
 
     val parts = Iceberg.primaryPartitions(tableName, "ds", "")
     parts should contain theSameElementsAs List("2024-02-01", "2024-02-02", "2024-02-03")
+  }
+
+  "StepRunner" should "skip Iceberg tables when logical partitions cover the requested range" in {
+    val tableName = "default.iceberg_step_runner_logical_partitions_test"
+    val tableUtils = TableUtils(spark)
+    spark.sql(s"DROP TABLE IF EXISTS $tableName")
+
+    try {
+      spark.sql(s"""
+        CREATE TABLE $tableName (
+          id INT,
+          value STRING,
+          ds STRING
+        ) USING iceberg
+      """)
+
+      spark.sql(s"""
+        INSERT INTO $tableName VALUES
+        (1, 'a', '2024-02-01'),
+        (2, 'b', '2024-02-02'),
+        (3, 'c', '2024-02-03')
+      """)
+
+      val dateRange = new DateRange().setStartDate("2024-02-01").setEndDate("2024-02-03")
+      val metadata = new MetaData()
+        .setName("iceberg_step_runner_logical_partitions_test")
+        .setOutputNamespace("default")
+        .setExecutionInfo(
+          new ExecutionInfo()
+            .setOutputTableInfo(new TableInfo().setTable(tableName))
+            .setStepDays(1)
+        )
+
+      var defaultRuns = 0
+      StepRunner(dateRange, metadata) { _ =>
+        defaultRuns += 1
+      }(tableUtils)
+      defaultRuns shouldBe 3
+
+      var logicalPartitionRuns = 0
+      StepRunner(dateRange, metadata, deriveLogicalPartitions = true) { _ =>
+        logicalPartitionRuns += 1
+      }(tableUtils)
+      logicalPartitionRuns shouldBe 0
+    } finally {
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+    }
+  }
+
+  "TableUtils.unfilledRanges" should "reuse unpartitioned Iceberg tables using logical partitions" in {
+    val tableName = "default.iceberg_unfilled_ranges_logical_partitions_test"
+    val tableUtils = TableUtils(spark)
+    spark.sql(s"DROP TABLE IF EXISTS $tableName")
+
+    try {
+      spark.sql(s"""
+        CREATE TABLE $tableName (
+          id INT,
+          value STRING,
+          ds STRING
+        ) USING iceberg
+      """)
+
+      spark.sql(s"""
+        INSERT INTO $tableName VALUES
+        (1, 'a', '2024-02-01'),
+        (2, 'b', '2024-02-02'),
+        (3, 'c', '2024-02-03')
+      """)
+
+      val requestedRange = PartitionRange("2024-02-01", "2024-02-03")(PartitionSpec.daily)
+      tableUtils.unfilledRanges(tableName, requestedRange) shouldBe None
+    } finally {
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+    }
   }
 
   it should "throw NotImplementedError when subPartitionsFilter is non-empty" in {


### PR DESCRIPTION
## Summary

When a table is written to UC Iceberg, it is not partitioned so there are no partitions available when requested during the Join to determine which JoinPart tables must be recomputed (so every table gets recomputed). This gives us a fallback in the StepRunner only path to pull partitions as a query against the table. Given `ds` is often a string we can't effectively use file stats here to pull the partition info. 

## Checklist
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added optional logical-partition derivation for Iceberg tables (disabled by default) to improve partition discovery for unpartitioned tables and improve unfilled-range calculations.
  * Updated join-part execution and partition-existence checks to enable logical-partition derivation and to use an explicit date range.
* **Tests**
  * Added coverage for unpartitioned Iceberg tables validating execution behavior and `unfilledRanges` results when logical partitions are enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->