### PR TITLE
feat(aws): configure Flink (eks) pod labels via FLINK_EKS_POD_LABELS env var

### DIFF
--- a/cloud_aws/src/main/scala/ai/chronon/integrations/aws/EksFlinkSubmitter.scala
+++ b/cloud_aws/src/main/scala/ai/chronon/integrations/aws/EksFlinkSubmitter.scala
@@ -35,6 +35,27 @@ object EksFlinkSubmitter {
 
   def shellQuote(s: String): String = "'" + s.replace("'", "'\"'\"'") + "'"
 
+  // Extra pod labels stamped on the Flink JobManager/TaskManager pods, read from an env var so
+  // deployments can attach their own labels without code changes. Merged with the per-job
+  // chronon/job_name label by K8sFlinkSubmitter. Format: comma-separated key=value pairs, split
+  // on the first '=' (values may contain '='); entries with an empty key or value are skipped.
+  private[aws] val PodTemplateLabelsEnvVar = "FLINK_EKS_POD_LABELS"
+
+  private[aws] def parsePodTemplateLabels(raw: Option[String]): Map[String, String] =
+    raw.map(_.trim).filter(_.nonEmpty).fold(Map.empty[String, String]) { s =>
+      s.split(",")
+        .toSeq
+        .flatMap { entry =>
+          val eq = entry.indexOf('=')
+          if (eq > 0 && eq < entry.length - 1) {
+            val key = entry.substring(0, eq).trim
+            val value = entry.substring(eq + 1).trim
+            if (key.nonEmpty && value.nonEmpty) Some(key -> value) else None
+          } else None
+        }
+        .toMap
+    }
+
   // AWS IRSA credential config and Prometheus metrics reporter — injected into K8sFlinkSubmitter
   // so the base class stays cloud-agnostic.
   val extraAwsFlinkConfig: Map[String, String] = Map(
@@ -103,6 +124,7 @@ object EksFlinkSubmitter {
       extraJarNames = EksOnlyAdditionalJarNames,
       defaultJarsBasePath = DefaultS3FlinkJarsBasePath,
       k8sConfig = k8sConfig,
-      ingressBaseUrl = ingressBaseUrl
+      ingressBaseUrl = ingressBaseUrl,
+      podTemplateLabels = parsePodTemplateLabels(sys.env.get(PodTemplateLabelsEnvVar))
     )
 }

--- a/cloud_aws/src/test/scala/ai/chronon/integrations/aws/EksFlinkSubmitterTest.scala
+++ b/cloud_aws/src/test/scala/ai/chronon/integrations/aws/EksFlinkSubmitterTest.scala
@@ -128,6 +128,33 @@ class EksFlinkSubmitterTest extends AnyFlatSpec {
     assertEquals("foo-bar", K8sFlinkSubmitter.sanitizeDeploymentName("--foo-bar--"))
   }
 
+  "parsePodTemplateLabels" should "parse comma-separated key=value pairs" in {
+    val labels = EksFlinkSubmitter.parsePodTemplateLabels(Some("team=ml,tier=streaming,env=prod"))
+    assertEquals("ml", labels("team"))
+    assertEquals("streaming", labels("tier"))
+    assertEquals("prod", labels("env"))
+  }
+
+  it should "keep keys containing dots and slashes" in {
+    val labels = EksFlinkSubmitter.parsePodTemplateLabels(Some("app.kubernetes.io/component=jobmanager"))
+    assertEquals("jobmanager", labels("app.kubernetes.io/component"))
+  }
+
+  it should "return an empty map when the env var is unset or blank" in {
+    assertTrue(EksFlinkSubmitter.parsePodTemplateLabels(None).isEmpty)
+    assertTrue(EksFlinkSubmitter.parsePodTemplateLabels(Some("   ")).isEmpty)
+  }
+
+  it should "skip entries with an empty key or value and trim whitespace" in {
+    val labels = EksFlinkSubmitter.parsePodTemplateLabels(Some("=novalue, nokey , tier = streaming ,valid=ok"))
+    assertEquals(Map("tier" -> "streaming", "valid" -> "ok"), labels)
+  }
+
+  it should "split on the first '=' so values may contain '='" in {
+    val labels = EksFlinkSubmitter.parsePodTemplateLabels(Some("key=val=extra"))
+    assertEquals("val=extra", labels("key"))
+  }
+
   "eksAdditionalFlinkJars" should "resolve jar names against the base path" in {
     val jars = EksFlinkSubmitter.eksAdditionalFlinkJars("s3://my-bucket/libs/")
     EksFlinkSubmitter.EksOnlyAdditionalJarNames.foreach { name =>


### PR DESCRIPTION
## Summary

`EksFlinkSubmitter.apply` passed no `podTemplateLabels` to `K8sFlinkSubmitter`,
so the Flink JobManager/TaskManager pods only carried the labels the submitter
adds itself (`chronon/job_name`, the Prometheus scrape annotations). There was no
way for a deployment to attach its own pod labels (e.g. for log/metric service
attribution by an external observability pipeline) without changing code.

This reads an optional `FLINK_EKS_POD_LABELS` env var and passes the parsed
labels through as `podTemplateLabels`. The name follows the existing `FLINK_EKS_*`
convention and mirrors the Azure submitter, which already passes
a static `podTemplateLabels` map.

- Format: comma-separated `key=value` pairs, split on the first `=` (values may
  contain `=`); entries with an empty key or value are skipped. Parsing follows
  the existing `OTEL_RESOURCE_ATTRIBUTES` helper style.
- Unset/blank env var yields no labels, so there is no behavior change by default.
- The labels are merged with the per-job `chronon/job_name` label and applied to
  both the JM and TM pods by `K8sFlinkSubmitter`.

## Checklist
- [x] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kubernetes pod labels can now be configured for Flink JobManager and TaskManager pods in AWS EKS deployments through an environment variable, enabling better customization and management of pod metadata.

* **Tests**
  * Added test coverage for the new pod label configuration functionality, including validation of label parsing and edge case handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->