### PR TITLE
Validate upstream partition bounds over grid early

### DIFF
--- a/api/src/main/scala/ai/chronon/api/PartitionSpec.scala
+++ b/api/src/main/scala/ai/chronon/api/PartitionSpec.scala
@@ -271,20 +271,40 @@ case class PartitionSpec(column: String, format: String, spanMillis: Long, offse
   }
 
   /** Normalizes a start value by translating from the fallback spec's interval start when needed. */
-  def normalizeStart(partition: String, fallbackSpec: PartitionSpec): String = {
+  def normalizeStart(partition: String, fallbackSpec: PartitionSpec): String =
+    normalizeStart(partition, Seq(fallbackSpec))
+
+  /** Normalizes a start value by translating from the first fallback spec that can parse it. */
+  def normalizeStart(partition: String, fallbackSpecs: Seq[PartitionSpec]): String = {
     if (partition == null) return null
+    require(fallbackSpecs.nonEmpty, "At least one fallback partition spec is required")
     val startMillis =
       Try(epochMillis(partition)).toOption
-        .getOrElse(fallbackSpec.partitionStartMillis(partition))
+        .orElse(
+          fallbackSpecs.iterator
+            .map(spec => Try(spec.partitionStartMillis(partition)).toOption)
+            .collectFirst { case Some(millis) => millis }
+        )
+        .getOrElse(fallbackSpecs.last.partitionStartMillis(partition))
     at(startMillis)
   }
 
   /** Normalizes an end value by translating from the fallback spec's interval end when needed. */
-  def normalizeEnd(partition: String, fallbackSpec: PartitionSpec): String = {
+  def normalizeEnd(partition: String, fallbackSpec: PartitionSpec): String =
+    normalizeEnd(partition, Seq(fallbackSpec))
+
+  /** Normalizes an end value by translating from the first fallback spec that can parse it. */
+  def normalizeEnd(partition: String, fallbackSpecs: Seq[PartitionSpec]): String = {
     if (partition == null) return null
+    require(fallbackSpecs.nonEmpty, "At least one fallback partition spec is required")
     val endMillis =
       Try(partitionEndMillis(partition)).toOption
-        .getOrElse(fallbackSpec.partitionEndMillis(partition))
+        .orElse(
+          fallbackSpecs.iterator
+            .map(spec => Try(spec.partitionEndMillis(partition)).toOption)
+            .collectFirst { case Some(millis) => millis }
+        )
+        .getOrElse(fallbackSpecs.last.partitionEndMillis(partition))
     at(endMillis - 1)
   }
 
@@ -312,6 +332,16 @@ object PartitionSpec {
     .optionalEnd()
     .toFormatter(Locale.US)
     .withResolverStyle(ResolverStyle.STRICT)
+
+  def cutoffFallbackSpecs(downstreamSpec: PartitionSpec, timePartitioned: Boolean): Seq[PartitionSpec] =
+    if (timePartitioned) Seq(downstreamSpec, daily).distinct
+    else Seq(downstreamSpec)
+
+  def cutoffFallbackSpecs(query: Query, downstreamSpec: PartitionSpec): Seq[PartitionSpec] =
+    cutoffFallbackSpecs(downstreamSpec, Option(query).exists(q => q.isSetTimePartitioned && q.timePartitioned))
+
+  def cutoffFallbackSpecs(tableInfo: TableInfo, downstreamSpec: PartitionSpec): Seq[PartitionSpec] =
+    cutoffFallbackSpecs(downstreamSpec, Option(tableInfo).exists(t => t.isSetTimePartitioned && t.timePartitioned))
 
   def validate(column: String, format: String, spanMillis: Long, offsetMillis: Long = 0L): Unit = {
     val grid = PartitionGrid(spanMillis, offsetMillis)

--- a/api/src/main/scala/ai/chronon/api/planner/DependencyResolver.scala
+++ b/api/src/main/scala/ai/chronon/api/planner/DependencyResolver.scala
@@ -53,8 +53,11 @@ object DependencyResolver {
     require(tableDep.tableInfo != null, "TableDependency.tableInfo cannot be null")
 
     implicit val inputPartitionSpec: PartitionSpec = tableDep.tableInfo.partitionSpec(queryRange.partitionSpec)
-    val startCutOff = inputPartitionSpec.normalizeStart(tableDep.getStartCutOff, queryRange.partitionSpec)
-    val endCutOff = inputPartitionSpec.normalizeEnd(tableDep.getEndCutOff, queryRange.partitionSpec)
+    val cutoffFallbackSpec =
+      if (tableDep.tableInfo.isSetTimePartitioned && tableDep.tableInfo.timePartitioned) PartitionSpec.daily
+      else queryRange.partitionSpec
+    val startCutOff = inputPartitionSpec.normalizeStart(tableDep.getStartCutOff, cutoffFallbackSpec)
+    val endCutOff = inputPartitionSpec.normalizeEnd(tableDep.getEndCutOff, cutoffFallbackSpec)
 
     val inputEndMillis = queryRange.endMillis - Option(tableDep.getEndOffset).map(_.millis).getOrElse(0L)
 

--- a/api/src/main/scala/ai/chronon/api/planner/DependencyResolver.scala
+++ b/api/src/main/scala/ai/chronon/api/planner/DependencyResolver.scala
@@ -53,11 +53,9 @@ object DependencyResolver {
     require(tableDep.tableInfo != null, "TableDependency.tableInfo cannot be null")
 
     implicit val inputPartitionSpec: PartitionSpec = tableDep.tableInfo.partitionSpec(queryRange.partitionSpec)
-    val cutoffFallbackSpec =
-      if (tableDep.tableInfo.isSetTimePartitioned && tableDep.tableInfo.timePartitioned) PartitionSpec.daily
-      else queryRange.partitionSpec
-    val startCutOff = inputPartitionSpec.normalizeStart(tableDep.getStartCutOff, cutoffFallbackSpec)
-    val endCutOff = inputPartitionSpec.normalizeEnd(tableDep.getEndCutOff, cutoffFallbackSpec)
+    val fallbackSpecs = PartitionSpec.cutoffFallbackSpecs(tableDep.tableInfo, queryRange.partitionSpec)
+    val startCutOff = inputPartitionSpec.normalizeStart(tableDep.getStartCutOff, fallbackSpecs)
+    val endCutOff = inputPartitionSpec.normalizeEnd(tableDep.getEndCutOff, fallbackSpecs)
 
     val inputEndMillis = queryRange.endMillis - Option(tableDep.getEndOffset).map(_.millis).getOrElse(0L)
 

--- a/api/src/test/scala/ai/chronon/api/test/planner/DependencyResolverTest.scala
+++ b/api/src/test/scala/ai/chronon/api/test/planner/DependencyResolverTest.scala
@@ -91,6 +91,24 @@ class DependencyResolverTest extends AnyFlatSpec with Matchers {
     result shouldBe Some(PartitionRange("2024-01-05-00-00", "2024-01-05-21-00")(threeHourSpec))
   }
 
+  it should "allow date-shaped cutoffs for time-partitioned dependencies on sub-daily grids" in {
+    val queryRange = PartitionRange("2024-01-02-01-00", "2024-01-03-01-00")(offsetThreeHourSpec)
+    val tableDep = dep("test.time_partitioned_table")
+    tableDep.setStartCutOff("2024-01-02")
+    tableDep.setEndCutOff("2024-01-02")
+    tableDep.setTableInfo(
+      new TableInfo()
+        .setTable("test.time_partitioned_table")
+        .setPartitionColumn("event_ts")
+        .setPartitionFormat(offsetThreeHourSpec.format)
+        .setTimePartitioned(true)
+    )
+
+    val result = DependencyResolver.computeInputRange(queryRange, tableDep)
+
+    result shouldBe Some(PartitionRange("2024-01-02-01-00", "2024-01-02-22-00")(offsetThreeHourSpec))
+  }
+
   it should "map a daily downstream range to boundary-crossing offset input partitions" in {
     val queryRange = PartitionRange("2024-01-02", "2024-01-02")
     val tableDep = dep("test.hourly_table")

--- a/api/src/test/scala/ai/chronon/api/test/planner/DependencyResolverTest.scala
+++ b/api/src/test/scala/ai/chronon/api/test/planner/DependencyResolverTest.scala
@@ -12,6 +12,7 @@ class DependencyResolverTest extends AnyFlatSpec with Matchers {
   implicit val partitionSpec: PartitionSpec = PartitionSpec.daily
   private val threeHourSpec = PartitionSpec("ds", "yyyy-MM-dd-HH-mm", 3 * 60 * 60 * 1000)
   private val offsetThreeHourSpec = PartitionSpec("ds", "yyyy-MM-dd-HH-mm", 3 * 60 * 60 * 1000, 60 * 60 * 1000)
+  private val compactOffsetThreeHourSpec = PartitionSpec("ds", "yyyyMMddHH", 3 * 60 * 60 * 1000, 60 * 60 * 1000)
 
   "computeOutputRange" should "return same range when no offsets are set" in {
     val parentRange = PartitionRange("2024-01-01", "2024-01-05")
@@ -107,6 +108,24 @@ class DependencyResolverTest extends AnyFlatSpec with Matchers {
     val result = DependencyResolver.computeInputRange(queryRange, tableDep)
 
     result shouldBe Some(PartitionRange("2024-01-02-01-00", "2024-01-02-22-00")(offsetThreeHourSpec))
+  }
+
+  it should "preserve downstream-format cutoff fallback for time-partitioned dependencies" in {
+    val queryRange = PartitionRange("2024-01-02-01-00", "2024-01-02-01-00")(offsetThreeHourSpec)
+    val tableDep = dep("test.compact_time_partitioned_table")
+    tableDep.setStartCutOff("2024-01-02-01-00")
+    tableDep.setEndCutOff("2024-01-02-01-00")
+    tableDep.setTableInfo(
+      new TableInfo()
+        .setTable("test.compact_time_partitioned_table")
+        .setPartitionColumn("event_ts")
+        .setPartitionFormat(compactOffsetThreeHourSpec.format)
+        .setTimePartitioned(true)
+    )
+
+    val result = DependencyResolver.computeInputRange(queryRange, tableDep)
+
+    result shouldBe Some(PartitionRange("2024010201", "2024010201")(compactOffsetThreeHourSpec))
   }
 
   it should "map a daily downstream range to boundary-crossing offset input partitions" in {

--- a/python/src/ai/chronon/cli/compile/conf_validator.py
+++ b/python/src/ai/chronon/cli/compile/conf_validator.py
@@ -21,7 +21,10 @@ import sys
 import textwrap
 from collections import defaultdict
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import List, Optional, Tuple
+
+from sqlglot.dialects.spark import Spark
 
 import gen_thrift.common.ttypes as common
 from ai.chronon.cli.compile.column_hashing import (
@@ -36,6 +39,7 @@ from ai.chronon.cli.theme import console
 from ai.chronon.logger import get_logger
 from ai.chronon.repo.serializer import thrift_simple_json
 from ai.chronon.utils import get_query, get_root_source
+from ai.chronon.windows import DAILY_PARTITION_FORMAT, PartitionSpec
 from gen_thrift.api.ttypes import (
     Accuracy,
     Aggregation,
@@ -86,6 +90,79 @@ def _output_grid_token(obj) -> Optional[str]:
     if interval_ms == DAY_MILLIS and offset_ms == 0:
         return None
     return f"grid:interval_ms={interval_ms},offset_ms={offset_ms}"
+
+
+def _legacy_partition_spec() -> PartitionSpec:
+    return PartitionSpec(format=DAILY_PARTITION_FORMAT, interval="1d")
+
+
+def _resolve_partition_spec(table_info, default_spec: PartitionSpec) -> PartitionSpec:
+    """Mirror Scala TableInfoOps/QueryOps.partitionSpec defaulting."""
+    declared_interval = getattr(table_info, "partitionInterval", None)
+    time_partitioned = bool(getattr(table_info, "timePartitioned", False))
+    if declared_interval is not None:
+        interval = declared_interval
+    elif time_partitioned:
+        interval = default_spec.interval
+    else:
+        interval = "1d"
+
+    declared_offset = getattr(table_info, "partitionOffset", None)
+    if declared_offset is not None:
+        offset = declared_offset
+    elif declared_interval is not None:
+        offset = None
+    else:
+        offset = default_spec.offset
+
+    return PartitionSpec(
+        column=getattr(table_info, "partitionColumn", None) or default_spec.column,
+        format=getattr(table_info, "partitionFormat", None) or default_spec.format,
+        interval=interval,
+        offset=offset,
+        time_partitioned=getattr(table_info, "timePartitioned", None),
+    )
+
+
+def _config_partition_spec(obj, default_spec: PartitionSpec = None) -> PartitionSpec:
+    default_spec = default_spec or _legacy_partition_spec()
+    metadata = getattr(obj, "metaData", None)
+    execution_info = getattr(metadata, "executionInfo", None) if metadata else None
+    table_info = getattr(execution_info, "outputTableInfo", None) if execution_info else None
+    return _resolve_partition_spec(table_info, default_spec) if table_info else default_spec
+
+
+def _partition_value_millis(value: str, partition_format: str) -> Optional[int]:
+    if "'" in partition_format:
+        return None
+    python_format = Spark.format_time(f"'{partition_format}'").this
+    if "%-" in python_format:
+        return None
+    parsed = datetime.strptime(value, python_format)
+    if parsed.strftime(python_format) != value:
+        raise ValueError(
+            f"Partition value '{value}' does not match partition format '{partition_format}'"
+        )
+    return int(parsed.replace(tzinfo=timezone.utc).timestamp() * 1000)
+
+
+def _partition_bound_error(value: str, partition_spec: PartitionSpec) -> Optional[str]:
+    java_format = partition_spec.defaulted_format()
+    try:
+        partition_millis = _partition_value_millis(value, java_format)
+    except (TypeError, ValueError):
+        return f"does not match partition_format '{java_format}'"
+    if partition_millis is None:
+        return None
+
+    interval_millis = partition_spec.interval_millis()
+    offset_millis = partition_spec.offset_millis()
+    if interval_millis is not None and (partition_millis - offset_millis) % interval_millis != 0:
+        return (
+            f"is not on the {interval_millis}ms partition grid with "
+            f"partition_offset={offset_millis}ms"
+        )
+    return None
 
 
 def _strip_fields_recursive(obj, fields_to_strip):
@@ -306,12 +383,89 @@ class ConfValidator(object):
         old_obj = self._get_old_obj(type(obj), obj.metaData.name)
         return not old_obj or not self._has_diff(obj, old_obj) or not old_obj.metaData.online
 
-    def _validate_time_partitioned_query(
-        self, query: Optional[Query], source_context: str
+    def _validate_partition_bounds(
+        self,
+        query: Optional[Query],
+        source_context: str,
+        downstream_partition_spec: PartitionSpec,
     ) -> BaseException | None:
-        # timePartitioned flag is deprecated — partition column type is detected automatically.
-        # Kept for backwards compatibility but no longer enforced.
-        return None
+        if query is None:
+            return None
+        if getattr(query, "timePartitioned", False):
+            return None
+
+        effective_spec = _resolve_partition_spec(query, downstream_partition_spec)
+        invalid_bounds = []
+        for field_name in ("startPartition", "endPartition"):
+            value = getattr(query, field_name, None)
+            if value is None:
+                continue
+            reason = _partition_bound_error(value, effective_spec)
+            if reason:
+                invalid_bounds.append(f"{field_name} '{value}' {reason}")
+
+        if not invalid_bounds:
+            return None
+        return ValueError(
+            f"{source_context} has partition bounds that do not align with the effective "
+            f"downstream grid: {'; '.join(invalid_bounds)}"
+        )
+
+    def _validate_embedded_join_bounds(
+        self, join: Join, default_spec: PartitionSpec, source_context: str, seen=None
+    ) -> List[BaseException]:
+        """Validate bounds in an embedded JoinSource using its inherited consumer grid."""
+        seen = seen or set()
+        if id(join) in seen:
+            return []
+        seen.add(id(join))
+        join_spec = _config_partition_spec(join, default_spec)
+        errors = []
+
+        if join.left:
+            left_query = get_query(join.left)
+            error = self._validate_partition_bounds(
+                left_query, f"{source_context} left", join_spec
+            )
+            if error:
+                errors.append(error)
+            if join.left.joinSource and join.left.joinSource.join:
+                errors.extend(
+                    self._validate_embedded_join_bounds(
+                        join.left.joinSource.join, join_spec, f"{source_context} left", seen
+                    )
+                )
+
+        for index, bootstrap_part in enumerate(join.bootstrapParts or []):
+            error = self._validate_partition_bounds(
+                bootstrap_part.query,
+                f"{source_context} bootstrapParts[{index}]",
+                join_spec,
+            )
+            if error:
+                errors.append(error)
+
+        for index, join_part in enumerate(join.joinParts or []):
+            group_by = join_part.groupBy
+            group_by_spec = _config_partition_spec(group_by, join_spec)
+            for source_index, source in enumerate(group_by.sources or []):
+                error = self._validate_partition_bounds(
+                    get_query(source),
+                    f"{source_context} joinParts[{index}] group_by source[{source_index}]",
+                    join_spec,
+                )
+                if error:
+                    errors.append(error)
+                if source.joinSource and source.joinSource.join:
+                    errors.extend(
+                        self._validate_embedded_join_bounds(
+                            source.joinSource.join,
+                            group_by_spec,
+                            f"{source_context} joinParts[{index}] group_by source[{source_index}]",
+                            seen,
+                        )
+                    )
+        return errors
 
     def _validate_derivations(
         self, pre_derived_cols: List[str], derivations: List[Derivation]
@@ -453,17 +607,28 @@ class ConfValidator(object):
             if not gb.metaData or gb.metaData.online is False
         ]
         errors = []
+        join_partition_spec = _config_partition_spec(join)
 
         if join.left and (left_query := get_query(join.left)) is not None:
-            left_query_err = self._validate_time_partitioned_query(
-                left_query, f"join {join.metaData.name} left"
+            left_query_err = self._validate_partition_bounds(
+                left_query, f"join {join.metaData.name} left", join_partition_spec
             )
             if left_query_err:
                 errors.append(left_query_err)
+            if join.left.joinSource and join.left.joinSource.join:
+                errors.extend(
+                    self._validate_embedded_join_bounds(
+                        join.left.joinSource.join,
+                        join_partition_spec,
+                        f"join {join.metaData.name} left",
+                    )
+                )
 
         for index, bootstrap_part in enumerate(join.bootstrapParts or []):
-            bootstrap_query_err = self._validate_time_partitioned_query(
-                bootstrap_part.query, f"join {join.metaData.name} bootstrapParts[{index}]"
+            bootstrap_query_err = self._validate_partition_bounds(
+                bootstrap_part.query,
+                f"join {join.metaData.name} bootstrapParts[{index}]",
+                join_partition_spec,
             )
             if bootstrap_query_err:
                 errors.append(bootstrap_query_err)
@@ -479,7 +644,10 @@ class ConfValidator(object):
             if group_by.metaData.production is False
         ]
         # Check if the underlying groupBy is valid
-        group_by_errors = [self._validate_group_by(group_by) for group_by in included_group_bys]
+        group_by_errors = [
+            self._validate_group_by(group_by, join_partition_spec)
+            for group_by in included_group_bys
+        ]
         errors += [
             ValueError(f"join {join.metaData.name}'s underlying {error}")
             for errors in group_by_errors
@@ -528,7 +696,9 @@ class ConfValidator(object):
 
         return errors
 
-    def _validate_group_by(self, group_by: GroupBy) -> List[BaseException]:
+    def _validate_group_by(
+        self, group_by: GroupBy, downstream_partition_spec: PartitionSpec = None
+    ) -> List[BaseException]:
         """
         Validate group_by's status with materialized versions of joins
         including the group_by.
@@ -540,6 +710,7 @@ class ConfValidator(object):
         online_joins = [join.metaData.name for join in joins if join.metaData.online is True]
         prod_joins = [join.metaData.name for join in joins if join.metaData.production is True]
         errors = []
+        consumer_partition_spec = downstream_partition_spec or _config_partition_spec(group_by)
 
         non_temporal = group_by.accuracy is None or group_by.accuracy == Accuracy.SNAPSHOT
 
@@ -625,11 +796,21 @@ class ConfValidator(object):
 
         for index, source in enumerate(group_by.sources):
             src: Source = source
-            query_error = self._validate_time_partitioned_query(
-                get_query(src), f"group_by {group_by.metaData.name} source[{index}]"
+            query_error = self._validate_partition_bounds(
+                get_query(src),
+                f"group_by {group_by.metaData.name} source[{index}]",
+                consumer_partition_spec,
             )
             if query_error:
                 errors.append(query_error)
+            if src.joinSource and src.joinSource.join:
+                errors.extend(
+                    self._validate_embedded_join_bounds(
+                        src.joinSource.join,
+                        consumer_partition_spec,
+                        f"group_by {group_by.metaData.name} source[{index}]",
+                    )
+                )
 
             if src.events and src.events.isCumulative and (src.events.query.timeColumn is None):
                 errors.append(

--- a/python/src/ai/chronon/cli/compile/conf_validator.py
+++ b/python/src/ai/chronon/cli/compile/conf_validator.py
@@ -450,8 +450,9 @@ class ConfValidator(object):
     ) -> PartitionSpec:
         inferred_accuracy = _group_by_inferred_accuracy(group_by)
         group_by_data_model = _group_by_data_model(group_by)
-        if left_data_model == "EVENTS" and (
-            inferred_accuracy == Accuracy.SNAPSHOT or group_by_data_model == "ENTITIES"
+        if left_data_model == "ENTITIES" or (
+            left_data_model == "EVENTS"
+            and (inferred_accuracy == Accuracy.SNAPSHOT or group_by_data_model == "ENTITIES")
         ):
             return _config_partition_spec(group_by, downstream_partition_spec)
         if left_data_model is None and inferred_accuracy == Accuracy.SNAPSHOT:

--- a/python/src/ai/chronon/cli/compile/conf_validator.py
+++ b/python/src/ai/chronon/cli/compile/conf_validator.py
@@ -124,12 +124,50 @@ def _resolve_partition_spec(table_info, default_spec: PartitionSpec) -> Partitio
     )
 
 
-def _config_partition_spec(obj, default_spec: PartitionSpec = None) -> PartitionSpec:
-    default_spec = default_spec or _legacy_partition_spec()
+def _output_table_info(obj):
     metadata = getattr(obj, "metaData", None)
     execution_info = getattr(metadata, "executionInfo", None) if metadata else None
-    table_info = getattr(execution_info, "outputTableInfo", None) if execution_info else None
+    return getattr(execution_info, "outputTableInfo", None) if execution_info else None
+
+
+def _config_partition_spec(obj, default_spec: PartitionSpec = None) -> PartitionSpec:
+    default_spec = default_spec or _legacy_partition_spec()
+    table_info = _output_table_info(obj)
     return _resolve_partition_spec(table_info, default_spec) if table_info else default_spec
+
+
+def _declared_source_partition_spec(
+    source: Source, default_spec: PartitionSpec
+) -> Optional[PartitionSpec]:
+    join_source = getattr(source, "joinSource", None)
+    upstream_join = getattr(join_source, "join", None) if join_source else None
+    output_table_info = _output_table_info(upstream_join) if upstream_join else None
+    if output_table_info and getattr(output_table_info, "partitionInterval", None):
+        return _resolve_partition_spec(output_table_info, default_spec)
+
+    query = getattr(join_source, "query", None) if join_source else get_query(source)
+    if query and getattr(query, "partitionInterval", None):
+        return _resolve_partition_spec(query, default_spec)
+    return None
+
+
+def _snapshot_group_by_partition_spec(
+    group_by: GroupBy, downstream_spec: PartitionSpec
+) -> PartitionSpec:
+    output_table_info = _output_table_info(group_by)
+    if output_table_info and getattr(output_table_info, "partitionInterval", None):
+        return _resolve_partition_spec(output_table_info, downstream_spec)
+
+    declared_sources = [
+        spec
+        for source in group_by.sources or []
+        if (spec := _declared_source_partition_spec(source, downstream_spec))
+    ]
+    return max(
+        declared_sources,
+        key=lambda spec: spec.interval_millis(),
+        default=downstream_spec,
+    )
 
 
 def _partition_value_millis(value: str, partition_format: str) -> Optional[int]:
@@ -420,17 +458,20 @@ class ConfValidator(object):
     ) -> BaseException | None:
         if query is None:
             return None
-        if getattr(query, "timePartitioned", False):
-            return None
 
         effective_spec = _resolve_partition_spec(query, downstream_partition_spec)
+        fallback_specs = [downstream_partition_spec]
+        if getattr(query, "timePartitioned", False):
+            fallback_specs.append(_legacy_partition_spec())
         invalid_bounds = []
         for field_name in ("startPartition", "endPartition"):
             value = getattr(query, field_name, None)
             if value is None:
                 continue
             reason = _partition_bound_error(value, effective_spec)
-            if reason and _partition_bound_error(value, downstream_partition_spec) is None:
+            if reason and any(
+                _partition_bound_error(value, spec) is None for spec in fallback_specs
+            ):
                 reason = None
             if reason:
                 invalid_bounds.append(f"{field_name} '{value}' {reason}")
@@ -454,9 +495,9 @@ class ConfValidator(object):
             left_data_model == "EVENTS"
             and (inferred_accuracy == Accuracy.SNAPSHOT or group_by_data_model == "ENTITIES")
         ):
-            return _config_partition_spec(group_by, downstream_partition_spec)
+            return _snapshot_group_by_partition_spec(group_by, downstream_partition_spec)
         if left_data_model is None and inferred_accuracy == Accuracy.SNAPSHOT:
-            return _config_partition_spec(group_by, downstream_partition_spec)
+            return _snapshot_group_by_partition_spec(group_by, downstream_partition_spec)
         return downstream_partition_spec
 
     def _validate_embedded_join_bounds(

--- a/python/src/ai/chronon/cli/compile/conf_validator.py
+++ b/python/src/ai/chronon/cli/compile/conf_validator.py
@@ -203,6 +203,35 @@ def _group_by_has_topic(groupBy: GroupBy) -> bool:
     return any(_source_has_topic(source) for source in groupBy.sources)
 
 
+def _source_data_model(source: Source) -> Optional[str]:
+    if source.events:
+        return "EVENTS"
+    if source.entities:
+        return "ENTITIES"
+    if source.joinSource and source.joinSource.join and source.joinSource.join.left:
+        return _source_data_model(source.joinSource.join.left)
+    return None
+
+
+def _group_by_data_model(group_by: GroupBy) -> Optional[str]:
+    models = {
+        model
+        for model in (_source_data_model(source) for source in group_by.sources or [])
+        if model is not None
+    }
+    if len(models) == 1:
+        return next(iter(models))
+    return None
+
+
+def _group_by_inferred_accuracy(group_by: GroupBy) -> Accuracy:
+    if group_by.accuracy is not None:
+        return group_by.accuracy
+    if _group_by_has_topic(group_by):
+        return Accuracy.TEMPORAL
+    return Accuracy.SNAPSHOT
+
+
 def _group_by_has_hourly_windows(groupBy: GroupBy) -> bool:
     aggs: List[Aggregation] = groupBy.aggregations
 
@@ -401,6 +430,8 @@ class ConfValidator(object):
             if value is None:
                 continue
             reason = _partition_bound_error(value, effective_spec)
+            if reason and _partition_bound_error(value, downstream_partition_spec) is None:
+                reason = None
             if reason:
                 invalid_bounds.append(f"{field_name} '{value}' {reason}")
 
@@ -411,6 +442,22 @@ class ConfValidator(object):
             f"downstream grid: {'; '.join(invalid_bounds)}"
         )
 
+    def _group_by_consumer_partition_spec(
+        self,
+        group_by: GroupBy,
+        downstream_partition_spec: PartitionSpec,
+        left_data_model: Optional[str] = None,
+    ) -> PartitionSpec:
+        inferred_accuracy = _group_by_inferred_accuracy(group_by)
+        group_by_data_model = _group_by_data_model(group_by)
+        if left_data_model == "EVENTS" and (
+            inferred_accuracy == Accuracy.SNAPSHOT or group_by_data_model == "ENTITIES"
+        ):
+            return _config_partition_spec(group_by, downstream_partition_spec)
+        if left_data_model is None and inferred_accuracy == Accuracy.SNAPSHOT:
+            return _config_partition_spec(group_by, downstream_partition_spec)
+        return downstream_partition_spec
+
     def _validate_embedded_join_bounds(
         self, join: Join, default_spec: PartitionSpec, source_context: str, seen=None
     ) -> List[BaseException]:
@@ -420,6 +467,7 @@ class ConfValidator(object):
             return []
         seen.add(id(join))
         join_spec = _config_partition_spec(join, default_spec)
+        left_data_model = _source_data_model(join.left) if join.left else None
         errors = []
 
         if join.left:
@@ -447,12 +495,14 @@ class ConfValidator(object):
 
         for index, join_part in enumerate(join.joinParts or []):
             group_by = join_part.groupBy
-            group_by_spec = _config_partition_spec(group_by, join_spec)
+            group_by_spec = self._group_by_consumer_partition_spec(
+                group_by, join_spec, left_data_model
+            )
             for source_index, source in enumerate(group_by.sources or []):
                 error = self._validate_partition_bounds(
                     get_query(source),
                     f"{source_context} joinParts[{index}] group_by source[{source_index}]",
-                    join_spec,
+                    group_by_spec,
                 )
                 if error:
                     errors.append(error)
@@ -608,6 +658,7 @@ class ConfValidator(object):
         ]
         errors = []
         join_partition_spec = _config_partition_spec(join)
+        left_data_model = _source_data_model(join.left) if join.left else None
 
         if join.left and (left_query := get_query(join.left)) is not None:
             left_query_err = self._validate_partition_bounds(
@@ -645,7 +696,7 @@ class ConfValidator(object):
         ]
         # Check if the underlying groupBy is valid
         group_by_errors = [
-            self._validate_group_by(group_by, join_partition_spec)
+            self._validate_group_by(group_by, join_partition_spec, left_data_model)
             for group_by in included_group_bys
         ]
         errors += [
@@ -697,7 +748,10 @@ class ConfValidator(object):
         return errors
 
     def _validate_group_by(
-        self, group_by: GroupBy, downstream_partition_spec: PartitionSpec = None
+        self,
+        group_by: GroupBy,
+        downstream_partition_spec: PartitionSpec = None,
+        left_data_model: Optional[str] = None,
     ) -> List[BaseException]:
         """
         Validate group_by's status with materialized versions of joins
@@ -710,9 +764,13 @@ class ConfValidator(object):
         online_joins = [join.metaData.name for join in joins if join.metaData.online is True]
         prod_joins = [join.metaData.name for join in joins if join.metaData.production is True]
         errors = []
-        consumer_partition_spec = downstream_partition_spec or _config_partition_spec(group_by)
 
-        non_temporal = group_by.accuracy is None or group_by.accuracy == Accuracy.SNAPSHOT
+        inferred_accuracy = _group_by_inferred_accuracy(group_by)
+        non_temporal = inferred_accuracy == Accuracy.SNAPSHOT
+        default_partition_spec = downstream_partition_spec or _legacy_partition_spec()
+        consumer_partition_spec = self._group_by_consumer_partition_spec(
+            group_by, default_partition_spec, left_data_model
+        )
 
         no_topic = not _group_by_has_topic(group_by)
         has_hourly_windows = _group_by_has_hourly_windows(group_by)

--- a/python/test/test_compile.py
+++ b/python/test/test_compile.py
@@ -696,6 +696,7 @@ def test_compile_substitutes_namespace_placeholder_in_key_filter(tmp_path, monke
                 keys=["subject"],
                 aggregations=[Aggregation(input_column="event", operation=Operation.SUM, windows=["1d"])],
                 key_filter=active_subjects,
+                version=1,
             )
             """
         ).strip(),
@@ -703,6 +704,79 @@ def test_compile_substitutes_namespace_placeholder_in_key_filter(tmp_path, monke
 
     _run_compile(tmp_path, monkeypatch)
     _assert_no_namespace_placeholder_in_compiled(tmp_path / "compiled")
+
+
+def test_compile_allows_time_partitioned_bounds_on_downstream_subdaily_grid(
+    tmp_path, monkeypatch
+):
+    _scaffold_repo(tmp_path)
+    _write(
+        tmp_path / "group_bys" / "sample_team" / "time_partitioned_bounds.py",
+        dedent(
+            """
+            from ai.chronon.types import Aggregation, EventSource, GroupBy, Operation, Query, selects
+
+            v1 = GroupBy(
+                sources=[
+                    EventSource(
+                        table="external.time_partitioned_events",
+                        query=Query(
+                            selects=selects(value="value", user_id="user_id"),
+                            time_column="event_ts",
+                            partition_column="event_ts",
+                            time_partitioned=True,
+                            start_partition="2025-11-29",
+                            end_partition="2026-04-12",
+                        ),
+                    )
+                ],
+                keys=["user_id"],
+                aggregations=[Aggregation(input_column="value", operation=Operation.SUM, windows=["1d"])],
+                version=1,
+            )
+            """
+        ).strip(),
+    )
+    _write(
+        tmp_path / "joins" / "sample_team" / "time_partitioned_bounds_join.py",
+        dedent(
+            """
+            from group_bys.sample_team.time_partitioned_bounds import v1 as bounds_gb
+            from ai.chronon.types import EventSource, Join, JoinPart, Query, selects
+
+            v1 = Join(
+                left=EventSource(
+                    table="external.left_events",
+                    query=Query(
+                        selects=selects("user_id"),
+                        time_column="event_ts",
+                        partition_column="ds",
+                        partition_interval="3h",
+                        partition_offset="1h",
+                        start_partition="2025-11-29-01-00",
+                    ),
+                ),
+                right_parts=[JoinPart(group_by=bounds_gb)],
+                offline_schedule="0 1-22/3 * * *",
+                partition_interval="3h",
+                partition_offset="1h",
+                version=1,
+            )
+            """
+        ).strip(),
+    )
+
+    results, has_errors, _ = _run_compile(
+        tmp_path, monkeypatch, ignore_python_errors=False
+    )
+
+    from gen_thrift.api.ttypes import ConfType
+
+    assert not has_errors
+    assert (
+        "sample_team.time_partitioned_bounds_join.v1__1"
+        in results[ConfType.JOIN].obj_dict
+    )
 
 
 def test_compile_rejects_lost_table_reference_grid_metadata(tmp_path, monkeypatch, capsys):

--- a/python/test/test_conf_validator.py
+++ b/python/test/test_conf_validator.py
@@ -1,3 +1,4 @@
+import gen_thrift.common.ttypes as common
 from gen_thrift.api.ttypes import (
     Aggregation,
     BootstrapPart,
@@ -462,3 +463,69 @@ class TestTimePartitionedValidation:
 
         errors = validator.validate_obj(group_by)
         assert not _has_time_partitioned_missing_partition_column_error(errors)
+
+    def test_downstream_consumer_validates_partition_bounds_against_full_chain_grid(self):
+        group_by = _make_group_by()
+        source_query = group_by.sources[0].events.query
+        source_query.timePartitioned = False
+        source_query.startPartition = "2025-11-29"
+        source_query.endPartition = "2026-04-12-02-00"
+
+        downstream_consumer = _make_join(group_by=group_by)
+        downstream_consumer.metaData.executionInfo = common.ExecutionInfo(
+            outputTableInfo=common.TableInfo(
+                partitionFormat="yyyy-MM-dd-HH-mm",
+                partitionInterval=common.Window(length=3, timeUnit=common.TimeUnit.HOURS),
+                partitionOffset=common.Window(length=1, timeUnit=common.TimeUnit.HOURS),
+            )
+        )
+
+        errors = _make_validator().validate_obj(downstream_consumer)
+        messages = "\n".join(str(error) for error in errors)
+
+        assert "join team.my_join's underlying group_by team.my_gb source[0]" in messages
+        assert "startPartition '2025-11-29'" in messages
+        assert "endPartition '2026-04-12-02-00'" in messages
+        assert "yyyy-MM-dd-HH-mm" in messages
+
+    def test_downstream_consumer_accepts_partition_bounds_on_full_chain_grid(self):
+        group_by = _make_group_by()
+        source_query = group_by.sources[0].events.query
+        source_query.timePartitioned = False
+        source_query.partitionInterval = common.Window(length=3, timeUnit=common.TimeUnit.HOURS)
+        source_query.partitionOffset = common.Window(length=1, timeUnit=common.TimeUnit.HOURS)
+        source_query.startPartition = "2025-11-29-01-00"
+        source_query.endPartition = "2026-04-12-04-00"
+
+        downstream_consumer = _make_join(group_by=group_by)
+        downstream_consumer.metaData.executionInfo = common.ExecutionInfo(
+            outputTableInfo=common.TableInfo(
+                partitionFormat="yyyy-MM-dd-HH-mm",
+                partitionInterval=common.Window(length=3, timeUnit=common.TimeUnit.HOURS),
+                partitionOffset=common.Window(length=1, timeUnit=common.TimeUnit.HOURS),
+            )
+        )
+
+        errors = _make_validator().validate_obj(downstream_consumer)
+
+        assert not any("partition bounds" in str(error) for error in errors)
+
+    def test_downstream_consumer_allows_time_partitioned_partition_bounds(self):
+        group_by = _make_group_by()
+        source_query = group_by.sources[0].events.query
+        source_query.timePartitioned = True
+        source_query.startPartition = "2025-11-29"
+        source_query.endPartition = "2026-04-12"
+
+        downstream_consumer = _make_join(group_by=group_by)
+        downstream_consumer.metaData.executionInfo = common.ExecutionInfo(
+            outputTableInfo=common.TableInfo(
+                partitionFormat="yyyy-MM-dd-HH-mm",
+                partitionInterval=common.Window(length=3, timeUnit=common.TimeUnit.HOURS),
+                partitionOffset=common.Window(length=1, timeUnit=common.TimeUnit.HOURS),
+            )
+        )
+
+        errors = _make_validator().validate_obj(downstream_consumer)
+
+        assert not any("partition bounds" in str(error) for error in errors)

--- a/python/test/test_conf_validator.py
+++ b/python/test/test_conf_validator.py
@@ -1,7 +1,9 @@
 import gen_thrift.common.ttypes as common
 from gen_thrift.api.ttypes import (
+    Accuracy,
     Aggregation,
     BootstrapPart,
+    EntitySource,
     EventSource,
     ExternalPart,
     GroupBy,
@@ -507,6 +509,155 @@ class TestTimePartitionedValidation:
         )
 
         errors = _make_validator().validate_obj(downstream_consumer)
+
+        assert not any("partition bounds" in str(error) for error in errors)
+
+    def test_snapshot_group_by_uses_its_declared_output_grid_for_source_bounds(self):
+        group_by = _make_group_by()
+        group_by.accuracy = Accuracy.SNAPSHOT
+        group_by.metaData.executionInfo = common.ExecutionInfo(
+            outputTableInfo=common.TableInfo(
+                partitionFormat="yyyy-MM-dd",
+                partitionInterval=common.Window(length=1, timeUnit=common.TimeUnit.DAYS),
+            )
+        )
+        source_query = group_by.sources[0].events.query
+        source_query.startPartition = "2025-11-29"
+        source_query.endPartition = "2026-04-12"
+
+        downstream_consumer = _make_join(group_by=group_by)
+        downstream_consumer.metaData.executionInfo = common.ExecutionInfo(
+            outputTableInfo=common.TableInfo(
+                partitionFormat="yyyy-MM-dd-HH-mm",
+                partitionInterval=common.Window(length=3, timeUnit=common.TimeUnit.HOURS),
+                partitionOffset=common.Window(length=1, timeUnit=common.TimeUnit.HOURS),
+            )
+        )
+
+        errors = _make_validator().validate_obj(downstream_consumer)
+
+        assert not any("partition bounds" in str(error) for error in errors)
+
+    def test_event_left_temporal_entity_group_by_uses_snapshot_grid_for_source_bounds(self):
+        group_by = GroupBy(
+            sources=[
+                Source(
+                    entities=EntitySource(
+                        snapshotTable="entity_table",
+                        query=Query(
+                            selects={"user_id": "user_id", "price": "price"},
+                            startPartition="2025-11-29",
+                            endPartition="2026-04-12",
+                        ),
+                    )
+                )
+            ],
+            keyColumns=["user_id"],
+            aggregations=[
+                Aggregation(inputColumn="price", operation=Operation.SUM),
+            ],
+            accuracy=Accuracy.TEMPORAL,
+            metaData=MetaData(
+                name="team.temporal_entity_gb",
+                executionInfo=common.ExecutionInfo(
+                    outputTableInfo=common.TableInfo(
+                        partitionFormat="yyyy-MM-dd",
+                        partitionInterval=common.Window(
+                            length=1, timeUnit=common.TimeUnit.DAYS
+                        ),
+                    )
+                ),
+            ),
+        )
+        downstream_consumer = _make_join(group_by=group_by)
+        downstream_consumer.metaData.executionInfo = common.ExecutionInfo(
+            outputTableInfo=common.TableInfo(
+                partitionFormat="yyyy-MM-dd-HH-mm",
+                partitionInterval=common.Window(length=3, timeUnit=common.TimeUnit.HOURS),
+                partitionOffset=common.Window(length=1, timeUnit=common.TimeUnit.HOURS),
+            )
+        )
+
+        errors = _make_validator().validate_obj(downstream_consumer)
+
+        assert not any("partition bounds" in str(error) for error in errors)
+
+    def test_accuracy_none_with_topic_infers_temporal_for_source_bounds(self):
+        group_by = _make_group_by()
+        group_by.sources[0].events.topic = "events.topic"
+        group_by.metaData.executionInfo = common.ExecutionInfo(
+            outputTableInfo=common.TableInfo(
+                partitionFormat="yyyy-MM-dd",
+                partitionInterval=common.Window(length=1, timeUnit=common.TimeUnit.DAYS),
+            )
+        )
+        source_query = group_by.sources[0].events.query
+        source_query.startPartition = "2025-11-29"
+
+        downstream_consumer = _make_join(group_by=group_by)
+        downstream_consumer.metaData.executionInfo = common.ExecutionInfo(
+            outputTableInfo=common.TableInfo(
+                partitionFormat="yyyy-MM-dd-HH-mm",
+                partitionInterval=common.Window(length=3, timeUnit=common.TimeUnit.HOURS),
+                partitionOffset=common.Window(length=1, timeUnit=common.TimeUnit.HOURS),
+            )
+        )
+
+        errors = _make_validator().validate_obj(downstream_consumer)
+        messages = "\n".join(str(error) for error in errors)
+
+        assert "join team.my_join's underlying group_by team.my_gb source[0]" in messages
+        assert "startPartition '2025-11-29'" in messages
+        assert "yyyy-MM-dd-HH-mm" in messages
+
+    def test_embedded_snapshot_group_by_uses_its_declared_output_grid_for_source_bounds(self):
+        group_by = _make_group_by(name="team.embedded_gb")
+        group_by.accuracy = Accuracy.SNAPSHOT
+        group_by.metaData.executionInfo = common.ExecutionInfo(
+            outputTableInfo=common.TableInfo(
+                partitionFormat="yyyy-MM-dd",
+                partitionInterval=common.Window(length=1, timeUnit=common.TimeUnit.DAYS),
+            )
+        )
+        source_query = group_by.sources[0].events.query
+        source_query.startPartition = "2025-11-29"
+        source_query.endPartition = "2026-04-12"
+
+        embedded_join = _make_join(name="team.embedded_join", group_by=group_by)
+        embedded_join.metaData.executionInfo = common.ExecutionInfo(
+            outputTableInfo=common.TableInfo(
+                partitionFormat="yyyy-MM-dd-HH-mm",
+                partitionInterval=common.Window(length=3, timeUnit=common.TimeUnit.HOURS),
+                partitionOffset=common.Window(length=1, timeUnit=common.TimeUnit.HOURS),
+            )
+        )
+        downstream_consumer = _make_join()
+        downstream_consumer.left = Source(
+            joinSource=JoinSource(
+                join=embedded_join,
+                query=Query(selects={"user_id": "user_id"}, timeColumn="timestamp"),
+            )
+        )
+        downstream_consumer.metaData.executionInfo = common.ExecutionInfo(
+            outputTableInfo=common.TableInfo(
+                partitionFormat="yyyy-MM-dd-HH-mm",
+                partitionInterval=common.Window(length=3, timeUnit=common.TimeUnit.HOURS),
+                partitionOffset=common.Window(length=1, timeUnit=common.TimeUnit.HOURS),
+            )
+        )
+
+        errors = _make_validator().validate_obj(downstream_consumer)
+
+        assert not any("partition bounds" in str(error) for error in errors)
+
+    def test_partition_bounds_accept_the_downstream_fallback_format(self):
+        group_by = _make_group_by()
+        source_query = group_by.sources[0].events.query
+        source_query.partitionFormat = "yyyyMMdd"
+        source_query.startPartition = "2025-11-29"
+        source_query.endPartition = "2026-04-12"
+
+        errors = _make_validator().validate_obj(group_by)
 
         assert not any("partition bounds" in str(error) for error in errors)
 

--- a/python/test/test_conf_validator.py
+++ b/python/test/test_conf_validator.py
@@ -582,6 +582,38 @@ class TestTimePartitionedValidation:
 
         assert not any("partition bounds" in str(error) for error in errors)
 
+    def test_entity_left_group_by_uses_snapshot_grid_for_source_bounds(self):
+        group_by = _make_group_by()
+        group_by.accuracy = Accuracy.TEMPORAL
+        group_by.metaData.executionInfo = common.ExecutionInfo(
+            outputTableInfo=common.TableInfo(
+                partitionFormat="yyyy-MM-dd",
+                partitionInterval=common.Window(length=1, timeUnit=common.TimeUnit.DAYS),
+            )
+        )
+        source_query = group_by.sources[0].events.query
+        source_query.startPartition = "2025-11-29"
+        source_query.endPartition = "2026-04-12"
+
+        downstream_consumer = _make_join(group_by=group_by)
+        downstream_consumer.left = Source(
+            entities=EntitySource(
+                snapshotTable="left_entity_table",
+                query=Query(selects={"user_id": "user_id"}),
+            )
+        )
+        downstream_consumer.metaData.executionInfo = common.ExecutionInfo(
+            outputTableInfo=common.TableInfo(
+                partitionFormat="yyyy-MM-dd-HH-mm",
+                partitionInterval=common.Window(length=3, timeUnit=common.TimeUnit.HOURS),
+                partitionOffset=common.Window(length=1, timeUnit=common.TimeUnit.HOURS),
+            )
+        )
+
+        errors = _make_validator().validate_obj(downstream_consumer)
+
+        assert not any("partition bounds" in str(error) for error in errors)
+
     def test_accuracy_none_with_topic_infers_temporal_for_source_bounds(self):
         group_by = _make_group_by()
         group_by.sources[0].events.topic = "events.topic"

--- a/python/test/test_conf_validator.py
+++ b/python/test/test_conf_validator.py
@@ -538,6 +538,39 @@ class TestTimePartitionedValidation:
 
         assert not any("partition bounds" in str(error) for error in errors)
 
+    def test_snapshot_group_by_uses_coarsest_declared_source_grid_for_source_bounds(self):
+        group_by = _make_group_by()
+        group_by.accuracy = Accuracy.SNAPSHOT
+        source_query = group_by.sources[0].events.query
+        source_query.startPartition = "2025-11-29"
+        source_query.endPartition = "2026-04-12"
+        group_by.sources.append(
+            Source(
+                events=EventSource(
+                    table="daily_table",
+                    query=Query(
+                        selects={"user_id": "user_id", "price": "price"},
+                        timeColumn="timestamp",
+                        partitionFormat="yyyy-MM-dd",
+                        partitionInterval=common.Window(length=1, timeUnit=common.TimeUnit.DAYS),
+                    ),
+                )
+            )
+        )
+
+        downstream_consumer = _make_join(group_by=group_by)
+        downstream_consumer.metaData.executionInfo = common.ExecutionInfo(
+            outputTableInfo=common.TableInfo(
+                partitionFormat="yyyy-MM-dd-HH-mm",
+                partitionInterval=common.Window(length=3, timeUnit=common.TimeUnit.HOURS),
+                partitionOffset=common.Window(length=1, timeUnit=common.TimeUnit.HOURS),
+            )
+        )
+
+        errors = _make_validator().validate_obj(downstream_consumer)
+
+        assert not any("partition bounds" in str(error) for error in errors)
+
     def test_event_left_temporal_entity_group_by_uses_snapshot_grid_for_source_bounds(self):
         group_by = GroupBy(
             sources=[
@@ -712,3 +745,13 @@ class TestTimePartitionedValidation:
         errors = _make_validator().validate_obj(downstream_consumer)
 
         assert not any("partition bounds" in str(error) for error in errors)
+
+    def test_time_partitioned_source_rejects_unparseable_partition_bounds(self):
+        group_by = _make_group_by()
+        source_query = group_by.sources[0].events.query
+        source_query.timePartitioned = True
+        source_query.startPartition = "not-a-partition"
+
+        errors = _make_validator().validate_obj(group_by)
+
+        assert any("startPartition 'not-a-partition'" in str(error) for error in errors)

--- a/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
@@ -764,8 +764,9 @@ object GroupBy {
     implicit val sourcePartitionSpec: PartitionSpec = source.query.partitionSpec(tableUtils.partitionSpec)
     // intersectingRange so a coarser source still supplies the query range's full time interval
     val effectiveQueryRange = queryRange.intersectingRange(sourcePartitionSpec)
-    val sourceStartPartition = sourcePartitionSpec.normalizeStart(source.query.startPartition, tableUtils.partitionSpec)
-    val sourceEndPartition = sourcePartitionSpec.normalizeEnd(source.query.endPartition, tableUtils.partitionSpec)
+    val cutoffFallbackSpecs = PartitionSpec.cutoffFallbackSpecs(source.query, tableUtils.partitionSpec)
+    val sourceStartPartition = sourcePartitionSpec.normalizeStart(source.query.startPartition, cutoffFallbackSpecs)
+    val sourceEndPartition = sourcePartitionSpec.normalizeEnd(source.query.endPartition, cutoffFallbackSpecs)
 
     // from here on down - the math is based entirely on source partition spec
     val PartitionRange(queryStart, queryEnd) = effectiveQueryRange

--- a/spark/src/main/scala/ai/chronon/spark/batch/BatchNodeRunner.scala
+++ b/spark/src/main/scala/ai/chronon/spark/batch/BatchNodeRunner.scala
@@ -695,40 +695,6 @@ class BatchNodeRunner(node: Node, tableUtils: TableUtils, api: Api) extends Node
     node.metaData.name.toLowerCase.contains("sensor")
   }
 
-  private def isTimePartitionedExternalSensor(conf: NodeContent): Boolean =
-    conf.isSetExternalSourceSensor &&
-      Option(conf.getExternalSourceSensor.sourceTableDependency)
-        .flatMap(dep => Option(dep.tableInfo))
-        .exists(tableInfo => tableInfo.isSetTimePartitioned && tableInfo.timePartitioned)
-
-  private[batch] def rangeFromArgs(startDs: String, endDs: String): PartitionRange = {
-    val metadata = node.metaData
-    val spec = runPartitionSpec(metadata, node.content)
-    val allowDailyFallback = isTimePartitionedExternalSensor(node.content)
-
-    def normalize(ds: String, isStart: Boolean): String = {
-      if (ds == null) return null
-      if (Try(spec.at(spec.epochMillis(ds)) == ds).getOrElse(false)) return ds
-
-      val normalized =
-        if (allowDailyFallback) {
-          Try {
-            if (isStart) spec.normalizeStart(ds, PartitionSpec.daily)
-            else spec.normalizeEnd(ds, PartitionSpec.daily)
-          }.toOption
-        } else None
-
-      require(
-        normalized.nonEmpty,
-        s"--start-ds/--end-ds value '$ds' is not a valid partition value for node '${metadata.name}' " +
-          s"(expected format '${spec.format}' on a ${spec.spanMillis}ms grid with offset ${spec.offsetMillis}ms)"
-      )
-      normalized.get
-    }
-
-    PartitionRange(normalize(startDs, isStart = true), normalize(endDs, isStart = false))(spec)
-  }
-
   def runFromArgs(
       startDs: String,
       endDs: String,
@@ -736,7 +702,16 @@ class BatchNodeRunner(node: Node, tableUtils: TableUtils, api: Api) extends Node
   ): Int = {
     Try {
       val metadata = node.metaData
-      val range = rangeFromArgs(startDs, endDs)
+      val spec = runPartitionSpec(metadata, node.content)
+      // catch a daily-formatted arg handed to a sub-daily node (and vice versa) before any work runs
+      Seq(startDs, endDs).foreach { ds =>
+        require(
+          Try(spec.at(spec.epochMillis(ds)) == ds).getOrElse(false),
+          s"--start-ds/--end-ds value '$ds' is not a valid partition value for node '${metadata.name}' " +
+            s"(expected format '${spec.format}' on a ${spec.spanMillis}ms grid with offset ${spec.offsetMillis}ms)"
+        )
+      }
+      val range = PartitionRange(startDs, endDs)(spec)
 
       val inputTablePartitionStatuses = computeInputTablePartitionStatuses(metadata, range, tableUtils)
 

--- a/spark/src/main/scala/ai/chronon/spark/batch/BatchNodeRunner.scala
+++ b/spark/src/main/scala/ai/chronon/spark/batch/BatchNodeRunner.scala
@@ -695,6 +695,40 @@ class BatchNodeRunner(node: Node, tableUtils: TableUtils, api: Api) extends Node
     node.metaData.name.toLowerCase.contains("sensor")
   }
 
+  private def isTimePartitionedExternalSensor(conf: NodeContent): Boolean =
+    conf.isSetExternalSourceSensor &&
+      Option(conf.getExternalSourceSensor.sourceTableDependency)
+        .flatMap(dep => Option(dep.tableInfo))
+        .exists(tableInfo => tableInfo.isSetTimePartitioned && tableInfo.timePartitioned)
+
+  private[batch] def rangeFromArgs(startDs: String, endDs: String): PartitionRange = {
+    val metadata = node.metaData
+    val spec = runPartitionSpec(metadata, node.content)
+    val allowDailyFallback = isTimePartitionedExternalSensor(node.content)
+
+    def normalize(ds: String, isStart: Boolean): String = {
+      if (ds == null) return null
+      if (Try(spec.at(spec.epochMillis(ds)) == ds).getOrElse(false)) return ds
+
+      val normalized =
+        if (allowDailyFallback) {
+          Try {
+            if (isStart) spec.normalizeStart(ds, PartitionSpec.daily)
+            else spec.normalizeEnd(ds, PartitionSpec.daily)
+          }.toOption
+        } else None
+
+      require(
+        normalized.nonEmpty,
+        s"--start-ds/--end-ds value '$ds' is not a valid partition value for node '${metadata.name}' " +
+          s"(expected format '${spec.format}' on a ${spec.spanMillis}ms grid with offset ${spec.offsetMillis}ms)"
+      )
+      normalized.get
+    }
+
+    PartitionRange(normalize(startDs, isStart = true), normalize(endDs, isStart = false))(spec)
+  }
+
   def runFromArgs(
       startDs: String,
       endDs: String,
@@ -702,16 +736,7 @@ class BatchNodeRunner(node: Node, tableUtils: TableUtils, api: Api) extends Node
   ): Int = {
     Try {
       val metadata = node.metaData
-      val spec = runPartitionSpec(metadata, node.content)
-      // catch a daily-formatted arg handed to a sub-daily node (and vice versa) before any work runs
-      Seq(startDs, endDs).foreach { ds =>
-        require(
-          Try(spec.at(spec.epochMillis(ds)) == ds).getOrElse(false),
-          s"--start-ds/--end-ds value '$ds' is not a valid partition value for node '${metadata.name}' " +
-            s"(expected format '${spec.format}' on a ${spec.spanMillis}ms grid with offset ${spec.offsetMillis}ms)"
-        )
-      }
-      val range = PartitionRange(startDs, endDs)(spec)
+      val range = rangeFromArgs(startDs, endDs)
 
       val inputTablePartitionStatuses = computeInputTablePartitionStatuses(metadata, range, tableUtils)
 

--- a/spark/src/test/scala/ai/chronon/spark/batch/BatchNodeRunnerTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/batch/BatchNodeRunnerTest.scala
@@ -1458,6 +1458,8 @@ class BatchNodeRunnerTest extends SparkTestBase with Matchers with BeforeAndAfte
   // ---------- sub-daily sensor readiness ----------
 
   private val threeHourSpec = PartitionSpec("ds", "yyyy-MM-dd-HH-mm", 3 * 60 * 60 * 1000)
+  private val offsetThreeHourSpec =
+    PartitionSpec("ds", "yyyy-MM-dd-HH-mm", 3 * 60 * 60 * 1000, 60 * 60 * 1000)
 
   private def subDailyQuery(partitionColumn: String = "ds"): Query =
     new Query()
@@ -1568,6 +1570,34 @@ class BatchNodeRunnerTest extends SparkTestBase with Matchers with BeforeAndAfte
 
     args.startDs() shouldBe "2024-01-01-06-00"
     args.endDs() shouldBe "2024-01-01-09-00"
+  }
+
+  "BatchNodeRunner" should "normalize date-shaped run args for time-partitioned sensors" in {
+    val tableInfo = new TableInfo()
+      .setTable("test_db.time_partitioned_source")
+      .setPartitionColumn("event_ts")
+      .setPartitionFormat(offsetThreeHourSpec.format)
+      .setTimePartitioned(true)
+    val dep = new TableDependency().setTableInfo(tableInfo)
+    val sensor = sensorFor(dep)
+    val content = new NodeContent()
+    content.setExternalSourceSensor(sensor)
+    val metadata = new MetaData()
+      .setName("test_db.time_partitioned_source__sensor")
+      .setTeam("test_team")
+      .setOutputNamespace("test_db")
+      .setExecutionInfo(
+        new ExecutionInfo().setOutputTableInfo(
+          new TableInfo().setTable("test_db.time_partitioned_source").withSpec(offsetThreeHourSpec)
+        )
+      )
+    val node = new Node().setMetaData(metadata).setContent(content)
+    val runner = new BatchNodeRunner(node, tableUtils, mockApi)
+
+    val range = runner.rangeFromArgs("2024-01-02", "2024-01-02")
+
+    range.start shouldBe "2024-01-01-22-00"
+    range.end shouldBe "2024-01-02-22-00"
   }
 
   "Sub-daily partitioned sensors" should "distinguish two fires on the same day" in {

--- a/spark/src/test/scala/ai/chronon/spark/batch/BatchNodeRunnerTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/batch/BatchNodeRunnerTest.scala
@@ -1555,6 +1555,68 @@ class BatchNodeRunnerTest extends SparkTestBase with Matchers with BeforeAndAfte
       "2024-01-01-06-00")
   }
 
+  "GroupBy backfill with timePartitioned source" should "normalize date-shaped source cutoffs on sub-daily grids" in {
+    val inputTable = "test_db.time_partitioned_gb_source"
+    spark.sql(s"DROP TABLE IF EXISTS $inputTable")
+    spark.sql(
+      s"""CREATE TABLE $inputTable (
+         |  user_id INT,
+         |  value DOUBLE,
+         |  event_ts TIMESTAMP
+         |)""".stripMargin)
+    spark.sql(
+      s"""INSERT INTO $inputTable VALUES
+         |(1, 10.0, TIMESTAMP '2024-01-02 02:00:00'),
+         |(1, 30.0, TIMESTAMP '2024-01-02 20:00:00'),
+         |(2, 50.0, TIMESTAMP '2024-01-03 02:00:00')
+         |""".stripMargin)
+
+    val sourceQuery = Builders
+      .Query(
+        selects = Builders.Selects("user_id", "value"),
+        partitionColumn = "event_ts",
+        timeColumn = "UNIX_TIMESTAMP(event_ts) * 1000",
+        startPartition = "2024-01-02",
+        endPartition = "2024-01-02"
+      )
+      .setTimePartitioned(true)
+    val source = Builders.Source.events(sourceQuery, table = inputTable)
+    val tableDep = TableDependencies.fromSource(source).get
+
+    val gbMetaData = Builders.MetaData(namespace = "test_db", name = "time_partitioned_subdaily_gb", team = "test_team")
+    val outputTable = gbMetaData.outputTable
+    spark.sql(s"DROP TABLE IF EXISTS $outputTable")
+    val groupByConf = Builders.GroupBy(
+      sources = Seq(source),
+      keyColumns = Seq("user_id"),
+      aggregations = Seq(Builders.Aggregation(inputColumn = "value", operation = Operation.SUM)),
+      metaData = gbMetaData
+    )
+
+    val gbNode = new GroupByBackfillNode().setGroupBy(groupByConf)
+    val nodeContent = new NodeContent()
+    nodeContent.setGroupByBackfill(gbNode)
+
+    implicit val partitionSpec: PartitionSpec = offsetThreeHourSpec
+    val metadata = MetaDataUtils.layer(
+      baseMetadata = new MetaData().setOutputNamespace("test_db").setTeam("test_team"),
+      modeName = "backfill",
+      nodeName = "time_partitioned_subdaily_gb",
+      tableDependencies = Seq(tableDep),
+      stepDays = Some(1),
+      outputTableOverride = Some(outputTable)
+    )
+
+    val node = new Node().setMetaData(metadata).setContent(nodeContent)
+    val runner = new BatchNodeRunner(node, tableUtils, mockApi)
+    val range = PartitionRange("2024-01-02-01-00", "2024-01-03-01-00")(offsetThreeHourSpec)
+
+    runner.run(metadata, nodeContent, Option(range))
+
+    val rows = spark.sql(s"SELECT user_id FROM $outputTable").collect()
+    rows.map(_.getInt(0)).toSet shouldBe Set(1)
+  }
+
   "BatchNodeRunnerArgs" should "accept formatted sub-daily start and end ds values" in {
     val args = new BatchNodeRunnerArgs(
       Array(
@@ -1572,32 +1634,48 @@ class BatchNodeRunnerTest extends SparkTestBase with Matchers with BeforeAndAfte
     args.endDs() shouldBe "2024-01-01-09-00"
   }
 
-  "BatchNodeRunner" should "normalize date-shaped run args for time-partitioned sensors" in {
+  "BatchNodeRunner.computeInputTablePartitionStatuses" should "normalize date-shaped cutoffs for time-partitioned join dependencies" in {
+    spark.sql("DROP TABLE IF EXISTS test_db.time_partitioned_source")
+    spark.sql(
+      """CREATE TABLE test_db.time_partitioned_source (
+        |  id INT,
+        |  event_ts TIMESTAMP
+        |)""".stripMargin)
+    spark.sql(
+      """INSERT INTO test_db.time_partitioned_source VALUES
+        |(1, TIMESTAMP '2024-01-02 23:59:00')
+        |""".stripMargin)
+
     val tableInfo = new TableInfo()
       .setTable("test_db.time_partitioned_source")
+      .withSpec(offsetThreeHourSpec)
       .setPartitionColumn("event_ts")
-      .setPartitionFormat(offsetThreeHourSpec.format)
       .setTimePartitioned(true)
-    val dep = new TableDependency().setTableInfo(tableInfo)
-    val sensor = sensorFor(dep)
-    val content = new NodeContent()
-    content.setExternalSourceSensor(sensor)
+    val dep = new TableDependency()
+      .setTableInfo(tableInfo)
+      .setStartCutOff("2024-01-02")
+      .setEndCutOff("2024-01-02")
     val metadata = new MetaData()
-      .setName("test_db.time_partitioned_source__sensor")
+      .setName("test_db.time_partitioned_join")
       .setTeam("test_team")
       .setOutputNamespace("test_db")
       .setExecutionInfo(
-        new ExecutionInfo().setOutputTableInfo(
-          new TableInfo().setTable("test_db.time_partitioned_source").withSpec(offsetThreeHourSpec)
-        )
+        new ExecutionInfo()
+          .setOutputTableInfo(new TableInfo().setTable("test_db.time_partitioned_join").withSpec(offsetThreeHourSpec))
+          .setTableDependencies(Seq(dep).asJava)
       )
+    val content = createTestNodeContent()
     val node = new Node().setMetaData(metadata).setContent(content)
     val runner = new BatchNodeRunner(node, tableUtils, mockApi)
+    val range = PartitionRange("2024-01-02-01-00", "2024-01-03-01-00")(offsetThreeHourSpec)
 
-    val range = runner.rangeFromArgs("2024-01-02", "2024-01-02")
+    val statuses = runner.computeInputTablePartitionStatuses(metadata, range, tableUtils).toSeq
+    statuses should have size 1
+    val status = statuses.head
 
-    range.start shouldBe "2024-01-01-22-00"
-    range.end shouldBe "2024-01-02-22-00"
+    status.ready shouldBe true
+    status.lastAvailablePartition shouldBe Some("2024-01-02-22-00")
+    status.requiredEndMillis shouldBe offsetThreeHourSpec.partitionEndMillis("2024-01-02-22-00") - 1
   }
 
   "Sub-daily partitioned sensors" should "distinguish two fires on the same day" in {


### PR DESCRIPTION
## Summary

- Currently if say a Join is on a sub-daily grid, and there is a GroupBy in that Join with a Source that has a start or end bounds that is daily, the Join only fails when the actual Join job runs, not during compile. We can validate this early - additionally, if the Source is time-partitioned we do not need to fail, we can map to the partition that includes that date - compile now validates this. 
- Updated the `getIntersectedRange` to use the same cutoff behavior. Where normalized start/end bounds are set. 
- Corrects an issue where for a JoinPartJob a temporal GroupBy grid was not being treated as it is online and was not inferring accuracy. 

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-fallback partition-spec support to improve normalization of partition-bound start/end values for time-partitioned, sub-daily workflows.
  * Expanded partition-bound configuration validation to use an effective partition spec resolved from query/join/group-by metadata (including legacy `timePartitioned` behavior).
* **Bug Fixes**
  * Corrected cutoff handling across planner and Spark flows to preserve inclusive end semantics and apply format-aware fallback alignment.
* **Tests**
  * Added regression tests covering downstream sub-daily grids, compact vs date-shaped cutoff normalization, and nested/embedded join & group-by validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->