### PR TITLE
Retry json string tests up to 3 times in push_to_canary

### DIFF
--- a/.github/workflows/push_to_canary.yaml
+++ b/.github/workflows/push_to_canary.yaml
@@ -387,13 +387,18 @@ jobs:
         shell: bash
         run: |
           docker ps -a
-          TEST_FAILED=false
-          python3 scripts/fetcher_tests/json_string_test.py || TEST_FAILED=true
-          if [ "$TEST_FAILED" = "true" ]; then
-            echo "JSON string tests failed"
-            docker logs chronon-service-chronon-fetcher-1
-            exit 1
-          fi
+          MAX_ATTEMPTS=3
+          for attempt in $(seq 1 $MAX_ATTEMPTS); do
+            echo "JSON string tests attempt $attempt of $MAX_ATTEMPTS"
+            if python3 scripts/fetcher_tests/json_string_test.py; then
+              echo "JSON string tests passed on attempt $attempt"
+              exit 0
+            fi
+            echo "JSON string tests failed on attempt $attempt"
+          done
+          echo "JSON string tests failed after $MAX_ATTEMPTS attempts"
+          docker logs chronon-service-chronon-fetcher-1
+          exit 1
 
       - name: Run fetcher integration tests
         shell: bash


### PR DESCRIPTION
## Summary
- Wrap the "Run json string tests" step in a 3-attempt retry loop so transient failures do not fail the canary workflow.
- On success at any attempt the step exits 0; only after all 3 attempts fail do we dump fetcher logs and exit 1.

## Test plan
- [ ] Verify the workflow runs on next push to canary and the step succeeds when the underlying test passes.
- [ ] Confirm log dump + failure occurs when the test fails 3 consecutive times.

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the JSON string integration check by retrying it automatically up to 3 times before failing.
  * Added clearer failure handling by capturing service logs when all attempts fail, making issues easier to diagnose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->