### PR TITLE
Retry failed Dataproc cluster creation

### DIFF
--- a/cloud_gcp/src/main/scala/ai/chronon/integrations/cloud_gcp/DataprocSubmitter.scala
+++ b/cloud_gcp/src/main/scala/ai/chronon/integrations/cloud_gcp/DataprocSubmitter.scala
@@ -16,7 +16,7 @@ import com.google.protobuf.util.JsonFormat
 
 import java.time.{Duration, Instant}
 import scala.collection.concurrent.TrieMap
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success}
 import scala.util.matching.Regex
@@ -763,7 +763,8 @@ class DataprocSubmitter(jobControllerClient: JobControllerClient,
 
   private def surfaceFailedAsyncClusterCreation(clusterName: String,
                                                 clusterConf: Option[Map[String, String]],
-                                                ccClient: ClusterControllerClient)(implicit ec: ExecutionContext): Unit = {
+                                                ccClient: ClusterControllerClient)(implicit
+      ec: ExecutionContext): Unit = {
     asyncClusterCreationAttempts.get(clusterName).foreach { creationAttempt =>
       creationAttempt.value match {
         case Some(Failure(ex)) =>
@@ -786,21 +787,30 @@ class DataprocSubmitter(jobControllerClient: JobControllerClient,
                                           clusterConf: Option[Map[String, String]],
                                           ccClient: ClusterControllerClient)(implicit ec: ExecutionContext): Unit = {
     if (hasDataprocClusterConfig(clusterConf)) {
-      asyncClusterCreationAttempts.get(clusterName) match {
-        case Some(existingAttempt) if !existingAttempt.isCompleted =>
-          logger.info(s"Async Dataproc cluster creation already in progress for $clusterName.")
-        case _ =>
-          logger.info(s"Cluster $clusterName not ready. Triggering creation asynchronously.")
-          val creationAttempt = Future {
-            DataprocSubmitter.getOrCreateCluster(clusterName, clusterConf, projectId, region, ccClient)
-          }
-          asyncClusterCreationAttempts.put(clusterName, creationAttempt)
-          creationAttempt.onComplete {
-            case Success(_) =>
-              asyncClusterCreationAttempts.remove(clusterName, creationAttempt)
-            case Failure(ex) =>
-              logger.error(s"Failed to create cluster $clusterName asynchronously", ex)
-          }
+      val creationAttemptToStart = asyncClusterCreationAttempts.synchronized {
+        asyncClusterCreationAttempts.get(clusterName) match {
+          case Some(_) =>
+            logger.info(s"Async Dataproc cluster creation already tracked for $clusterName.")
+            None
+          case None =>
+            logger.info(s"Cluster $clusterName not ready. Triggering creation asynchronously.")
+            val creationAttempt = Promise[String]()
+            asyncClusterCreationAttempts.put(clusterName, creationAttempt.future)
+            Some(creationAttempt)
+        }
+      }
+
+      creationAttemptToStart.foreach { creationAttempt =>
+        Future {
+          DataprocSubmitter.getOrCreateCluster(clusterName, clusterConf, projectId, region, ccClient)
+        }.onComplete {
+          case Success(cluster) =>
+            creationAttempt.success(cluster)
+            asyncClusterCreationAttempts.remove(clusterName, creationAttempt.future)
+          case Failure(ex) =>
+            creationAttempt.failure(ex)
+            logger.error(s"Failed to create cluster $clusterName asynchronously", ex)
+        }
       }
     } else {
       logger.error(s"Cluster $clusterName does not exist and no cluster configuration provided to create it.")

--- a/cloud_gcp/src/main/scala/ai/chronon/integrations/cloud_gcp/DataprocSubmitter.scala
+++ b/cloud_gcp/src/main/scala/ai/chronon/integrations/cloud_gcp/DataprocSubmitter.scala
@@ -15,8 +15,10 @@ import com.google.cloud.storage.{Storage, StorageOptions}
 import com.google.protobuf.util.JsonFormat
 
 import java.time.{Duration, Instant}
+import scala.collection.concurrent.TrieMap
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
+import scala.util.{Failure, Success}
 import scala.util.matching.Regex
 
 case class MoreThanOneRunningFlinkJob(message: String) extends Exception(message)
@@ -34,6 +36,8 @@ class DataprocSubmitter(jobControllerClient: JobControllerClient,
                         flinkHealthCheckFn: Option[String] => Boolean = _ => true,
                         flinkInternalJobIdFetchFn: Option[String] => Option[String] = _ => None)
     extends JobSubmitter {
+
+  private val asyncClusterCreationAttempts = TrieMap.empty[String, Future[String]]
 
   def listRunningGroupByFlinkJobs(groupByName: String): List[String] = {
     val groupByNameDataprocLabel = DataprocUtils.formatDataprocLabel(groupByName)
@@ -719,6 +723,7 @@ class DataprocSubmitter(jobControllerClient: JobControllerClient,
     clusterControllerClient match {
       case None => Some(clusterName)
       case Some(ccClient) =>
+        surfaceFailedAsyncClusterCreation(clusterName, clusterConf, ccClient)
         try {
           val cluster = ccClient.getCluster(projectId, region, clusterName)
           if (cluster == null) {
@@ -731,6 +736,11 @@ class DataprocSubmitter(jobControllerClient: JobControllerClient,
               case ClusterStatus.State.UNKNOWN | ClusterStatus.State.CREATING | ClusterStatus.State.STARTING |
                   ClusterStatus.State.REPAIRING =>
                 logger.info(s"Cluster $clusterName not ready (state: ${cluster.getStatus.getState}).")
+                None
+              case state if hasDataprocClusterConfig(clusterConf) =>
+                logger.warn(
+                  s"Cluster $clusterName is in state $state. Triggering recreation asynchronously with the provided config.")
+                triggerAsyncClusterCreation(clusterName, clusterConf, ccClient)
                 None
               case state =>
                 throw new IllegalStateException(
@@ -748,15 +758,49 @@ class DataprocSubmitter(jobControllerClient: JobControllerClient,
     }
   }
 
+  private def hasDataprocClusterConfig(clusterConf: Option[Map[String, String]]): Boolean =
+    clusterConf.exists(_.contains("dataproc.config"))
+
+  private def surfaceFailedAsyncClusterCreation(clusterName: String,
+                                                clusterConf: Option[Map[String, String]],
+                                                ccClient: ClusterControllerClient)(implicit ec: ExecutionContext): Unit = {
+    asyncClusterCreationAttempts.get(clusterName).foreach { creationAttempt =>
+      creationAttempt.value match {
+        case Some(Failure(ex)) =>
+          asyncClusterCreationAttempts.remove(clusterName, creationAttempt)
+          logger.warn(
+            s"Previous async Dataproc cluster creation attempt for $clusterName failed. Starting a new attempt.",
+            ex)
+          triggerAsyncClusterCreation(clusterName, clusterConf, ccClient)
+          throw new RuntimeException(
+            s"Previous async Dataproc cluster creation attempt for $clusterName failed; retrying cluster creation.",
+            ex)
+        case Some(Success(_)) =>
+          asyncClusterCreationAttempts.remove(clusterName, creationAttempt)
+        case None =>
+      }
+    }
+  }
+
   private def triggerAsyncClusterCreation(clusterName: String,
                                           clusterConf: Option[Map[String, String]],
                                           ccClient: ClusterControllerClient)(implicit ec: ExecutionContext): Unit = {
-    if (clusterConf.isDefined && clusterConf.get.contains("dataproc.config")) {
-      logger.info(s"Cluster $clusterName not found. Triggering creation asynchronously.")
-      Future {
-        DataprocSubmitter.getOrCreateCluster(clusterName, clusterConf, projectId, region, ccClient)
-      }.recover { case ex: Exception =>
-        logger.error(s"Failed to create cluster $clusterName asynchronously", ex)
+    if (hasDataprocClusterConfig(clusterConf)) {
+      asyncClusterCreationAttempts.get(clusterName) match {
+        case Some(existingAttempt) if !existingAttempt.isCompleted =>
+          logger.info(s"Async Dataproc cluster creation already in progress for $clusterName.")
+        case _ =>
+          logger.info(s"Cluster $clusterName not ready. Triggering creation asynchronously.")
+          val creationAttempt = Future {
+            DataprocSubmitter.getOrCreateCluster(clusterName, clusterConf, projectId, region, ccClient)
+          }
+          asyncClusterCreationAttempts.put(clusterName, creationAttempt)
+          creationAttempt.onComplete {
+            case Success(_) =>
+              asyncClusterCreationAttempts.remove(clusterName, creationAttempt)
+            case Failure(ex) =>
+              logger.error(s"Failed to create cluster $clusterName asynchronously", ex)
+          }
       }
     } else {
       logger.error(s"Cluster $clusterName does not exist and no cluster configuration provided to create it.")

--- a/cloud_gcp/src/test/scala/ai/chronon/integrations/cloud_gcp/DataprocSubmitterTest.scala
+++ b/cloud_gcp/src/test/scala/ai/chronon/integrations/cloud_gcp/DataprocSubmitterTest.scala
@@ -21,7 +21,8 @@ import org.scalatestplus.mockito.MockitoSugar
 
 import java.nio.file.Paths
 import java.util.UUID
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, TimeUnit}
 import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
 
@@ -1311,6 +1312,97 @@ class DataprocSubmitterTest extends AnyFlatSpec with MockitoSugar {
 
     assert(exception.getMessage.contains("Previous async Dataproc cluster creation attempt for test-cluster failed"))
     verify(mockClusterControllerClient, times(2)).createClusterAsync(any[CreateClusterRequest])
+  }
+
+  it should "dedupe concurrent async cluster creation attempts" in {
+    val mockClusterControllerClient = mock[ClusterControllerClient]
+    val mockOperationFuture = mock[OperationFuture[Cluster, ClusterOperationMetadata]]
+    val clusterConfigStr =
+      """{
+      "masterConfig": {
+        "numInstances": 1,
+        "machineTypeUri": "n1-standard-4"
+      }
+    }"""
+    val clusterConf = Some(Map("dataproc.config" -> clusterConfigStr))
+
+    val readinessChecksReady = new CountDownLatch(2)
+    val createStarted = new CountDownLatch(1)
+    val releaseCreate = new CountDownLatch(1)
+    val oneReadinessCheckReturned = new CountDownLatch(1)
+    val getClusterCalls = new AtomicInteger(0)
+    val createClusterCalls = new AtomicInteger(0)
+    val threadErrors = new ConcurrentLinkedQueue[Throwable]()
+
+    when(mockClusterControllerClient.getCluster(any[String], any[String], any[String]))
+      .thenAnswer { _ =>
+        if (getClusterCalls.incrementAndGet() <= 2) {
+          readinessChecksReady.countDown()
+          readinessChecksReady.await(5, TimeUnit.SECONDS)
+        }
+        null
+      }
+    when(mockClusterControllerClient.createClusterAsync(any[CreateClusterRequest]))
+      .thenAnswer { _ =>
+        createClusterCalls.incrementAndGet()
+        mockOperationFuture
+      }
+    when(mockOperationFuture.get(anyLong(), any[TimeUnit]))
+      .thenAnswer { _ =>
+        createStarted.countDown()
+        releaseCreate.await(5, TimeUnit.SECONDS)
+        throw new RuntimeException("create failed")
+      }
+
+    val submitterWithClusterClient = new DataprocSubmitter(
+      jobControllerClient = mock[JobControllerClient],
+      gcsClient = mock[GCSClient],
+      region = "test-region",
+      projectId = "test-project",
+      clusterControllerClient = Some(mockClusterControllerClient)
+    )
+
+    val directExecutionContext = new ExecutionContext {
+      override def execute(runnable: Runnable): Unit = runnable.run()
+      override def reportFailure(cause: Throwable): Unit = ()
+    }
+
+    val start = new CountDownLatch(1)
+    val done = new CountDownLatch(2)
+    val threads = (1 to 2).map { _ =>
+      new Thread(() => {
+        try {
+          start.await(5, TimeUnit.SECONDS)
+          val result = submitterWithClusterClient.ensureClusterReady(
+            "test-cluster",
+            clusterConf
+          )(directExecutionContext)
+          assert(result.isEmpty)
+          oneReadinessCheckReturned.countDown()
+        } catch {
+          case ex: Throwable => threadErrors.add(ex)
+        } finally {
+          done.countDown()
+        }
+      })
+    }
+
+    threads.foreach(_.start())
+    start.countDown()
+
+    try {
+      assert(createStarted.await(5, TimeUnit.SECONDS))
+      assert(oneReadinessCheckReturned.await(5, TimeUnit.SECONDS))
+      assertEquals("Concurrent readiness checks should share one async cluster creation attempt",
+                   1,
+                   createClusterCalls.get())
+    } finally {
+      releaseCreate.countDown()
+      assert(done.await(5, TimeUnit.SECONDS))
+    }
+
+    assert(threadErrors.asScala.isEmpty)
+    verify(mockClusterControllerClient, times(1)).createClusterAsync(any[CreateClusterRequest])
   }
 
   it should "throw IllegalArgumentException when getOrCreateCluster is called with no config" in {

--- a/cloud_gcp/src/test/scala/ai/chronon/integrations/cloud_gcp/DataprocSubmitterTest.scala
+++ b/cloud_gcp/src/test/scala/ai/chronon/integrations/cloud_gcp/DataprocSubmitterTest.scala
@@ -22,6 +22,7 @@ import org.scalatestplus.mockito.MockitoSugar
 import java.nio.file.Paths
 import java.util.UUID
 import java.util.concurrent.TimeUnit
+import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
 
 class DataprocSubmitterTest extends AnyFlatSpec with MockitoSugar {
@@ -1261,6 +1262,55 @@ class DataprocSubmitterTest extends AnyFlatSpec with MockitoSugar {
     }
 
     assert(exception.getMessage.contains("cannot be used for job submission"))
+  }
+
+  it should "surface async cluster creation failures on next readiness check and retry creation" in {
+    val mockClusterControllerClient = mock[ClusterControllerClient]
+    val mockOperationFuture = mock[OperationFuture[Cluster, ClusterOperationMetadata]]
+    val clusterConfigStr =
+      """{
+      "masterConfig": {
+        "numInstances": 1,
+        "machineTypeUri": "n1-standard-4"
+      }
+    }"""
+    val clusterConf = Some(Map("dataproc.config" -> clusterConfigStr))
+
+    when(mockClusterControllerClient.getCluster(any[String], any[String], any[String]))
+      .thenReturn(null)
+    when(mockClusterControllerClient.createClusterAsync(any[CreateClusterRequest]))
+      .thenReturn(mockOperationFuture)
+    when(mockOperationFuture.get(anyLong(), any[TimeUnit]))
+      .thenThrow(new RuntimeException("create failed"))
+
+    val submitterWithClusterClient = new DataprocSubmitter(
+      jobControllerClient = mock[JobControllerClient],
+      gcsClient = mock[GCSClient],
+      region = "test-region",
+      projectId = "test-project",
+      clusterControllerClient = Some(mockClusterControllerClient)
+    )
+
+    val directExecutionContext = new ExecutionContext {
+      override def execute(runnable: Runnable): Unit = runnable.run()
+      override def reportFailure(cause: Throwable): Unit = throw cause
+    }
+
+    val result = submitterWithClusterClient.ensureClusterReady(
+      "test-cluster",
+      clusterConf
+    )(directExecutionContext)
+    assert(result.isEmpty)
+
+    val exception = intercept[RuntimeException] {
+      submitterWithClusterClient.ensureClusterReady(
+        "test-cluster",
+        clusterConf
+      )(directExecutionContext)
+    }
+
+    assert(exception.getMessage.contains("Previous async Dataproc cluster creation attempt for test-cluster failed"))
+    verify(mockClusterControllerClient, times(2)).createClusterAsync(any[CreateClusterRequest])
   }
 
   it should "throw IllegalArgumentException when getOrCreateCluster is called with no config" in {


### PR DESCRIPTION
## Summary
- Track async Dataproc cluster creation attempts in the submitter
- Surface failed async creation on the next readiness check so platform retry accounting can advance
- Start a fresh async cluster creation attempt after surfacing the failure
- Add regression coverage for the failed async creation retry path

## Validation
- `./mill cloud_gcp.test.testOnly "ai.chronon.integrations.cloud_gcp.DataprocSubmitterTest"`
- `./mill cloud_gcp[2.13.17].test.testOnly "ai.chronon.integrations.cloud_gcp.DataprocSubmitterTest"`
- `./mill cloud_gcp.test`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asynchronous cluster creation with enhanced failure tracking and recovery mechanisms
  * Cluster readiness checks now properly surface and handle failed creation attempts

* **Tests**
  * Added test coverage for asynchronous cluster creation failure scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->