### PR TITLE
Fix modular join source readiness

### DIFF
--- a/api/src/main/scala/ai/chronon/api/planner/JoinPlanner.scala
+++ b/api/src/main/scala/ai/chronon/api/planner/JoinPlanner.scala
@@ -242,6 +242,33 @@ class JoinPlanner(join: Join)(implicit outputPartitionSpec: PartitionSpec)
       statsComputeNodeOpt
   }
 
+  private def tableDependencies(node: Node): Seq[TableDependency] =
+    Option(node.metaData)
+      .flatMap(metaData => Option(metaData.executionInfo))
+      .flatMap(executionInfo => Option(executionInfo.tableDependencies))
+      .map(_.toScala.toSeq)
+      .getOrElse(Seq.empty)
+
+  private def externalSensorNodes(nodes: Seq[Node]): Seq[Node] = {
+    val internalOutputTables = nodes.flatMap(node => Option(node.metaData).map(_.outputTable)).toSet
+    val externalDeps = nodes
+      .flatMap(tableDependencies)
+      .filter { tableDependency =>
+        Option(tableDependency.tableInfo)
+          .flatMap(tableInfo => Option(tableInfo.table))
+          .exists(table => !internalOutputTables.contains(table))
+      }
+      .distinct
+
+    val sensorMetaData =
+      MetaDataUtils.layer(join.metaData, "sensor", join.metaData.name + "__external_sensors", externalDeps)
+
+    ExternalSourceSensorUtil
+      .sensorNodes(sensorMetaData)
+      .map(es =>
+        toNode(es.metaData, _.setExternalSourceSensor(es), ExternalSourceSensorUtil.semanticExternalSourceSensor(es)))
+  }
+
   def metadataUploadNode: Node = {
     val stepDays = 1 // Default step days for metadata upload
 
@@ -343,11 +370,9 @@ class JoinPlanner(join: Join)(implicit outputPartitionSpec: PartitionSpec)
       // The final offline node is the backfill terminal
       val backfillTerminalNode = allOfflineNodes.last
 
-      // Get sensor nodes for the backfill terminal node
-      val sensorNodes = ExternalSourceSensorUtil
-        .sensorNodes(backfillTerminalNode.metaData)
-        .map((es) =>
-          toNode(es.metaData, _.setExternalSourceSensor(es), ExternalSourceSensorUtil.semanticExternalSourceSensor(es)))
+      // Modular offline nodes depend on each other through generated internal tables. Sensors should be created for
+      // the raw external inputs used anywhere in the modular DAG, not for only the terminal node's direct dependencies.
+      val sensorNodes = externalSensorNodes(allOfflineNodes)
 
       val metadataUpload = metadataUploadNode
 

--- a/api/src/test/scala/ai/chronon/api/test/planner/JoinPlannerTest.scala
+++ b/api/src/test/scala/ai/chronon/api/test/planner/JoinPlannerTest.scala
@@ -120,6 +120,46 @@ class JoinPlannerTest extends AnyFlatSpec with Matchers {
     mutationDep.endOffset should equal(WindowUtils.zero())
   }
 
+  it should "create external sensors for all standard modular offline inputs" in {
+    val standardGroupBy = Builders.GroupBy(
+      sources = Seq(Builders.Source.events(Builders.Query(partitionColumn = "ds"), table = "test.other_events")),
+      keyColumns = Seq("listing_id"),
+      aggregations = Seq(Builders.Aggregation(Operation.COUNT, "event_count", Seq(WindowUtils.Unbounded))),
+      accuracy = Accuracy.TEMPORAL,
+      metaData = Builders.MetaData(namespace = "test_namespace", name = "standard_events_gb")
+    )
+
+    val join = Join(
+      metaData = MetaData(
+        name = "modular_standard_join",
+        namespace = "test_namespace",
+        executionInfo = modularExecutionInfo
+      ),
+      left = Builders.Source.events(Builders.Query(partitionColumn = "ds"), table = "test.left_events"),
+      joinParts = Seq(
+        Builders.JoinPart(groupBy = temporalEntityGroupBy("standard_temporal_entity_gb")),
+        Builders.JoinPart(groupBy = standardGroupBy)
+      ),
+      bootstrapParts = Seq.empty
+    )
+
+    val plan = new JoinPlanner(join).buildPlan
+    val nonSensorOutputTables = plan.nodes.asScala
+      .filterNot(_.content.isSetExternalSourceSensor)
+      .map(_.metaData.outputTable)
+      .toSet
+
+    val sensorOutputTables = plan.nodes.asScala
+      .filter(_.content.isSetExternalSourceSensor)
+      .map(_.content.getExternalSourceSensor.metaData.executionInfo.outputTableInfo.table)
+      .toSet
+
+    sensorOutputTables should equal(
+      Set("test.left_events", "test.dim_snapshot", "test.dim_mutations", "test.other_events")
+    )
+    sensorOutputTables.intersect(nonSensorOutputTables) should be(empty)
+  }
+
   it should "depend on upstream join output when the left source is a join source" in {
     val upstreamListingLookup = Builders.GroupBy(
       sources = Seq(Builders.Source.events(Builders.Query(partitionColumn = "ds"), table = "test.user_listings")),

--- a/spark/src/main/scala/ai/chronon/spark/batch/SourceJob.scala
+++ b/spark/src/main/scala/ai/chronon/spark/batch/SourceJob.scala
@@ -47,11 +47,17 @@ class SourceJob(node: SourceWithFilterNode, metaData: MetaData, range: DateRange
       })
       .getOrElse(source)
 
+    val sourcePartitionSpec = Option(source.query)
+      .map(_.partitionSpec(tableUtils.partitionSpec))
+      .getOrElse(tableUtils.partitionSpec)
+    val sourceDateRange = dateRange.translate(sourcePartitionSpec)
+    val sourcePartitionColumn = sourcePartitionSpec.column
+
     // This job benefits from a step day of 1 to avoid needing to shuffle on writing output (single partition)
-    dateRange.steps(days = 1).foreach { dayStep =>
+    sourceDateRange.steps(days = 1).foreach { dayStep =>
       val df = tableUtils.scanDf(skewFilteredSource.query,
                                  skewFilteredSource.table,
-                                 Some((Map(tableUtils.partitionColumn -> null) ++ timeProjection).toMap),
+                                 Some((Map(sourcePartitionColumn -> null) ++ timeProjection).toMap),
                                  range = Some(dayStep))
 
       if (df.isEmpty) {

--- a/spark/src/test/scala/ai/chronon/spark/batch/SourceJobTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/batch/SourceJobTest.scala
@@ -1,0 +1,59 @@
+package ai.chronon.spark.batch
+
+import ai.chronon.api.{Builders, DateRange}
+import ai.chronon.planner.SourceWithFilterNode
+import ai.chronon.spark.Extensions._
+import ai.chronon.spark.catalog.TableUtils
+import ai.chronon.spark.utils.SparkTestBase
+import org.scalatest.matchers.should.Matchers
+
+class SourceJobTest extends SparkTestBase with Matchers {
+
+  private implicit val tableUtils: TableUtils = TableUtils(spark)
+  private val namespace = "test_namespace_source_job"
+  createDatabase(namespace)
+
+  it should "scan custom source partition columns when explicit selects are present" in {
+    import spark.implicits._
+
+    val inputTable = s"$namespace.source_events_custom_partition"
+    val outputTable = s"$namespace.source_job_custom_partition_output"
+    spark.sql(s"DROP TABLE IF EXISTS $inputTable")
+    spark.sql(s"DROP TABLE IF EXISTS $outputTable")
+
+    Seq(
+      ("u0", 0L, 100L, "2026-05-19"),
+      ("u1", 10L, 200L, "2026-05-20"),
+      ("u2", 20L, 300L, "2026-05-21"),
+      ("u3", 30L, 400L, "2026-05-22")
+    ).toDF("user", "value", "ts", "event_date")
+      .save(inputTable, partitionColumns = Seq("event_date"))
+
+    val source = Builders.Source.events(
+      query = Builders.Query(
+        selects = Builders.Selects("user", "value"),
+        partitionColumn = "event_date"
+      ),
+      table = inputTable
+    )
+    val node = new SourceWithFilterNode().setSource(source)
+    val metaData = Builders.MetaData(name = "source_job_custom_partition_output", namespace = namespace)
+    val range = new DateRange().setStartDate("2026-05-20").setEndDate("2026-05-21")
+
+    new SourceJob(node, metaData, range).run()
+
+    val rows = tableUtils
+      .loadTable(outputTable)
+      .select("user", "value", tableUtils.partitionColumn)
+      .as[(String, Long, String)]
+      .collect()
+      .toSet
+
+    rows should equal(
+      Set(
+        ("u1", 10L, "2026-05-20"),
+        ("u2", 20L, "2026-05-21")
+      )
+    )
+  }
+}


### PR DESCRIPTION
## Summary

Modular joins could wait on a Chronon-generated intermediate table instead of the real source table.

Simple example:

```text
raw.events -> my_join__source -> my_join__join_part
```

Before, Chronon could create a sensor for `my_join__source`. But that table is produced by Chronon, so the workflow could get stuck waiting on the wrong thing.

After this PR, standard modular joins create sensors for the real external inputs, like `raw.events`, and skip intermediate tables produced inside the same modular plan.

This also fixes `SourceJob` date handling for source tables that use a custom partition column, such as `event_date` instead of `ds`.

## Tests

- `JAVA_HOME=/tmp/jdks/jdk-17.0.19+10 PATH=/tmp/jdks/jdk-17.0.19+10/bin:$PATH ./mill --no-daemon -j 1 api.checkFormat + api.test.testOnly ai.chronon.api.test.planner.JoinPlannerTest`
- `JAVA_HOME=/tmp/jdks/jdk-17.0.19+10 PATH=/tmp/jdks/jdk-17.0.19+10/bin:$PATH ./mill --no-daemon -j 1 spark.test.testOnly ai.chronon.spark.batch.SourceJobTest`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced external source sensor identification in modular join planning to comprehensively evaluate all offline input tables, improving data dependency handling
  * Fixed source job execution to correctly apply source-specific partitioning during data scanning and iteration

* **Tests**
  * Added verification that join planner generates appropriate external source sensors for standard modular join configurations
  * Added validation of source job behavior with custom partitioning specifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->