### PR TITLE
CLI: Fix auth behind JWT-only API gateways

### DIFF
--- a/python/src/ai/chronon/repo/auth.py
+++ b/python/src/ai/chronon/repo/auth.py
@@ -21,6 +21,7 @@ from ai.chronon.cli.theme import (
     print_success,
     print_warning,
 )
+from ai.chronon.repo.token_exchange import decode_jwt_claims, exchange_session_for_jwt
 
 AUTH_DIR = Path.home() / ".zipline"
 AUTH_FILE = AUTH_DIR / "auth.json"
@@ -211,33 +212,39 @@ def login(url, no_browser):
 
         if "access_token" in token_data:
             # Success — save token and user info
+            session_token = token_data["access_token"]
             auth_config = {
                 "url": base_url,
-                "access_token": token_data["access_token"],
+                "access_token": session_token,
                 "token_type": token_data.get("token_type", "Bearer"),
             }
 
-            # Fetch user info to persist and display
+            # Verify the token end-to-end by exchanging it for a JWT — the same
+            # path the CLI uses for every API call — and read the user info from
+            # the JWT claims. Unlike /api/auth/get-session, this carries the
+            # opaque token in the request body, so a JWT-only perimeter gateway
+            # doesn't block it. A failure here means subsequent commands would
+            # fail too, so surface it instead of silently reporting success.
+            verified = False
             try:
-                session_resp = requests.get(
-                    f"{base_url}/api/auth/get-session",
-                    headers={"Authorization": f"Bearer {token_data['access_token']}"},
-                    timeout=10,
-                )
-                if session_resp.ok:
-                    session_data = session_resp.json()
-                    user = session_data.get("user", {})
-                    name = user.get("name", "Unknown")
-                    email = user.get("email", "")
-                    auth_config["name"] = name
-                    auth_config["email"] = email
-            except requests.RequestException:
+                jwt = exchange_session_for_jwt(session_token, base_url)
+                claims = decode_jwt_claims(jwt)
+                auth_config["name"] = claims.get("name") or "Unknown"
+                auth_config["email"] = claims.get("email") or ""
+                verified = True
+            except (RuntimeError, ValueError, KeyError, IndexError):
                 pass
 
             save_auth_config(auth_config)
             print_success("Authentication successful!")
             if auth_config.get("email"):
                 print_key_value("Logged in as", f"{auth_config['name']} ({auth_config['email']})")
+            if not verified:
+                print_warning(
+                    "Signed in, but the token could not be verified against the API. "
+                    "Subsequent commands may fail — check that the auth server is "
+                    "reachable and that any API gateway allows this request."
+                )
             return
 
         error = token_data.get("error", "")
@@ -283,20 +290,9 @@ def get_access_token(url):
     base_url = config["url"]
     session_token = config["access_token"]
     try:
-        resp = requests.get(
-            f"{base_url}/api/auth/token",
-            headers={"Authorization": f"Bearer {session_token}"},
-            timeout=10,
-        )
-        if resp.ok:
-            token = resp.json().get("token")
-            if token:
-                click.echo(token)
-                return
-        print_error("Session expired or invalid. Run 'zipline auth login' to re-authenticate.")
-        sys.exit(1)
-    except requests.RequestException as e:
-        print_error(f"Failed to fetch access token: {e}")
+        click.echo(exchange_session_for_jwt(session_token, base_url))
+    except RuntimeError as e:
+        print_error(str(e))
         sys.exit(1)
 
 
@@ -336,19 +332,18 @@ def _print_account_status(config, is_default=False):
 
     token = config.get("access_token")
     if base_url and token:
+        # Verify via the token exchange (body-carried, gateway-safe) rather than
+        # /api/auth/get-session, which presents the opaque token as a bearer and
+        # is blocked by JWT-only perimeter gateways. User info comes from the JWT
+        # claims returned by the exchange.
         try:
