### PR TITLE
fix(service): deduplicate OTLP resource attributes to prevent Microme…

### DIFF
--- a/online/src/main/scala/ai/chronon/online/metrics/OtelMetricsReporter.scala
+++ b/online/src/main/scala/ai/chronon/online/metrics/OtelMetricsReporter.scala
@@ -2,7 +2,7 @@ package ai.chronon.online.metrics
 
 import ai.chronon.online.metrics.Metrics.Context
 import io.opentelemetry.api.OpenTelemetry
-import io.opentelemetry.api.common.{AttributeKey, Attributes}
+import io.opentelemetry.api.common.{AttributeKey, Attributes, AttributesBuilder}
 import io.opentelemetry.api.metrics.{DoubleGauge, LongCounter, LongGauge, LongHistogram, Meter}
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
 import io.opentelemetry.context.propagation.ContextPropagators
@@ -151,23 +151,13 @@ object OtelMetricsReporter {
     }
   }
 
-  def buildOpenTelemetryClient(metricReader: MetricReader): OpenTelemetry = {
-    // Create resource with service information
-    val configuredResourceKVPairs = System
-      .getProperty(MetricsExporterResourceKey, "")
-      .split(",")
-      .map(_.split("="))
-      .filter(_.length == 2)
-      .map { case Array(k, v) => k.trim -> v.trim }
-      .toMap
+  def buildOpenTelemetryClient(metricReader: MetricReader): OpenTelemetry =
+    buildOpenTelemetryClient(metricReader, sys.env.get)
 
-    val builder = Attributes.builder()
-    configuredResourceKVPairs.map { case (k, v) =>
-      val key = AttributeKey.stringKey(k)
-      builder.put(key, v)
-    }
-
-    val resource = Resource.getDefault.merge(Resource.create(builder.build()))
+  // Overload that accepts an env lookup function for testability.
+  private[metrics] def buildOpenTelemetryClient(metricReader: MetricReader,
+                                                envLookup: String => Option[String]): OpenTelemetry = {
+    val resource = buildResource(envLookup)
 
     val meterProvider = SdkMeterProvider.builder
       .setResource(resource)
@@ -186,6 +176,40 @@ object OtelMetricsReporter {
       .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance))
       .build
   }
