### PR TITLE
Support minute hops for sub-hour windows

### DIFF
--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/HopsAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/HopsAggregator.scala
@@ -36,9 +36,11 @@ import java.util
 class HopsAggregatorBase(aggregations: Seq[Aggregation], inputSchema: Seq[(String, DataType)], resolution: Resolution)
     extends Serializable {
 
+  protected val effectiveResolution: Resolution = ResolutionUtils.effectiveResolution(aggregations, resolution)
+
   @transient lazy val rowAggregator =
     new RowAggregator(inputSchema, aggregations.flatMap(_.unWindowed))
-  val hopSizes: Array[Long] = resolution.hopSizes
+  val hopSizes: Array[Long] = effectiveResolution.hopSizes
 
   def init(): IrMapType =
     Array.fill(hopSizes.length)(new java.util.HashMap[Long, HopIr])
@@ -110,20 +112,20 @@ class HopsAggregator(minQueryTs: Long,
     // from where(leftBoundary) a particular hops size is relevant
     val hopSizeToMaxWindow =
       allWindows
-        .groupBy(resolution.calculateTailHop)
+        .groupBy(effectiveResolution.calculateTailHop)
         .mapValues(_.map(_.millis).max)
 
-    val maxHopSize = resolution.calculateTailHop(allWindows.maxBy(_.millis))
+    val maxHopSize = effectiveResolution.calculateTailHop(allWindows.maxBy(_.millis))
 
-    val result: Array[Option[Long]] = resolution.hopSizes.indices.map { hopIndex =>
-      val hopSize = resolution.hopSizes(hopIndex)
+    val result: Array[Option[Long]] = effectiveResolution.hopSizes.indices.map { hopIndex =>
+      val hopSize = effectiveResolution.hopSizes(hopIndex)
       // for windows with this hop as the tail hop size
       val windowBasedLeftBoundary = hopSizeToMaxWindow.get(hopSize).map(TsUtils.round(minQueryTs, hopSize) - _)
       // for windows larger with tail hop larger than this hop
       val largerWindowBasedLeftBoundary = if (hopIndex == 0) { // largest window already
         None
       } else { // smaller hop is only used to construct windows' head with larger hopsize.
-        val previousHopSize = resolution.hopSizes(hopIndex - 1)
+        val previousHopSize = effectiveResolution.hopSizes(hopIndex - 1)
         Some(TsUtils.round(minQueryTs, previousHopSize))
       }
       if (hopSize > maxHopSize) { // this hop size is not relevant
@@ -134,7 +136,7 @@ class HopsAggregator(minQueryTs: Long,
       }
     }.toArray
 
-    val readableHopSizes = resolution.hopSizes.map(WindowUtils.millisToString)
+    val readableHopSizes = effectiveResolution.hopSizes.map(WindowUtils.millisToString)
     val readableLeftBounds = result.map(_.map(TsUtils.toStr).getOrElse("unused"))
     val readableHopsToBoundsMap = readableHopSizes
       .zip(readableLeftBounds)

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/Resolution.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/Resolution.scala
@@ -18,6 +18,7 @@ package ai.chronon.aggregator.windowing
 
 import ai.chronon.api.Extensions.WindowOps
 import ai.chronon.api.Extensions.WindowUtils
+import ai.chronon.api.Aggregation
 import ai.chronon.api.GroupBy
 import ai.chronon.api.ScalaJavaConversions._
 import ai.chronon.api.TimeUnit
@@ -47,6 +48,22 @@ object FiveMinuteResolution extends Resolution {
     Array(WindowUtils.Day.millis, WindowUtils.Hour.millis, WindowUtils.FiveMinutes)
 }
 
+private[windowing] object MinuteWindowResolution extends Resolution {
+  private val OneHourMillis = new Window(1, TimeUnit.HOURS).millis
+
+  def calculateTailHop(window: Window): Long =
+    window.millis match {
+      case x if x <= 0                                     => WindowUtils.FiveMinutes
+      case x if x >= new Window(12, TimeUnit.DAYS).millis  => WindowUtils.Day.millis
+      case x if x >= new Window(12, TimeUnit.HOURS).millis => WindowUtils.Hour.millis
+      case x if x >= OneHourMillis                         => WindowUtils.FiveMinutes
+      case _                                               => WindowUtils.Minute
+    }
+
+  val hopSizes: Array[Long] =
+    Array(WindowUtils.Day.millis, WindowUtils.Hour.millis, WindowUtils.FiveMinutes, WindowUtils.Minute)
+}
+
 object DailyResolution extends Resolution {
 
   def calculateTailHop(window: Window): Long =
@@ -63,11 +80,25 @@ object DailyResolution extends Resolution {
 }
 
 object ResolutionUtils {
+  private val MinuteResolutionWindowThresholdMillis: Long = new Window(1, TimeUnit.HOURS).millis
+
+  private def hasMinuteWindow(aggregations: Seq[Aggregation]): Boolean =
+    Option(aggregations)
+      .exists(_.exists(agg =>
+        Option(agg.windows).exists(_.iterator().toScala.exists(window =>
+          window != null && window.millis > 0 && window.millis < MinuteResolutionWindowThresholdMillis))))
+
+  def effectiveResolution(aggregations: Seq[Aggregation], resolution: Resolution): Resolution =
+    if ((resolution eq FiveMinuteResolution) && hasMinuteWindow(aggregations)) MinuteWindowResolution
+    else resolution
 
   /** Find the smallest tail window resolution in a GroupBy. Returns 1D if the GroupBy does not define any windows (all-time aggregates).
-    * The window resolutions are: 5 min for a GroupBy a window < 12 hrs, 1 hr for < 12 days, 1 day for > 12 days.
+    * The window resolutions are: 1 min for a GroupBy window < 1 hr, 5 min for < 12 hrs,
+    * 1 hr for < 12 days, 1 day for > 12 days.
     */
   def getSmallestTailHopMillis(groupBy: GroupBy): Long = {
+    val aggregations = Option(groupBy.aggregations).map(_.toScala.toSeq).getOrElse(Seq.empty)
+    val resolution = effectiveResolution(aggregations, FiveMinuteResolution)
 
     val tailHops =
       for (
@@ -76,7 +107,7 @@ object ResolutionUtils {
         windows <- Option(agg.windows).toSeq;
         window <- windows.iterator().toScala
       ) yield {
-        FiveMinuteResolution.calculateTailHop(window)
+        resolution.calculateTailHop(window)
       }
 
     if (tailHops.isEmpty) WindowUtils.Day.millis

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/SawtoothAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/SawtoothAggregator.scala
@@ -45,11 +45,12 @@ import scala.collection.mutable
 class SawtoothAggregator(aggregations: Seq[Aggregation], inputSchema: Seq[(String, DataType)], resolution: Resolution)
     extends Serializable {
 
-  protected val hopSizes = resolution.hopSizes
+  protected val effectiveResolution: Resolution = ResolutionUtils.effectiveResolution(aggregations, resolution)
+  protected val hopSizes = effectiveResolution.hopSizes
 
   @transient lazy val unpackedAggs: UnpackedAggregations = UnpackedAggregations.from(aggregations)
   @transient lazy protected val tailHopIndices: Array[Int] = windowMappings.map { mapping =>
-    hopSizes.indexOf(resolution.calculateTailHop(mapping.aggregationPart.window))
+    hopSizes.indexOf(effectiveResolution.calculateTailHop(mapping.aggregationPart.window))
   }
 
   @transient lazy val windowMappings: Array[WindowMapping] = unpackedAggs.perWindow
@@ -61,7 +62,7 @@ class SawtoothAggregator(aggregations: Seq[Aggregation], inputSchema: Seq[(Strin
   // the cache uses this space to work out the IRs for the whole window based on hops
   // we only create this arena once, so GC kicks in fewer times
   @transient private lazy val arena =
-    Array.fill(resolution.hopSizes.length)(Array.fill[Entry](windowedAggregator.length)(null))
+    Array.fill(hopSizes.length)(Array.fill[Entry](windowedAggregator.length)(null))
 
   def computeWindowsIterator(hops: HopsAggregator.OutputArrayType, endTimes: Array[Long]): Iterator[Array[Any]] = {
 

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/SawtoothMutationAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/SawtoothMutationAggregator.scala
@@ -16,7 +16,7 @@
 
 package ai.chronon.aggregator.windowing
 
-import ai.chronon.api.Extensions.WindowOps
+import ai.chronon.api.Extensions.{WindowOps, WindowUtils}
 import ai.chronon.api._
 
 import java.util
@@ -47,7 +47,7 @@ class SawtoothMutationAggregator(aggregations: Seq[Aggregation],
                                inputSchema: Seq[(String, DataType)],
                                resolution: Resolution) {
 
-  val hopsAggregator = new HopsAggregatorBase(aggregations, inputSchema, resolution)
+  val hopsAggregator = new HopsAggregatorBase(aggregations, inputSchema, effectiveResolution)
 
   def batchIrSchema: Array[(String, DataType)] = {
     val collapsedSchema = windowedAggregator.irSchema
@@ -69,6 +69,18 @@ class SawtoothMutationAggregator(aggregations: Seq[Aggregation],
     windowMappings.map { mapping => Option(mapping.aggregationPart.window).map { batchEndTs - _.millis } }
 
   def init: BatchIr = BatchIr(Array.fill(windowedAggregator.length)(null), hopsAggregator.init())
+
+  // Minutely resolution appends a 1-minute hop after the legacy [1d, 1h, 5m] layout.
+  // Existing online batch IRs can therefore be missing only that newest tail bucket.
+  protected def storedTailHopIndex(batchIr: FinalBatchIr, hopIndex: Int): Int = {
+    val storedHopCount = Option(batchIr.tailHops).map(_.length).getOrElse(0)
+    if (hopIndex < storedHopCount) {
+      hopIndex
+    } else {
+      val fiveMinuteHopIndex = hopSizes.indexOf(WindowUtils.FiveMinutes)
+      if (fiveMinuteHopIndex >= 0 && fiveMinuteHopIndex < storedHopCount) fiveMinuteHopIndex else hopIndex
+    }
+  }
 
   def update(batchEndTs: Long, batchIr: BatchIr, row: Row): BatchIr = {
     val batchTails = tailTs(batchEndTs)
@@ -163,8 +175,9 @@ class SawtoothMutationAggregator(aggregations: Seq[Aggregation],
       val window = windowMappings(i).aggregationPart.window
       if (window != null) { // no hops for unwindowed
         val hopIndex = tailHopIndices(i)
-        val queryTail = TsUtils.round(queryTs - windowMillis, hopSizes(hopIndex))
-        val hopIrs = batchIr.tailHops(hopIndex)
+        val storedHopIndex = storedTailHopIndex(batchIr, hopIndex)
+        val queryTail = TsUtils.round(queryTs - windowMillis, hopSizes(storedHopIndex))
+        val hopIrs = batchIr.tailHops(storedHopIndex)
         val relevantHops = mutable.ArrayBuffer[Any](ir(i))
         var idx: Int = 0
         while (idx < hopIrs.length) {

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/SawtoothOnlineAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/SawtoothOnlineAggregator.scala
@@ -195,9 +195,10 @@ class SawtoothOnlineAggregator(val batchEndTs: Long,
       val hasNonNull = if (window != null) { // no hops for unwindowed
         val windowMillis = windowMappings(i).millis
         val hopIndex = tailHopIndices(i)
-        val queryTail = TsUtils.round(batchEndTs - windowMillis, hopSizes(hopIndex))
+        val storedHopIndex = storedTailHopIndex(batchIr, hopIndex)
+        val queryTail = TsUtils.round(batchEndTs - windowMillis, hopSizes(storedHopIndex))
 
-        val hopIrs = batchIr.tailHops(hopIndex)
+        val hopIrs = batchIr.tailHops(storedHopIndex)
         var idx: Int = 0
 
         lazy val hasNonNullTailHop = {

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/TwoStackLiteAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/TwoStackLiteAggregator.scala
@@ -28,13 +28,14 @@ class TwoStackLiteAggregator(inputSchema: StructType,
                              aggregations: Seq[Aggregation],
                              resolution: Resolution = FiveMinuteResolution) {
 
+  private val effectiveResolution = ResolutionUtils.effectiveResolution(aggregations, resolution)
   private val allParts = aggregations.flatMap(_.unpack)
   allParts.map(_.outputColumnName)
   // create row aggregator per window - we will loop over data as many times as there are unique windows
   // we will use different row aggregators to do so
   case class PerWindowAggregator(window: Window, agg: RowAggregator, indexMapping: Array[Int]) {
     private val windowLength: Long = window.millis
-    private val tailHopSize = resolution.calculateTailHop(window)
+    private val tailHopSize = effectiveResolution.calculateTailHop(window)
     def tailTs(queryTs: Long): Long = ((queryTs - windowLength) / tailHopSize) * tailHopSize
     def bankersBuffer(inputSize: Int) = new TwoStackLiteAggregationBuffer[Row, Array[Any], Array[Any]](agg, inputSize)
     def init = new Array[Any](agg.length)

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/ResolutionTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/ResolutionTest.scala
@@ -1,0 +1,230 @@
+/*
+ *    Copyright (C) 2023 The Chronon Authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package ai.chronon.aggregator.test
+
+import ai.chronon.aggregator.row.RowAggregator
+import ai.chronon.aggregator.test.SawtoothAggregatorTest.sawtoothAggregate
+import ai.chronon.aggregator.windowing._
+import ai.chronon.api.Extensions.{AggregationOps, WindowOps, WindowUtils}
+import ai.chronon.api._
+import com.google.gson.Gson
+import org.junit.Assert._
+import org.scalatest.flatspec.AnyFlatSpec
+
+import scala.collection.JavaConverters._
+
+class ResolutionTest extends AnyFlatSpec {
+
+  private object LegacyFiveMinuteResolution extends Resolution {
+    def calculateTailHop(window: Window): Long =
+      window.millis match {
+        case x if x >= new Window(12, TimeUnit.DAYS).millis  => WindowUtils.Day.millis
+        case x if x >= new Window(12, TimeUnit.HOURS).millis => WindowUtils.Hour.millis
+        case _                                               => WindowUtils.FiveMinutes
+      }
+
+    val hopSizes: Array[Long] =
+      Array(WindowUtils.Day.millis, WindowUtils.Hour.millis, WindowUtils.FiveMinutes)
+  }
+
+  private val schema = Seq("ts" -> LongType, "value" -> LongType)
+  private val baseTs = 1704067200000L
+  private val gson = new Gson
+
+  private def groupBy(aggregations: Seq[Aggregation]): GroupBy = {
+    val groupBy = new GroupBy()
+    groupBy.setAggregations(aggregations.asJava)
+    groupBy
+  }
+
+  it should "preserve legacy resolution for hour and day windows" in {
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM,
+                           "value",
+                           Seq(new Window(1, TimeUnit.HOURS), new Window(1, TimeUnit.DAYS)))
+    )
+
+    val resolution = ResolutionUtils.effectiveResolution(aggregations, FiveMinuteResolution)
+
+    assertSame(FiveMinuteResolution, resolution)
+    assertEquals(LegacyFiveMinuteResolution.hopSizes.toSeq, resolution.hopSizes.toSeq)
+    assertEquals(WindowUtils.FiveMinutes, resolution.calculateTailHop(new Window(1, TimeUnit.HOURS)))
+    assertEquals(WindowUtils.Hour.millis, resolution.calculateTailHop(new Window(1, TimeUnit.DAYS)))
+    assertEquals(WindowUtils.FiveMinutes, ResolutionUtils.getSmallestTailHopMillis(groupBy(aggregations)))
+  }
+
+  it should "ignore non-positive and unbounded windows when selecting minute resolution" in {
+    val zeroWindow = new Window(0, TimeUnit.MINUTES)
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM, "value", Seq(zeroWindow, WindowUtils.Unbounded))
+    )
+
+    val resolution = ResolutionUtils.effectiveResolution(aggregations, FiveMinuteResolution)
+
+    assertSame(FiveMinuteResolution, resolution)
+    assertEquals(WindowUtils.FiveMinutes, resolution.calculateTailHop(zeroWindow))
+    assertEquals(WindowUtils.Day.millis, resolution.calculateTailHop(WindowUtils.Unbounded))
+  }
+
+  it should "use minute hops only for windows below one hour" in {
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM,
+                           "value",
+                           Seq(new Window(30, TimeUnit.MINUTES), new Window(1, TimeUnit.HOURS)))
+    )
+
+    val resolution = ResolutionUtils.effectiveResolution(aggregations, FiveMinuteResolution)
+
+    assertNotSame(FiveMinuteResolution, resolution)
+    assertEquals(Seq(WindowUtils.Day.millis, WindowUtils.Hour.millis, WindowUtils.FiveMinutes, WindowUtils.Minute),
+                 resolution.hopSizes.toSeq)
+    assertEquals(WindowUtils.Minute, resolution.calculateTailHop(new Window(30, TimeUnit.MINUTES)))
+    assertEquals(WindowUtils.Minute, resolution.calculateTailHop(new Window(59, TimeUnit.MINUTES)))
+    assertEquals(WindowUtils.FiveMinutes, resolution.calculateTailHop(new Window(60, TimeUnit.MINUTES)))
+    assertEquals(WindowUtils.FiveMinutes, resolution.calculateTailHop(new Window(1, TimeUnit.HOURS)))
+    assertEquals(WindowUtils.Hour.millis, resolution.calculateTailHop(new Window(12, TimeUnit.HOURS)))
+    assertEquals(WindowUtils.Day.millis, resolution.calculateTailHop(new Window(12, TimeUnit.DAYS)))
+    assertEquals(WindowUtils.Minute, ResolutionUtils.getSmallestTailHopMillis(groupBy(aggregations)))
+  }
+
+  it should "preserve existing offline values for non-minute windows" in {
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.COUNT,
+                           "value",
+                           Seq(new Window(1, TimeUnit.HOURS), new Window(1, TimeUnit.DAYS))),
+      Builders.Aggregation(Operation.SUM,
+                           "value",
+                           Seq(new Window(1, TimeUnit.HOURS), new Window(1, TimeUnit.DAYS)))
+    )
+    val events = Array(
+      new TestRow(baseTs + 5 * WindowUtils.Minute, 10L)(0),
+      new TestRow(baseTs + 35 * WindowUtils.Minute, 20L)(0),
+      new TestRow(baseTs + 90 * WindowUtils.Minute, 30L)(0),
+      new TestRow(baseTs + 3 * WindowUtils.Hour.millis, 40L)(0)
+    )
+    val queries = Array(baseTs + 2 * WindowUtils.Hour.millis, baseTs + 4 * WindowUtils.Hour.millis)
+
+    val current = sawtoothAggregate(events, queries, aggregations, schema, FiveMinuteResolution)
+    val legacy = sawtoothAggregate(events, queries, aggregations, schema, LegacyFiveMinuteResolution)
+
+    assertEquals(gson.toJson(legacy), gson.toJson(current))
+  }
+
+  it should "serve existing online batch data unchanged for non-minute windows" in {
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.COUNT,
+                           "value",
+                           Seq(new Window(1, TimeUnit.HOURS), new Window(1, TimeUnit.DAYS))),
+      Builders.Aggregation(Operation.SUM,
+                           "value",
+                           Seq(new Window(1, TimeUnit.HOURS), new Window(1, TimeUnit.DAYS)))
+    )
+    val batchEndTs = baseTs + WindowUtils.Day.millis
+    val events = Array(
+      new TestRow(baseTs + 5 * WindowUtils.Minute, 10L)(0),
+      new TestRow(baseTs + 35 * WindowUtils.Minute, 20L)(0),
+      new TestRow(baseTs + 23 * WindowUtils.Hour.millis, 30L)(0),
+      new TestRow(batchEndTs + 10 * WindowUtils.Minute, 40L)(0),
+      new TestRow(batchEndTs + 70 * WindowUtils.Minute, 50L)(0)
+    )
+    val legacyUpload = new SawtoothOnlineAggregator(batchEndTs, aggregations, schema, LegacyFiveMinuteResolution)
+    val oldFinalBatchIr = legacyUpload.normalizeBatchIr(
+      events.filter(_.ts < batchEndTs).foldLeft(legacyUpload.init)(legacyUpload.update)
+    )
+    val oldDenormalizedBatchIr = legacyUpload.denormalizeBatchIr(oldFinalBatchIr)
+    val currentServing = new SawtoothOnlineAggregator(batchEndTs, aggregations, schema, FiveMinuteResolution)
+    val legacyServing = new SawtoothOnlineAggregator(batchEndTs, aggregations, schema, LegacyFiveMinuteResolution)
+    val queries = Array(batchEndTs + WindowUtils.Hour.millis, batchEndTs + 2 * WindowUtils.Hour.millis)
+    val streamingRows = events.filter(_.ts >= batchEndTs)
+
+    assertEquals(LegacyFiveMinuteResolution.hopSizes.length, oldFinalBatchIr.tailHops.length)
+    assertEquals(LegacyFiveMinuteResolution.hopSizes.length, currentServing.init.tailHops.length)
+
+    queries.foreach { queryTs =>
+      val current = currentServing.windowedAggregator.finalize(
+        currentServing.lambdaAggregateIr(oldDenormalizedBatchIr, streamingRows.iterator, queryTs))
+      val legacy = legacyServing.windowedAggregator.finalize(
+        legacyServing.lambdaAggregateIr(oldDenormalizedBatchIr, streamingRows.iterator, queryTs))
+      assertEquals(gson.toJson(legacy), gson.toJson(current))
+    }
+  }
+
+  it should "serve existing online batch data for minute windows from the legacy hop layout" in {
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.COUNT,
+                           "value",
+                           Seq(new Window(30, TimeUnit.MINUTES), new Window(1, TimeUnit.HOURS))),
+      Builders.Aggregation(Operation.SUM,
+                           "value",
+                           Seq(new Window(30, TimeUnit.MINUTES), new Window(1, TimeUnit.HOURS)))
+    )
+    val batchEndTs = baseTs + WindowUtils.Day.millis
+    val events = Array(
+      new TestRow(batchEndTs - 27 * WindowUtils.Minute, 10L)(0),
+      new TestRow(batchEndTs - 11 * WindowUtils.Minute, 20L)(0),
+      new TestRow(batchEndTs - 2 * WindowUtils.Minute, 30L)(0)
+    )
+    val legacyUpload = new SawtoothOnlineAggregator(batchEndTs, aggregations, schema, LegacyFiveMinuteResolution)
+    val oldFinalBatchIr = legacyUpload.normalizeBatchIr(events.foldLeft(legacyUpload.init)(legacyUpload.update))
+    val oldDenormalizedBatchIr = legacyUpload.denormalizeBatchIr(oldFinalBatchIr)
+    val currentServing = new SawtoothOnlineAggregator(batchEndTs, aggregations, schema, FiveMinuteResolution)
+    val legacyServing = new SawtoothOnlineAggregator(batchEndTs, aggregations, schema, LegacyFiveMinuteResolution)
+    val queryTs = batchEndTs + 3 * WindowUtils.Minute
+
+    assertEquals(LegacyFiveMinuteResolution.hopSizes.length, oldFinalBatchIr.tailHops.length)
+    assertEquals(4, currentServing.init.tailHops.length)
+
+    val current = currentServing.windowedAggregator.finalize(
+      currentServing.lambdaAggregateIr(oldDenormalizedBatchIr, Iterator.empty, queryTs))
+    val legacy = legacyServing.windowedAggregator.finalize(
+      legacyServing.lambdaAggregateIr(oldDenormalizedBatchIr, Iterator.empty, queryTs))
+
+    assertEquals(gson.toJson(legacy), gson.toJson(current))
+  }
+
+  it should "aggregate minute windows with minute hop accuracy" in {
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.COUNT,
+                           "value",
+                           Seq(new Window(30, TimeUnit.MINUTES), new Window(1, TimeUnit.HOURS))),
+      Builders.Aggregation(Operation.SUM,
+                           "value",
+                           Seq(new Window(30, TimeUnit.MINUTES), new Window(1, TimeUnit.HOURS)))
+    )
+    val events = Array(
+      new TestRow(baseTs + 1 * WindowUtils.Minute, 10L)(0),
+      new TestRow(baseTs + 3 * WindowUtils.Minute, 20L)(0),
+      new TestRow(baseTs + 32 * WindowUtils.Minute, 30L)(0),
+      new TestRow(baseTs + 58 * WindowUtils.Minute, 40L)(0)
+    )
+    val queries = Array(baseTs + 35 * WindowUtils.Minute, baseTs + 59 * WindowUtils.Minute)
+    val resolution = ResolutionUtils.effectiveResolution(aggregations, FiveMinuteResolution)
+    val windows = aggregations.flatMap(_.unpack.map(_.window)).toArray
+    val tailHops = windows.map(resolution.calculateTailHop)
+    val rowAggregator = new RowAggregator(schema, aggregations.flatMap(_.unpack))
+    val sawtooth = sawtoothAggregate(events, queries, aggregations, schema, FiveMinuteResolution)
+    val naive = new NaiveAggregator(rowAggregator, windows, tailHops).aggregate(events, queries)
+
+    assertEquals(4, new HopsAggregator(queries.min, aggregations, schema, FiveMinuteResolution).hopSizes.length)
+    assertEquals(4, new SawtoothOnlineAggregator(queries.min, aggregations, schema, FiveMinuteResolution).init.tailHops.length)
+
+    queries.indices.foreach { idx =>
+      assertEquals(gson.toJson(rowAggregator.finalize(naive(idx))),
+                   gson.toJson(rowAggregator.finalize(sawtooth(idx))))
+    }
+  }
+}

--- a/api/src/main/scala/ai/chronon/api/Extensions.scala
+++ b/api/src/main/scala/ai/chronon/api/Extensions.scala
@@ -95,7 +95,7 @@ object Extensions {
     val Null: Window = null
 
     private val SecondMillis: Long = 1000
-    private val Minute: Long = 60 * SecondMillis
+    val Minute: Long = 60 * SecondMillis
     val FiveMinutes: Long = 5 * Minute
     private val defaultPartitionSize: api.TimeUnit = api.TimeUnit.DAYS
     val onePartition: api.Window = new api.Window(1, defaultPartitionSize)

--- a/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
@@ -348,15 +348,16 @@ class GroupBy(val aggregations: Seq[api.Aggregation],
                      queryTimeRange: Option[TimeRange] = None,
                      resolution: Resolution = FiveMinuteResolution): DataFrame =
     tableUtils.withJobDescription(s"temporalEvents(${keyColumns.mkString(",")})") {
+      val effectiveResolution = ResolutionUtils.effectiveResolution(aggregations, resolution)
 
       val queriesDf = skewFilter
         .map { queriesUnfilteredDf.filter }
         .getOrElse(queriesUnfilteredDf.removeNulls(keyColumns))
 
       val TimeRange(minQueryTs, maxQueryTs) = queryTimeRange.getOrElse(queriesDf.calculateTimeRange)
-      val hopsDs = hopsAggregate(minQueryTs, resolution)
+      val hopsDs = hopsAggregate(minQueryTs, effectiveResolution)
 
-      def headStart(ts: Long): Long = TsUtils.round(ts, resolution.hopSizes.min)
+      def headStart(ts: Long): Long = TsUtils.round(ts, effectiveResolution.hopSizes.min)
       queriesDf.validateJoinKeys(inputDf, keyColumns)
 
       val queriesKeyGen = FastHashing.generateKeyBuilder(keyColumns.toArray, queriesDf.schema)
@@ -395,7 +396,7 @@ class GroupBy(val aggregations: Seq[api.Aggregation],
       }
 
       val sawtoothAggregator =
-        new SawtoothAggregator(aggregations, selectedSchema, resolution)
+        new SawtoothAggregator(aggregations, selectedSchema, effectiveResolution)
 
       // create the IRs up to minHop accuracy
       val headStartsWithIrsDs: Dataset[(CKey, Array[Any])] = {

--- a/spark/src/main/scala/ai/chronon/spark/join/AggregationInfo.scala
+++ b/spark/src/main/scala/ai/chronon/spark/join/AggregationInfo.scala
@@ -1,6 +1,12 @@
 package ai.chronon.spark.join
 
-import ai.chronon.aggregator.windowing.{FiveMinuteResolution, HopsAggregator, Resolution, SawtoothAggregator}
+import ai.chronon.aggregator.windowing.{
+  FiveMinuteResolution,
+  HopsAggregator,
+  Resolution,
+  ResolutionUtils,
+  SawtoothAggregator
+}
 import ai.chronon.api
 import ai.chronon.api.ScalaJavaConversions.IterableOps
 import ai.chronon.api.{Constants, TsUtils}
@@ -26,7 +32,7 @@ class CGenericRow(val values: Array[Any]) extends SparkRow {
 
   override def get(i: Int): Any = values(i)
 
-  override def toSeq: Seq[Any] = values.clone()
+  override def toSeq: Seq[Any] = values.clone().toIndexedSeq
 
   override def copy(): CGenericRow = this
 }
@@ -76,13 +82,14 @@ object AggregationInfo {
            rightSchema: spark.StructType,
            resolution: Resolution = FiveMinuteResolution): AggregationInfo = {
 
-    val specs = groupBy.aggregations.toScala.toArray
-    val schema = SparkConversions.toChrononSchema(rightSchema)
+    val specs = groupBy.aggregations.toScala.toIndexedSeq
+    val schema = SparkConversions.toChrononSchema(rightSchema).toIndexedSeq
+    val effectiveResolution = ResolutionUtils.effectiveResolution(specs, resolution)
 
     val hopsAggregator =
-      new HopsAggregator(minQueryTs, specs, schema, resolution)
+      new HopsAggregator(minQueryTs, specs, schema, effectiveResolution)
     val sawtoothAggregator =
-      new SawtoothAggregator(specs, schema, resolution)
+      new SawtoothAggregator(specs, schema, effectiveResolution)
 
     val rightTimeIndex = rightSchema.indexWhere(_.name == Constants.TimeColumn)
     val leftTimeIndex = leftSchema.indexWhere(_.name == Constants.TimeColumn)
@@ -105,7 +112,7 @@ object AggregationInfo {
       leftSchema = leftSchema,
       aggregateChrononSchema = aggregateSchema,
       outputSparkSchema = outputSparkSchema,
-      resolution = resolution
+      resolution = effectiveResolution
     )
   }
 }

--- a/thrift/api.thrift
+++ b/thrift/api.thrift
@@ -253,7 +253,8 @@ struct Aggregation {
     For TEMPORAL case windows are sawtooth. Meaning head slides ahead continuously in time, whereas, the tail only hops ahead, at discrete points in time. Hop is determined by the window size automatically. The maximum hop size is 1/12 of window size. You can specify multiple such windows at once.
       - Window > 12 days  -> Hop Size = 1 day
       - Window > 12 hours -> Hop Size = 1 hr
-      - Window > 1hr      -> Hop Size = 5 minutes
+      - Window >= 1hr     -> Hop Size = 5 minutes
+      - Window < 1hr      -> Hop Size = 1 minute
     */
     4: optional list<common.Window> windows
 


### PR DESCRIPTION
## Summary
- Add adaptive window resolution so configs with windows under 60 minutes use minute hops internally.
- Keep the existing user API unchanged: users specify minutely window sizes, not a resolution field.
- Preserve legacy 1d/1h/5m behavior for existing hour/day windows, including offline output and online serving of existing batch IRs.

## Compatibility
- Existing non-minute windows keep the previous hop layout and output values.
- Online serving can read existing 3-hop batch IR data for sub-hour configs via a legacy tail-hop fallback.
- Offline and online regression coverage verifies unchanged behavior for existing data paths.

## Verification
- `./mill aggregator.test`
- `./mill spark.test.testOnly ai.chronon.spark.groupby.GroupByTest ai.chronon.spark.join.SawtoothUdfSpec`
- `./mill online.test`
- `./mill 'aggregator[2.13.17].compile' + 'spark[2.13.17].compile'`
- `./mill __.checkFormat`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced windowing precision for sub-hour aggregations: windows smaller than 1 hour now automatically use finer-grained (1-minute) hop sizes for improved accuracy.

* **Improvements**
  * Automatic resolution selection now intelligently optimizes window boundaries based on your configured aggregations.

* **Tests**
  * Added comprehensive test coverage for resolution selection and windowing behavior validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->