-            resp = requests.get(
-                f"{base_url}/api/auth/get-session",
-                headers={"Authorization": f"Bearer {token}"},
-                timeout=10,
-            )
-            if resp.ok:
-                user = resp.json().get("user", {})
-                name = user.get("name", "Unknown")
-                email = user.get("email", "")
-                print_key_value("User", f"{name} ({email})")
-                print_key_value("Status", "authenticated")
-            else:
-                print_warning("Token expired or invalid. Run 'zipline auth login' to re-authenticate.")
-        except requests.RequestException:
-            print_warning("Unable to verify token (network error).")
+            jwt = exchange_session_for_jwt(token, base_url)
+            claims = decode_jwt_claims(jwt)
+            name = claims.get("name") or "Unknown"
+            email = claims.get("email") or ""
+            print_key_value("User", f"{name} ({email})")
+            print_key_value("Status", "authenticated")
+        except RuntimeError as e:
+            print_warning(str(e))
+        except (ValueError, KeyError, IndexError):
+            print_warning("Unable to verify token (malformed response from auth server).")

--- a/python/src/ai/chronon/repo/token_exchange.py
+++ b/python/src/ai/chronon/repo/token_exchange.py
@@ -2,9 +2,16 @@
 
 Supports two token types (auto-detected):
 - **JWT** (from ``zipline auth get-access-token``): used directly, no exchange needed.
-- **Session token** (from a service principal): exchanged for a short-lived JWT
-  via ``GET {auth_url}/api/auth/token``.  Exchanged JWTs are cached and
-  automatically refreshed when within 60 s of expiry.
+- **Session token** (from a service principal or CLI login): exchanged for a
+  short-lived JWT via ``POST {auth_url}/auth/cli-token``.  Exchanged JWTs are
+  cached and automatically refreshed when within 60 s of expiry.
+
+The exchange sends the opaque session token in the request body rather than the
+``Authorization`` header. Perimeter API gateways commonly reject any
+``Authorization`` header that isn't a JWT, which would block a bearer-carried
+opaque token before it reaches the origin; a header-less request is not blocked.
+Older frontends that predate ``/auth/cli-token`` are handled by falling back to
+the legacy ``GET /api/auth/token`` bearer exchange.
 """
 
 import base64
@@ -30,43 +37,66 @@ def is_jwt(token: str) -> bool:
     return True
 
 
-def _decode_jwt_exp(jwt_token: str) -> float:
-    """Decode the ``exp`` claim from a JWT without signature verification."""
+def decode_jwt_claims(jwt_token: str) -> dict:
+    """Decode a JWT payload (claims) without verifying the signature."""
     payload_b64 = jwt_token.split(".")[1]
     payload_b64 += "=" * (4 - len(payload_b64) % 4)
-    payload = json.loads(base64.urlsafe_b64decode(payload_b64))
-    return float(payload["exp"])
+    return json.loads(base64.urlsafe_b64decode(payload_b64))
+
+
+def _decode_jwt_exp(jwt_token: str) -> float:
+    """Decode the ``exp`` claim from a JWT without signature verification."""
+    return float(decode_jwt_claims(jwt_token)["exp"])
+
+
+def _request_exchange(session_token: str, base_url: str) -> requests.Response:
+    """Call the token-exchange endpoint, carrying the opaque token in the body.
+
+    Sends ``POST {base_url}/auth/cli-token`` with the session token in the JSON
+    body (no ``Authorization`` header) so JWT-only perimeter gateways don't
+    reject it. Falls back to the legacy ``GET /api/auth/token`` bearer exchange
+    when the frontend predates ``/auth/cli-token`` (HTTP 404).
+    """
+    resp = requests.post(
+        f"{base_url}/auth/cli-token",
+        json={"session_token": session_token},
+        headers={"Content-Type": "application/json"},
+        timeout=10,
+    )
+    if resp.status_code == 404:
+        resp = requests.get(
+            f"{base_url}/api/auth/token",
+            headers={"Authorization": f"Bearer {session_token}"},
+            timeout=10,
+        )
+    return resp
 
 
 def exchange_session_for_jwt(session_token: str, auth_url: str) -> str:
     """Exchange a BetterAuth session token for a short-lived JWT.
 
