### PR TITLE
Support a window around the end period for time based partition checks

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/batch/BatchNodeRunner.scala
+++ b/spark/src/main/scala/ai/chronon/spark/batch/BatchNodeRunner.scala
@@ -10,7 +10,7 @@ import ai.chronon.planner._
 import ai.chronon.spark.Extensions._
 import ai.chronon.spark.batch.iceberg.IcebergPartitionStatsExtractor
 import ai.chronon.spark.batch.{StagingQuery => StagingQueryUtil}
-import ai.chronon.spark.catalog.TableUtils
+import ai.chronon.spark.catalog.{Format, TableUtils}
 import ai.chronon.spark.join.UnionJoin
 import ai.chronon.spark.submission.{NodeConfReader, SparkSessionBuilder}
 import ai.chronon.spark.utils.SemanticUtils
@@ -134,8 +134,13 @@ class BatchNodeRunner(node: Node, tableUtils: TableUtils, api: Api) extends Node
             .dataWatermarkMillis(tableName, Some(spec))
             .getOrElse(throw new RuntimeException(s"Could not determine data watermark for ${tableName}"))
 
-          val requiredEndMillis = requiredRange.maxMillis
-          logger.info(s"Data watermark: ${TsUtils.toStr(watermark)}, required end: ${TsUtils.toStr(requiredEndMillis)}")
+          val readinessOffsetMillis = BatchNodeRunner.readinessOffsetMillis(tableUtils)
+          val requiredEndMillis = BatchNodeRunner.effectiveRequiredEndMillis(requiredRange.maxMillis, tableUtils)
+          logger.info(
+            s"Data watermark: ${TsUtils.toStr(watermark)}, " +
+              s"required end: ${TsUtils.toStr(requiredRange.maxMillis)}, " +
+              s"readiness offset millis: ${readinessOffsetMillis}, " +
+              s"effective required end: ${TsUtils.toStr(requiredEndMillis)}")
 
           if (watermark > requiredEndMillis) {
             logger.info(s"Sensor succeeded: ${TsUtils.toStr(watermark)} > ${TsUtils.toStr(requiredEndMillis)}")
@@ -654,7 +659,7 @@ class BatchNodeRunner(node: Node, tableUtils: TableUtils, api: Api) extends Node
               inputPartitionSpec.translate(value, tableUtils.partitionSpec)
             else value
           }
-          val requiredEndMillis = requiredEndsMillis.last
+          val requiredEndMillis = BatchNodeRunner.effectiveRequiredEndMillis(requiredEndsMillis.last, tableUtils)
           val ready = watermark.exists(_._2 > requiredEndMillis)
 
           // Collect semanticHash values from all dependencies for this table
