### PR TITLE
Promote only tested commits and verify release candidate provenance

### DIFF
--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -114,6 +114,20 @@ jobs:
       - name: Set up Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
+      - name: Verify passing-candidate provenance
+        run: |
+          # passing-candidate holds whatever the LAST green canary run built. Refuse to
+          # promote it as this release unless it was built at the tagged commit, otherwise
+          # a canary run racing the release ships bytes the tag does not name.
+          CANDIDATE_COMMIT=$(gcloud storage objects describe \
+            gs://zipline-artifacts-canary/release/passing-candidate/jars/cloud_gcp_lib_deploy.jar \
+            --format=json | jq -r '.custom_fields.commit // .metadata.commit // empty')
+          if [ "$CANDIDATE_COMMIT" != "${{ github.sha }}" ]; then
+            echo "passing-candidate was built at '$CANDIDATE_COMMIT' but the release tag points at '${{ github.sha }}'." >&2
+            echo "Re-run this release once the tagged commit's canary run has promoted its candidate." >&2
+            exit 1
+          fi
+
       - name: Download GCP JARs
         run: |
           mkdir -p gcp-jars
@@ -139,6 +153,20 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::${{secrets.AWS_ACCOUNT_ID}}:role/github_actions
           aws-region: ${{secrets.AWS_REGION}}
+
+      - name: Verify passing-candidate provenance
+        run: |
+          # See the GCP job: never promote a candidate built at a different commit
+          # than the one this release tags.
+          CANDIDATE_COMMIT=$(aws s3api head-object \
+            --bucket zipline-artifacts-canary \
+            --key release/passing-candidate/jars/cloud_aws_lib_deploy.jar \
+            --query "Metadata.commit" --output text)
+          if [ "$CANDIDATE_COMMIT" != "${{ github.sha }}" ]; then
+            echo "passing-candidate was built at '$CANDIDATE_COMMIT' but the release tag points at '${{ github.sha }}'." >&2
+            echo "Re-run this release once the tagged commit's canary run has promoted its candidate." >&2
+            exit 1
+          fi
 
       - name: Download AWS JARs
         run: |
@@ -167,6 +195,22 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Verify passing-candidate provenance
+        run: |
+          # See the GCP job: never promote a candidate built at a different commit
+          # than the one this release tags.
+          CANDIDATE_COMMIT=$(az storage blob show \
+            --account-name ziplineai2 \
+            --auth-mode login \
+            --container-name dev-zipline-artifacts \
+            --name release/passing-candidate/jars/cloud_azure_lib_deploy.jar \
+            --query "metadata.commit" -o tsv)
+          if [ "$CANDIDATE_COMMIT" != "${{ github.sha }}" ]; then
+            echo "passing-candidate was built at '$CANDIDATE_COMMIT' but the release tag points at '${{ github.sha }}'." >&2
+            echo "Re-run this release once the tagged commit's canary run has promoted its candidate." >&2
+            exit 1
+          fi
 
       - name: Download Azure JARs
         run: |

--- a/.github/workflows/push_to_canary.yaml
+++ b/.github/workflows/push_to_canary.yaml
@@ -705,12 +705,16 @@ jobs:
             set -eo pipefail
             ACCOUNT="ziplineai2"
             CONTAINER="dev-zipline-artifacts"
+            # commit metadata mirrors the aws/gcp candidate uploads; publish_release
+            # verifies it against the release tag before promoting.
+            METADATA="commit=${{ github.sha }} branch=${{ github.ref_name }}"
             az storage blob upload \
               --account-name $ACCOUNT \
               --auth-mode login \
               --container-name $CONTAINER \
               --file cloud_azure_lib_deploy.jar \
               --name release/passing-candidate/jars/cloud_azure_lib_deploy.jar \
+              --metadata $METADATA \
               --tier cool \
               --overwrite
             az storage blob upload \
@@ -719,6 +723,7 @@ jobs:
                 --container-name $CONTAINER \
                 --file flink_assembly_deploy.jar \
                 --name release/passing-candidate/jars/flink_assembly_deploy.jar \
+                --metadata $METADATA \
                 --tier cool \
                 --overwrite
             az storage blob upload \
