### PR TITLE
[draft] Add BT bulkLoad tests

### DIFF
--- a/cloud_gcp/package.mill
+++ b/cloud_gcp/package.mill
@@ -78,6 +78,7 @@ trait CloudGcpModule extends Cross.Module[String] with build.BaseModule {
 
   def compileMvnDeps = build.Constants.sparkDeps ++ Seq(
     mvn"com.google.cloud.spark:spark-3.5-bigquery:0.42.0",
+    mvn"com.google.cloud.spark.bigtable:spark-bigtable_2.12:0.9.1",
   )
 
 //  val googleBigdataVersion = "2.2.26"

--- a/cloud_gcp/src/main/scala/ai/chronon/integrations/cloud_gcp/BigTableKVStoreImpl.scala
+++ b/cloud_gcp/src/main/scala/ai/chronon/integrations/cloud_gcp/BigTableKVStoreImpl.scala
@@ -497,8 +497,8 @@ class BigTableKVStoreImpl(dataClient: BigtableDataClient,
       throw new RuntimeException("BigQuery client is needed to export data to BigTable")
     }
 
-    // we write groupby data to 1 large multi use-case table
-    val batchTable = "GROUPBY_BATCH"
+    // we write groupby data to 1 large multi use-case table; overridable for testing
+    val batchTable = conf.getOrElse("BT_BATCH_TABLE_OVERRIDE", "GROUPBY_BATCH")
 
     // we use the endDs + span to indicate the timestamp of all the cell data we upload for endDs
     // this is used in the KV store multiget calls
@@ -544,8 +544,14 @@ class BigTableKVStoreImpl(dataClient: BigtableDataClient,
 
       val startTs = System.currentTimeMillis()
       // we append the timestamp to the jobID as BigQuery doesn't allow us to re-run the same job
+      // Location must match the reservation region; defaults to us-central1 where the BQ→BT reservation lives.
+      val bqLocation = conf.getOrElse("GCP_LOCATION", "us-central1")
       val jobId =
-        JobId.of(adminClient.getProjectId, s"export_${sourceOfflineTable.sanitize}_to_bigtable_${partition}_$startTs")
+        JobId.newBuilder()
+          .setProject(adminClient.getProjectId)
+          .setLocation(bqLocation)
+          .setJob(s"export_${sourceOfflineTable.sanitize}_to_bigtable_${partition}_$startTs")
+          .build()
       val job: Job = bigQueryClient.create(JobInfo.newBuilder(queryConfig).setJobId(jobId).build())
       logger.info(s"Export job started with Id: $jobId and link: ${job.getSelfLink}")
       val retryConfig =

--- a/cloud_gcp/src/main/scala/ai/chronon/integrations/cloud_gcp/BigTableKVStoreImpl.scala
+++ b/cloud_gcp/src/main/scala/ai/chronon/integrations/cloud_gcp/BigTableKVStoreImpl.scala
@@ -547,7 +547,8 @@ class BigTableKVStoreImpl(dataClient: BigtableDataClient,
       // Location must match the reservation region; defaults to us-central1 where the BQ→BT reservation lives.
       val bqLocation = conf.getOrElse("GCP_LOCATION", "us-central1")
       val jobId =
-        JobId.newBuilder()
+        JobId
+          .newBuilder()
           .setProject(adminClient.getProjectId)
           .setLocation(bqLocation)
           .setJob(s"export_${sourceOfflineTable.sanitize}_to_bigtable_${partition}_$startTs")

--- a/cloud_gcp/src/main/scala/ai/chronon/integrations/cloud_gcp/Spark2BigTableLoader.scala
+++ b/cloud_gcp/src/main/scala/ai/chronon/integrations/cloud_gcp/Spark2BigTableLoader.scala
@@ -7,6 +7,7 @@ import ai.chronon.integrations.cloud_gcp.BigTableKVStore.ColumnFamilyQualifierSt
 import ai.chronon.integrations.cloud_gcp.BigTableKVStore.ColumnFamilyString
 import ai.chronon.spark.catalog.TableUtils
 import ai.chronon.spark.submission.SparkSessionBuilder
+import com.google.cloud.spark.bigquery.v2.Spark35BigQueryTableProvider
 import org.apache.spark.sql.functions
 import org.apache.spark.sql.functions.udf
 import org.rogach.scallop.ScallopConf
@@ -96,14 +97,24 @@ object Spark2BigTableLoader {
       BigTableKVStore.buildRowKey(keyBytes, dataset)
     })
 
-    val dataDf =
-      tableUtils.sql(s"""SELECT key_bytes, value_bytes, '$datasetName' as dataset
-         |FROM $tableName
-         |$partitionFilter""".stripMargin)
+    // Use the BQ Spark connector to read the table directly — Spark SQL cannot resolve
+    // fully-qualified BQ table names (project.dataset.table) without the connector catalog.
+    val bqFormat = classOf[Spark35BigQueryTableProvider].getName
+    val rawDf = spark.read
+      .format(bqFormat)
+      .option("filter", s"ds = '$endDate'")
+      .load(tableName)
+
+    val dataDf = rawDf
+      .select(
+        functions.col("key_bytes"),
+        functions.col("value_bytes"),
+        functions.lit(datasetName).as("dataset")
+      )
     val finalDataDf =
       dataDf
         .withColumn("data_rowkey", buildRowKeyUDF(functions.col("key_bytes"), functions.col("dataset")))
-        .drop("key_bytes", "dataset", "ts") // BT connector seems to not handle extra columns well
+        .drop("key_bytes", "dataset") // BT connector seems to not handle extra columns well
 
     finalDataDf.write
       .format("bigtable")

--- a/cloud_gcp/src/test/scala/ai/chronon/integrations/cloud_gcp/bt_load/BQDataGenerator.scala
+++ b/cloud_gcp/src/test/scala/ai/chronon/integrations/cloud_gcp/bt_load/BQDataGenerator.scala
@@ -1,0 +1,86 @@
+package ai.chronon.integrations.cloud_gcp.bt_load
+
+import com.google.cloud.bigquery.{BigQuery, DatasetId, DatasetInfo, JobId, JobInfo, QueryJobConfiguration, TableId}
+import org.slf4j.{Logger, LoggerFactory}
+
+/** Synthesizes a BigQuery source table with the schema expected by bulkPutFromBigQuery:
+  *   key_bytes  BYTES  (~32-64 bytes, two concatenated MD5 hashes of the row index)
+  *   value_bytes BYTES (~2KB, padded to exactly 2048 bytes)
+  *   ds         STRING (the partition label passed to bulkPut)
+  *
+  * Generation runs entirely inside BigQuery — no local data movement.
+  */
+object BQDataGenerator {
+
+  private val logger: Logger = LoggerFactory.getLogger(getClass)
+
+  def run(
+      bigQueryClient: BigQuery,
+      project: String,
+      bqDataset: String,
+      bqTable: String,
+      numRows: Long,
+      partition: String
+  ): Unit = {
+    val fqTable = s"`$project.$bqDataset.$bqTable`"
+    logger.info(s"Generating $numRows rows into $fqTable (ds='$partition')")
+
+    // Create the dataset if it doesn't already exist; swallow ALREADY_EXISTS races.
+    try {
+      bigQueryClient.create(DatasetInfo.newBuilder(DatasetId.of(project, bqDataset)).build())
+      logger.info(s"BQ dataset $project:$bqDataset created")
+    } catch {
+      case e: com.google.cloud.bigquery.BigQueryException if e.getCode == 409 =>
+        logger.info(s"BQ dataset $project:$bqDataset already exists")
+    }
+
+    // Two MD5 hashes concatenated → 32 bytes per key (well within 30-50B target).
+    // Value is padded to exactly 2048 bytes using b'\x00'.
+    // GENERATE_ARRAY is limited to ~10M elements per call; for larger counts we use
+    // a cross-join of two arrays (rows = a_size * b_size) where each factor ≤ ceiling(sqrt(numRows)).
+    val (aSize, bSize) = splitRowCount(numRows)
+    // The bulkPut export SQL only reads key_bytes, value_bytes, and filters WHERE ds = '$partition'.
+    // No partitioning is needed on this staging table.
+    val sql =
+      s"""CREATE OR REPLACE TABLE $fqTable
+         |AS
+         |SELECT
+         |  CONCAT(
+         |    MD5(CAST(a AS STRING)),
+         |    MD5(CAST(a * 7 + b AS STRING))
+         |  ) AS key_bytes,
+         |  RPAD(MD5(CAST(a + b AS STRING)), 2048, b'\\x00') AS value_bytes,
+         |  '$partition' AS ds
+         |FROM
+         |  UNNEST(GENERATE_ARRAY(0, ${aSize - 1})) AS a,
+         |  UNNEST(GENERATE_ARRAY(0, ${bSize - 1})) AS b
+         |WHERE a * $bSize + b < $numRows
+         |""".stripMargin
+
+    logger.info(s"Running BQ CREATE TABLE AS:\n$sql")
+    val jobConfig = QueryJobConfiguration.newBuilder(sql).setUseLegacySql(false).build()
+    val jobId = JobId.of(project, s"bt_load_gen_${partition.replace("-", "")}_${System.currentTimeMillis()}")
+    val job = bigQueryClient.create(JobInfo.newBuilder(jobConfig).setJobId(jobId).build())
+    logger.info(s"BQ data-gen job started: ${job.getJobId} — link: ${job.getSelfLink}")
+
+    val completed = job.waitFor()
+    if (completed == null) {
+      throw new RuntimeException(s"BQ data-gen job ${job.getJobId} no longer exists")
+    } else if (completed.getStatus.getError != null) {
+      throw new RuntimeException(s"BQ data-gen job failed: ${completed.getStatus.getError}")
+    }
+
+    val tableInfo = bigQueryClient.getTable(TableId.of(project, bqDataset, bqTable))
+    val actualRows = tableInfo.getNumRows
+    val numBytes = tableInfo.getNumBytes
+    logger.info(s"BQ data-gen complete: $actualRows rows, $numBytes bytes in $fqTable")
+  }
+
+  // GENERATE_ARRAY supports up to ~Int.MaxValue elements; for numRows > 10M we use a cross-join
+  // of two arrays whose product equals numRows.
+  private[bt_load] def splitRowCount(numRows: Long): (Long, Long) = {
+    val aSize = math.ceil(math.sqrt(numRows.toDouble)).toLong
+    val bSize = math.ceil(numRows.toDouble / aSize).toLong
+    (aSize, bSize)
+  }
+}

--- a/cloud_gcp/src/test/scala/ai/chronon/integrations/cloud_gcp/bt_load/BigTableBulkLoadPerfTestHarness.scala
+++ b/cloud_gcp/src/test/scala/ai/chronon/integrations/cloud_gcp/bt_load/BigTableBulkLoadPerfTestHarness.scala
@@ -1,0 +1,164 @@
+package ai.chronon.integrations.cloud_gcp.bt_load
+
+import ai.chronon.integrations.cloud_gcp.GcpApiImpl
+import com.google.cloud.bigquery.BigQueryOptions
+import org.scalatest.flatspec.AnyFlatSpec
+import org.slf4j.{Logger, LoggerFactory}
+
+/** ScalaTest entry point for the BigTable bulkPut (BQ → BT) load test.
+  *
+  * Tests are gated behind CHRONON_PERF_TEST_ENABLED=true; when absent they are
+  * *canceled* (not failed) so a normal `./mill cloud_gcp.test` run is unaffected.
+  *
+  * Workflow:
+  *   Phase 1 — BQDataGenerator creates a synthetic BQ table with the schema
+  *              expected by bulkPutFromBigQuery (key_bytes, value_bytes, ds).
+  *   Phase 2 — bulkPut is called, which issues a BQ EXPORT DATA job that streams
+  *              the rows directly into BigTable.  Wall-clock time and throughput
+  *              are logged at the end.
+  *
+  * Environment variables:
+  *   CHRONON_PERF_TEST_ENABLED    must be "true" to run (required)
+  *   GCP_PROJECT_ID               GCP project (required)
+  *   GCP_BIGTABLE_INSTANCE_ID     BigTable instance (required)
+  *   BT_LOAD_NUM_ROWS             row count target; default 50000000 (50M)
+  *   BT_LOAD_BQ_DATASET           BQ dataset for the synthetic table; default chronon_perf_test
+  *   BT_LOAD_BQ_TABLE             BQ table name; default bt_bulk_load_perf_src
+  *   BT_LOAD_PARTITION            ds value written into every row and passed to bulkPut;
+  *                                default 2026-06-11
+  *   BT_LOAD_DESTINATION_DATASET  destinationOnlineDataSet arg to bulkPut; default bt_load_perf_test
+  *   BT_LOAD_SKIP_DATA_GEN        set to "true" to skip Phase 1 (reuse existing BQ table)
+  *   BT_LOAD_UPLOADER             "bigquery" (default) or "spark"; spark path submits to Dataproc
+  *   BT_LOAD_DATAPROC_CLUSTER     Dataproc cluster name (required when BT_LOAD_UPLOADER=spark)
+  *   BT_LOAD_JAR_URI              GCS URI of cloud_gcp assembly jar (required when BT_LOAD_UPLOADER=spark)
+  *   BT_LOAD_EXTRA_JAR_URIS       comma-separated GCS URIs of extra jars (e.g. spark-bigtable connector)
+  */
+class BigTableBulkLoadPerfTestHarness extends AnyFlatSpec {
+
+  private val logger: Logger = LoggerFactory.getLogger(classOf[BigTableBulkLoadPerfTestHarness])
+
+  private val perfTestEnabled: Boolean =
+    sys.env.getOrElse("CHRONON_PERF_TEST_ENABLED", "false").toLowerCase == "true"
+
+  // --- Parameters ------------------------------------------------------------
+  private val projectId: String =
+    sys.env.getOrElse("GCP_PROJECT_ID", "")
+
+  private val instanceId: String =
+    sys.env.getOrElse("GCP_BIGTABLE_INSTANCE_ID", "")
+
+  private val numRows: Long =
+    sys.env.getOrElse("BT_LOAD_NUM_ROWS", "50000000").toLong
+
+  private val bqDataset: String =
+    sys.env.getOrElse("BT_LOAD_BQ_DATASET", "chronon_perf_test")
+
+  // Suffix derived from numRows so each scale run lands in its own table (e.g. bt_bulk_load_perf_src_50M).
+  private val rowSuffix: String = numRows match {
+    case n if n % 1000000 == 0 => s"${n / 1000000}M"
+    case n if n % 1000 == 0    => s"${n / 1000}K"
+    case n                     => s"$n"
+  }
+
+  private val bqTable: String =
+    sys.env.getOrElse("BT_LOAD_BQ_TABLE", s"bt_bulk_load_perf_src_$rowSuffix")
+
+  private val partition: String =
+    sys.env.getOrElse("BT_LOAD_PARTITION", "2026-06-11")
+
+  private val destinationDataset: String =
+    sys.env.getOrElse("BT_LOAD_DESTINATION_DATASET", "bt_load_perf_test")
+
+  private val skipDataGen: Boolean =
+    sys.env.getOrElse("BT_LOAD_SKIP_DATA_GEN", "false").toLowerCase == "true"
+
+  private val uploader: String =
+    sys.env.getOrElse("BT_LOAD_UPLOADER", "bigquery").toLowerCase
+
+  private val dataprocCluster: String =
+    sys.env.getOrElse("BT_LOAD_DATAPROC_CLUSTER", "")
+
+  private val jarUri: String =
+    sys.env.getOrElse("BT_LOAD_JAR_URI", "")
+
+  private val extraJarUris: Seq[String] =
+    sys.env.getOrElse("BT_LOAD_EXTRA_JAR_URIS", "").split(",").map(_.trim).filter(_.nonEmpty).toSeq
+
+  // Lazy so clients are not created when tests are canceled.
+  private val gcpLocation: String =
+    sys.env.getOrElse("GCP_LOCATION", "us-central1")
+
+  // Optional override for the target BT table name; defaults to GROUPBY_BATCH in production.
+  // Set to a throwaway table name during perf testing to avoid polluting the live table.
+  private val btBatchTableOverride: Option[String] =
+    sys.env.get("BT_BATCH_TABLE_OVERRIDE")
+
+  private lazy val gcpApi: GcpApiImpl =
+    new GcpApiImpl(
+      Map(
+        "GCP_PROJECT_ID"           -> projectId,
+        "GCP_BIGTABLE_INSTANCE_ID" -> instanceId,
+        "GCP_LOCATION"             -> gcpLocation,
+        "ENABLE_UPLOAD_CLIENTS"    -> "true"
+      ) ++ btBatchTableOverride.map("BT_BATCH_TABLE_OVERRIDE" -> _)
+    )
+
+  private lazy val kvStore = gcpApi.genKvStore
+
+  private lazy val bigQueryClient = BigQueryOptions.getDefaultInstance.getService
+
+  // --- Phase 1: synthesize BQ source table -----------------------------------
+  "BigTable bulkPut load test" should "generate BQ source data" in {
+    assume(perfTestEnabled, "Set CHRONON_PERF_TEST_ENABLED=true to run perf tests")
+    assume(projectId.nonEmpty, "Set GCP_PROJECT_ID")
+    assume(instanceId.nonEmpty, "Set GCP_BIGTABLE_INSTANCE_ID")
+
+    if (skipDataGen) {
+      logger.info("BT_LOAD_SKIP_DATA_GEN=true — skipping BQ data generation phase")
+    } else {
+      logger.info(
+        s"Phase 1: generating $numRows rows into $projectId.$bqDataset.$bqTable (ds='$partition')")
+      BQDataGenerator.run(bigQueryClient, projectId, bqDataset, bqTable, numRows, partition)
+    }
+  }
+
+  // --- Phase 2: load BQ → BigTable -------------------------------------------
+  it should "run bulkPut from BQ to BigTable and report throughput" in {
+    assume(perfTestEnabled, "Set CHRONON_PERF_TEST_ENABLED=true to run perf tests")
+    assume(projectId.nonEmpty, "Set GCP_PROJECT_ID")
+    assume(instanceId.nonEmpty, "Set GCP_BIGTABLE_INSTANCE_ID")
+
+    val srcTable = s"$projectId.$bqDataset.$bqTable"
+    logger.info(
+      s"Phase 2 [$uploader]: $srcTable → BigTable instance $instanceId " +
+        s"(destinationDataset=$destinationDataset, partition=$partition, numRows=$numRows)")
+
+    val startMs = System.currentTimeMillis()
+
+    uploader match {
+      case "spark" =>
+        assume(dataprocCluster.nonEmpty, "Set BT_LOAD_DATAPROC_CLUSTER for spark uploader")
+        assume(jarUri.nonEmpty, "Set BT_LOAD_JAR_URI for spark uploader")
+        SparkDataprocLoader.run(
+          projectId    = projectId,
+          region       = gcpLocation,
+          clusterName  = dataprocCluster,
+          jarUri       = jarUri,
+          tableName    = srcTable,
+          dataset      = destinationDataset,
+          endDs        = partition,
+          instanceId   = instanceId,
+          extraJarUris = extraJarUris
+        )
+      case _ =>
+        kvStore.create(destinationDataset)
+        kvStore.bulkPut(srcTable, destinationDataset, partition)
+    }
+
+    val elapsedMs = System.currentTimeMillis() - startMs
+    val elapsedSec = elapsedMs / 1000.0
+    val rowsPerSec = if (elapsedSec > 0) (numRows / elapsedSec).toLong else 0L
+    logger.info(
+      s"bulkPut complete: uploader=$uploader, numRows=$numRows, elapsed=${elapsedSec}s, throughput=${rowsPerSec} rows/s")
+  }
+}

--- a/cloud_gcp/src/test/scala/ai/chronon/integrations/cloud_gcp/bt_load/SparkDataprocLoader.scala
+++ b/cloud_gcp/src/test/scala/ai/chronon/integrations/cloud_gcp/bt_load/SparkDataprocLoader.scala
@@ -1,0 +1,103 @@
+package ai.chronon.integrations.cloud_gcp.bt_load
+
+import com.google.cloud.dataproc.v1._
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.jdk.CollectionConverters._
+
+/** Submits a Spark2BigTableLoader job to Dataproc and polls until completion.
+  * Used as an alternative to the BQ EXPORT path when BT_LOAD_UPLOADER=spark.
+  *
+  * The jar at jarUri must contain Spark2BigTableLoader and all its dependencies
+  * (i.e. the cloud_gcp assembly jar uploaded to GCS).
+  */
+object SparkDataprocLoader {
+
+  private val logger: Logger = LoggerFactory.getLogger(getClass)
+
+  private val MainClass = "ai.chronon.integrations.cloud_gcp.Spark2BigTableLoader"
+
+  def run(
+      projectId: String,
+      region: String,
+      clusterName: String,
+      jarUri: String,
+      tableName: String,
+      dataset: String,
+      endDs: String,
+      instanceId: String,
+      // Spark BigTable connector jar must be supplied separately — it uses ServiceLoader
+      // and cannot be shaded into the assembly jar.
+      extraJarUris: Seq[String] = Seq.empty
+  ): Unit = {
+    val endpoint = s"$region-dataproc.googleapis.com:443"
+    val settings = JobControllerSettings.newBuilder().setEndpoint(endpoint).build()
+    val client = JobControllerClient.create(settings)
+
+    try {
+      val args = Seq(
+        "--table-name", tableName,
+        "--dataset", dataset,
+        "--end-ds", endDs,
+        "--project-id", projectId,
+        "--instance-id", instanceId
+      )
+
+      // BT connector uses a driver-side client registry keyed by these config values.
+      // They must be set as Spark properties (i.e. --conf on spark-submit) so executors
+      // see them when initialising the client — runtime spark.conf.set does not propagate.
+      val sparkProperties = Map(
+        "spark.bigtable.project.id"  -> projectId,
+        "spark.bigtable.instance.id" -> instanceId
+      )
+
+      val sparkJob = SparkJob
+        .newBuilder()
+        .setMainClass(MainClass)
+        .addAllJarFileUris((Seq(jarUri) ++ extraJarUris).asJava)
+        .putAllProperties(sparkProperties.asJava)
+        .addAllArgs(args.asJava)
+        .build()
+
+      val jobId = s"bt-load-spark-${endDs.replace("-", "")}-${System.currentTimeMillis()}"
+
+      val job = Job
+        .newBuilder()
+        .setReference(JobReference.newBuilder().setJobId(jobId).build())
+        .setPlacement(JobPlacement.newBuilder().setClusterName(clusterName).build())
+        .setSparkJob(sparkJob)
+        .build()
+
+      logger.info(s"Submitting Dataproc Spark job $jobId to cluster $clusterName in $region")
+      val submitted = client.submitJob(projectId, region, job)
+      val submittedId = submitted.getReference.getJobId
+      logger.info(
+        s"Job submitted: $submittedId — https://console.cloud.google.com/dataproc/jobs/$submittedId?region=$region&project=$projectId")
+
+      pollUntilDone(client, projectId, region, submittedId)
+    } finally {
+      client.shutdown()
+    }
+  }
+
+  private def pollUntilDone(client: JobControllerClient, projectId: String, region: String, jobId: String): Unit = {
+    val pollIntervalMs = 30000L
+    var done = false
+    while (!done) {
+      val job = client.getJob(projectId, region, jobId)
+      job.getStatus.getState match {
+        case JobStatus.State.DONE =>
+          logger.info(s"Dataproc job $jobId completed successfully")
+          done = true
+        case JobStatus.State.ERROR =>
+          throw new RuntimeException(
+            s"Dataproc job $jobId failed: ${job.getStatus.getDetails}")
+        case JobStatus.State.CANCELLED =>
+          throw new RuntimeException(s"Dataproc job $jobId was cancelled")
+        case state =>
+          logger.info(s"Dataproc job $jobId state: $state — waiting ${pollIntervalMs / 1000}s")
+          Thread.sleep(pollIntervalMs)
+      }
+    }
+  }
+}

--- a/scripts/gcp/bigtable_load_tests/PERF_TESTING.md
+++ b/scripts/gcp/bigtable_load_tests/PERF_TESTING.md
@@ -1,0 +1,145 @@
+# BigTable bulkPut Load Test
+
+Load tests the `BigTableKVStoreImpl.bulkPut` path at various row counts (50M, 100M, 200M, 225M).
+Two uploaders are supported:
+
+| Uploader | Path | Requires |
+|---|---|---|
+| `bigquery` (default) | BQ `EXPORT DATA` job streams rows directly into BigTable | BQ reservation in the target region |
+| `spark` | Dataproc Spark job via `Spark2BigTableLoader` | Dataproc cluster + assembly jar on GCS |
+
+## What it tests
+
+Two sequential phases:
+
+1. **Data generation** — creates a synthetic BigQuery source table with the schema expected
+   by `bulkPut`: `key_bytes BYTES` (~32B, MD5-based, uniformly distributed), `value_bytes BYTES`
+   (~2KB), `ds STRING`. Runs entirely inside BigQuery — no local data movement.
+
+2. **bulkPut** — loads the BQ table into BigTable and logs wall-clock duration and rows/s throughput.
+
+---
+
+## BigQuery uploader (default)
+
+### Prerequisites
+
+- `gcloud auth application-default login` (or a service account with BQ + BT IAM roles)
+- A BQ reservation assigned to the project in the target region (BQ→BT export requires a reservation;
+  on-demand slots are not supported). Set `GCP_LOCATION` to match the region where the reservation
+  lives (e.g. `us-central1`).
+- A real BigTable instance (BQ EXPORT cannot target the emulator)
+- Mill build tool (`./mill` in repo root)
+
+### Running
+
+```bash
+cd scripts/gcp/bigtable_load_tests
+
+# 50M rows (default)
+GCP_PROJECT_ID=my-project GCP_BIGTABLE_INSTANCE_ID=my-instance GCP_LOCATION=us-central1 ./run-perf-test.sh
+
+# 100M rows
+GCP_PROJECT_ID=my-project GCP_BIGTABLE_INSTANCE_ID=my-instance GCP_LOCATION=us-central1 BT_LOAD_NUM_ROWS=100000000 ./run-perf-test.sh
+
+# Reuse existing BQ table (skip data gen)
+GCP_PROJECT_ID=my-project GCP_BIGTABLE_INSTANCE_ID=my-instance GCP_LOCATION=us-central1 BT_LOAD_SKIP_DATA_GEN=true ./run-perf-test.sh
+```
+
+---
+
+## Spark uploader
+
+Uses `Spark2BigTableLoader` submitted as a Dataproc Spark job. Does not require a BQ reservation.
+
+### Prerequisites
+
+- A running Dataproc cluster in the same region as the BigTable instance
+- The `cloud_gcp` assembly jar built and uploaded to GCS
+- The `spark-bigtable` connector jar (v0.9.1+) uploaded to GCS separately — it cannot be shaded
+  into the assembly because Spark loads it via `ServiceLoader`
+
+### One-time jar setup
+
+```bash
+# Build the assembly jar
+./mill clean cloud_gcp.assembly
+
+# Upload assembly jar
+gsutil cp out/cloud_gcp/assembly.dest/out.jar \
+  gs://YOUR_BUCKET/jars/cloud_gcp_lib_deploy.jar
+
+# Download and upload the spark-bigtable connector (0.9.1+)
+curl -L -o /tmp/spark-bigtable_2.12-0.9.1.jar \
+  https://repo1.maven.org/maven2/com/google/cloud/spark/bigtable/spark-bigtable_2.12/0.9.1/spark-bigtable_2.12-0.9.1.jar
+
+gsutil cp /tmp/spark-bigtable_2.12-0.9.1.jar \
+  gs://YOUR_BUCKET/jars/spark-bigtable_2.12-0.9.1.jar
+```
+
+Re-upload the assembly jar whenever `Spark2BigTableLoader` or its dependencies change.
+The connector jar only needs to be re-uploaded if you upgrade its version.
+
+### Running
+
+```bash
+cd scripts/gcp/bigtable_load_tests
+
+GCP_PROJECT_ID=my-project \
+GCP_BIGTABLE_INSTANCE_ID=my-instance \
+GCP_LOCATION=us-central1 \
+BT_LOAD_UPLOADER=spark \
+BT_LOAD_DATAPROC_CLUSTER=my-cluster \
+BT_LOAD_JAR_URI=gs://YOUR_BUCKET/jars/cloud_gcp_lib_deploy.jar \
+BT_LOAD_EXTRA_JAR_URIS=gs://YOUR_BUCKET/jars/spark-bigtable_2.12-0.9.1.jar \
+BT_LOAD_NUM_ROWS=100000000 \
+./run-perf-test.sh
+```
+
+---
+
+## Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `GCP_PROJECT_ID` | (required) | GCP project |
+| `GCP_BIGTABLE_INSTANCE_ID` | (required) | BigTable instance |
+| `GCP_LOCATION` | `us-central1` | Region for BQ jobs and Dataproc; must match the BQ reservation region |
+| `BT_LOAD_NUM_ROWS` | `50000000` | Row count — table name is auto-suffixed (e.g. `bt_bulk_load_perf_src_50M`) |
+| `BT_LOAD_BQ_DATASET` | `chronon_perf_test` | BQ dataset for the synthetic source table |
+| `BT_LOAD_BQ_TABLE` | _(derived from row count)_ | Override the BQ table name |
+| `BT_LOAD_PARTITION` | `2026-06-11` | `ds` value written into every row; passed as `partition` to `bulkPut` |
+| `BT_LOAD_DESTINATION_DATASET` | `bt_load_perf_test` | `destinationOnlineDataSet` arg to `bulkPut` |
+| `BT_LOAD_SKIP_DATA_GEN` | `false` | Skip Phase 1 (reuse existing BQ table) |
+| `BT_LOAD_UPLOADER` | `bigquery` | `bigquery` or `spark` |
+| `BT_LOAD_DATAPROC_CLUSTER` | — | Dataproc cluster name (required for `spark`) |
+| `BT_LOAD_JAR_URI` | — | GCS URI of `cloud_gcp` assembly jar (required for `spark`) |
+| `BT_LOAD_EXTRA_JAR_URIS` | — | Comma-separated GCS URIs of extra jars; use for `spark-bigtable` connector |
+
+## Reading results
+
+The script extracts the throughput summary line from the log:
+
+```
+bulkPut complete: uploader=bigquery, numRows=50000000, elapsed=423.1s, throughput=118157 rows/s
+```
+
+Full logs are written to `bt-load-test-results-YYYYMMDD-HHMMSS.log` in the directory
+where the script is run.
+
+## Running directly via mill (without the script)
+
+```bash
+# BigQuery uploader
+GCP_PROJECT_ID=my-project GCP_BIGTABLE_INSTANCE_ID=my-instance GCP_LOCATION=us-central1 \
+BT_LOAD_NUM_ROWS=50000000 CHRONON_PERF_TEST_ENABLED=true \
+./mill cloud_gcp.test.testOnly "ai.chronon.integrations.cloud_gcp.bt_load.BigTableBulkLoadPerfTestHarness"
+
+# Spark uploader
+GCP_PROJECT_ID=my-project GCP_BIGTABLE_INSTANCE_ID=my-instance GCP_LOCATION=us-central1 \
+BT_LOAD_UPLOADER=spark BT_LOAD_DATAPROC_CLUSTER=my-cluster \
+BT_LOAD_JAR_URI=gs://YOUR_BUCKET/jars/cloud_gcp_lib_deploy.jar \
+BT_LOAD_EXTRA_JAR_URIS=gs://YOUR_BUCKET/jars/spark-bigtable_2.12-0.9.1.jar \
+BT_LOAD_NUM_ROWS=100000000 CHRONON_PERF_TEST_ENABLED=true \
+./mill cloud_gcp.test.testOnly "ai.chronon.integrations.cloud_gcp.bt_load.BigTableBulkLoadPerfTestHarness"
+```

--- a/scripts/gcp/bigtable_load_tests/run-perf-test.sh
+++ b/scripts/gcp/bigtable_load_tests/run-perf-test.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+# Run the BigTable bulkPut load test harness.
+# Can be run locally (requires gcloud auth and project/instance env vars) or
+# on a GCE VM after syncing the repo.
+#
+# Required env vars:
+#   GCP_PROJECT_ID            GCP project containing the BigTable instance
+#   GCP_BIGTABLE_INSTANCE_ID  target BigTable instance
+#
+# Optional env vars:
+#   BT_LOAD_NUM_ROWS          row count; default 50000000 (50M)
+#   BT_LOAD_BQ_DATASET        BQ dataset for synthetic source table; default chronon_perf_test
+#   BT_LOAD_BQ_TABLE          BQ table name; default bt_bulk_load_perf_src
+#   BT_LOAD_PARTITION         ds value used in data gen and bulkPut; default 2026-06-11
+#   BT_LOAD_DESTINATION_DATASET  destinationOnlineDataSet passed to bulkPut; default bt_load_perf_test
+#   BT_LOAD_SKIP_DATA_GEN     set "true" to skip BQ table creation; default false
+#   BT_LOAD_UPLOADER          "bigquery" (default) or "spark" (submits Spark job to Dataproc)
+#   BT_LOAD_DATAPROC_CLUSTER  Dataproc cluster name (required when BT_LOAD_UPLOADER=spark)
+#   BT_LOAD_JAR_URI           GCS URI of the cloud_gcp assembly jar (required when BT_LOAD_UPLOADER=spark)
+#   BT_LOAD_EXTRA_JAR_URIS    comma-separated GCS URIs of extra jars, e.g. the spark-bigtable connector
+
+set -e
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info()    { echo -e "${BLUE}[INFO]${NC} $1"; }
+log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
+log_warning() { echo -e "${YELLOW}[WARNING]${NC} $1"; }
+log_error()   { echo -e "${RED}[ERROR]${NC} $1"; }
+
+# --- Validate required env vars -----------------------------------------------
+if [ -z "$GCP_PROJECT_ID" ]; then
+    log_error "GCP_PROJECT_ID is not set"
+    exit 1
+fi
+
+if [ -z "$GCP_BIGTABLE_INSTANCE_ID" ]; then
+    log_error "GCP_BIGTABLE_INSTANCE_ID is not set"
+    exit 1
+fi
+
+# --- Defaults -----------------------------------------------------------------
+BT_LOAD_NUM_ROWS=${BT_LOAD_NUM_ROWS:-50000000}
+BT_LOAD_BQ_DATASET=${BT_LOAD_BQ_DATASET:-chronon_perf_test}
+# BT_LOAD_BQ_TABLE intentionally has no default here — the harness derives it from
+# BT_LOAD_NUM_ROWS (e.g. bt_bulk_load_perf_src_50M).  Set explicitly to override.
+BT_LOAD_PARTITION=${BT_LOAD_PARTITION:-2026-06-11}
+BT_LOAD_DESTINATION_DATASET=${BT_LOAD_DESTINATION_DATASET:-bt_load_perf_test}
+BT_LOAD_SKIP_DATA_GEN=${BT_LOAD_SKIP_DATA_GEN:-false}
+BT_LOAD_UPLOADER=${BT_LOAD_UPLOADER:-bigquery}
+# BT_LOAD_DATAPROC_CLUSTER, BT_LOAD_JAR_URI: no defaults — required only when BT_LOAD_UPLOADER=spark.
+# BT_BATCH_TABLE_OVERRIDE intentionally has no default — when unset, bulkPut uses GROUPBY_BATCH.
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+
+echo ""
+echo "==================================================================="
+log_info "BigTable bulkPut Load Test"
+echo "==================================================================="
+log_info "Project:             $GCP_PROJECT_ID"
+log_info "BigTable instance:   $GCP_BIGTABLE_INSTANCE_ID"
+log_info "Row count:           $BT_LOAD_NUM_ROWS"
+log_info "BQ dataset:          $BT_LOAD_BQ_DATASET"
+log_info "BQ table:            ${BT_LOAD_BQ_TABLE:-(derived from row count)}"
+log_info "Partition (ds):      $BT_LOAD_PARTITION"
+log_info "Destination dataset: $BT_LOAD_DESTINATION_DATASET"
+log_info "Skip data gen:       $BT_LOAD_SKIP_DATA_GEN"
+log_info "Uploader:            $BT_LOAD_UPLOADER"
+if [ "$BT_LOAD_UPLOADER" = "spark" ]; then
+  log_info "Dataproc cluster:    ${BT_LOAD_DATAPROC_CLUSTER:-(not set)}"
+  log_info "Jar URI:             ${BT_LOAD_JAR_URI:-(not set)}"
+fi
+log_info "BT table override:   ${BT_BATCH_TABLE_OVERRIDE:-(none, uses GROUPBY_BATCH)}"
+echo "==================================================================="
+echo ""
+
+TIMESTAMP=$(date +"%Y%m%d-%H%M%S")
+RESULTS_FILE="bt-load-test-results-${TIMESTAMP}.log"
+
+cd "$REPO_ROOT"
+
+env_args=(
+  CHRONON_PERF_TEST_ENABLED=true
+  GCP_PROJECT_ID="$GCP_PROJECT_ID"
+  GCP_BIGTABLE_INSTANCE_ID="$GCP_BIGTABLE_INSTANCE_ID"
+  BT_LOAD_NUM_ROWS="$BT_LOAD_NUM_ROWS"
+  BT_LOAD_BQ_DATASET="$BT_LOAD_BQ_DATASET"
+  BT_LOAD_PARTITION="$BT_LOAD_PARTITION"
+  BT_LOAD_DESTINATION_DATASET="$BT_LOAD_DESTINATION_DATASET"
+  BT_LOAD_SKIP_DATA_GEN="$BT_LOAD_SKIP_DATA_GEN"
+  BT_LOAD_UPLOADER="$BT_LOAD_UPLOADER"
+)
+if [ -n "$BT_LOAD_DATAPROC_CLUSTER" ]; then
+  env_args+=(BT_LOAD_DATAPROC_CLUSTER="$BT_LOAD_DATAPROC_CLUSTER")
+fi
+if [ -n "$BT_LOAD_JAR_URI" ]; then
+  env_args+=(BT_LOAD_JAR_URI="$BT_LOAD_JAR_URI")
+fi
+if [ -n "$BT_LOAD_EXTRA_JAR_URIS" ]; then
+  env_args+=(BT_LOAD_EXTRA_JAR_URIS="$BT_LOAD_EXTRA_JAR_URIS")
+fi
+# Only forward BT_LOAD_BQ_TABLE if explicitly set; otherwise let the harness derive it from row count.
+if [ -n "$BT_LOAD_BQ_TABLE" ]; then
+  env_args+=(BT_LOAD_BQ_TABLE="$BT_LOAD_BQ_TABLE")
+fi
+# Only forward BT_BATCH_TABLE_OVERRIDE if explicitly set; otherwise bulkPut uses GROUPBY_BATCH.
+if [ -n "$BT_BATCH_TABLE_OVERRIDE" ]; then
+  env_args+=(BT_BATCH_TABLE_OVERRIDE="$BT_BATCH_TABLE_OVERRIDE")
+fi
+
+env "${env_args[@]}" \
+./mill cloud_gcp.test.testOnly "ai.chronon.integrations.cloud_gcp.bt_load.BigTableBulkLoadPerfTestHarness" 2>&1 | tee "$RESULTS_FILE"
+
+log_success "Test complete! Full results in: $RESULTS_FILE"
+
+echo ""
+echo "==================================================================="
+echo "THROUGHPUT RESULT"
+echo "==================================================================="
+grep "bulkPut complete" "$RESULTS_FILE" || log_warning "Could not find throughput line in results"
+echo "==================================================================="
+echo ""
+
+log_info "To re-run at a different scale (skipping data gen):"
+log_info "  BT_LOAD_NUM_ROWS=100000000 BT_LOAD_SKIP_DATA_GEN=true ./run-perf-test.sh"


### PR DESCRIPTION
## Summary
A draft that captures some BT related load tests targeting the bulkPut side. Covers both the BQ and the Spark based bulk load. Can make this a bit more generic (different payload sizes / key sizes and distribution) and also cover the other methods in the BT store. 

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable BigTable batch table name and BigQuery reservation region settings
  * Enabled BigTable bulk load performance testing with Spark and BigQuery export modes

* **Documentation**
  * Added comprehensive performance testing guide with environment variable configuration and usage examples

* **Tests**
  * Added performance test harness and supporting testing utilities for BigTable bulk load operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->