-    Calls ``GET {auth_url}/api/auth/token`` with the session token as a
-    Bearer credential and returns the JWT string.
+    Posts the session token to ``{auth_url}/auth/cli-token`` (see
+    :func:`_request_exchange`) and returns the JWT string.
     """
-    endpoint = f"{auth_url.rstrip('/')}/api/auth/token"
+    base_url = auth_url.rstrip("/")
     try:
-        resp = requests.get(
-            endpoint,
-            headers={"Authorization": f"Bearer {session_token}"},
-            timeout=10,
-        )
+        resp = _request_exchange(session_token, base_url)
     except requests.ConnectionError:
         raise RuntimeError(
-            f"Could not connect to auth server at {endpoint}. "
+            f"Could not connect to auth server at {base_url}. "
             "Check that ZIPLINE_AUTH_URL is correct and the frontend is running. "
             f"Current ZIPLINE_AUTH_URL: {auth_url}"
         ) from None
     except requests.Timeout:
         raise RuntimeError(
-            f"Timed out connecting to auth server at {endpoint}. "
+            f"Timed out connecting to auth server at {base_url}. "
             "Check that ZIPLINE_AUTH_URL is correct and the frontend is reachable."
         ) from None
 
     if resp.status_code == 401:
         raise RuntimeError(
-            f"Token rejected by auth server at {endpoint} (HTTP 401). "
-            "The ZIPLINE_TOKEN may be expired, revoked, or does not belong to "
+            f"Token rejected by auth server at {base_url} (HTTP 401). "
+            "The token may be expired, revoked, or does not belong to "
             "this auth server. Check that ZIPLINE_AUTH_URL matches the frontend "
             "where the token was created. If using a service principal, rotate "
             "the token in the admin UI. If using a personal session, run "
@@ -74,14 +104,14 @@ def exchange_session_for_jwt(session_token: str, auth_url: str) -> str:
         )
     if not resp.ok:
         raise RuntimeError(
-            f"Token exchange failed (HTTP {resp.status_code}) at {endpoint}. "
+            f"Token exchange failed (HTTP {resp.status_code}) at {base_url}. "
             f"Response: {resp.text[:200]}"
         )
 
     token = resp.json().get("token")
     if not token:
         raise RuntimeError(
-            f"Token exchange at {endpoint} succeeded but no JWT was returned. "
+            f"Token exchange at {base_url} succeeded but no JWT was returned. "
             "Check that the auth server is configured correctly."
         )
     return token

--- a/python/src/ai/chronon/repo/zipline_hub.py
+++ b/python/src/ai/chronon/repo/zipline_hub.py
@@ -208,25 +208,15 @@ class ZiplineHub:
 
     def _get_hub_jwt(self):
         """Fetch a short-lived JWT from Zipline Hub using the stored session token."""
+        from ai.chronon.repo.token_exchange import exchange_session_for_jwt
+
         config = self._hub_auth_config
-        hub_url = config["url"]
-        session_token = config["access_token"]
         try:
-            resp = requests.get(
-                f"{hub_url}/api/auth/token",
-                headers={"Authorization": f"Bearer {session_token}"},
-                timeout=10,
-            )
-            if resp.ok:
-                return resp.json().get("token")
-            else:
-                print_warning(
-                    "Session expired. Run 'zipline auth login' to re-authenticate.",
-                    format=self.format,
-                )
-                return None
-        except requests.RequestException as e:
-            print_warning(f"Failed to fetch JWT from hub: {e}", format=self.format)
+            return exchange_session_for_jwt(config["access_token"], config["url"])
+        except RuntimeError as e:
+            # exchange_session_for_jwt already produces an actionable message
+            # (expired session, connectivity, misconfigured auth server).
+            print_warning(str(e), format=self.format)
             return None
 
     def _get_error_details(self, e: requests.RequestException) -> str:

--- a/python/test/test_auth.py
+++ b/python/test/test_auth.py
@@ -1,3 +1,4 @@
+import base64
 import json
 import os
 from unittest.mock import Mock, patch
@@ -15,6 +16,19 @@ from ai.chronon.repo.auth import (
     get_user_email,
     save_auth_config,
 )
+
+
+def _make_jwt(claims: dict) -> str:
+    """Build a fake (unsigned) JWT whose payload decodes to *claims*.
+
+    Matches what ``decode_jwt_claims`` reads — base64url-encoded JSON payload —
+    so tests can exercise the real claim-decoding path.
+    """
+
+    def b64(obj: dict) -> str:
+        return base64.urlsafe_b64encode(json.dumps(obj).encode()).decode().rstrip("=")
+
+    return f"{b64({'alg': 'HS256', 'typ': 'JWT'})}.{b64(claims)}.sig"
 
 
 @pytest.fixture
@@ -240,15 +254,11 @@ class TestLoginCommand:
             "token_type": "Bearer",
         }
 
-        session_resp = Mock()
-        session_resp.ok = True
-        session_resp.json.return_value = {
-            "user": {"name": "Jane Doe", "email": "jane@example.com"}
-        }
+        jwt = _make_jwt({"name": "Jane Doe", "email": "jane@example.com"})
 
         with (
             patch("ai.chronon.repo.auth.requests.post", return_value=device_code_resp) as mock_post,
-            patch("ai.chronon.repo.auth.requests.get", return_value=session_resp),
+            patch("ai.chronon.repo.auth.exchange_session_for_jwt", return_value=jwt) as mock_exchange,
             patch("ai.chronon.repo.auth.webbrowser.open"),
             patch("ai.chronon.repo.auth.time.sleep"),
             patch("ai.chronon.repo.auth.time.time", side_effect=[0, 1]),
@@ -260,6 +270,8 @@ class TestLoginCommand:
 
         assert result.exit_code == 0
         assert "Authentication successful" in result.output
+        # Login verifies the token via the exchange (not /api/auth/get-session).
+        mock_exchange.assert_called_once_with("session-tok-123", "https://hub.example.com")
 
         data = json.loads(auth_file.read_text())
         saved = data["accounts"]["https://hub.example.com"]
@@ -326,13 +338,11 @@ class TestLoginCommand:
         token_resp = Mock()
         token_resp.json.return_value = {"access_token": "tok-b", "token_type": "Bearer"}
 
-        session_resp = Mock()
-        session_resp.ok = True
-        session_resp.json.return_value = {"user": {"name": "User B", "email": "b@example.com"}}
+        jwt = _make_jwt({"name": "User B", "email": "b@example.com"})
 
         with (
             patch("ai.chronon.repo.auth.requests.post", side_effect=[device_code_resp, token_resp]),
-            patch("ai.chronon.repo.auth.requests.get", return_value=session_resp),
+            patch("ai.chronon.repo.auth.exchange_session_for_jwt", return_value=jwt),
             patch("ai.chronon.repo.auth.webbrowser.open"),
             patch("ai.chronon.repo.auth.time.sleep"),
             patch("ai.chronon.repo.auth.time.time", side_effect=[0, 1]),
@@ -345,6 +355,42 @@ class TestLoginCommand:
         assert "https://hub-a.example.com" in data["accounts"]
         assert "https://hub-b.example.com" in data["accounts"]
         assert data["default"] == "https://hub-b.example.com"
+
+    def test_login_warns_when_verification_fails(self, auth_dir):
+        """Token is still saved, but a failed exchange surfaces a warning
+        instead of silently reporting success (the perimeter-gateway case)."""
+        _, auth_file = auth_dir
+        runner = CliRunner()
+
+        device_code_resp = Mock()
+        device_code_resp.raise_for_status = Mock()
+        device_code_resp.json.return_value = {
+            "device_code": "dev123",
+            "user_code": "ABCD-1234",
+            "interval": 0,
+            "expires_in": 10,
+        }
+
+        token_resp = Mock()
+        token_resp.json.return_value = {"access_token": "session-tok-123", "token_type": "Bearer"}
+
+        with (
+            patch("ai.chronon.repo.auth.requests.post", side_effect=[device_code_resp, token_resp]),
+            patch(
+                "ai.chronon.repo.auth.exchange_session_for_jwt",
+                side_effect=RuntimeError("Token rejected by auth server (HTTP 401)."),
+            ),
+            patch("ai.chronon.repo.auth.webbrowser.open"),
+            patch("ai.chronon.repo.auth.time.sleep"),
+            patch("ai.chronon.repo.auth.time.time", side_effect=[0, 1]),
+        ):
+            result = runner.invoke(auth, ["login", "--url", "https://hub.example.com", "--no-browser"])
+
+        assert result.exit_code == 0
+        assert "could not be verified" in result.output
+        # Token is still persisted so the user can retry / inspect it.
+        saved = get_auth_config(url="https://hub.example.com")
+        assert saved["access_token"] == "session-tok-123"
 
 
 class TestLogoutCommand:
@@ -395,13 +441,9 @@ class TestStatusCommand:
         save_auth_config(sample_config)
         runner = CliRunner()
 
-        session_resp = Mock()
-        session_resp.ok = True
-        session_resp.json.return_value = {
-            "user": {"name": "Test User", "email": "test@example.com"}
-        }
+        jwt = _make_jwt({"name": "Test User", "email": "test@example.com"})
 
-        with patch("ai.chronon.repo.auth.requests.get", return_value=session_resp):
+        with patch("ai.chronon.repo.auth.exchange_session_for_jwt", return_value=jwt):
             result = runner.invoke(auth, ["status"])
 
         assert result.exit_code == 0
@@ -412,38 +454,38 @@ class TestStatusCommand:
         save_auth_config(sample_config)
         runner = CliRunner()
 
-        expired_resp = Mock()
-        expired_resp.ok = False
-        expired_resp.status_code = 401
-
-        with patch("ai.chronon.repo.auth.requests.get", return_value=expired_resp):
+        with patch(
+            "ai.chronon.repo.auth.exchange_session_for_jwt",
+            side_effect=RuntimeError(
+                "Token rejected by auth server (HTTP 401). The token may be expired, "
+                "revoked, or does not belong to this auth server."
+            ),
+        ):
             result = runner.invoke(auth, ["status"])
 
         assert result.exit_code == 0
-        assert "expired or invalid" in result.output
+        assert "expired" in result.output
 
     def test_status_network_error(self, auth_dir, sample_config):
         save_auth_config(sample_config)
         runner = CliRunner()
 
         with patch(
-            "ai.chronon.repo.auth.requests.get",
-            side_effect=requests.ConnectionError("no network"),
+            "ai.chronon.repo.auth.exchange_session_for_jwt",
+            side_effect=RuntimeError("Could not connect to auth server at https://hub.example.com."),
         ):
             result = runner.invoke(auth, ["status"])
 
         assert result.exit_code == 0
-        assert "network error" in result.output
+        assert "Could not connect" in result.output
 
     def test_status_shows_default_label(self, auth_dir, sample_config):
         save_auth_config(sample_config)
         runner = CliRunner()
 
-        session_resp = Mock()
-        session_resp.ok = True
-        session_resp.json.return_value = {"user": {"name": "Test", "email": "t@e.com"}}
+        jwt = _make_jwt({"name": "Test", "email": "t@e.com"})
 
-        with patch("ai.chronon.repo.auth.requests.get", return_value=session_resp):
+        with patch("ai.chronon.repo.auth.exchange_session_for_jwt", return_value=jwt):
             result = runner.invoke(auth, ["status"])
 
         assert "(default)" in result.output
@@ -454,11 +496,9 @@ class TestStatusCommand:
 
         runner = CliRunner()
 
-        session_resp = Mock()
-        session_resp.ok = True
-        session_resp.json.return_value = {"user": {"name": "User A", "email": "a@e.com"}}
+        jwt = _make_jwt({"name": "User A", "email": "a@e.com"})
 
-        with patch("ai.chronon.repo.auth.requests.get", return_value=session_resp):
+        with patch("ai.chronon.repo.auth.exchange_session_for_jwt", return_value=jwt):
             result = runner.invoke(auth, ["status", "--url", "https://hub-a.example.com"])
 
         assert result.exit_code == 0
@@ -471,11 +511,9 @@ class TestStatusCommand:
 
         runner = CliRunner()
 
-        session_resp = Mock()
-        session_resp.ok = True
-        session_resp.json.return_value = {"user": {"name": "User", "email": "u@e.com"}}
+        jwt = _make_jwt({"name": "User", "email": "u@e.com"})
 
-        with patch("ai.chronon.repo.auth.requests.get", return_value=session_resp):
+        with patch("ai.chronon.repo.auth.exchange_session_for_jwt", return_value=jwt):
             result = runner.invoke(auth, ["status"])
 
         assert result.exit_code == 0
@@ -500,11 +538,10 @@ class TestGetAccessTokenCommand:
         save_auth_config(sample_config)
         runner = CliRunner()
 
-        token_resp = Mock()
-        token_resp.ok = True
-        token_resp.json.return_value = {"token": "eyJhbGciOi.payload.signature"}
-
-        with patch("ai.chronon.repo.auth.requests.get", return_value=token_resp):
+        with patch(
+            "ai.chronon.repo.auth.exchange_session_for_jwt",
+            return_value="eyJhbGciOi.payload.signature",
+        ):
             result = runner.invoke(auth, ["get-access-token"])
 
         assert result.exit_code == 0
@@ -521,28 +558,30 @@ class TestGetAccessTokenCommand:
         save_auth_config(sample_config)
         runner = CliRunner()
 
-        expired_resp = Mock()
-        expired_resp.ok = False
-        expired_resp.status_code = 401
-
-        with patch("ai.chronon.repo.auth.requests.get", return_value=expired_resp):
+        with patch(
+            "ai.chronon.repo.auth.exchange_session_for_jwt",
+            side_effect=RuntimeError(
+                "Token rejected by auth server (HTTP 401). The token may be "
+                "expired, revoked, or does not belong to this auth server."
+            ),
+        ):
             result = runner.invoke(auth, ["get-access-token"])
 
         assert result.exit_code != 0
-        assert "expired or invalid" in result.output
+        assert "expired" in result.output
 
     def test_network_error(self, auth_dir, sample_config):
         save_auth_config(sample_config)
         runner = CliRunner()
 
         with patch(
-            "ai.chronon.repo.auth.requests.get",
-            side_effect=requests.ConnectionError("connection refused"),
+            "ai.chronon.repo.auth.exchange_session_for_jwt",
+            side_effect=RuntimeError("Could not connect to auth server at https://hub.example.com."),
         ):
             result = runner.invoke(auth, ["get-access-token"])
 
         assert result.exit_code != 0
-        assert "Failed to fetch access token" in result.output
+        assert "Could not connect" in result.output
 
     def test_get_access_token_for_specific_url(self, auth_dir):
         save_auth_config({"url": "https://hub-a.example.com", "access_token": "tok-a"})
@@ -550,19 +589,15 @@ class TestGetAccessTokenCommand:
 
         runner = CliRunner()
 
-        token_resp = Mock()
-        token_resp.ok = True
-        token_resp.json.return_value = {"token": "jwt-for-a"}
-
-        with patch("ai.chronon.repo.auth.requests.get", return_value=token_resp) as mock_get:
+        with patch(
+            "ai.chronon.repo.auth.exchange_session_for_jwt", return_value="jwt-for-a"
+        ) as mock_exchange:
             result = runner.invoke(auth, ["get-access-token", "--url", "https://hub-a.example.com"])
 
         assert result.exit_code == 0
         assert result.output.strip() == "jwt-for-a"
-        # Verify it called hub-a, not hub-b
-        mock_get.assert_called_once()
-        call_url = mock_get.call_args[0][0]
-        assert "hub-a.example.com" in call_url
+        # Verify it exchanged hub-a's token against hub-a, not hub-b.
+        mock_exchange.assert_called_once_with("tok-a", "https://hub-a.example.com")
 
 
 class TestGetFrontendUrlFromTeams:
@@ -629,16 +664,12 @@ class TestLoginDefaultUrl:
             "token_type": "Bearer",
         }
 
-        session_resp = Mock()
-        session_resp.ok = True
-        session_resp.json.return_value = {
-            "user": {"name": "Jane Doe", "email": "jane@example.com"}
-        }
+        jwt = _make_jwt({"name": "Jane Doe", "email": "jane@example.com"})
 
         with (
             patch("ai.chronon.repo.auth.get_frontend_url_from_teams", return_value="https://zipline.example.com"),
             patch("ai.chronon.repo.auth.requests.post", side_effect=[device_code_resp, token_resp]),
-            patch("ai.chronon.repo.auth.requests.get", return_value=session_resp),
+            patch("ai.chronon.repo.auth.exchange_session_for_jwt", return_value=jwt),
             patch("ai.chronon.repo.auth.webbrowser.open"),
             patch("ai.chronon.repo.auth.time.sleep"),
             patch("ai.chronon.repo.auth.time.time", side_effect=[0, 1]),

--- a/python/test/test_token_exchange.py
+++ b/python/test/test_token_exchange.py
@@ -1,0 +1,95 @@
+import base64
+import json
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+from ai.chronon.repo.token_exchange import decode_jwt_claims, exchange_session_for_jwt
+
+
+def _resp(status_code, *, json_body=None):
+    resp = Mock()
+    resp.status_code = status_code
+    resp.ok = 200 <= status_code < 300
+    resp.json.return_value = json_body or {}
+    resp.text = json.dumps(json_body or {})
+    return resp
+
+
+def test_decode_jwt_claims():
+    payload = {"email": "a@b.com", "name": "A B", "role": "admin", "exp": 123}
+    b64 = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+    assert decode_jwt_claims(f"header.{b64}.sig") == payload
+
+
+def test_exchange_posts_token_in_body_without_authorization_header():
+    """The opaque token must ride in the body, never the Authorization header —
+    that is the whole point (JWT-only gateways reject non-JWT bearer tokens)."""
+    post_resp = _resp(200, json_body={"token": "jwt-123"})
+    with (
+        patch("ai.chronon.repo.token_exchange.requests.post", return_value=post_resp) as mock_post,
+        patch("ai.chronon.repo.token_exchange.requests.get") as mock_get,
+    ):
+        token = exchange_session_for_jwt("sess-abc", "https://hub.example.com")
+
+    assert token == "jwt-123"
+    mock_get.assert_not_called()
+    args, kwargs = mock_post.call_args
+    assert args[0] == "https://hub.example.com/auth/cli-token"
+    assert kwargs["json"] == {"session_token": "sess-abc"}
+    assert "Authorization" not in (kwargs.get("headers") or {})
+
+
+def test_exchange_strips_trailing_slash():
+    post_resp = _resp(200, json_body={"token": "jwt-123"})
+    with (
+        patch("ai.chronon.repo.token_exchange.requests.post", return_value=post_resp) as mock_post,
+        patch("ai.chronon.repo.token_exchange.requests.get"),
+    ):
+        exchange_session_for_jwt("sess-abc", "https://hub.example.com/")
+    assert mock_post.call_args[0][0] == "https://hub.example.com/auth/cli-token"
+
+
+def test_exchange_falls_back_to_legacy_endpoint_on_404():
+    """Older frontends predate /auth/cli-token — fall back to the legacy
+    bearer exchange so a CLI upgrade doesn't break against an old server."""
+    post_resp = _resp(404)
+    get_resp = _resp(200, json_body={"token": "legacy-jwt"})
+    with (
+        patch("ai.chronon.repo.token_exchange.requests.post", return_value=post_resp),
+        patch("ai.chronon.repo.token_exchange.requests.get", return_value=get_resp) as mock_get,
+    ):
+        token = exchange_session_for_jwt("sess-abc", "https://hub.example.com")
+
+    assert token == "legacy-jwt"
+    args, kwargs = mock_get.call_args
+    assert args[0] == "https://hub.example.com/api/auth/token"
+    assert kwargs["headers"]["Authorization"] == "Bearer sess-abc"
+
+
+def test_exchange_raises_on_401():
+    with (
+        patch("ai.chronon.repo.token_exchange.requests.post", return_value=_resp(401)),
+        patch("ai.chronon.repo.token_exchange.requests.get"),
+    ):
+        with pytest.raises(RuntimeError, match="expired"):
+            exchange_session_for_jwt("sess-abc", "https://hub.example.com")
+
+
+def test_exchange_raises_on_connection_error():
+    with patch(
+        "ai.chronon.repo.token_exchange.requests.post",
+        side_effect=requests.ConnectionError("boom"),
+    ):
+        with pytest.raises(RuntimeError, match="Could not connect"):
+            exchange_session_for_jwt("sess-abc", "https://hub.example.com")
+
+
+def test_exchange_raises_when_no_token_returned():
+    with (
+        patch("ai.chronon.repo.token_exchange.requests.post", return_value=_resp(200, json_body={})),
+        patch("ai.chronon.repo.token_exchange.requests.get"),
+    ):
+        with pytest.raises(RuntimeError, match="no JWT was returned"):
+            exchange_session_for_jwt("sess-abc", "https://hub.example.com")


