### PR TITLE
Bump logback to 1.5.38 to fix GHSA-jhq6-gfmj-v8fx grype failures

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -50,8 +50,8 @@ object Constants {
   )
 
   def loggingDeps = loggingApiDeps ++ Seq(
-    mvn"ch.qos.logback:logback-classic:1.5.33",
-    mvn"ch.qos.logback:logback-core:1.5.33",
+    mvn"ch.qos.logback:logback-classic:1.5.38",
+    mvn"ch.qos.logback:logback-core:1.5.38",
     // Used for structured JSON logging (8.x uses Jackson 2.x; 9.x switched to Jackson 3.x)
     mvn"net.logstash.logback:logstash-logback-encoder:8.1"
   )


### PR DESCRIPTION
## Summary

The nightly Grype scan failed on three assembly JAR targets (`service`, `cloud-gcp`, and `cloud-aws`) with the same Low-severity finding:

| Package | Installed | Fixed in | Advisory | Severity |
|---|---|---|---|---|
| logback-core | 1.5.33 | 1.5.35 | GHSA-jhq6-gfmj-v8fx | Low |

This bumps `logback-classic` and `logback-core` from 1.5.33 to 1.5.38. No Grype exceptions are added.

## Verification

CI builds and scans the affected assembly JARs with Grype.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded the Logback logging components to version **1.5.38**.
  * Bumped the Netty dependency to **4.1.136.Final** to include the latest security fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->