### PR TITLE
adding open telemetry changes

### DIFF
--- a/online/src/main/scala/ai/chronon/online/fetcher/Fetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/Fetcher.scala
@@ -232,7 +232,8 @@ class Fetcher(val kvStore: KVStore,
   }
 
   def fetchGroupBys(requests: Seq[Request]): Future[Seq[Response]] = {
-    val attrs = Attributes.builder()
+    val attrs = Attributes
+      .builder()
       .put(Metrics.Tag.GroupBy, requests.map(_.name).distinct.mkString(","))
       .put("request.count", requests.size.toLong)
       .build()
@@ -242,7 +243,8 @@ class Fetcher(val kvStore: KVStore,
   }
 
   def fetchJoin(requests: Seq[Request], joinConf: Option[api.Join] = None): Future[Seq[Response]] = {
-    val joinSpanAttrs = Attributes.builder()
+    val joinSpanAttrs = Attributes
+      .builder()
       .put(Metrics.Tag.Join, requests.map(_.name).distinct.mkString(","))
       .put("request.count", requests.size.toLong)
       .build()
@@ -659,7 +661,8 @@ class Fetcher(val kvStore: KVStore,
 
   // Pulling external features in a batched fashion across services in-parallel
   private def fetchExternal(joinRequests: Seq[Request]): Future[Seq[Response]] = {
-    val attrs = Attributes.builder()
+    val attrs = Attributes
+      .builder()
       .put(Metrics.Tag.Join, joinRequests.map(_.name).distinct.mkString(","))
       .put("request.count", joinRequests.size.toLong)
       .build()

--- a/online/src/main/scala/ai/chronon/online/fetcher/Fetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/Fetcher.scala
@@ -34,7 +34,8 @@ import ai.chronon.online.fetcher.Fetcher.{
   ResponseWithContext
 }
 import ai.chronon.online.fetcher.FeaturesResponseType.ResponseType
-import ai.chronon.online.metrics.{Metrics, TTLCache}
+import ai.chronon.online.metrics.{Metrics, OtelTracing, TTLCache}
+import io.opentelemetry.api.common.{AttributeKey, Attributes}
 import ai.chronon.online.serde._
 import com.google.gson.Gson
 import org.apache.avro.generic.GenericRecord
@@ -193,7 +194,10 @@ class Fetcher(val kvStore: KVStore,
                  joinConfTtlMillis,
                  joinCodecTtlMillis)
 
-  implicit private val executionContext: ExecutionContext = fetchContext.getOrCreateExecutionContext
+  // Wrap the execution context so OTel Context (active span) is propagated to Future callbacks
+  // running on pool threads. Without this, child spans created in async callbacks would be orphaned.
+  implicit private val executionContext: ExecutionContext =
+    OtelTracing.instance.contextPropagatingEc(fetchContext.getOrCreateExecutionContext)
   val metadataStore: MetadataStore = new MetadataStore(fetchContext)
   private val joinPartFetcher = new JoinPartFetcher(fetchContext, metadataStore)
 
@@ -228,10 +232,26 @@ class Fetcher(val kvStore: KVStore,
   }
 
   def fetchGroupBys(requests: Seq[Request]): Future[Seq[Response]] = {
-    joinPartFetcher.fetchGroupBys(requests)
+    val attrs = Attributes.of(
+      AttributeKey.stringKey(Metrics.Tag.GroupBy), requests.iterator.map(_.name).distinct.mkString(","),
+      AttributeKey.longKey("request.count"), requests.size.toLong
+    )
+    OtelTracing.instance.withSpan("chronon.fetch.group_bys", attrs) {
+      joinPartFetcher.fetchGroupBys(requests)
+    }
   }
 
   def fetchJoin(requests: Seq[Request], joinConf: Option[api.Join] = None): Future[Seq[Response]] = {
+    val joinSpanAttrs = Attributes.of(
+      AttributeKey.stringKey(Metrics.Tag.Join), requests.iterator.map(_.name).distinct.mkString(","),
+      AttributeKey.longKey("request.count"), requests.size.toLong
+    )
+    OtelTracing.instance.withSpan("chronon.fetch.join", joinSpanAttrs) {
+      fetchJoinInternal(requests, joinConf)
+    }
+  }
+
+  private def fetchJoinInternal(requests: Seq[Request], joinConf: Option[api.Join]): Future[Seq[Response]] = {
     val ts = System.currentTimeMillis()
     val cachedJoinCodecsByName = mutable.Map.empty[String, Try[JoinCodec]]
     val joinCodecForName: String => Option[Try[JoinCodec]] = joinConf match {
@@ -639,7 +659,16 @@ class Fetcher(val kvStore: KVStore,
 
   // Pulling external features in a batched fashion across services in-parallel
   private def fetchExternal(joinRequests: Seq[Request]): Future[Seq[Response]] = {
+    val attrs = Attributes.of(
+      AttributeKey.stringKey(Metrics.Tag.Join), joinRequests.iterator.map(_.name).distinct.mkString(","),
+      AttributeKey.longKey("request.count"), joinRequests.size.toLong
+    )
+    OtelTracing.instance.withSpan("chronon.fetch.external", attrs) {
+      fetchExternalInternal(joinRequests)
+    }
+  }
 
+  private def fetchExternalInternal(joinRequests: Seq[Request]): Future[Seq[Response]] = {
     val startTime = System.currentTimeMillis()
     val resultMap = new mutable.LinkedHashMap[Request, Try[mutable.HashMap[String, Any]]]
     var invalidCount = 0

--- a/online/src/main/scala/ai/chronon/online/fetcher/Fetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/Fetcher.scala
@@ -35,7 +35,7 @@ import ai.chronon.online.fetcher.Fetcher.{
 }
 import ai.chronon.online.fetcher.FeaturesResponseType.ResponseType
 import ai.chronon.online.metrics.{Metrics, OtelTracing, TTLCache}
-import io.opentelemetry.api.common.{AttributeKey, Attributes}
+import io.opentelemetry.api.common.Attributes
 import ai.chronon.online.serde._
 import com.google.gson.Gson
 import org.apache.avro.generic.GenericRecord
@@ -232,20 +232,20 @@ class Fetcher(val kvStore: KVStore,
   }
 
   def fetchGroupBys(requests: Seq[Request]): Future[Seq[Response]] = {
-    val attrs = Attributes.of(
-      AttributeKey.stringKey(Metrics.Tag.GroupBy), requests.map(_.name).distinct.mkString(","),
-      AttributeKey.longKey("request.count"), requests.size.toLong
-    )
+    val attrs = Attributes.builder()
+      .put(Metrics.Tag.GroupBy, requests.map(_.name).distinct.mkString(","))
+      .put("request.count", requests.size.toLong)
+      .build()
     OtelTracing.instance.withSpan("chronon.fetch.group_bys", attrs) {
       joinPartFetcher.fetchGroupBys(requests)
     }
   }
 
   def fetchJoin(requests: Seq[Request], joinConf: Option[api.Join] = None): Future[Seq[Response]] = {
-    val joinSpanAttrs = Attributes.of(
-      AttributeKey.stringKey(Metrics.Tag.Join), requests.map(_.name).distinct.mkString(","),
-      AttributeKey.longKey("request.count"), requests.size.toLong
-    )
+    val joinSpanAttrs = Attributes.builder()
+      .put(Metrics.Tag.Join, requests.map(_.name).distinct.mkString(","))
+      .put("request.count", requests.size.toLong)
+      .build()
     OtelTracing.instance.withSpan("chronon.fetch.join", joinSpanAttrs) {
       fetchJoinInternal(requests, joinConf)
     }
@@ -659,10 +659,10 @@ class Fetcher(val kvStore: KVStore,
 
   // Pulling external features in a batched fashion across services in-parallel
   private def fetchExternal(joinRequests: Seq[Request]): Future[Seq[Response]] = {
-    val attrs = Attributes.of(
-      AttributeKey.stringKey(Metrics.Tag.Join), joinRequests.map(_.name).distinct.mkString(","),
-      AttributeKey.longKey("request.count"), joinRequests.size.toLong
-    )
+    val attrs = Attributes.builder()
+      .put(Metrics.Tag.Join, joinRequests.map(_.name).distinct.mkString(","))
+      .put("request.count", joinRequests.size.toLong)
+      .build()
     OtelTracing.instance.withSpan("chronon.fetch.external", attrs) {
       fetchExternalInternal(joinRequests)
     }

--- a/online/src/main/scala/ai/chronon/online/fetcher/Fetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/Fetcher.scala
@@ -233,7 +233,7 @@ class Fetcher(val kvStore: KVStore,
 
   def fetchGroupBys(requests: Seq[Request]): Future[Seq[Response]] = {
     val attrs = Attributes.of(
-      AttributeKey.stringKey(Metrics.Tag.GroupBy), requests.iterator.map(_.name).distinct.mkString(","),
+      AttributeKey.stringKey(Metrics.Tag.GroupBy), requests.map(_.name).distinct.mkString(","),
       AttributeKey.longKey("request.count"), requests.size.toLong
     )
     OtelTracing.instance.withSpan("chronon.fetch.group_bys", attrs) {
@@ -243,7 +243,7 @@ class Fetcher(val kvStore: KVStore,
 
   def fetchJoin(requests: Seq[Request], joinConf: Option[api.Join] = None): Future[Seq[Response]] = {
     val joinSpanAttrs = Attributes.of(
-      AttributeKey.stringKey(Metrics.Tag.Join), requests.iterator.map(_.name).distinct.mkString(","),
+      AttributeKey.stringKey(Metrics.Tag.Join), requests.map(_.name).distinct.mkString(","),
       AttributeKey.longKey("request.count"), requests.size.toLong
     )
     OtelTracing.instance.withSpan("chronon.fetch.join", joinSpanAttrs) {
@@ -660,7 +660,7 @@ class Fetcher(val kvStore: KVStore,
   // Pulling external features in a batched fashion across services in-parallel
   private def fetchExternal(joinRequests: Seq[Request]): Future[Seq[Response]] = {
     val attrs = Attributes.of(
-      AttributeKey.stringKey(Metrics.Tag.Join), joinRequests.iterator.map(_.name).distinct.mkString(","),
+      AttributeKey.stringKey(Metrics.Tag.Join), joinRequests.map(_.name).distinct.mkString(","),
       AttributeKey.longKey("request.count"), joinRequests.size.toLong
     )
     OtelTracing.instance.withSpan("chronon.fetch.external", attrs) {

--- a/online/src/main/scala/ai/chronon/online/fetcher/GroupByFetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/GroupByFetcher.scala
@@ -7,6 +7,8 @@ import ai.chronon.online.OnlineDerivationUtil.applyDeriveFunc
 import ai.chronon.online.fetcher.Fetcher.{ColumnSpec, PrefixedRequest, Request, Response}
 import ai.chronon.online.fetcher.FetcherCache.{BatchResponses, CachedBatchResponse}
 import ai.chronon.online._
+import ai.chronon.online.metrics.OtelTracing
+import io.opentelemetry.api.common.{AttributeKey, Attributes}
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -19,7 +21,8 @@ import scala.util.{Failure, Success, Try}
 class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
     extends GroupByResponseHandler(fetchContext, metadataStore) {
 
-  implicit val executionContext: ExecutionContext = fetchContext.getOrCreateExecutionContext
+  implicit val executionContext: ExecutionContext =
+    OtelTracing.instance.contextPropagatingEc(fetchContext.getOrCreateExecutionContext)
 
   @transient private implicit lazy val logger: Logger = LoggerFactory.getLogger(getClass)
 
@@ -179,7 +182,12 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
 
     val startTimeMs = System.currentTimeMillis()
     val kvResponseFuture: Future[Seq[GetResponse]] = if (allRequestsToFetch.nonEmpty) {
-      fetchContext.kvStore.multiGet(allRequestsToFetch)
+      OtelTracing.instance.withSpan(
+        "chronon.kv_store.multi_get",
+        Attributes.of(AttributeKey.longKey("request.count"), allRequestsToFetch.length.toLong)
+      ) {
+        fetchContext.kvStore.multiGet(allRequestsToFetch)
+      }
     } else {
       Future(Seq.empty[GetResponse])
     }

--- a/online/src/main/scala/ai/chronon/online/fetcher/GroupByFetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/GroupByFetcher.scala
@@ -8,7 +8,7 @@ import ai.chronon.online.fetcher.Fetcher.{ColumnSpec, PrefixedRequest, Request, 
 import ai.chronon.online.fetcher.FetcherCache.{BatchResponses, CachedBatchResponse}
 import ai.chronon.online._
 import ai.chronon.online.metrics.OtelTracing
-import io.opentelemetry.api.common.{AttributeKey, Attributes}
+import io.opentelemetry.api.common.Attributes
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -184,7 +184,7 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
     val kvResponseFuture: Future[Seq[GetResponse]] = if (allRequestsToFetch.nonEmpty) {
       OtelTracing.instance.withSpan(
         "chronon.kv_store.multi_get",
-        Attributes.of(AttributeKey.longKey("request.count"), allRequestsToFetch.length.toLong)
+        Attributes.builder().put("request.count", allRequestsToFetch.length.toLong).build()
       ) {
         fetchContext.kvStore.multiGet(allRequestsToFetch)
       }

--- a/online/src/main/scala/ai/chronon/online/metrics/Metrics.scala
+++ b/online/src/main/scala/ai/chronon/online/metrics/Metrics.scala
@@ -153,13 +153,20 @@ object Metrics {
 
       reporter.toLowerCase match {
         case "otel" | "opentelemetry" =>
-          if (metricsEnabled) {
+          // Build one OpenTelemetrySdk for both metrics and tracing so they share the same
+          // resource attributes, propagator config, and SDK lifecycle. When tracing is enabled
+          // OtelMetricsReporter.buildOpenTelemetryClient also attaches a SdkTracerProvider.
+          val openTelemetry = if (metricsEnabled) {
             val metricReader = OtelMetricsReporter.buildOtelMetricReader()
-            val openTelemetry = OtelMetricsReporter.buildOpenTelemetryClient(metricReader)
-            new OtelMetricsReporter(openTelemetry)
+            OtelMetricsReporter.buildOpenTelemetryClient(metricReader)
           } else {
-            new OtelMetricsReporter(OpenTelemetry.noop())
+            OpenTelemetry.noop()
           }
+          // Register the global tracing singleton from the same OpenTelemetry instance so
+          // fetcher code (and the Java service layer) can call OtelTracing.instance() without
+          // carrying an extra constructor parameter through the whole call chain.
+          OtelTracing.globalInstance = new OtelTracing(openTelemetry)
+          new OtelMetricsReporter(openTelemetry)
         case _ =>
           throw new IllegalArgumentException(s"Unknown metrics reporter: $reporter. Only opentelemetry is supported.")
       }

--- a/online/src/main/scala/ai/chronon/online/metrics/OtelMetricsReporter.scala
+++ b/online/src/main/scala/ai/chronon/online/metrics/OtelMetricsReporter.scala
@@ -13,6 +13,7 @@ import io.opentelemetry.sdk.OpenTelemetrySdk
 import io.opentelemetry.sdk.metrics.SdkMeterProvider
 import io.opentelemetry.sdk.metrics.export.{MetricReader, PeriodicMetricReader}
 import io.opentelemetry.sdk.resources.Resource
+import io.opentelemetry.sdk.trace.SdkTracerProvider
 
 import java.time.Duration
 import scala.collection.concurrent.TrieMap
@@ -181,10 +182,37 @@ object OtelMetricsReporter {
     // immediately.
     Runtime.getRuntime.addShutdownHook(shutdownFlushHook(meterProvider, ShutdownFlushTimeoutMillis))
 
-    OpenTelemetrySdk.builder
+    val sdkBuilder = OpenTelemetrySdk.builder
       .setMeterProvider(meterProvider)
       .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance))
-      .build
+
+    // Add a SdkTracerProvider to the same SDK when tracing is enabled — one SDK, two signal
+    // providers. This keeps the resource attributes and propagator config consistent between
+    // metrics and traces without instantiating a second OpenTelemetrySdk.
+    val finalBuilder = if (OtelTracing.isEnabled) {
+      val tracerProvider = OtelTracing.buildTracerProvider(resource)
+      Runtime.getRuntime.addShutdownHook(shutdownTracerHook(tracerProvider, ShutdownFlushTimeoutMillis))
+      sdkBuilder.setTracerProvider(tracerProvider)
+    } else {
+      sdkBuilder
+    }
+
+    finalBuilder.build
+  }
+
+  private[metrics] def shutdownTracerHook(provider: SdkTracerProvider, timeoutMillis: Long): Thread = {
+    val t = new Thread(new Runnable {
+      override def run(): Unit = {
+        try {
+          provider.forceFlush().join(timeoutMillis, java.util.concurrent.TimeUnit.MILLISECONDS)
+          provider.shutdown().join(timeoutMillis, java.util.concurrent.TimeUnit.MILLISECONDS)
+        } catch {
+          case _: Throwable => ()
+        }
+      }
+    })
+    t.setName("otel-tracer-flush-shutdown")
+    t
   }
 
   private[metrics] def shutdownFlushHook(provider: SdkMeterProvider, timeoutMillis: Long): Thread = {

--- a/online/src/main/scala/ai/chronon/online/metrics/OtelTracing.scala
+++ b/online/src/main/scala/ai/chronon/online/metrics/OtelTracing.scala
@@ -1,0 +1,135 @@
+package ai.chronon.online.metrics
+
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.trace.{Span, StatusCode, Tracer}
+import io.opentelemetry.context.{Context, Scope}
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter
+import io.opentelemetry.sdk.resources.Resource
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor
+import org.slf4j.LoggerFactory
+
+import java.util.concurrent.Executor
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+
+/** Thin wrapper around the OTel [[Tracer]] that provides Scala-friendly span helpers and
+  * handles async context propagation across [[Future]] thread hops.
+  *
+  * Obtain via [[OtelTracing.instance]] — do not construct directly in production code.
+  */
+class OtelTracing(val openTelemetry: OpenTelemetry) {
+
+  private val tracer: Tracer = openTelemetry
+    .tracerBuilder("ai.chronon")
+    .setInstrumentationVersion("0.0.0")
+    .build()
+
+  /** Wrap an [[ExecutionContext]] so every task submitted to it captures and restores the current
+    * OTel [[Context]]. Without this, Future callbacks running on a thread pool would lose the
+    * active span, breaking parent-child span relationships across async boundaries.
+    */
+  def contextPropagatingEc(ec: ExecutionContext): ExecutionContext = {
+    val wrappedExecutor: Executor = Context.taskWrapping(ec.execute _)
+    ExecutionContext.fromExecutor(wrappedExecutor)
+  }
+
+  /** Run a Future-producing block inside a named span. The span is ended (OK or ERROR) when the
+    * returned Future settles. The [[Scope]] is closed synchronously after `f()` returns, so child
+    * spans started synchronously inside `f` correctly inherit the parent — deeper async children
+    * rely on a context-propagating EC (see [[contextPropagatingEc]]).
+    */
+  def withSpan[T](spanName: String, attributes: Attributes = Attributes.empty())(
+      f: => Future[T])(implicit ec: ExecutionContext): Future[T] = {
+    val span: Span = tracer.spanBuilder(spanName).setAllAttributes(attributes).startSpan()
+    val scope: Scope = span.makeCurrent()
+    val fut =
+      try { f }
+      catch {
+        case t: Throwable =>
+          scope.close()
+          span.recordException(t)
+          span.setStatus(StatusCode.ERROR)
+          span.end()
+          return Future.failed(t)
+      }
+    scope.close()
+    fut.transform {
+      case s @ Success(_) =>
+        span.setStatus(StatusCode.OK)
+        span.end()
+        s
+      case f @ Failure(t) =>
+        span.recordException(t)
+        span.setStatus(StatusCode.ERROR)
+        span.end()
+        f
+    }
+  }
+
+  /** Synchronous span helper — starts a span, runs `f`, then ends the span. */
+  def withSpanSync[T](spanName: String, attributes: Attributes = Attributes.empty())(f: => T): T = {
+    val span: Span = tracer.spanBuilder(spanName).setAllAttributes(attributes).startSpan()
+    val scope: Scope = span.makeCurrent()
+    try {
+      val result = f
+      span.setStatus(StatusCode.OK)
+      result
+    } catch {
+      case t: Throwable =>
+        span.recordException(t)
+        span.setStatus(StatusCode.ERROR)
+        throw t
+    } finally {
+      scope.close()
+      span.end()
+    }
+  }
+}
+
+object OtelTracing {
+
+  private val logger = LoggerFactory.getLogger(classOf[OtelTracing])
+
+  // ---- Config keys (mirror the ai.chronon.metrics.* pattern) ----
+  val TracingEnabled = "ai.chronon.tracing.enabled"
+  val TracingExporterUrlKey = "ai.chronon.tracing.exporter.url"
+  val TracingExporterProtocolKey = "ai.chronon.tracing.exporter.protocol"
+
+  // Module-level singleton — initialised during Metrics.Context init so it shares the same
+  // OpenTelemetry SDK instance as the metrics reporter. Defaults to noop so callers are safe
+  // before Metrics is first accessed.
+  @volatile private[metrics] var globalInstance: OtelTracing = new OtelTracing(OpenTelemetry.noop())
+
+  /** Returns the active [[OtelTracing]] singleton.
+    * Also accessible from Java as the static method OtelTracing.instance().
+    */
+  def instance: OtelTracing = globalInstance
+
+  def isEnabled: Boolean = System.getProperty(TracingEnabled, "false").toBoolean
+
+  /** Build a [[SdkTracerProvider]] using config aligned with the metrics exporter config.
+    * Called from [[OtelMetricsReporter.buildOpenTelemetryClient]] so both signal providers
+    * share the same [[Resource]] and [[io.opentelemetry.sdk.OpenTelemetrySdk]] instance.
+    */
+  def buildTracerProvider(resource: Resource): SdkTracerProvider = {
+    val protocol = System.getProperty(TracingExporterProtocolKey, "http").toLowerCase
+    val exporterUrl = System.getProperty(TracingExporterUrlKey, OtelMetricsReporter.MetricsExporterUrlDefault)
+
+    val spanExporter = protocol match {
+      case "grpc" =>
+        OtlpGrpcSpanExporter.builder().setEndpoint(exporterUrl).build()
+      case _ =>
+        OtlpHttpSpanExporter.builder().setEndpoint(s"$exporterUrl/v1/traces").build()
+    }
+
+    logger.info(s"Building OTel tracer provider: protocol=$protocol, url=$exporterUrl")
+
+    SdkTracerProvider.builder()
+      .setResource(resource)
+      .addSpanProcessor(BatchSpanProcessor.builder(spanExporter).build())
+      .build()
+  }
+}

--- a/online/src/main/scala/ai/chronon/online/metrics/OtelTracing.scala
+++ b/online/src/main/scala/ai/chronon/online/metrics/OtelTracing.scala
@@ -32,8 +32,12 @@ class OtelTracing(val openTelemetry: OpenTelemetry) {
     * active span, breaking parent-child span relationships across async boundaries.
     */
   def contextPropagatingEc(ec: ExecutionContext): ExecutionContext = {
-    val wrappedExecutor: Executor = Context.taskWrapping(ec.execute _)
-    ExecutionContext.fromExecutor(wrappedExecutor)
+    // Wrap as explicit Executor — Scala 2.12 SAM conversion doesn't apply to eta-expanded
+    // `ec.execute _` (type Runnable => Unit) when the target type is java.util.concurrent.Executor.
+    val asExecutor: Executor = new Executor {
+      override def execute(command: Runnable): Unit = ec.execute(command)
+    }
+    ExecutionContext.fromExecutor(Context.taskWrapping(asExecutor))
   }
 
   /** Run a Future-producing block inside a named span. The span is ended (OK or ERROR) when the

--- a/online/src/main/scala/ai/chronon/online/metrics/OtelTracing.scala
+++ b/online/src/main/scala/ai/chronon/online/metrics/OtelTracing.scala
@@ -45,8 +45,8 @@ class OtelTracing(val openTelemetry: OpenTelemetry) {
     * spans started synchronously inside `f` correctly inherit the parent — deeper async children
     * rely on a context-propagating EC (see [[contextPropagatingEc]]).
     */
-  def withSpan[T](spanName: String, attributes: Attributes = Attributes.empty())(
-      f: => Future[T])(implicit ec: ExecutionContext): Future[T] = {
+  def withSpan[T](spanName: String, attributes: Attributes = Attributes.empty())(f: => Future[T])(implicit
+      ec: ExecutionContext): Future[T] = {
     val span: Span = tracer.spanBuilder(spanName).setAllAttributes(attributes).startSpan()
     val scope: Scope = span.makeCurrent()
     val fut =
@@ -131,7 +131,8 @@ object OtelTracing {
 
     logger.info(s"Building OTel tracer provider: protocol=$protocol, url=$exporterUrl")
 
-    SdkTracerProvider.builder()
+    SdkTracerProvider
+      .builder()
       .setResource(resource)
       .addSpanProcessor(BatchSpanProcessor.builder(spanExporter).build())
       .build()

--- a/service/src/main/java/ai/chronon/service/handlers/FetchHandler.java
+++ b/service/src/main/java/ai/chronon/service/handlers/FetchHandler.java
@@ -93,7 +93,6 @@ public class FetchHandler implements Handler<RoutingContext> {
                 .setParent(parentContext)
                 .setSpanKind(SpanKind.SERVER)
                 .setAttribute(AttributeKey.stringKey("chronon.entity.name"), entityName)
-                .setAttribute(AttributeKey.stringKey("http.method"), ctx.request().method().name())
                 .startSpan();
         Scope scope = span.makeCurrent();
 

--- a/service/src/main/java/ai/chronon/service/handlers/FetchHandler.java
+++ b/service/src/main/java/ai/chronon/service/handlers/FetchHandler.java
@@ -4,17 +4,27 @@ import ai.chronon.online.JTry;
 import ai.chronon.online.JavaFetcher;
 import ai.chronon.online.JavaRequest;
 import ai.chronon.online.JavaResponse;
+import ai.chronon.online.metrics.OtelTracing;
 import ai.chronon.service.model.GetFeaturesResponse;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.context.propagation.TextMapGetter;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RequestBody;
 import io.vertx.ext.web.RoutingContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -42,6 +52,20 @@ public class FetchHandler implements Handler<RoutingContext> {
     private static final Logger logger = LoggerFactory.getLogger(FetchHandler.class);
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
+    // W3C TraceContext header extractor for Vert.x routing contexts.
+    private static final TextMapGetter<RoutingContext> TRACE_CONTEXT_GETTER =
+            new TextMapGetter<RoutingContext>() {
+                @Override
+                public Iterable<String> keys(RoutingContext carrier) {
+                    return carrier.request().headers().names();
+                }
+                @Nullable
+                @Override
+                public String get(@Nullable RoutingContext carrier, String key) {
+                    return carrier == null ? null : carrier.request().headers().get(key);
+                }
+            };
+
     private final JavaFetcher fetcher;
     private final BiFunction<JavaFetcher, List<JavaRequest>, CompletableFuture<List<JavaResponse>>> fetchFunction;
 
@@ -57,12 +81,34 @@ public class FetchHandler implements Handler<RoutingContext> {
 
         logger.debug("Retrieving {}", entityName);
 
+        // Extract incoming W3C trace context so distributed traces stitch correctly across
+        // service boundaries. If no traceparent header is present this produces a root context.
+        OtelTracing otelTracing = OtelTracing.instance();
+        Context parentContext = otelTracing.openTelemetry()
+                .getPropagators()
+                .getTextMapPropagator()
+                .extract(Context.current(), ctx, TRACE_CONTEXT_GETTER);
+
+        Span span = otelTracing.openTelemetry()
+                .getTracer("ai.chronon")
+                .spanBuilder("http.fetch")
+                .setParent(parentContext)
+                .setSpanKind(SpanKind.SERVER)
+                .setAttribute(AttributeKey.stringKey("chronon.entity.name"), entityName)
+                .setAttribute(AttributeKey.stringKey("http.method"), ctx.request().method().name())
+                .startSpan();
+        Scope scope = span.makeCurrent();
+
         String requestBody = ctx.body().asString();
         JTry<List<JavaRequest>> maybeRequest = parseJavaRequest(entityName, requestBody);
 
         if (! maybeRequest.isSuccess()) {
 
             logger.error("Unable to parse request body", maybeRequest.getException());
+            scope.close();
+            span.recordException(maybeRequest.getException());
+            span.setStatus(StatusCode.ERROR);
+            span.end();
 
             List<String> errorMessages = Collections.singletonList(maybeRequest.getException().getMessage());
 
@@ -87,6 +133,10 @@ public class FetchHandler implements Handler<RoutingContext> {
 
         maybeFeatureResponses.onSuccess(
                 resultList -> {
+                    scope.close();
+                    span.setStatus(StatusCode.OK);
+                    span.end();
+
                     // as this is a bulkGet request, we might have some successful and some failed responses
                     // we return the responses in the same order as they come in and mark them as successful / failed based
                     // on the lookups
@@ -101,6 +151,10 @@ public class FetchHandler implements Handler<RoutingContext> {
 
         maybeFeatureResponses.onFailure(
                 err -> {
+                    scope.close();
+                    span.recordException(err);
+                    span.setStatus(StatusCode.ERROR);
+                    span.end();
 
                     List<String> failureMessages = Collections.singletonList(err.getMessage());
 

--- a/service/src/main/java/ai/chronon/service/handlers/FetchHandler.java
+++ b/service/src/main/java/ai/chronon/service/handlers/FetchHandler.java
@@ -24,7 +24,6 @@ import io.vertx.ext.web.RoutingContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -59,9 +58,8 @@ public class FetchHandler implements Handler<RoutingContext> {
                 public Iterable<String> keys(RoutingContext carrier) {
                     return carrier.request().headers().names();
                 }
-                @Nullable
                 @Override
-                public String get(@Nullable RoutingContext carrier, String key) {
+                public String get(RoutingContext carrier, String key) {
                     return carrier == null ? null : carrier.request().headers().get(key);
                 }
             };

--- a/service/src/main/java/ai/chronon/service/handlers/FetchHandlerV2.java
+++ b/service/src/main/java/ai/chronon/service/handlers/FetchHandlerV2.java
@@ -5,9 +5,17 @@ import ai.chronon.online.JavaFetcher;
 import ai.chronon.online.JavaRequest;
 import ai.chronon.online.JavaResponse;
 import ai.chronon.online.fetcher.FeaturesResponseType;
+import ai.chronon.online.metrics.OtelTracing;
 import ai.chronon.service.model.GetFeaturesResponse;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.context.propagation.TextMapGetter;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
@@ -16,6 +24,7 @@ import io.vertx.ext.web.RoutingContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -29,6 +38,20 @@ import static ai.chronon.service.model.GetFeaturesResponse.Result.Status.Success
 public class FetchHandlerV2 implements Handler<RoutingContext> {
     private static final Logger logger = LoggerFactory.getLogger(FetchHandlerV2.class);
     private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    // W3C TraceContext header extractor for Vert.x routing contexts.
+    private static final TextMapGetter<RoutingContext> TRACE_CONTEXT_GETTER =
+            new TextMapGetter<RoutingContext>() {
+                @Override
+                public Iterable<String> keys(RoutingContext carrier) {
+                    return carrier.request().headers().names();
+                }
+                @Nullable
+                @Override
+                public String get(@Nullable RoutingContext carrier, String key) {
+                    return carrier == null ? null : carrier.request().headers().get(key);
+                }
+            };
 
     private final JavaFetcher fetcher;
     private final BiFunction<JavaFetcher, List<JavaRequest>, CompletableFuture<List<JavaResponse>>> fetchFunction;
@@ -50,11 +73,33 @@ public class FetchHandlerV2 implements Handler<RoutingContext> {
 
         logger.debug("Retrieving {}", entityName);
 
+        // Extract incoming W3C trace context so distributed traces stitch correctly across
+        // service boundaries. If no traceparent header is present this produces a root context.
+        OtelTracing otelTracing = OtelTracing.instance();
+        Context parentContext = otelTracing.openTelemetry()
+                .getPropagators()
+                .getTextMapPropagator()
+                .extract(Context.current(), ctx, TRACE_CONTEXT_GETTER);
+
+        Span span = otelTracing.openTelemetry()
+                .getTracer("ai.chronon")
+                .spanBuilder("http.fetch")
+                .setParent(parentContext)
+                .setSpanKind(SpanKind.SERVER)
+                .setAttribute(AttributeKey.stringKey("chronon.entity.name"), entityName)
+                .setAttribute(AttributeKey.stringKey("http.method"), ctx.request().method().name())
+                .startSpan();
+        Scope scope = span.makeCurrent();
+
         JTry<List<JavaRequest>> maybeRequest = parseJavaRequest(entityName, ctx.body());
 
         if (! maybeRequest.isSuccess()) {
 
             logger.error("Unable to parse request body", maybeRequest.getException());
+            scope.close();
+            span.recordException(maybeRequest.getException());
+            span.setStatus(StatusCode.ERROR);
+            span.end();
 
             List<String> errorMessages = Collections.singletonList(maybeRequest.getException().getMessage());
 
@@ -77,10 +122,19 @@ public class FetchHandlerV2 implements Handler<RoutingContext> {
                                         .map(FetchHandlerV2::responseToPoJo)
                                         .collect(Collectors.toList()));
 
-        maybeFeatureResponses.onSuccess(resultList -> onSuccessFunction.apply(resultList, ctx));
+        maybeFeatureResponses.onSuccess(resultList -> {
+            scope.close();
+            span.setStatus(StatusCode.OK);
+            span.end();
+            onSuccessFunction.apply(resultList, ctx);
+        });
 
         maybeFeatureResponses.onFailure(
                 err -> {
+                    scope.close();
+                    span.recordException(err);
+                    span.setStatus(StatusCode.ERROR);
+                    span.end();
 
                     List<String> failureMessages = Collections.singletonList(err.getMessage());
 

--- a/service/src/main/java/ai/chronon/service/handlers/FetchHandlerV2.java
+++ b/service/src/main/java/ai/chronon/service/handlers/FetchHandlerV2.java
@@ -24,7 +24,6 @@ import io.vertx.ext.web.RoutingContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -46,9 +45,8 @@ public class FetchHandlerV2 implements Handler<RoutingContext> {
                 public Iterable<String> keys(RoutingContext carrier) {
                     return carrier.request().headers().names();
                 }
-                @Nullable
                 @Override
-                public String get(@Nullable RoutingContext carrier, String key) {
+                public String get(RoutingContext carrier, String key) {
                     return carrier == null ? null : carrier.request().headers().get(key);
                 }
             };

--- a/service/src/main/java/ai/chronon/service/handlers/FetchHandlerV2.java
+++ b/service/src/main/java/ai/chronon/service/handlers/FetchHandlerV2.java
@@ -85,7 +85,6 @@ public class FetchHandlerV2 implements Handler<RoutingContext> {
                 .setParent(parentContext)
                 .setSpanKind(SpanKind.SERVER)
                 .setAttribute(AttributeKey.stringKey("chronon.entity.name"), entityName)
-                .setAttribute(AttributeKey.stringKey("http.method"), ctx.request().method().name())
                 .startSpan();
         Scope scope = span.makeCurrent();
 


### PR DESCRIPTION
## Summary
Adding support for open telemetry tracing in the Fetcher service

To enable tracing, set these JVM properties when starting the service:
-Dai.chronon.tracing.enabled=true
-Dai.chronon.tracing.exporter.url=http://your-otel-collector:4318
-Dai.chronon.tracing.exporter.protocol=http   # or grpc

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end OpenTelemetry tracing across fetch flows: group-by, join, external fetches, and KV multi-get operations.
  * Async work now propagates active trace context so spans continue across thread hops.
  * Fetch operations create descriptive spans with request-count and join/group attributes for better observability.
  * HTTP fetch endpoints instrumented with server spans, attribute tagging, error recording, and proper span lifecycle handling.
  * Metrics and tracing now share a unified OpenTelemetry lifecycle with best-effort tracer shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->