### PR TITLE
Fix stale version stamps in released jar manifests

### DIFF
--- a/.github/workflows/reusable_build_and_push.yaml
+++ b/.github/workflows/reusable_build_and_push.yaml
@@ -51,6 +51,10 @@ jobs:
           echo "Latest release tag: $TAG"
 
           echo "tag=$TAG" >> $GITHUB_OUTPUT
+          # Stamp every subsequent mill invocation (wheel AND jars): jar manifests read
+          # Implementation-Version from publishVersion, which falls back to a placeholder
+          # when CHRONON_VERSION is unset.
+          echo "CHRONON_VERSION=$TAG+${{ github.sha }}" >> $GITHUB_ENV
 
       - name: Build Python Wheel
         id: build-wheel

--- a/api/package.mill
+++ b/api/package.mill
@@ -24,8 +24,8 @@ trait ApiModule extends Cross.Module[String] with build.BaseModule {
       mvn"org.apache.commons:commons-lang3:3.18.0"
     )
 
-    override def publishVersion = Task {
-      sys.env.getOrElse("CHRONON_VERSION", "0.0.32")
+    override def publishVersion = Task.Input {
+      Task.env.getOrElse("CHRONON_VERSION", "0.0.32")
     }
 
     def pomSettings = build.Constants.pomSettingsFor("chronon-api-thrift-base")
@@ -45,8 +45,8 @@ trait ApiModule extends Cross.Module[String] with build.BaseModule {
       Seq(build.thrift.generateJavaThrift())
     }
 
-    override def publishVersion = Task {
-      sys.env.getOrElse("CHRONON_VERSION", "0.0.32")
+    override def publishVersion = Task.Input {
+      Task.env.getOrElse("CHRONON_VERSION", "0.0.32")
     }
 
     def pomSettings = build.Constants.pomSettingsFor("chronon-api-thrift-java")

--- a/build.mill
+++ b/build.mill
@@ -345,8 +345,10 @@ trait BaseModule extends CrossScalaModule with ScalafmtModule with GcsPublishMod
     developers = Constants.developers
   )
 
-  // Override to read version from environment at task execution time
-  override def publishVersion = Task { sys.env.getOrElse("CHRONON_VERSION", "0.0.32") }
+  // Task.Input + Task.env so the version participates in cache invalidation: a plain Task
+  // reading sys.env is cached in out/ across commits (CI restores out/), which froze stale
+  // strings (0.0.32, 1.17.3+sha) into released jar manifests.
+  override def publishVersion = Task.Input { Task.env.getOrElse("CHRONON_VERSION", "0.0.32") }
 }
 
 // Common test module configuration


### PR DESCRIPTION
## Summary

Released jars self-identify with frozen version strings — the official v1.17.2/v1.17.3 `cloud_aws_lib_deploy.jar` manifests say `Implementation-Version: 0.0.32`, and the v1.17.4 one says `1.17.3+94ed020...` even though its bytes were built at the tag commit. During the Depop stale-schedule incident this sent us chasing phantom stale artifacts.

Two compounding causes:

1. `publishVersion` read `sys.env` inside a plain `Task`, which mill caches in `out/`. CI restores `out/` across commits (`setup-mill-cache`, shared with `warm_ci_cache` which builds with no version set), so the stamp only re-evaluated when `build.mill`/`package.mill` changed. `94ed020` (#1997) was the last commit touching `build.mill` — every jar since is stamped `1.17.3+94ed020` regardless of content.
2. `reusable_build_and_push.yaml` only set `CHRONON_VERSION` on the wheel step; the jar build step ran without it.

## Fix

- `build.mill` / `api/package.mill`: `Task.Input { Task.env.getOrElse(...) }` — the tracked-env pattern `python/package.mill` already uses — so the version participates in invalidation.
- `reusable_build_and_push.yaml`: export `CHRONON_VERSION` via `GITHUB_ENV` in the get_tag step so every subsequent mill invocation (wheel and jars) is stamped.

## Verification

Ran against the same mill daemon: `CHRONON_VERSION=test-1 ./mill show api.publishVersion` → `"test-1"`, then `test-2` → `"test-2"`, then unset → `"0.0.32"`. Under the old code the first value froze (that is exactly the release-asset evidence). YAML validated with yq.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Build artifacts now include a version stamp based on the latest release tag and the current commit, enabling clearer identification of exactly what was built.

* **Bug Fixes**
  * Version determination is now handled as an explicit build input, improving caching accuracy and preventing stale version strings from being reused across runs.
  * Default version behavior remains unchanged when no release tag is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->