### PR TITLE
add a warning if the max ts from a sensor is after now()

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/catalog/DeltaLake.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/DeltaLake.scala
@@ -15,6 +15,7 @@ import org.apache.spark.sql.functions.{
   max,
   to_date,
   to_timestamp,
+  unix_timestamp,
   when
 }
 import org.apache.spark.sql.types.{DataType, DateType, MapType, StringType, StructField, StructType, TimestampType}
@@ -112,7 +113,10 @@ case object DeltaLake extends Format {
           count(lit(1)).as("fileCount"),
           count(when(col("min_value").isNull || col("max_value").isNull, lit(1))).as("missingCount"),
           date_format(min(statsBoundary("min_value", columnType, partitionSpec)), partitionSpec.format).as("start"),
-          date_format(max(statsBoundary("max_value", columnType, partitionSpec)), partitionSpec.format).as("end")
+          date_format(max(statsBoundary("max_value", columnType, partitionSpec)), partitionSpec.format).as("end"),
+          (unix_timestamp(max(statsBoundary("max_value", columnType, partitionSpec)).cast("timestamp")) * 1000)
+            .cast("long")
+            .as("maxTimestampMillis")
         )
         .collect()
         .headOption
@@ -124,6 +128,10 @@ case object DeltaLake extends Format {
         val end = row.getAs[String]("end")
 
         if (fileCount > 0 && missingCount == 0 && start != null && end != null) {
+          val maxTimestampMillisIdx = row.fieldIndex("maxTimestampMillis")
+          if (!row.isNullAt(maxTimestampMillisIdx)) {
+            warnIfMaxTimestampMillisIsFuture(tableName, columnName, row.getLong(maxTimestampMillisIdx))
+          }
           Some(StatsDateRange(start = start, end = end))
         } else {
           None

--- a/spark/src/main/scala/ai/chronon/spark/catalog/Format.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/Format.scala
@@ -5,10 +5,11 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException
 import org.apache.spark.sql.catalyst.util.QuotingUtils
 import org.apache.spark.sql.connector.catalog.Identifier
-import org.apache.spark.sql.functions.{col, date_format, date_sub, min, max}
+import org.apache.spark.sql.functions.{col, date_format, date_sub, min, max, unix_timestamp}
 import org.apache.spark.sql.types.{DateType, StringType, StructType}
 import org.slf4j.{Logger, LoggerFactory}
 
+import java.time.Instant
 import scala.util.{Failure, Success, Try}
 
 trait Format {
@@ -140,6 +141,15 @@ trait Format {
       sparkSession: SparkSession): Option[String] =
     metadataPartitions(tableName, partitionColumn).flatMap(Format.pickMaxPartition)
 
+  protected def warnIfMaxTimestampMillisIsFuture(tableName: String, timestampColumn: String, maxMillis: Long): Unit = {
+    val nowMillis = System.currentTimeMillis()
+    if (maxMillis > nowMillis) {
+      logger.warn(
+        s"Max timestamp for time-partitioned table $tableName column $timestampColumn is ${Instant.ofEpochMilli(maxMillis)}, " +
+          s"which is after current time ${Instant.ofEpochMilli(nowMillis)}. The table data is likely in a bad state; continuing without failing.")
+    }
+  }
+
   protected def scanLastAvailablePartition(tableName: String, partitionColumn: String, partitionSpec: PartitionSpec)(
       implicit sparkSession: SparkSession): Option[String] = {
     import sparkSession.implicits._
@@ -154,12 +164,20 @@ trait Format {
             .headOption
             .flatMap(v => Option(v))
         case _ =>
-          df.select(date_format(date_sub(max(col(partitionColumn)).cast(DateType), 1), partitionSpec.format)
-            .as("last_partition"))
-            .as[String]
-            .collect()
+          df.select(
+            (unix_timestamp(max(col(partitionColumn)).cast("timestamp")) * 1000)
+              .cast("long")
+              .as("max_timestamp_millis"),
+            date_format(date_sub(max(col(partitionColumn)).cast(DateType), 1), partitionSpec.format)
+              .as("last_partition")
+          ).collect()
             .headOption
-            .flatMap(v => Option(v))
+            .flatMap { row =>
+              if (!row.isNullAt(0)) {
+                warnIfMaxTimestampMillisIsFuture(tableName, partitionColumn, row.getLong(0))
+              }
+              if (row.isNullAt(1)) None else Option(row.getString(1))
+            }
       }
     } match {
       case Success(result) => result
@@ -224,14 +242,21 @@ trait Format {
   @deprecated("Use lastAvailablePartition instead", "0.1.0")
   def maxTimestampDate(tableName: String, timestampColumn: String, partitionSpec: PartitionSpec)(implicit
       sparkSession: SparkSession): Option[String] = {
-    import sparkSession.implicits._
     Try {
       val df = sparkSession.read.table(tableName)
-      df.select(date_format(max(col(timestampColumn)).cast(DateType), partitionSpec.format).as("max_date"))
-        .as[String]
-        .collect()
+      df.select(
+        (unix_timestamp(max(col(timestampColumn)).cast("timestamp")) * 1000)
+          .cast("long")
+          .as("max_timestamp_millis"),
+        date_format(max(col(timestampColumn)).cast(DateType), partitionSpec.format).as("max_date")
+      ).collect()
         .headOption
-        .flatMap(v => Option(v))
+        .flatMap { row =>
+          if (!row.isNullAt(0)) {
+            warnIfMaxTimestampMillisIsFuture(tableName, timestampColumn, row.getLong(0))
+          }
+          if (row.isNullAt(1)) None else Option(row.getString(1))
+        }
     } match {
       case Success(result) => result
       case Failure(e) =>

--- a/spark/src/main/scala/ai/chronon/spark/catalog/Iceberg.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/Iceberg.scala
@@ -126,7 +126,7 @@ case object Iceberg extends Format {
       val fieldType = field.`type`()
       val extractor = new IcebergPartitionStatsExtractor(sparkSession)
 
-      currentDataFilesDateRange(table, fieldId, fieldType, partitionSpec, extractor)
+      currentDataFilesDateRange(table, tableName, columnName, fieldId, fieldType, partitionSpec, extractor)
     } match {
       case Success(result) =>
         if (result.isDefined) {
@@ -176,6 +176,8 @@ case object Iceberg extends Format {
     }
 
   private def currentDataFilesDateRange(table: org.apache.iceberg.Table,
+                                        tableName: String,
+                                        columnName: String,
                                         fieldId: java.lang.Integer,
                                         fieldType: org.apache.iceberg.types.Type,
                                         partitionSpec: PartitionSpec,
@@ -195,6 +197,7 @@ case object Iceberg extends Format {
         }
 
         range.flatten.map { case (minMillis, maxMillis) =>
+          warnIfMaxTimestampMillisIsFuture(tableName, columnName, maxMillis)
           StatsDateRange(
             start = partitionSpec.at(minMillis),
             end = partitionSpec.at(maxMillis)

--- a/spark/src/test/scala/ai/chronon/spark/other/TableUtilsTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/other/TableUtilsTest.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.{Row, _}
 import org.junit.Assert.{assertEquals, assertFalse, assertNull, assertTrue}
 import org.scalatest.flatspec.AnyFlatSpec
 
+import scala.jdk.CollectionConverters._
 import scala.util.Try
 
 case class TestRecord(ds: String, id: String)
@@ -669,6 +670,45 @@ class TableUtilsTest extends AnyFlatSpec {
 
     spark.sql(s"DROP TABLE IF EXISTS $tableName")
     spark.sql(s"DROP DATABASE IF EXISTS $dbName")
+  }
+
+  it should "warn without failing when time-partitioned max timestamp is in the future" in {
+    val dbName = s"db_${System.nanoTime()}"
+    val tableName = s"$dbName.future_time_partitioned"
+    spark.sql(s"CREATE DATABASE IF NOT EXISTS $dbName")
+    spark.sql(s"CREATE TABLE $tableName (user_id STRING, created_at TIMESTAMP)")
+    spark.sql(
+      s"""INSERT INTO $tableName VALUES
+         |('user1', TIMESTAMP '2999-01-02 12:00:00')
+         |""".stripMargin)
+
+    val underlying = org.slf4j.LoggerFactory
+      .getLogger(Hive.getClass.getName)
+      .asInstanceOf[ch.qos.logback.classic.Logger]
+    val appender = new ch.qos.logback.core.read.ListAppender[ch.qos.logback.classic.spi.ILoggingEvent]()
+    appender.start()
+    underlying.addAppender(appender)
+    try {
+      val lastPartition = tableUtils.lastAvailablePartition(
+        tableName,
+        tablePartitionSpec = Some(PartitionSpec("created_at", "yyyy-MM-dd", 24 * 60 * 60 * 1000))
+      )
+
+      assertEquals(Some("2999-01-01"), lastPartition)
+      val messages = appender.list.asScala.map(_.getFormattedMessage)
+      assertTrue(
+        s"Expected future max timestamp warning, got: $messages",
+        messages.exists(message =>
+          message.contains(s"Max timestamp for time-partitioned table $tableName column created_at") &&
+            message.contains("likely in a bad state") &&
+            message.contains("continuing without failing"))
+      )
+    } finally {
+      underlying.detachAppender(appender)
+      appender.stop()
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+      spark.sql(s"DROP DATABASE IF EXISTS $dbName")
+    }
   }
 
   it should "return empty list for virtual partitions on empty table" in {


### PR DESCRIPTION
## Summary

Came across this instance where the timestamps being produced were invalid (pointed to future times), but we were sensing over the column that contained those future timestamps. This causes each sensor to always immediately trigger a job run before the data actually lands, marking the partitions as complete in the orchestrator and then causing downstream jobs to fail. 

Adding a small warning to help people in the future where if the ts found is > now(), we add a warning (but not fail). 

## Checklist
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection and warnings for maximum timestamps in table partitions that are in the future, improving data quality monitoring.

* **Tests**
  * Added test coverage for future timestamp detection in partition data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->