### PR TITLE
fix(flink): handle missing streamingSource when topic-override is provided

### DIFF
--- a/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
@@ -247,8 +247,10 @@ object FlinkJob {
                             servingInfo: GroupByServingInfoParsed,
                             enableDebug: Boolean = false,
                             maybeTopicOverride: Option[String] = None): BaseFlinkJob = {
-    // Check if this is a JoinSource GroupBy
-    if (servingInfo.groupBy.streamingSource.get.isSetJoinSource) {
+    // streamingSource is None when no source has a topic set (e.g. topic
+    // provided only via --topic-override). Default to regular GroupBy path.
+    val isJoinSource = servingInfo.groupBy.streamingSource.exists(_.isSetJoinSource)
+    if (isJoinSource) {
       buildJoinSourceFlinkJob(groupByName, props, api, servingInfo, enableDebug, maybeTopicOverride)
     } else {
       buildGroupByStreamingJob(groupByName, props, api, servingInfo, enableDebug, maybeTopicOverride)
@@ -329,7 +331,13 @@ object FlinkJob {
                                        maybeTopicOverride: Option[String] = None): FlinkGroupByStreamingJob = {
     val logger = LoggerFactory.getLogger(getClass)
 
-    val rawTopic = maybeTopicOverride.getOrElse(servingInfo.groupBy.streamingSource.get.topic)
+    val rawTopic = maybeTopicOverride
+      .orElse(servingInfo.groupBy.streamingSource.map(_.topic))
+      .getOrElse(
+        throw new IllegalArgumentException(
+          s"No topic available for GroupBy '$groupByName'. Either set a topic on the EventSource " +
+            s"in the feature definition, or provide --topic-override at deploy time.")
+      )
     val topicInfo = TopicInfo.parse(rawTopic)
     val schemaProvider = FlinkSerDeProvider.build(topicInfo)
 

--- a/flink/src/test/scala/ai/chronon/flink/test/FlinkJobBuildRoutingTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/FlinkJobBuildRoutingTest.scala
@@ -1,0 +1,100 @@
+package ai.chronon.flink.test
+
+import ai.chronon.api.Builders
+import ai.chronon.api.Extensions.{GroupByOps, SourceOps}
+import ai.chronon.api.{Accuracy, Operation, TimeUnit, Window}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/**
+  * Tests for FlinkJob.buildFlinkJob routing logic.
+  *
+  * buildFlinkJob is private, so we test the condition it uses:
+  * `servingInfo.groupBy.streamingSource.exists(_.isSetJoinSource)`
+  *
+  * streamingSource is derived from the first source with a non-null topic
+  * (see Extensions.GroupByOps.streamingSource). When no source has a topic,
+  * streamingSource is None. FlinkJob must handle this gracefully when
+  * --topic-override is provided at deploy time.
+  */
+class FlinkJobBuildRoutingTest extends AnyFlatSpec with Matchers {
+
+  private def makeGroupByWithTopic(topic: String): ai.chronon.api.GroupBy =
+    Builders.GroupBy(
+      sources = Seq(
+        Builders.Source.events(
+          table = "test_db.test_table",
+          topic = topic,
+          query = Builders.Query(
+            selects = Map("id" -> "id", "value" -> "value"),
+            timeColumn = "ts"
+          )
+        )
+      ),
+      keyColumns = Seq("id"),
+      aggregations = Seq(
+        Builders.Aggregation(
+          operation = Operation.COUNT,
+          inputColumn = "id",
+          windows = Seq(new Window(7, TimeUnit.DAYS))
+        )
+      ),
+      metaData = Builders.MetaData(name = "test.group_by.v1"),
+      accuracy = Accuracy.TEMPORAL
+    )
+
+  private def makeGroupByWithoutTopic(): ai.chronon.api.GroupBy =
+    Builders.GroupBy(
+      sources = Seq(
+        Builders.Source.events(
+          table = "test_db.test_table",
+          query = Builders.Query(
+            selects = Map("id" -> "id", "value" -> "value"),
+            timeColumn = "ts"
+          )
+        )
+      ),
+      keyColumns = Seq("id"),
+      aggregations = Seq(
+        Builders.Aggregation(
+          operation = Operation.COUNT,
+          inputColumn = "id",
+          windows = Seq(new Window(7, TimeUnit.DAYS))
+        )
+      ),
+      metaData = Builders.MetaData(name = "test.group_by.v1"),
+      accuracy = Accuracy.TEMPORAL
+    )
+
+  "streamingSource" should "be Some when EventSource has a topic" in {
+    val groupBy = makeGroupByWithTopic("kafka://test-topic")
+    groupBy.streamingSource shouldBe defined
+    groupBy.streamingSource.get.topic shouldBe "kafka://test-topic"
+  }
+
+  it should "be None when EventSource has no topic" in {
+    val groupBy = makeGroupByWithoutTopic()
+    groupBy.streamingSource shouldBe None
+  }
+
+  "buildFlinkJob routing condition" should "return false (not JoinSource) when streamingSource is defined without JoinSource" in {
+    val groupBy = makeGroupByWithTopic("kafka://test-topic")
+    val isJoinSource = groupBy.streamingSource.exists(_.isSetJoinSource)
+    isJoinSource shouldBe false
+  }
+
+  it should "return false (not JoinSource) when streamingSource is None" in {
+    val groupBy = makeGroupByWithoutTopic()
+    val isJoinSource = groupBy.streamingSource.exists(_.isSetJoinSource)
+    isJoinSource shouldBe false
+  }
+
+  it should "not throw when streamingSource is None (the old .get would crash)" in {
+    val groupBy = makeGroupByWithoutTopic()
+    // This is the exact condition from the fix. The old code did .get.isSetJoinSource
+    // which would throw NoSuchElementException: None.get
+    noException should be thrownBy {
+      groupBy.streamingSource.exists(_.isSetJoinSource)
+    }
+  }
+}


### PR DESCRIPTION
`FlinkJob.buildFlinkJob` crashes with `NoSuchElementException: None.get` when the GroupBy config has no `topic` on the EventSource — even when `--topic-override` is provided at deploy time.

This happens because `streamingSource` is derived from the first source with a non-null topic. When the topic is only specified via `--topic-override` (not in the feature definition), `streamingSource` is `None`, and the code does `.get` on it unconditionally.

**Fix:**
- Use `.exists()` instead of `.get` for the JoinSource check
- Chain `topicOverride.orElse(streamingSource)` so either path works
- Clear error message when neither topic source is available

Includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and validation in Flink job processing with clearer error messages when streaming source configuration is unavailable, making it easier to identify and troubleshoot configuration issues.

* **Tests**
  * Added comprehensive test coverage for job routing behavior and configuration validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->