@@ -727,6 +732,7 @@ jobs:
                 --container-name $CONTAINER \
                 --file service_assembly_deploy.jar \
                 --name release/passing-candidate/jars/service_assembly_deploy.jar \
+                --metadata $METADATA \
                 --tier cool \
                 --overwrite
             az storage blob upload \
@@ -735,6 +741,7 @@ jobs:
                 --container-name $CONTAINER \
                 --file ${{ needs.build_and_push.outputs.wheel_name }} \
                 --name release/passing-candidate/wheels/${{ needs.build_and_push.outputs.wheel_name }} \
+                --metadata $METADATA \
                 --tier cool \
                 --overwrite
 
@@ -818,16 +825,23 @@ jobs:
         env:
           TARGET_BRANCH: main-passing-tests
         run: |
-          echo "Merging to main-passing-tests branch after successful push to canary"
-          if git show-ref --quiet refs/heads/$TARGET_BRANCH; then
-            echo "Target branch $TARGET_BRANCH exists. Merging main into it..."
-            git checkout $TARGET_BRANCH
-            git merge main --no-ff -m "Merge main into $TARGET_BRANCH"
-          else
-            echo "Target branch $TARGET_BRANCH does not exist. Creating it..."
-            git checkout -b $TARGET_BRANCH main
+          # Promote exactly the commit these integration tests ran against. The previous
+          # merge flow checked refs/heads/$TARGET_BRANCH, which never exists in a fresh
+          # checkout (only refs/remotes/origin/...), so it always recreated the branch from
+          # the current main tip - promoting commits that never passed tests.
+          echo "Promoting tested commit ${{ github.sha }} to $TARGET_BRANCH"
+          if git push origin ${{ github.sha }}:refs/heads/$TARGET_BRANCH; then
+            exit 0
           fi
-          git push origin $TARGET_BRANCH
+          # Non-fast-forward: a run for a newer commit finished first. That newer commit
+          # also passed tests, so losing this race is fine as long as ours is contained.
+          git fetch origin $TARGET_BRANCH
+          if git merge-base --is-ancestor ${{ github.sha }} origin/$TARGET_BRANCH; then
+            echo "$TARGET_BRANCH already contains ${{ github.sha }}; nothing to promote."
+          else
+            echo "Failed to promote ${{ github.sha }} to $TARGET_BRANCH" >&2
+            exit 1
+          fi
 
       - name: Create CI Status File
         run: |


### PR DESCRIPTION
## Summary

Closes two provenance holes found while investigating the Depop v1.17.4 incident.

### 1. `main-passing-tests` promoted untested commits

The merge job checked `git show-ref refs/heads/main-passing-tests`, which never matches in a fresh checkout (the branch only exists as `refs/remotes/origin/...`), so it always took the else-path and recreated the branch from the **current main tip** — whatever main contained at job time, not the sha the integration tests ran against. The platform repo's twin job has the same bug (fix in a platform PR); it fast-forwarded `main-passing-tests` to `cf41ab676` — a commit whose own CI run had failed — minutes before the v1.17.4 release built the hub image from it.

Now the job pushes `${{ github.sha }}` (the tested commit) directly. If a run for a newer commit wins the race, we verify containment and no-op.

### 2. Release promoted `passing-candidate` without checking what built it

`publish_release` downloads `release/passing-candidate/jars` and republishes them as the release — with no check that the candidate was built at the tagged commit. For v1.17.4 the lineage was correct only by timing luck (candidate last written 02:20 UTC by the tag commit's canary run; release fired 03:02 with nothing in between).

The three download jobs now verify the candidate's `commit` metadata equals `github.sha` (the tag commit) and fail with a clear message otherwise. Azure candidate uploads previously carried no metadata, so it's added there to match aws/gcp.

## Notes

- After merge, the first Azure verification requires one green canary run to stamp metadata on the Azure candidate; until then an Azure release check would fail loudly rather than promote unverifiable bytes.
- YAML validated with yq; job/step structure verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release artifact checks to help prevent publishing mismatched builds.
  * Added safeguards so cloud releases only promote candidate artifacts that match the tagged commit.
* **Chores**
  * Updated canary and release publishing steps to include artifact metadata and more reliable branch update handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->