### PR TITLE
Add branch tag to Metrics.Context

### DIFF
--- a/docs/source/management_in_production/metrics.md
+++ b/docs/source/management_in_production/metrics.md
@@ -45,6 +45,7 @@ Every metric is automatically tagged with the following dimensions from its `Met
 | `join` | Join name (when applicable) |
 | `team` | Team owning the entity, from metadata |
 | `production` | `"true"` or `"false"`, from metadata |
+| `branch` | Git/deploy branch for Hub-orchestrated runs (when set on `Metrics.Context`) |
 | `accuracy` | `"TEMPORAL"` or `"SNAPSHOT"` (for GroupBy contexts) |
 | `join_part_prefix` | Prefix for a specific join part |
 | `staging_query` | StagingQuery name (when applicable) |

--- a/online/src/main/java/ai/chronon/online/JavaFetcher.java
+++ b/online/src/main/java/ai/chronon/online/JavaFetcher.java
@@ -248,10 +248,10 @@ public class JavaFetcher {
   }
 
   private Metrics.Context getJoinContext(String joinName) {
-    return new Metrics.Context("join.fetch", joinName, null, null, false, null, null, null, null, null, null, null);
+    return new Metrics.Context("join.fetch", joinName, null, null, false, null, null, null, null, null, null, null, null);
   }
 
   private Metrics.Context getGroupByContext(String groupByName) {
-    return new Metrics.Context("group_by.fetch", null, groupByName, null, false, null, null, null, null, null, null, null);
+    return new Metrics.Context("group_by.fetch", null, groupByName, null, false, null, null, null, null, null, null, null, null);
   }
 }

--- a/online/src/main/scala/ai/chronon/online/metrics/Metrics.scala
+++ b/online/src/main/scala/ai/chronon/online/metrics/Metrics.scala
@@ -179,6 +179,8 @@ object Metrics {
                      dataset: String = null,
                      model: String = null,
                      modelTransforms: String = null,
+                     // Set only on Orchestrator contexts. `branch` is high-cardinality; emitting it on
+                     // fetch/KVStore/streaming metrics would multiply time-series per active branch.
                      branch: String = null)
       extends Serializable {
 

--- a/online/src/main/scala/ai/chronon/online/metrics/Metrics.scala
+++ b/online/src/main/scala/ai/chronon/online/metrics/Metrics.scala
@@ -65,6 +65,7 @@ object Metrics {
     val StagingQuery = "staging_query"
     val Environment = "environment"
     val Production = "production"
+    val Branch = "branch"
     val Accuracy = "accuracy"
     val Team = "team"
     val Dataset = "dataset"
@@ -177,7 +178,8 @@ object Metrics {
                      suffix: String = null,
                      dataset: String = null,
                      model: String = null,
-                     modelTransforms: String = null)
+                     modelTransforms: String = null,
+                     branch: String = null)
       extends Serializable {
 
     def withSuffix(suffixN: String): Context = copy(suffix = (Option(suffix) ++ Seq(suffixN)).mkString("."))
@@ -211,6 +213,7 @@ object Metrics {
 
       addTag(Tag.StagingQuery, stagingQuery)
       addTag(Tag.Production, production.toString)
+      addTag(Tag.Branch, branch)
       addTag(Tag.Team, team)
       addTag(Tag.Environment, environment)
       addTag(Tag.JoinPartPrefix, joinPartPrefix)

--- a/online/src/test/scala/ai/chronon/online/test/TagsTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/TagsTest.scala
@@ -63,4 +63,12 @@ class TagsTest extends AnyFlatSpec {
     assertEquals(slowTags, fastTags)
   }
 
+  it should "include branch tag only when set" in {
+    val withBranch = Metrics.Context(Environment.JoinFetching, branch = "release/1.2")
+    assertEquals("release/1.2", withBranch.toTags(Metrics.Tag.Branch))
+
+    val withoutBranch = Metrics.Context(Environment.JoinFetching)
+    assertEquals(false, withoutBranch.toTags.contains(Metrics.Tag.Branch))
+  }
+
 }


### PR DESCRIPTION
## Summary
- Add `Tag.Branch` / `Context.branch` and emit it from `toTags` so Hub can attach `workflow.branch` on orchestrator metrics.
- Document `branch` in the metrics standard tags table.

This is the shared Chronon plumbing only. Callers in Hub/platform still need to set `branch` from the workflow/job record for values to appear in Datadog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an optional `branch` metric tag to identify the Git or deployment branch for Hub-orchestrated runs.
  * Metrics now emit `branch` automatically when supplied via the metrics context.

* **Documentation**
  * Documented the new `branch` metric tag and what it represents in the production metrics guide.

* **Tests**
  * Added coverage to verify that the `branch` tag is included when set and omitted when not.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->