### PR DESCRIPTION
## Summary

## Summary
`zipline auth login` succeeds but subsequent commands report the token as
invalid when the hub is behind a perimeter API gateway that only accepts JWT
bearer tokens. The CLI holds an **opaque** session token and exchanges
it for a JWT on every call via `GET /api/auth/token` — presenting the opaque token
in the `Authorization` header, which the gateway blocks.

This routes the opaque→JWT exchange through a new gateway-safe endpoint that takes
the token in the request **body**, so the opaque token never rides in the
`Authorization` header.

## Changes
- `token_exchange.py`: `exchange_session_for_jwt()` now `POST`s the session token
  to `/auth/cli-token` (body-carried), with a legacy `GET /api/auth/token` fallback
  on HTTP 404 for older frontends. Added `decode_jwt_claims()`.
- `zipline_hub.py`: `_get_hub_jwt()` (the per-command hub path) routed through the
  shared exchange helper — fixes every authenticated CLI command at once.
- `auth.py`:
  - `login` now **verifies** the token by exchanging it and reads user info from the
    JWT claims, warning loudly if verification fails instead of silently reporting
    success (fixes the "says successful but token invalid" symptom).
  - `get-access-token` and `status` use the same gateway-safe exchange path (no
    longer hit `/api/auth/get-session` with an opaque bearer).

## Companion
Requires the frontend endpoint in [platform PR](https://github.com/zipline-ai/platform/pull/1153). Works against older frontends via the 404 → legacy `GET /api/auth/token` fallback.

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update

