### PR TITLE
fix: pass workflow config to KV bulk upload

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -66,6 +66,9 @@ object Driver {
   def parseConf[T <: TBase[_, _]: Manifest: ClassTag](confPath: String): T =
     ThriftJsonCodec.fromJsonFile[T](confPath, check = false)
 
+  private[spark] def onlineProps(metaData: api.MetaData, props: Map[String, String]): Map[String, String] =
+    metaData.commonConf ++ props
+
   trait SharedSubCommandArgs {
     this: ScallopConf =>
     val isGcp: ScallopOption[Boolean] =
@@ -612,10 +615,12 @@ object Driver {
       "ENABLE_UPLOAD_CLIENTS" -> enableUploadClients.toOption.getOrElse("true")
     )
 
-    lazy val api: Api = isGcp.toOption match {
-      case Some(true) => impl(serializableProps ++ gcpMap)
-      case _          => impl(serializableProps)
+    def apiForProps(props: Map[String, String]): Api = isGcp.toOption match {
+      case Some(true) => impl(props ++ gcpMap)
+      case _          => impl(props)
     }
+
+    lazy val api: Api = apiForProps(serializableProps)
 
     lazy val fetchContext: FetchContext =
       FetchContext(api.genKvStore, MetadataDataset)
@@ -694,7 +699,7 @@ object Driver {
         s"Triggering bulk load for GroupBy: ${groupByName} for partition: ${args.partitionString()} " +
           s"from table: ${offlineTable} using ${uploader}")
 
-      val kvStore = args.api.genKvStore
+      val kvStore = args.apiForProps(onlineProps(groupByConf.metaData, args.serializableProps)).genKvStore
 
       try {
         // The kvStore implementation will handle different warehouse types based on the configuration

--- a/spark/src/test/scala/ai/chronon/spark/DriverTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/DriverTest.scala
@@ -1,0 +1,28 @@
+package ai.chronon.spark
+
+import ai.chronon.api.{ConfigProperties, ExecutionInfo, MetaData}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.collection.JavaConverters._
+
+class DriverTest extends AnyFlatSpec with Matchers {
+
+  behavior of "Driver"
+
+  it should "merge metadata common conf into online props with explicit props taking precedence" in {
+    val conf = new ConfigProperties()
+      .setCommon(
+        Map(
+          "spark.chronon.table_writer.ion_writer.timeout_ms" -> "5400000",
+          "explicit" -> "metadata"
+        ).asJava
+      )
+    val metadata = new MetaData().setExecutionInfo(new ExecutionInfo().setConf(conf))
+
+    Driver.onlineProps(metadata, Map("explicit" -> "cli")) shouldBe Map(
+      "spark.chronon.table_writer.ion_writer.timeout_ms" -> "5400000",
+      "explicit" -> "cli"
+    )
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the KV bulk upload path so workflow-level `ConfigProperties.common` values are passed into the online API/KV store configuration.

This ensures settings like `spark.chronon.table_writer.ion_writer.timeout_ms` are respected during DynamoDB Ion bulk imports.

## Changes

- Add shared online prop merging from metadata common conf and explicit CLI/API props
- Use merged props when constructing the online API for `group-by-upload-bulk-load`
- Add a regression test covering metadata common config propagation and CLI prop precedence
