### PR TITLE
Make final join explain optional (default: false)

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/Join.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Join.scala
@@ -394,7 +394,7 @@ class Join(joinConf: api.Join,
     val finalDf = cleanUpContextualFields(applyDerivation(finalBaseDf, bootstrapInfo, leftDf.columns),
                                           bootstrapInfo,
                                           leftDf.columns)
-    finalDf.explain()
+    explainFinalDfIfEnabled(finalDf)(tableUtils)
     finalDf
   }
 

--- a/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
@@ -39,6 +39,14 @@ import scala.jdk.CollectionConverters._
 object JoinUtils {
   @transient lazy val logger: Logger = LoggerFactory.getLogger(getClass)
 
+  val FinalDfExplainEnabled: String = "spark.chronon.join.final_df.explain.enabled"
+
+  def explainFinalDfIfEnabled(df: DataFrame)(implicit tableUtils: TableUtils): Unit = {
+    if (tableUtils.sparkSession.conf.get(FinalDfExplainEnabled, "false").toBoolean) {
+      df.explain()
+    }
+  }
+
   def materializeJoin(joinConf: api.Join,
                       endPartition: String,
                       tableUtils: TableUtils,

--- a/spark/src/main/scala/ai/chronon/spark/batch/MergeJob.scala
+++ b/spark/src/main/scala/ai/chronon/spark/batch/MergeJob.scala
@@ -134,7 +134,9 @@ class MergeJob(node: JoinMergeNode, metaData: MetaData, range: DateRange, joinPa
 
       val tableProps = createTableProperties
 
-      joinedDfTry.get.save(outputTable, tableProps, autoExpand = true)
+      val joinedDf = joinedDfTry.get
+      JoinUtils.explainFinalDfIfEnabled(joinedDf)
+      joinedDf.save(outputTable, tableProps, autoExpand = true)
     }
   }
 


### PR DESCRIPTION
## Summary

The explain() call can be very large which causes the driver to get locked up during the merge job

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to enable emitting the final join DataFrame execution plan.
  * This is disabled by default to avoid additional output/overhead.
* **Bug Fixes**
  * Prevented unconditional execution plan generation, so explanations are now produced only when explicitly enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->