+
+  // Build resource attributes. Precedence is last-write-wins:
+  // system property first, then OTEL_SERVICE_NAME for service.name.
+  private[metrics] def buildResource(envLookup: String => Option[String]): Resource = {
+    // Precedence (later wins):
+    //   1. OTEL_RESOURCE_ATTRIBUTES env var
+    //   2. ai.chronon.metrics.exporter.resources system property
+    //   3. OTEL_SERVICE_NAME env var (highest priority for service.name)
+    val builder = Attributes.builder()
+    appendParsedAttributes(builder, envLookup("OTEL_RESOURCE_ATTRIBUTES"))
+    appendParsedAttributes(builder, Option(System.getProperty(MetricsExporterResourceKey, "")).filter(_.trim.nonEmpty))
+    envLookup("OTEL_SERVICE_NAME").filter(_.trim.nonEmpty).foreach { name =>
+      builder.put(AttributeKey.stringKey("service.name"), name.trim)
+    }
+
+    Resource.getDefault.merge(Resource.create(builder.build()))
+  }
+
+  // Parse comma-separated key=value pairs into the Attributes builder.
+  // Split on first '=' only (values may contain '='), reject empty keys/values.
+  // Mirrors ChrononServiceLauncher.appendParsedAttributes.
+  private def appendParsedAttributes(builder: AttributesBuilder, raw: Option[String]): Unit =
+    raw.filter(_.trim.nonEmpty).foreach { s =>
+      s.trim.split(",").foreach { entry =>
+        val eq = entry.indexOf('=')
+        if (eq > 0 && eq < entry.length - 1) {
+          val key = entry.substring(0, eq).trim
+          val value = entry.substring(eq + 1).trim
+          if (key.nonEmpty && value.nonEmpty) {
+            builder.put(AttributeKey.stringKey(key), value)
+          }
+        }
+      }
+    }
 
   private[metrics] def shutdownFlushHook(provider: SdkMeterProvider, timeoutMillis: Long): Thread = {
     val t = new Thread(new Runnable {

--- a/online/src/test/scala/ai/chronon/online/metrics/OtelMetricsReporterResourceTest.scala
+++ b/online/src/test/scala/ai/chronon/online/metrics/OtelMetricsReporterResourceTest.scala
@@ -1,0 +1,125 @@
+package ai.chronon.online.metrics
+
+import io.opentelemetry.api.common.AttributeKey
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/** Verifies OtelMetricsReporter's resource attributes are deduplicated and honor OTEL_SERVICE_NAME. */
+class OtelMetricsReporterResourceTest extends AnyFlatSpec with Matchers with BeforeAndAfterEach {
+
+  private val ResourceKey = OtelMetricsReporter.MetricsExporterResourceKey
+  private val ServiceNameKey = AttributeKey.stringKey("service.name")
+  private val RegionKey = AttributeKey.stringKey("region")
+  private val EnvKey = AttributeKey.stringKey("env")
+
+  private var savedProp: Option[String] = None
+
+  override def beforeEach(): Unit = {
+    savedProp = Option(System.getProperty(ResourceKey))
+    System.clearProperty(ResourceKey)
+  }
+
+  override def afterEach(): Unit = {
+    savedProp match {
+      case Some(v) => System.setProperty(ResourceKey, v)
+      case None    => System.clearProperty(ResourceKey)
+    }
+  }
+
+  "resource attribute parsing" should "not throw on duplicate keys in the system property" in {
+    System.setProperty(ResourceKey, "service.name=first,region=us-east-1,service.name=second")
+
+    val resource = OtelMetricsReporter.buildResource(_ => None)
+
+    resource.getAttribute(ServiceNameKey) shouldBe "second"
+    resource.getAttribute(RegionKey) shouldBe "us-east-1"
+  }
+
+  it should "take the last value when the same key appears multiple times" in {
+    System.setProperty(ResourceKey, "env=staging,env=production")
+
+    val resource = OtelMetricsReporter.buildResource(_ => None)
+
+    resource.getAttribute(EnvKey) shouldBe "production"
+  }
+
+  "OTEL_RESOURCE_ATTRIBUTES" should "be included in the resource" in {
+    System.clearProperty(ResourceKey)
+    val envLookup: String => Option[String] = {
+      case "OTEL_RESOURCE_ATTRIBUTES" => Some("region=us-east-1,team=ml")
+      case _                          => None
+    }
+
+    val resource = OtelMetricsReporter.buildResource(envLookup)
+
+    resource.getAttribute(RegionKey) shouldBe "us-east-1"
+    resource.getAttribute(AttributeKey.stringKey("team")) shouldBe "ml"
+  }
+
+  it should "be overridden by the system property for the same key" in {
+    System.setProperty(ResourceKey, "region=eu-west-1")
+    val envLookup: String => Option[String] = {
+      case "OTEL_RESOURCE_ATTRIBUTES" => Some("region=us-east-1")
+      case _                          => None
+    }
+
+    val resource = OtelMetricsReporter.buildResource(envLookup)
+
+    resource.getAttribute(RegionKey) shouldBe "eu-west-1"
+  }
+
+  "OTEL_SERVICE_NAME" should "be included in resource attributes when building the OTel client" in {
+    System.clearProperty(ResourceKey)
+    val envLookup: String => Option[String] = {
+      case "OTEL_SERVICE_NAME" => Some("zipline-fetcher")
+      case _                   => None
+    }
+
+    val resource = OtelMetricsReporter.buildResource(envLookup)
+
+    resource.getAttribute(ServiceNameKey) shouldBe "zipline-fetcher"
+  }
+
+  it should "not set service.name when env var is absent" in {
+    System.clearProperty(ResourceKey)
+    val envLookup: String => Option[String] = _ => None
+
+    val resource = OtelMetricsReporter.buildResource(envLookup)
+
+    resource.getAttribute(ServiceNameKey) should not be "zipline-fetcher"
+  }
+
+  it should "win over service.name set in OTEL_RESOURCE_ATTRIBUTES" in {
+    System.clearProperty(ResourceKey)
+    val envLookup: String => Option[String] = {
+      case "OTEL_RESOURCE_ATTRIBUTES" => Some("service.name=from-resource-attrs,region=us-east-1")
+      case "OTEL_SERVICE_NAME"        => Some("from-service-name-env")
+      case _                          => None
+    }
+
+    val resource = OtelMetricsReporter.buildResource(envLookup)
+
+    resource.getAttribute(ServiceNameKey) shouldBe "from-service-name-env"
+    resource.getAttribute(RegionKey) shouldBe "us-east-1"
+  }
+
+  "resource attribute parsing edge cases" should "keep values containing '=' (split on first '=' only)" in {
+    System.setProperty(ResourceKey, "key=val=extra")
+
+    val resource = OtelMetricsReporter.buildResource(_ => None)
+
+    resource.getAttribute(AttributeKey.stringKey("key")) shouldBe "val=extra"
+  }
+
+  it should "reject entries with empty key or empty value" in {
+    System.setProperty(ResourceKey, "=value,key=,valid=ok")
+
+    val resource = OtelMetricsReporter.buildResource(_ => None)
+
+    resource.getAttribute(AttributeKey.stringKey("")) shouldBe null
+    resource.getAttribute(AttributeKey.stringKey("key")) shouldBe null
+    resource.getAttribute(AttributeKey.stringKey("valid")) shouldBe "ok"
+  }
+
+}

--- a/service_commons/src/main/java/ai/chronon/service/ChrononServiceLauncher.java
+++ b/service_commons/src/main/java/ai/chronon/service/ChrononServiceLauncher.java
@@ -20,8 +20,10 @@ import io.vertx.micrometer.VertxPrometheusOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.LinkedHashMap;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Custom launcher to help configure the Chronon vertx feature service
@@ -147,21 +149,41 @@ public class ChrononServiceLauncher extends Launcher {
     }
 
     // Overload that takes an env lookup function for testability — System.getenv is immutable in-process.
+    // Micrometer does not tolerate duplicate resource attribute keys, so dedupe before passing to OtlpConfig.
+    // Produces a deduplicated, comma-separated key=value string. Precedence (later wins):
+    //   1. service.name=<default>
+    //   2. OTEL_RESOURCE_ATTRIBUTES env var
+    //   3. ai.chronon.metrics.exporter.resources system property
+    //   4. OTEL_SERVICE_NAME env var (overrides service.name)
     static String buildOtlpResourceAttributes(String defaultServiceName, Function<String, String> envLookup) {
-        StringBuilder sb = new StringBuilder("service.name=").append(defaultServiceName);
-        String envResourceAttrs = envLookup.apply("OTEL_RESOURCE_ATTRIBUTES");
-        if (envResourceAttrs != null && !envResourceAttrs.trim().isEmpty()) {
-            sb.append(',').append(envResourceAttrs.trim());
-        }
-        String chrononResourceAttrs = System.getProperty(OtelMetricsReporter.MetricsExporterResourceKey(), "");
-        if (!chrononResourceAttrs.trim().isEmpty()) {
-            sb.append(',').append(chrononResourceAttrs.trim());
-        }
+        LinkedHashMap<String, String> attrs = new LinkedHashMap<>();
+        attrs.put("service.name", defaultServiceName);
+
+        appendParsedAttributes(attrs, envLookup.apply("OTEL_RESOURCE_ATTRIBUTES"));
+        appendParsedAttributes(attrs, System.getProperty(OtelMetricsReporter.MetricsExporterResourceKey(), ""));
+
         String envServiceName = envLookup.apply("OTEL_SERVICE_NAME");
         if (envServiceName != null && !envServiceName.trim().isEmpty()) {
-            sb.append(',').append("service.name=").append(envServiceName.trim());
+            attrs.put("service.name", envServiceName.trim());
         }
-        return sb.toString();
+
+        return attrs.entrySet().stream()
+                .map(e -> e.getKey() + "=" + e.getValue())
+                .collect(Collectors.joining(","));
+    }
+
+    private static void appendParsedAttributes(LinkedHashMap<String, String> attrs, String raw) {
+        if (raw == null || raw.trim().isEmpty()) return;
+        for (String entry : raw.trim().split(",")) {
+            int eq = entry.indexOf('=');
+            if (eq > 0 && eq < entry.length() - 1) {
+                String key = entry.substring(0, eq).trim();
+                String value = entry.substring(eq + 1).trim();
+                if (!key.isEmpty() && !value.isEmpty()) {
+                    attrs.put(key, value);
+                }
+            }
+        }
     }
 
     public static void main(String[] args) {

--- a/service_commons/src/test/java/ai/chronon/service/ChrononServiceLauncherTest.java
+++ b/service_commons/src/test/java/ai/chronon/service/ChrononServiceLauncherTest.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class ChrononServiceLauncherTest {
 
@@ -76,6 +77,63 @@ class ChrononServiceLauncherTest {
         assertEquals("prod", parsed.get("deployment.environment.name"));
         assertEquals("ml", parsed.get("team"));
         assertEquals("us-east-1", parsed.get("region"));
+    }
+
+    @Test
+    void duplicateServiceNameDoesNotThrow() {
+        // Micrometer's OtlpConfig uses Collectors.toMap() which throws on duplicate keys.
+        // This test verifies that buildOtlpResourceAttributes deduplicates so the output
+        // is safe to pass to Micrometer without triggering IllegalStateException.
+        Map<String, String> env = new HashMap<>();
+        env.put("OTEL_RESOURCE_ATTRIBUTES", "service.name=ml-default-zipline-hub");
+
+        String result = ChrononServiceLauncher.buildOtlpResourceAttributes("ai.chronon", envOf(env));
+
+        // OTEL_RESOURCE_ATTRIBUTES wins over the default — last-write-wins
+        Map<String, String> parsed = parseAsMicrometerWould(result);
+        assertEquals("ml-default-zipline-hub", parsed.get("service.name"));
+        // Verify no duplicate keys in the raw string
+        long serviceNameCount = java.util.Arrays.stream(result.split(","))
+                .filter(s -> s.trim().startsWith("service.name="))
+                .count();
+        assertEquals(1, serviceNameCount, "Output must not contain duplicate service.name keys");
+    }
+
+    @Test
+    void otelServiceNameOverridesResourceAttributesServiceName() {
+        // OTEL_SERVICE_NAME has highest precedence for service.name
+        Map<String, String> env = new HashMap<>();
+        env.put("OTEL_RESOURCE_ATTRIBUTES", "service.name=from-resource-attrs");
+        env.put("OTEL_SERVICE_NAME", "from-otel-service-name");
+
+        Map<String, String> parsed = parseAsMicrometerWould(
+                ChrononServiceLauncher.buildOtlpResourceAttributes("ai.chronon", envOf(env)));
+
+        assertEquals("from-otel-service-name", parsed.get("service.name"));
+    }
+
+    @Test
+    void valuesContainingEqualsAreKeptIntact() {
+        Map<String, String> env = new HashMap<>();
+        env.put("OTEL_RESOURCE_ATTRIBUTES", "key=val=extra");
+
+        Map<String, String> parsed = parseAsMicrometerWould(
+                ChrononServiceLauncher.buildOtlpResourceAttributes("ai.chronon", envOf(env)));
+
+        assertEquals("val=extra", parsed.get("key"));
+    }
+
+    @Test
+    void entriesWithEmptyKeyOrValueAfterTrimAreRejected() {
+        Map<String, String> env = new HashMap<>();
+        env.put("OTEL_RESOURCE_ATTRIBUTES", "=value, key= , =,valid=ok");
+
+        Map<String, String> parsed = parseAsMicrometerWould(
+                ChrononServiceLauncher.buildOtlpResourceAttributes("ai.chronon", envOf(env)));
+
+        assertEquals("ok", parsed.get("valid"));
+        assertNull(parsed.get(""));
+        assertNull(parsed.get("key"));
     }
 
     @Test


### PR DESCRIPTION
 fix(service): deduplicate OTLP resource attributes to prevent Micrometer crashing due to duplicate keys service.name

  Micrometer's OtlpConfig throws on duplicate resource attribute keys.
  Deduplicate via LinkedHashMap in buildOtlpResourceAttributes so
  OTEL_SERVICE_NAME can safely override the default service.name.

  Also read OTEL_SERVICE_NAME in OtelMetricsReporter.buildResource so
  one env var sets service.name for both the Micrometer (Vert.x) and
  OTel SDK (Chronon) metric pipelines.

## Summary

## Checklist
- [x] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Metrics exporter now deduplicates OTLP resource attributes, enforces predictable last-write-wins across configuration sources, and ensures a single service.name is emitted with explicit override from the service name environment variable. OpenTelemetry client behavior around resource attributes is more consistent and testable.

* **Tests**
  * Added Java and Scala tests validating attribute deduplication, precedence rules, and safe parsing/restoration of environment/system state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->