### PR TITLE
ci: drop JDK 17 bootstrap from setup-mill-cache

### DIFF
--- a/.github/actions/setup-mill-cache/action.yaml
+++ b/.github/actions/setup-mill-cache/action.yaml
@@ -26,37 +26,6 @@ inputs:
 runs:
   using: composite
   steps:
-    # TODO(david): remove once chronon-ci:latest is republished from main with JDK 17.
-    # Mill 1.1.6 launcher is class file v61 (JDK 17); stale image still has JDK 11.
-    # GitHub-hosted runners already ship JDK 17 (Temurin); only the stale container needs apt install.
-    - name: Ensure JDK 17
-      shell: bash
-      run: |
-        set -eo pipefail
-        find_jdk17() {
-          for d in "${JAVA_HOME_17_X64:-}" /usr/lib/jvm/temurin-17-jdk-* /usr/lib/jvm/java-17-openjdk-* /usr/lib/jvm/zulu-17-* /usr/lib/jvm/*-17-jdk-*; do
-            if [ -n "$d" ] && [ -x "$d/bin/java" ]; then
-              echo "$d"
-              return 0
-            fi
-          done
-          return 0
-        }
-        JDK17="$(find_jdk17)"
-        if [ -z "$JDK17" ]; then
-          SUDO=""
-          [ "$(id -u)" != "0" ] && SUDO="sudo"
-          $SUDO apt-get update
-          $SUDO apt-get install -y --no-install-recommends openjdk-17-jdk
-          JDK17="$(find_jdk17)"
-        fi
-        if [ -z "$JDK17" ]; then
-          echo "Failed to locate JDK 17 after install" >&2
-          exit 1
-        fi
-        echo "JAVA_HOME=$JDK17" >> "$GITHUB_ENV"
-        echo "$JDK17/bin" >> "$GITHUB_PATH"
-
     - name: Configure cache paths
       shell: bash
       env:


### PR DESCRIPTION
## Summary
- Removes the `Ensure JDK 17` step (and its TODO) from `.github/actions/setup-mill-cache/action.yaml`.
- The workaround was added in #1912 because the stale `chronon-ci:latest` image still had JDK 11; the build_and_push_docker workflow republished the image with `openjdk-17-jdk` baked in on 2026-06-15 (run 27562578160).
- GitHub-hosted runners already ship JDK 17, so neither code path needs the in-action install/JAVA_HOME fixup anymore.

## Test plan
- [ ] CI green on this branch (container jobs + `ci-infra` job on `ubuntu-latest`)
- [ ] Mill builds/tests pick up JDK 17 without explicit JAVA_HOME shimming

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined build cache setup action by removing unnecessary JDK configuration step. Public action interface remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->