@@ -786,6 +791,14 @@ class BatchNodeRunner(node: Node, tableUtils: TableUtils, api: Api) extends Node
 }
 
 object BatchNodeRunner {
+  val ReadinessOffsetMillisConf: String = Format.ReadinessOffsetMillisConf
+  val DefaultReadinessOffsetMillis: Long = Format.DefaultReadinessOffsetMillis
+
+  private[batch] def readinessOffsetMillis(tableUtils: TableUtils): Long =
+    Format.readinessOffsetMillis(tableUtils.sparkSession)
+
+  private[batch] def effectiveRequiredEndMillis(requiredEndMillis: Long, tableUtils: TableUtils): Long =
+    requiredEndMillis - readinessOffsetMillis(tableUtils)
 
   def main(args: Array[String]): Unit = {
     val batchArgs = new BatchNodeRunnerArgs(args)

--- a/spark/src/main/scala/ai/chronon/spark/catalog/DeltaLake.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/DeltaLake.scala
@@ -90,12 +90,15 @@ case object DeltaLake extends Format {
 
   private def statsLastAvailablePartition(tableName: String, columnName: String, partitionSpec: PartitionSpec)(implicit
       sparkSession: SparkSession): Option[String] =
-    statsDateRange(tableName, columnName, partitionSpec).map { range =>
+    statsDateRangeWithMillis(tableName, columnName, partitionSpec).map { range =>
       sparkSession.read.table(tableName).schema(columnName).dataType match {
         // numeric columns are epoch millis per statsBoundary, so they carry the same
         // in-flight-tail semantics as timestamps
         case TimestampType | _: NumericType =>
-          Format.readinessPartition(range.lastAvailablePartition, partitionSpec)
+          Format.readinessPartition(range.lastAvailablePartition,
+                                    partitionSpec,
+                                    Some(range.endMillis),
+                                    Format.readinessOffsetMillis(sparkSession))
         case _ => range.lastAvailablePartition
       }
     }
@@ -111,7 +114,11 @@ case object DeltaLake extends Format {
     }
 
   private[catalog] def statsDateRange(tableName: String, columnName: String, partitionSpec: PartitionSpec)(implicit
-      sparkSession: SparkSession): Option[StatsDateRange] = {
+      sparkSession: SparkSession): Option[StatsDateRange] =
+    statsDateRangeWithMillis(tableName, columnName, partitionSpec).map(_.toStatsDateRange)
+
+  private def statsDateRangeWithMillis(tableName: String, columnName: String, partitionSpec: PartitionSpec)(implicit
+      sparkSession: SparkSession): Option[StatsDateRangeWithMillis] = {
     import sparkSession.implicits._
 
     Try {
@@ -152,8 +159,12 @@ case object DeltaLake extends Format {
 
         if (fileCount > 0 && missingCount == 0 && !row.isNullAt(2) && !row.isNullAt(3)) {
           Some(
-            StatsDateRange(start = partitionSpec.at(row.getAs[Long]("startMillis")),
-                           end = partitionSpec.at(row.getAs[Long]("endMillis"))))
+            StatsDateRangeWithMillis(
+              start = partitionSpec.at(row.getAs[Long]("startMillis")),
+              end = partitionSpec.at(row.getAs[Long]("endMillis")),
+              startMillis = row.getAs[Long]("startMillis"),
+              endMillis = row.getAs[Long]("endMillis")
+            ))
         } else {
           None
         }
@@ -161,7 +172,7 @@ case object DeltaLake extends Format {
     } match {
       case Success(result) =>
         if (result.isDefined) {
-          logger.info(s"Resolved Delta log stats boundaries for $tableName.$columnName: ${result.get}")
+          logger.info(s"Resolved Delta log stats boundaries for $tableName.$columnName: ${result.get.toStatsDateRange}")
         } else {
           logger.info(s"Delta log stats were incomplete for $tableName.$columnName; falling back to table scan")
         }

--- a/spark/src/main/scala/ai/chronon/spark/catalog/Format.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/Format.scala
@@ -208,7 +208,13 @@ trait Format {
             .collect()
             .headOption
             .filterNot(_.isNullAt(0))
-            .map(row => Format.readinessPartition(partitionSpec.at(row.getLong(0)), partitionSpec))
+            .map { row =>
+              val maxMillis = row.getLong(0)
+              Format.readinessPartition(partitionSpec.at(maxMillis),
+                                        partitionSpec,
+                                        Some(maxMillis),
+                                        Format.readinessOffsetMillis(sparkSession))
+            }
       }
     } match {
       case Success(result) => result
@@ -335,6 +341,14 @@ private[catalog] case class StatsDateRange(start: String, end: String) {
   def lastAvailablePartition: String = end
 }
 
+private[catalog] case class StatsDateRangeWithMillis(start: String, end: String, startMillis: Long, endMillis: Long) {
+  def toStatsDateRange: StatsDateRange = StatsDateRange(start, end)
+
+  def firstAvailablePartition: String = start
+
+  def lastAvailablePartition: String = end
+}
+
 case class ResolvedTableName(catalog: String, namespace: String, table: String) {
   def toIdentifier: Identifier = Identifier.of(Array(namespace), table)
 
@@ -372,9 +386,27 @@ object Format {
     * grids model streaming ingestion where the tail interval is genuinely in flight, so a
     * partition only counts once data crosses its interval end.
     */
-  def readinessPartition(dataBearingPartition: String, spec: PartitionSpec): String =
+  def readinessPartition(dataBearingPartition: String,
+                         spec: PartitionSpec,
+                         maxMillis: Option[Long] = None,
+                         readinessOffsetMillis: Long = DefaultReadinessOffsetMillis): String =
     if (spec.spanMillis >= PartitionSpec.daily.spanMillis) dataBearingPartition
-    else spec.before(dataBearingPartition)
+    else {
+      val isWithinReadinessOffset = maxMillis.exists { max =>
+        val distanceToPartitionEnd = spec.partitionEndMillis(dataBearingPartition) - max
+        distanceToPartitionEnd >= 0 && distanceToPartitionEnd <= readinessOffsetMillis
+      }
+      if (isWithinReadinessOffset) dataBearingPartition else spec.before(dataBearingPartition)
+    }
+
+  val ReadinessOffsetMillisConf: String = "spark.chronon.time_partitioned.readiness_offset.millis"
+  val DefaultReadinessOffsetMillis: Long = 0L
+
+  def readinessOffsetMillis(sparkSession: SparkSession): Long = {
+    val offset = sparkSession.conf.get(ReadinessOffsetMillisConf, DefaultReadinessOffsetMillis.toString).toLong
+    require(offset >= 0, s"$ReadinessOffsetMillisConf must be >= 0, got $offset")
+    offset
+  }
 
   def sanitizePartitionValues(partitions: Iterable[String]): List[String] = partitions.iterator
     .flatMap(Option(_))

--- a/spark/src/main/scala/ai/chronon/spark/catalog/Iceberg.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/Iceberg.scala
@@ -107,10 +107,14 @@ case object Iceberg extends Format {
 
   private def statsLastAvailablePartition(tableName: String, columnName: String, partitionSpec: PartitionSpec)(implicit
       sparkSession: SparkSession): Option[String] =
-    statsDateRange(tableName, columnName, partitionSpec).map { range =>
+    statsDateRangeWithMillis(tableName, columnName, partitionSpec).map { range =>
       sparkSession.read.table(tableName).schema(columnName).dataType match {
-        case TimestampType => Format.readinessPartition(range.lastAvailablePartition, partitionSpec)
-        case _             => range.lastAvailablePartition
+        case TimestampType =>
+          Format.readinessPartition(range.lastAvailablePartition,
+                                    partitionSpec,
+                                    Some(range.endMillis),
+                                    Format.readinessOffsetMillis(sparkSession))
+        case _ => range.lastAvailablePartition
       }
     }
 
@@ -126,6 +130,10 @@ case object Iceberg extends Format {
 
   private[catalog] def statsDateRange(tableName: String, columnName: String, partitionSpec: PartitionSpec)(implicit
       sparkSession: SparkSession): Option[StatsDateRange] =
+    statsDateRangeWithMillis(tableName, columnName, partitionSpec).map(_.toStatsDateRange)
+
+  private def statsDateRangeWithMillis(tableName: String, columnName: String, partitionSpec: PartitionSpec)(implicit
+      sparkSession: SparkSession): Option[StatsDateRangeWithMillis] =
     Try {
       val table = loadIcebergTable(tableName).getOrElse {
         throw new IllegalStateException(s"Could not load Iceberg table: $tableName")
@@ -141,7 +149,8 @@ case object Iceberg extends Format {
     } match {
       case Success(result) =>
         if (result.isDefined) {
-          logger.info(s"Resolved Iceberg file stats boundaries for $tableName.$columnName: ${result.get}")
+          logger.info(
+            s"Resolved Iceberg file stats boundaries for $tableName.$columnName: ${result.get.toStatsDateRange}")
         } else {
           logger.info(s"Iceberg file stats were incomplete for $tableName.$columnName; falling back to table scan")
         }
@@ -190,7 +199,7 @@ case object Iceberg extends Format {
                                         fieldId: java.lang.Integer,
                                         fieldType: org.apache.iceberg.types.Type,
                                         partitionSpec: PartitionSpec,
-                                        extractor: IcebergPartitionStatsExtractor): Option[StatsDateRange] =
+                                        extractor: IcebergPartitionStatsExtractor): Option[StatsDateRangeWithMillis] =
     Option(table.currentSnapshot()).flatMap { _ =>
       val tasks = table.newScan().includeColumnStats().planFiles()
       try {
@@ -206,9 +215,11 @@ case object Iceberg extends Format {
         }
 
         range.flatten.map { case (minMillis, maxMillis) =>
-          StatsDateRange(
+          StatsDateRangeWithMillis(
             start = partitionSpec.at(minMillis),
-            end = partitionSpec.at(maxMillis)
+            end = partitionSpec.at(maxMillis),
+            startMillis = minMillis,
+            endMillis = maxMillis
           )
         }
       } finally {

--- a/spark/src/test/scala/ai/chronon/spark/batch/BatchNodeRunnerTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/batch/BatchNodeRunnerTest.scala
@@ -265,6 +265,8 @@ class BatchNodeRunnerTest extends SparkTestBase with Matchers with BeforeAndAfte
   }
 
   override def beforeEach(): Unit = {
+    spark.conf.set(BatchNodeRunner.ReadinessOffsetMillisConf, BatchNodeRunner.DefaultReadinessOffsetMillis.toString)
+
     // Drop all test tables to ensure fresh start
     spark.sql("DROP TABLE IF EXISTS test_db.input_table")
     spark.sql("DROP TABLE IF EXISTS test_db.left_table")
@@ -283,6 +285,7 @@ class BatchNodeRunnerTest extends SparkTestBase with Matchers with BeforeAndAfte
     spark.sql("DROP TABLE IF EXISTS test_db.yyyymmdd_sq_test")
     spark.sql("DROP TABLE IF EXISTS test_db.yyyymmdd_join_test")
     spark.sql("DROP TABLE IF EXISTS test_db.yyyymmdd_join_gb")
+    spark.sql("DROP TABLE IF EXISTS test_db.subdaily_watermark_offset")
 
     setupTestTables()
     mockKVStore.reset()
@@ -547,6 +550,23 @@ class BatchNodeRunnerTest extends SparkTestBase with Matchers with BeforeAndAfte
       assertTrue("Should be ready", status.ready)
       assertTrue("Should have last available partition", status.lastAvailablePartition.isDefined)
     }
+  }
+
+  it should "apply the Spark readiness offset when computing input table statuses" in {
+    spark.conf.set(BatchNodeRunner.ReadinessOffsetMillisConf, (24 * 60 * 60 * 1000).toString)
+
+    val configPath = createTestConfigFile(today, today)
+    val node = ThriftJsonCodec.fromJsonFile[Node](configPath, check = true)
+    val runner = new BatchNodeRunner(node, tableUtils, mockApi)
+    val metadata = node.metaData
+    val range = PartitionRange(today, today)(tableUtils.partitionSpec)
+
+    val statuses = runner.computeInputTablePartitionStatuses(metadata, range, tableUtils).toSeq
+
+    assertEquals("Should have one table status", 1, statuses.size)
+    val status = statuses.head
+    assertTrue("Input should be ready with readiness offset", status.ready)
+    assertEquals(PartitionSpec.daily.epochMillis(today) - 1, status.requiredEndMillis)
   }
 
   it should "identify not-ready tables correctly" in {
@@ -1638,6 +1658,35 @@ class BatchNodeRunnerTest extends SparkTestBase with Matchers with BeforeAndAfte
     runner.checkPartitions(sensorFor(dep), sixOClockFire) match {
       case Success(_) => // ready
       case Failure(e) => fail(s"watermark at the interval end timestamp should be ready: ${e.getMessage}")
+    }
+  }
+
+  it should "apply the Spark readiness offset to the effective required end" in {
+    val oneHourSpec = PartitionSpec("ds", "yyyy-MM-dd-HH-mm", 60 * 60 * 1000)
+    val hourlyQuery = new Query()
+      .setPartitionColumn("created_at")
+      .setPartitionFormat(oneHourSpec.format)
+      .setPartitionInterval(new Window(1, TimeUnit.HOURS))
+
+    spark.conf.set(BatchNodeRunner.ReadinessOffsetMillisConf, (60 * 60 * 1000).toString)
+    spark.sql("DROP TABLE IF EXISTS test_db.subdaily_watermark_offset")
+    spark.sql(
+      """CREATE TABLE test_db.subdaily_watermark_offset (
+        |  id INT,
+        |  created_at TIMESTAMP
+        |)""".stripMargin)
+    spark.sql(
+      """INSERT INTO test_db.subdaily_watermark_offset VALUES
+        |(1, TIMESTAMP '2024-01-01 08:30:00')
+        |""".stripMargin)
+
+    val dep = TableDependencies.fromTable("test_db.subdaily_watermark_offset", hourlyQuery)
+    val runner = defaultRunner()
+    val eightOClockFire = PartitionRange("2024-01-01-08-00", "2024-01-01-08-00")(oneHourSpec)
+
+    runner.checkPartitions(sensorFor(dep), eightOClockFire) match {
+      case Success(_) => // ready because the 08:00 watermark is beyond the offset-adjusted 07:59:59 required end
+      case Failure(e) => fail(s"watermark should be ready with readiness offset: ${e.getMessage}")
     }
   }
 

--- a/spark/src/test/scala/ai/chronon/spark/catalog/DeltaLakeTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/catalog/DeltaLakeTest.scala
@@ -98,6 +98,66 @@ class DeltaLakeTest extends AnyFlatSpec with BeforeAndAfterAll {
     }
   }
 
+  it should "apply readiness offset to near-complete sub-daily Delta stats boundaries" in {
+    val dbName = s"delta_subdaily_readiness_offset_${System.nanoTime()}"
+    val tableName = s"$dbName.subdaily_near_complete_time_with_stats"
+    spark.sql(s"CREATE DATABASE IF NOT EXISTS $dbName")
+
+    val threeHourSpec = PartitionSpec("ds", "yyyy-MM-dd-HH-mm", 3 * 60 * 60 * 1000)
+
+    try {
+      spark.sql(s"""
+        CREATE TABLE $tableName (
+          created_at TIMESTAMP,
+          user_id STRING
+        ) USING DELTA
+      """)
+      spark.sql(s"""
+        INSERT INTO $tableName VALUES
+          (TIMESTAMP '2024-01-01 09:17:00', 'user1'),
+          (TIMESTAMP '2024-01-01 14:59:59.500', 'user2')
+      """)
+
+      DeltaLake.lastAvailablePartition(tableName, "created_at", threeHourSpec) shouldBe Some("2024-01-01-09-00")
+
+      spark.conf.set(Format.ReadinessOffsetMillisConf, "1000")
+      DeltaLake.lastAvailablePartition(tableName, "created_at", threeHourSpec) shouldBe Some("2024-01-01-12-00")
+    } finally {
+      spark.conf.set(Format.ReadinessOffsetMillisConf, Format.DefaultReadinessOffsetMillis.toString)
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+      spark.sql(s"DROP DATABASE IF EXISTS $dbName")
+    }
+  }
+
+  it should "keep sub-daily Delta stats conservative outside the readiness offset" in {
+    val dbName = s"delta_subdaily_readiness_offset_strict_${System.nanoTime()}"
+    val tableName = s"$dbName.subdaily_incomplete_time_with_stats"
+    spark.sql(s"CREATE DATABASE IF NOT EXISTS $dbName")
+
+    val threeHourSpec = PartitionSpec("ds", "yyyy-MM-dd-HH-mm", 3 * 60 * 60 * 1000)
+
+    try {
+      spark.conf.set(Format.ReadinessOffsetMillisConf, "1000")
+      spark.sql(s"""
+        CREATE TABLE $tableName (
+          created_at TIMESTAMP,
+          user_id STRING
+        ) USING DELTA
+      """)
+      spark.sql(s"""
+        INSERT INTO $tableName VALUES
+          (TIMESTAMP '2024-01-01 09:17:00', 'user1'),
+          (TIMESTAMP '2024-01-01 14:59:58.000', 'user2')
+      """)
+
+      DeltaLake.lastAvailablePartition(tableName, "created_at", threeHourSpec) shouldBe Some("2024-01-01-09-00")
+    } finally {
+      spark.conf.set(Format.ReadinessOffsetMillisConf, Format.DefaultReadinessOffsetMillis.toString)
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+      spark.sql(s"DROP DATABASE IF EXISTS $dbName")
+    }
+  }
+
   it should "apply readiness semantics to epoch-millis numeric columns in Delta log stats" in {
     val dbName = s"delta_numeric_stats_${System.nanoTime()}"
     val tableName = s"$dbName.numeric_epoch_with_stats"

--- a/spark/src/test/scala/ai/chronon/spark/catalog/FormatTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/catalog/FormatTest.scala
@@ -166,6 +166,37 @@ class FormatTest extends SparkTestBase {
     Format.readinessPartition("2024-04-03-06-00", threeHourly) shouldBe "2024-04-03-03-00"
   }
 
+  it should "apply readiness offset when scanning sub-daily timestamp boundaries" in {
+    val tableName = "format_scan_subdaily_readiness_offset_test"
+    val threeHourly = PartitionSpec("ds", "yyyy-MM-dd-HH-mm", 3 * 60 * 60 * 1000)
+    spark.sql(s"""
+      CREATE OR REPLACE TEMP VIEW $tableName AS
+      SELECT * FROM VALUES
+        (1, TIMESTAMP '2024-04-03 12:17:00'),
+        (2, TIMESTAMP '2024-04-03 14:59:59.500')
+      AS t(id, created_at)
+    """)
+
+    val fmt = new Format {
+      override def supportSubPartitionsFilter = false
+      override def partitions(tableName: String, partitionFilters: String)(implicit ss: SparkSession) = Nil
+      override def primaryPartitions(tableName: String,
+                                     partitionColumn: String,
+                                     partitionFilters: String,
+                                     subPartitionsFilter: Map[String, String])(implicit
+          ss: SparkSession) = Nil
+    }
+
+    try {
+      fmt.lastAvailablePartition(tableName, "created_at", threeHourly)(spark) shouldBe Some("2024-04-03-09-00")
+
+      spark.conf.set(Format.ReadinessOffsetMillisConf, "1000")
+      fmt.lastAvailablePartition(tableName, "created_at", threeHourly)(spark) shouldBe Some("2024-04-03-12-00")
+    } finally {
+      spark.conf.set(Format.ReadinessOffsetMillisConf, Format.DefaultReadinessOffsetMillis.toString)
+    }
+  }
+
   it should "return the max date when scanning a date column" in {
     val tableName = "format_date_scan_last_available_test"
     spark.sql(s"""

--- a/spark/src/test/scala/ai/chronon/spark/catalog/IcebergTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/catalog/IcebergTest.scala
@@ -158,6 +158,40 @@ class IcebergTest extends SparkTestBase with Matchers {
     Iceberg.lastAvailablePartition(tableName, "created_at", PartitionSpec.daily) shouldBe Some("2024-04-03")
   }
 
+  it should "apply readiness offset to near-complete sub-daily Iceberg stats boundaries" in {
+    val tableName = "default.iceberg_subdaily_readiness_offset_test"
+    val threeHourSpec = PartitionSpec("ds", "yyyy-MM-dd-HH-mm", 3 * 60 * 60 * 1000)
+    spark.sql(s"DROP TABLE IF EXISTS $tableName")
+
+    try {
+      spark.sql(s"""
+        CREATE TABLE $tableName (
+          id INT,
+          created_at TIMESTAMP
+        ) USING iceberg
+        TBLPROPERTIES (
+          'write.metadata.metrics.default' = 'full',
+          'write.metadata.metrics.column.created_at' = 'full'
+        )
+      """)
+      spark.sql(s"ALTER TABLE $tableName WRITE ORDERED BY created_at")
+
+      spark.sql(s"""
+        INSERT INTO $tableName VALUES
+        (1, TIMESTAMP '2024-04-03 12:17:00'),
+        (2, TIMESTAMP '2024-04-03 14:59:59.500')
+      """)
+
+      Iceberg.lastAvailablePartition(tableName, "created_at", threeHourSpec) shouldBe Some("2024-04-03-09-00")
+
+      spark.conf.set(Format.ReadinessOffsetMillisConf, "1000")
+      Iceberg.lastAvailablePartition(tableName, "created_at", threeHourSpec) shouldBe Some("2024-04-03-12-00")
+    } finally {
+      spark.conf.set(Format.ReadinessOffsetMillisConf, Format.DefaultReadinessOffsetMillis.toString)
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+    }
+  }
+
   it should "return the inclusive last partition from Iceberg file stats for a single-day timestamp range" in {
     val range = StatsDateRange(start = "2024-04-01", end = "2024-04-01")
 


### PR DESCRIPTION
## Summary

Add a new option that gives the time-partitioned sensor some leeway for when a partition landed. Currently we wait for the next virtual partition to have data as we floor within the partition window to find the watermark point. If we add an offset config we can let it only require say up to the last 5mins in that partition to be considered ready. 

Adds `spark.chronon.time_partitioned.readiness_offset.millis` to provide a path for that offset. 

## Checklist
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable readiness offset for partition-based data availability checks.
  * Improved sub-daily partition boundary handling with millisecond-level precision.

* **Bug Fixes**
  * Readiness checks now use a more accurate effective end time, reducing premature “ready” status.
  * Delta Lake and Iceberg partition selection now better handles near-complete time windows.

* **Tests**
  * Added coverage for offset-aware readiness behavior across batch processing, Delta Lake, Format, and Iceberg paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->