### PR TITLE
Use processing time for GigaTile PUSH freshness

### DIFF
--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStreamProcessor.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStreamProcessor.scala
@@ -182,24 +182,34 @@ class GigaTileStreamProcessor(
     else GigaEmitResult(null, droppedStaleEvent = droppedStaleEvent)
   }
 
-  /** Watermark-driven day transition. Updates currentDayStart and rebuilds the small-window
+  /** As-of-driven day transition. Updates currentDayStart and rebuilds the small-window
     * cache because each column's effectiveStart shifts with the new as-of horizon. Daily
     * large-IR slots are unaffected — they're keyed by day-start and persist across rollovers
     * until batch covers them.
     */
-  def advanceWatermark(watermarkTs: Long): Unit = {
+  def advanceWatermark(watermarkTs: Long): GigaEmitResult = {
     val currentDayStart = store.getCurrentDayStart
-    if (currentDayStart == -1L) return
+    if (currentDayStart == -1L) return GigaEmitResult(null)
     val wmDay = TsUtils.round(watermarkTs, DayMillis)
     if (wmDay > currentDayStart) {
       val isAdjacentRollover = wmDay == currentDayStart + DayMillis
       store.putCurrentDayStart(wmDay)
-      // Rebuild only on the adjacent-day case Bug B targets. Multi-day jumps and end-of-stream
+      // Rebuild only on an adjacent-day transition. Multi-day jumps and end-of-stream
       // (watermark = MAX) push the as-of so far past retained tiles that everything would be
       // marked stale and the cache cleared — emitting a spurious null that would overwrite the
-      // PUSH KV row. Leave those cases to the next event-time eviction at a sane timer ts.
-      if (isAdjacentRollover) rebuildCachedSmallWindowIr(watermarkTs, wmDay)
+      // PUSH KV row. Leave those cases to the next eviction at a sane timer timestamp.
+      if (isAdjacentRollover && hasSmallWindows) {
+        val previousPackedIr = windowedAgg.clone(pack())
+        rebuildCachedSmallWindowIr(watermarkTs, wmDay)
+        val packed = pack()
+        val packedIsEmpty = isAllNull(packed)
+        val previousWasEmpty = isAllNull(previousPackedIr)
+        if (!((packedIsEmpty && previousWasEmpty) || irEqual(previousPackedIr, packed))) {
+          return GigaEmitResult(windowedAgg.finalize(packed), isEmpty = packedIsEmpty)
+        }
+      }
     }
+    GigaEmitResult(null)
   }
 
   /** Direct eviction/serve-as-of: corrects small window sawtooth and large window tail selection. */
@@ -395,8 +405,10 @@ class GigaTileStreamProcessor(
         val windowMillis = megaTileAgg.columnWindowMillis(col)
         if (!isNoBatch(col) && windowMillis > 0) {
           val collapsedExpiry = addIfNoOverflow(batchEndTs, windowMillis)
-          if (batchIr.collapsed != null && col < batchIr.collapsed.length &&
-              batchIr.collapsed(col) != null && crossedSincePreviousTimer(queryTs, collapsedExpiry)) {
+          if (
+            batchIr.collapsed != null && col < batchIr.collapsed.length &&
+            batchIr.collapsed(col) != null && crossedSincePreviousTimer(queryTs, collapsedExpiry)
+          ) {
             return true
           }
 
@@ -590,6 +602,12 @@ class GigaTileStreamProcessor(
   }
 
   private[windowing] def packAndFinalize(): Array[Any] = windowedAgg.finalize(pack())
+
+  /** Snapshot the current value without moving either aggregation clock. */
+  private[chronon] def currentSnapshot: GigaEmitResult = {
+    val packed = pack()
+    GigaEmitResult(windowedAgg.finalize(packed), isEmpty = isAllNull(packed))
+  }
 
   /** Strip tail hops that are only used by small windows to reduce state size.
     * 5-min hops for ≤12h windows are never consumed by mergeTailHopsForBatchColumns.

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileBugRegressionTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileBugRegressionTest.scala
@@ -281,7 +281,9 @@ class GigaTileBugRegressionTest extends AnyFlatSpec {
 
     // Roll over — wall clock has moved to day+1, three hours past midnight.
     val day1_3h = baseDay + DayMillis + 3 * HourMillis
-    processor.advanceWatermark(day1_3h)
+    val rollover = processor.advanceWatermark(day1_3h)
+    assertNotNull("day rollover should surface the cache correction", rollover.finalizedVector)
+    assertNull("expired values should be removed at rollover", rollover.finalizedVector(0))
 
     // Single fresh event 55 minutes later. Only this event lies inside the 1h horizon now.
     val day1_3h_55m = day1_3h + 55 * MinuteMillis

--- a/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
@@ -11,6 +11,7 @@ import ai.chronon.online.serde.ArrayRow
 import org.apache.flink.api.common.state.{MapState, MapStateDescriptor, ValueState, ValueStateDescriptor}
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.metrics.Counter
+import org.apache.flink.streaming.api.{TimeDomain, TimerService}
 import org.apache.flink.streaming.api.functions.co.KeyedCoProcessFunction
 import org.apache.flink.util.Collector
 import org.slf4j.{Logger, LoggerFactory}
@@ -55,6 +56,9 @@ class GigaTileProcessFunction(
   private var batchIrState: ValueState[Array[Byte]] = _
   private var batchEndTsState: ValueState[java.lang.Long] = _
   private var runningLargeIrState: ValueState[Array[Byte]] = _
+  private var nextProcessingEvictionTimerState: ValueState[java.lang.Long] = _
+  private var lastEmittedVersionState: ValueState[java.lang.Long] = _
+  private var pendingVersionCollisionState: ValueState[java.lang.Long] = _
 
   override def open(parameters: Configuration): Unit = {
     super.open(parameters)
@@ -70,10 +74,9 @@ class GigaTileProcessFunction(
     megaTileIrState =
       getRuntimeContext.getState(new ValueStateDescriptor[Array[Byte]]("giga-tile-ir", classOf[Array[Byte]]))
     dailyLargeIrState = getRuntimeContext.getMapState(
-      new MapStateDescriptor[java.lang.Long, Array[Byte]](
-        "giga-tile-large-daily",
-        classOf[java.lang.Long],
-        classOf[Array[Byte]]))
+      new MapStateDescriptor[java.lang.Long, Array[Byte]]("giga-tile-large-daily",
+                                                          classOf[java.lang.Long],
+                                                          classOf[Array[Byte]]))
     currentDayStartState = getRuntimeContext.getState(
       new ValueStateDescriptor[java.lang.Long]("giga-tile-day-start", classOf[java.lang.Long]))
     earliestTileStartState = getRuntimeContext.getState(
@@ -82,8 +85,14 @@ class GigaTileProcessFunction(
       getRuntimeContext.getState(new ValueStateDescriptor[Array[Byte]]("giga-tile-batch-ir", classOf[Array[Byte]]))
     batchEndTsState = getRuntimeContext.getState(
       new ValueStateDescriptor[java.lang.Long]("giga-tile-batch-end", classOf[java.lang.Long]))
-    runningLargeIrState = getRuntimeContext.getState(
-      new ValueStateDescriptor[Array[Byte]]("giga-tile-running-large", classOf[Array[Byte]]))
+    runningLargeIrState =
+      getRuntimeContext.getState(new ValueStateDescriptor[Array[Byte]]("giga-tile-running-large", classOf[Array[Byte]]))
+    nextProcessingEvictionTimerState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Long]("giga-tile-next-evict-pt-timer", classOf[java.lang.Long]))
+    lastEmittedVersionState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Long]("giga-tile-last-emitted-version", classOf[java.lang.Long]))
+    pendingVersionCollisionState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Long]("giga-tile-pending-version-collision", classOf[java.lang.Long]))
 
     initializeTransients()
   }
@@ -106,10 +115,181 @@ class GigaTileProcessFunction(
     if (lastKey == null || !lastKey.equals(currentKey)) {
       lastKey = currentKey
       flinkStore.bindFlinkState(
-        tileState, megaTileIrState, dailyLargeIrState,
-        currentDayStartState, earliestTileStartState,
-        batchIrState, batchEndTsState, runningLargeIrState
+        tileState,
+        megaTileIrState,
+        dailyLargeIrState,
+        currentDayStartState,
+        earliestTileStartState,
+        batchIrState,
+        batchEndTsState,
+        runningLargeIrState
       )
+    }
+  }
+
+  /** Processing-time callbacks can share a millisecond. Coalesce later same-millisecond updates
+    * behind a timer so emitted versions are strictly increasing before async sink handoff.
+    */
+  private def emitOrCoalesceVersionCollision(
+      timerService: TimerService,
+      finalizedVector: Array[Any],
+      currentKey: java.util.List[Any],
+      versionMillis: Long,
+      startProcessingTimeMillis: Long,
+      out: Collector[TimestampedTile]
+  ): Unit = {
+    if (finalizedVector == null) return
+
+    val lastEmittedVersion = lastEmittedVersionState.value()
+    if (
+      pendingVersionCollisionState.value() != null ||
+      (lastEmittedVersion != null && versionMillis <= lastEmittedVersion.longValue())
+    ) {
+      scheduleVersionCollisionFlushIfNeeded(timerService, lastEmittedVersion)
+    } else {
+      try {
+        out.collect(
+          new TimestampedTile(currentKey,
+                              gigaTileCodec.encodeOutput(finalizedVector),
+                              versionMillis,
+                              startProcessingTimeMillis))
+        lastEmittedVersionState.update(versionMillis)
+      } catch {
+        case e: Exception =>
+          // State was already mutated. Retry the current snapshot on a future timer so a
+          // transient first-write failure cannot leave the key unpublished.
+          scheduleVersionCollisionFlushIfNeeded(timerService, lastEmittedVersion)
+          throw e
+      }
+    }
+  }
+
+  private def scheduleVersionCollisionFlushIfNeeded(
+      timerService: TimerService,
+      lastEmittedVersion: java.lang.Long
+  ): Unit = {
+    val currentProcessingTime = timerService.currentProcessingTime()
+    if (
+      pendingVersionCollisionState.value() == null && currentProcessingTime < Long.MaxValue &&
+      (lastEmittedVersion == null || lastEmittedVersion.longValue() < Long.MaxValue)
+    ) {
+      val flushVersion =
+        if (lastEmittedVersion == null) currentProcessingTime + 1L
+        else math.max(lastEmittedVersion.longValue() + 1L, currentProcessingTime + 1L)
+      timerService.registerProcessingTimeTimer(flushVersion)
+      pendingVersionCollisionState.update(flushVersion)
+    }
+  }
+
+  private def isCurrentVersionCollisionTimer(timestamp: Long): Boolean =
+    Option(pendingVersionCollisionState.value()).exists(_.longValue() == timestamp)
+
+  private def processingTimerMarkerIsExpired(
+      markerTimestamp: Long,
+      currentProcessingTime: Long,
+      currentTimerCallback: Option[(TimeDomain, Long)]
+  ): Boolean =
+    currentTimerCallback match {
+      case None => markerTimestamp <= currentProcessingTime
+      // Flink exposes the jump target as currentProcessingTime while draining every due
+      // timer in timestamp order. A later marker is still physically queued; only a marker
+      // before this callback can have been consumed without clearing its ownership state.
+      case Some((TimeDomain.PROCESSING_TIME, callbackTimestamp)) => markerTimestamp < callbackTimestamp
+      case Some((TimeDomain.EVENT_TIME, _))                      => false
+    }
+
+  private def isCurrentProcessingTimerCallback(
+      timestamp: Long,
+      currentTimerCallback: Option[(TimeDomain, Long)]
+  ): Boolean =
+    currentTimerCallback.contains(TimeDomain.PROCESSING_TIME -> timestamp)
+
+  /** An older binary can consume additive processing-time timers without clearing their
+    * keyed ownership markers. Repair expired ownership on the next keyed callback. This
+    * cannot repair a completely idle key because a KeyedCoProcessFunction cannot enumerate
+    * keyed state during open; rolling back below this timer-aware layer still requires a
+    * retained compatible checkpoint or a state migration.
+    */
+  private def repairExpiredProcessingTimerMarkers(
+      timerService: TimerService,
+      currentProcessingTime: Long,
+      currentTimerCallback: Option[(TimeDomain, Long)]
+  ): Unit = {
+    val trackedEviction = nextProcessingEvictionTimerState.value()
+    if (
+      trackedEviction != null && processingTimerMarkerIsExpired(trackedEviction.longValue(),
+                                                                currentProcessingTime,
+                                                                currentTimerCallback)
+    ) {
+      nextProcessingEvictionTimestamp(currentProcessingTime) match {
+        case Some(nextEviction) =>
+          // Register first. If registration fails, leave the stale marker visible so a later
+          // callback can retry instead of recording ownership with no physical timer.
+          timerService.registerProcessingTimeTimer(nextEviction)
+          nextProcessingEvictionTimerState.update(nextEviction)
+        case None => nextProcessingEvictionTimerState.clear()
+      }
+    }
+
+    val trackedCollision = pendingVersionCollisionState.value()
+    if (
+      trackedCollision != null && processingTimerMarkerIsExpired(trackedCollision.longValue(),
+                                                                 currentProcessingTime,
+                                                                 currentTimerCallback)
+    ) {
+      val sharedEviction = Option(nextProcessingEvictionTimerState.value())
+        .map(_.longValue())
+        .filterNot(processingTimerMarkerIsExpired(_, currentProcessingTime, currentTimerCallback))
+      val nextCollision = sharedEviction.orElse {
+        val lastEmittedVersion = lastEmittedVersionState.value()
+        if (
+          currentProcessingTime == Long.MaxValue ||
+          (lastEmittedVersion != null && lastEmittedVersion.longValue() == Long.MaxValue)
+        ) None
+        else {
+          val afterLast = if (lastEmittedVersion == null) Long.MinValue else lastEmittedVersion.longValue() + 1L
+          Some(math.max(currentProcessingTime + 1L, afterLast))
+        }
+      }
+      nextCollision match {
+        case Some(timestamp) =>
+          // If the collision joins the callback currently being drained, role discovery below
+          // will consume it in this invocation. Re-registering that timestamp would enqueue an
+          // unnecessary immediate duplicate after Flink has removed the physical timer.
+          if (!isCurrentProcessingTimerCallback(timestamp, currentTimerCallback)) {
+            timerService.registerProcessingTimeTimer(timestamp)
+          }
+          pendingVersionCollisionState.update(timestamp)
+        case None => pendingVersionCollisionState.clear()
+      }
+    }
+  }
+
+  private def flushVersionCollision(
+      timerService: TimerService,
+      currentProcessingTime: Long,
+      currentKey: java.util.List[Any],
+      out: Collector[TimestampedTile]
+  ): Unit = {
+    try {
+      val pendingVersion = pendingVersionCollisionState.value()
+      if (pendingVersion == null) return
+
+      val snapshot = processor.currentSnapshot
+      val encoded = gigaTileCodec.encodeOutput(snapshot.finalizedVector)
+      out.collect(new TimestampedTile(currentKey, encoded, pendingVersion.longValue(), System.currentTimeMillis()))
+      lastEmittedVersionState.update(pendingVersion)
+      pendingVersionCollisionState.clear()
+    } catch {
+      case e: Exception =>
+        // The fired timer was the only flush trigger. Re-arm before the outer handler records
+        // the failure so a transient encoding/collection error cannot strand the latest value.
+        if (currentProcessingTime < Long.MaxValue) {
+          val retryVersion = currentProcessingTime + 1L
+          timerService.registerProcessingTimeTimer(retryVersion)
+          pendingVersionCollisionState.update(retryVersion)
+        }
+        throw e
     }
   }
 
@@ -129,19 +309,21 @@ class GigaTileProcessFunction(
       val row = new ArrayRow(values, tsMills)
 
       ensureStateBound(ctx.getCurrentKey)
-      processor.advanceWatermark(ctx.timerService().currentWatermark())
-      val result = processor.onEvent(row, tsMills)
+      val timerService = ctx.timerService()
+      val currentProcessingTime = timerService.currentProcessingTime()
+      repairExpiredProcessingTimerMarkers(timerService, currentProcessingTime, None)
+      val rolloverResult = processor.advanceWatermark(currentProcessingTime)
+      val eventResult = processor.onEvent(row, tsMills, currentProcessingTime)
+      val result = if (eventResult.finalizedVector != null) eventResult else rolloverResult
 
-      if (result.finalizedVector != null) {
-        out.collect(
-          new TimestampedTile(ctx.getCurrentKey,
-                              gigaTileCodec.encodeOutput(result.finalizedVector),
-                              tsMills,
-                              event.startProcessingTimeMillis))
-      }
+      scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
+      emitOrCoalesceVersionCollision(timerService,
+                                     result.finalizedVector,
+                                     ctx.getCurrentKey,
+                                     currentProcessingTime,
+                                     event.startProcessingTimeMillis,
+                                     out)
 
-      val nextEviction = TsUtils.round(tsMills, processor.minEvictionInterval) + processor.minEvictionInterval
-      ctx.timerService().registerEventTimeTimer(nextEviction)
     } catch {
       case e: Exception =>
         logger.error(s"Error processing giga tile event for groupBy=${groupBy.getMetaData.getName}", e)
@@ -159,27 +341,26 @@ class GigaTileProcessFunction(
       if (processor == null) initializeTransients()
 
       ensureStateBound(ctx.getCurrentKey)
-      processor.advanceWatermark(ctx.timerService().currentWatermark())
+      val timerService = ctx.timerService()
+      val currentProcessingTime = timerService.currentProcessingTime()
+      repairExpiredProcessingTimerMarkers(timerService, currentProcessingTime, None)
+      val rolloverResult = processor.advanceWatermark(currentProcessingTime)
 
       val batchIr = gigaTileCodec.decodeBatchIr(batchRow.valueBytes)
-      val result = processor.onBatchUpdate(batchIr, batchRow.batchEndTs,
-        ctx.timerService().currentWatermark())
+      val batchResult = processor.onBatchUpdate(batchIr, batchRow.batchEndTs, currentProcessingTime)
+      val result = if (batchResult.finalizedVector != null) batchResult else rolloverResult
 
       batchUpdateCounter.inc()
 
-      if (result.finalizedVector != null) {
-        out.collect(
-          new TimestampedTile(ctx.getCurrentKey,
-                              gigaTileCodec.encodeOutput(result.finalizedVector),
-                              batchRow.batchEndTs,
-                              System.currentTimeMillis()))
+      if (batchResult.needsEvictionTimer) {
+        scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
       }
-
-      if (result.needsEvictionTimer) {
-        val nextEviction = TsUtils.round(ctx.timerService().currentWatermark(),
-          processor.minEvictionInterval) + processor.minEvictionInterval
-        ctx.timerService().registerEventTimeTimer(nextEviction)
-      }
+      emitOrCoalesceVersionCollision(timerService,
+                                     result.finalizedVector,
+                                     ctx.getCurrentKey,
+                                     currentProcessingTime,
+                                     System.currentTimeMillis(),
+                                     out)
     } catch {
       case e: Exception =>
         logger.error(s"Error processing batch IR for groupBy=${groupBy.getMetaData.getName}", e)
@@ -192,39 +373,122 @@ class GigaTileProcessFunction(
       ctx: KeyedCoProcessFunction[java.util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#OnTimerContext,
       out: Collector[TimestampedTile]
   ): Unit = {
+    var timerServiceOnFailure: TimerService = null
+    var processingTimeOnFailure = Long.MinValue
+    var evictionTimerFired = false
+    var versionCollisionTimerFired = false
     try {
       if (processor == null) initializeTransients()
 
       ensureStateBound(ctx.getCurrentKey)
-      processor.advanceWatermark(ctx.timerService().currentWatermark())
-      val result = processor.onScheduledEviction(timestamp)
+      val timerService = ctx.timerService()
+      val currentProcessingTime = timerService.currentProcessingTime()
+      timerServiceOnFailure = timerService
+      processingTimeOnFailure = currentProcessingTime
+      repairExpiredProcessingTimerMarkers(timerService, currentProcessingTime, Some(ctx.timeDomain() -> timestamp))
 
-      if (result.finalizedVector != null) {
-        out.collect(
-          new TimestampedTile(ctx.getCurrentKey,
-                              gigaTileCodec.encodeOutput(result.finalizedVector),
-                              timestamp,
-                              System.currentTimeMillis()))
+      // Checkpoints written by the event-time implementation may still contain several
+      // event-time eviction timers per key. Let those callbacks migrate the key to one
+      // processing-time timer, but do not publish from both timer domains.
+      if (ctx.timeDomain() == TimeDomain.EVENT_TIME) {
+        scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
+        return
       }
 
-      // Re-register the next eviction timer so idle keys keep decaying without waiting for
-      // a new event. The natural termination is `result.isEmpty`: once every column has
-      // decayed to null there's nothing more to correct, and no new timer is needed until a
-      // fresh event arrives. Without re-registration, an entity that goes silent serves the
-      // last emit forever — even after every event has aged out of every window.
-      if (!result.isEmpty) {
-        val interval = processor.minEvictionInterval
-        // Guard against integer overflow at end-of-stream (watermark = Long.MaxValue): if
-        // the next timer would wrap into the negative range, skip — Flink would either
-        // refuse the registration or fire it immediately, looping forever.
-        if (timestamp <= Long.MaxValue - interval) {
-          ctx.timerService().registerEventTimeTimer(timestamp + interval)
+      if (ctx.timeDomain() != TimeDomain.PROCESSING_TIME) {
+        return
+      }
+
+      val isEvictionTimer = isCurrentProcessingEvictionTimer(timestamp)
+      val isVersionCollisionTimer = isCurrentVersionCollisionTimer(timestamp)
+      evictionTimerFired = isEvictionTimer
+      versionCollisionTimerFired = isVersionCollisionTimer
+      if (!isEvictionTimer && !isVersionCollisionTimer) return
+
+      var finalizedVector: Array[Any] = null
+      if (isEvictionTimer) {
+        nextProcessingEvictionTimerState.clear()
+        val rolloverResult = processor.advanceWatermark(currentProcessingTime)
+        val evictionResult = processor.onScheduledEviction(currentProcessingTime)
+        finalizedVector =
+          if (evictionResult.finalizedVector != null) evictionResult.finalizedVector else rolloverResult.finalizedVector
+
+        // Re-register before a coincident collision flush: if encoding the flush fails, both
+        // the retry and normal eviction cadence remain live.
+        if (!evictionResult.isEmpty) {
+          scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
         }
+      }
+
+      if (isVersionCollisionTimer) {
+        // Eviction wins when both timers share a timestamp; publish one post-eviction snapshot.
+        flushVersionCollision(timerService, currentProcessingTime, ctx.getCurrentKey, out)
+      } else {
+        emitOrCoalesceVersionCollision(timerService,
+                                       finalizedVector,
+                                       ctx.getCurrentKey,
+                                       currentProcessingTime,
+                                       System.currentTimeMillis(),
+                                       out)
       }
     } catch {
       case e: Exception =>
+        if (timerServiceOnFailure != null) {
+          val trackedEviction = nextProcessingEvictionTimerState.value()
+          if (
+            evictionTimerFired &&
+            (trackedEviction == null || trackedEviction.longValue() <= timestamp)
+          ) {
+            nextProcessingEvictionTimerState.clear()
+            scheduleProcessingEvictionTimerIfNeeded(timerServiceOnFailure, processingTimeOnFailure)
+          }
+          val pendingCollision = pendingVersionCollisionState.value()
+          if (
+            versionCollisionTimerFired && pendingCollision != null &&
+            pendingCollision.longValue() <= timestamp && processingTimeOnFailure < Long.MaxValue
+          ) {
+            // A shared callback must preserve eviction-before-publication ordering. If
+            // eviction failed, park the collision on the re-armed eviction timer instead
+            // of publishing the stale pre-eviction snapshot one millisecond later.
+            val retryVersion =
+              if (evictionTimerFired) {
+                Option(nextProcessingEvictionTimerState.value())
+                  .map(_.longValue())
+                  .filter(_ > timestamp)
+                  .getOrElse(processingTimeOnFailure + 1L)
+              } else {
+                processingTimeOnFailure + 1L
+              }
+            timerServiceOnFailure.registerProcessingTimeTimer(retryVersion)
+            pendingVersionCollisionState.update(retryVersion)
+          }
+        }
         logger.error(s"Error in giga tile eviction for groupBy=${groupBy.getMetaData.getName}", e)
         eventProcessingErrorCounter.inc()
+    }
+  }
+
+  private def isCurrentProcessingEvictionTimer(timestamp: Long): Boolean =
+    Option(nextProcessingEvictionTimerState.value()).exists(_.longValue() == timestamp)
+
+  private def nextProcessingEvictionTimestamp(currentProcessingTime: Long): Option[Long] = {
+    val interval = processor.minEvictionInterval
+    if (currentProcessingTime <= Long.MaxValue - interval) {
+      Some(TsUtils.round(currentProcessingTime, interval) + interval)
+    } else {
+      None
+    }
+  }
+
+  private def scheduleProcessingEvictionTimerIfNeeded(
+      timerService: TimerService,
+      currentProcessingTime: Long
+  ): Unit = {
+    if (nextProcessingEvictionTimerState.value() == null) {
+      nextProcessingEvictionTimestamp(currentProcessingTime).foreach { nextEviction =>
+        timerService.registerProcessingTimeTimer(nextEviction)
+        nextProcessingEvictionTimerState.update(nextEviction)
+      }
     }
   }
 }

--- a/flink/src/test/scala/ai/chronon/flink/test/GigaTilePushFlinkIntegrationTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/GigaTilePushFlinkIntegrationTest.scala
@@ -30,7 +30,7 @@ import java.util
   * - GigaTileProcessFunction (CoProcessFunction) with connected streams
   * - FlinkGigaTileStore with real Flink keyed state (ValueState/MapState)
   * - Key switching across entities
-  * - Timer registration and event-time eviction
+  * - Timer registration and processing-time eviction
   * - GigaTileAvroCodecFn output encoding
   *
   * Does NOT test Iceberg source (requires a real Iceberg catalog).
@@ -143,12 +143,13 @@ class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
 
   it should "process events through GigaTileProcessFunction and emit finalized vectors" in {
     implicit val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment
+    val now = System.currentTimeMillis()
 
     // 3 events across 2 entities. Each entity should produce at least one finalized vector.
     val elements = Seq(
-      E2ETestEvent("test1", 12, 1.5, 1699366993123L),
-      E2ETestEvent("test2", 13, 1.6, 1699366993124L),
-      E2ETestEvent("test1", 14, 2.5, 1699366993125L)
+      E2ETestEvent("test1", 12, 1.5, now - 3000L),
+      E2ETestEvent("test2", 13, 1.6, now - 2000L),
+      E2ETestEvent("test1", 14, 2.5, now - 1000L)
     )
 
     val groupBy = makePushGroupBy(Seq("id"))
@@ -159,15 +160,12 @@ class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
 
     val results = CollectSink.values.toScala
 
-    // Each event should trigger an emit (finalized vector)
-    results.size should be >= elements.size
-
     // All writes should succeed
     results.forall(_.status) shouldBe true
 
-    // Both entities should have output
-    val keyBytes = results.map(_.keyBytes).distinct
-    keyBytes.size should be >= 2
+    // Same-millisecond updates may be coalesced, but every entity must publish final state.
+    val keyHashes = results.map(result => util.Arrays.hashCode(result.keyBytes)).distinct
+    keyHashes.size shouldBe 2
 
     // Value bytes should be non-empty (finalized vector encoded)
     results.foreach { wr =>
@@ -177,11 +175,12 @@ class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
 
   it should "produce decodable finalized vectors" in {
     implicit val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment
+    val now = System.currentTimeMillis()
 
     // Single entity, known values
     val elements = Seq(
-      E2ETestEvent("entity1", 10, 5.0, 1699366993100L),
-      E2ETestEvent("entity1", 20, 3.0, 1699366993200L)
+      E2ETestEvent("entity1", 10, 5.0, now - 2000L),
+      E2ETestEvent("entity1", 20, 3.0, now - 1000L)
     )
 
     val groupBy = makePushGroupBy(Seq("id"))
@@ -194,9 +193,8 @@ class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
     results should not be empty
     results.forall(_.status) shouldBe true
 
-    // The pipeline now decays idle entities via re-registered eviction timers, so the
-    // tsMillis-latest emit at end-of-stream is a tombstone (all-null). Pick the latest
-    // emit whose SUM is non-null to verify the aggregation itself is correct.
+    // Processing-time freshness gates events against the current wall clock, so these test
+    // rows are intentionally recent rather than fixed historical timestamps.
     val sumFieldName = servingInfo.outputCodec.decodeMap(results.head.valueBytes).keys
       .find(_.contains("double_val")).get
     val nonEmpty = results.toSeq.flatMap { wr =>
@@ -210,12 +208,13 @@ class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
 
   it should "handle multiple entities with correct key isolation" in {
     implicit val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment
+    val now = System.currentTimeMillis()
 
     // Two entities with different values — verify state isolation
     val elements = Seq(
-      E2ETestEvent("alice", 1, 10.0, 1699366993100L),
-      E2ETestEvent("bob", 2, 20.0, 1699366993200L),
-      E2ETestEvent("alice", 3, 5.0, 1699366993300L)
+      E2ETestEvent("alice", 1, 10.0, now - 3000L),
+      E2ETestEvent("bob", 2, 20.0, now - 2000L),
+      E2ETestEvent("alice", 3, 5.0, now - 1000L)
     )
 
     val groupBy = makePushGroupBy(Seq("id"))
@@ -228,10 +227,7 @@ class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
     results should not be empty
     results.forall(_.status) shouldBe true
 
-    // Group by key and pick the latest non-empty write per entity. Idle decay timers fire
-    // at end-of-stream and tombstone each key with an all-null vector after 1d window
-    // expiration; the test verifies the SUM aggregation, not the decay, so filter to non-
-    // null sums per key.
+    // Group by key and pick the latest non-empty write per entity.
     val sumFieldName = servingInfo.outputCodec.decodeMap(results.head.valueBytes).keys
       .find(_.contains("double_val")).get
     val latestSumPerKey: Set[Double] = results

--- a/flink/src/test/scala/ai/chronon/flink/test/window/GigaTileProcessFunctionTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/window/GigaTileProcessFunctionTest.scala
@@ -1,0 +1,683 @@
+package ai.chronon.flink.test.window
+
+import ai.chronon.aggregator.windowing.{
+  GigaEmitResult,
+  GigaTileStreamProcessor,
+  SawtoothOnlineAggregator
+}
+import ai.chronon.api._
+import ai.chronon.api.Extensions.WindowOps
+import ai.chronon.flink.deser.ProjectedEvent
+import ai.chronon.flink.types.{BatchIrRow, TimestampedTile}
+import ai.chronon.flink.window.GigaTileProcessFunction
+import ai.chronon.online.GigaTileCodec
+import ai.chronon.online.serde.{ArrayRow, AvroCodec}
+import org.apache.flink.api.common.state.ValueState
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.functions.KeySelector
+import org.apache.flink.runtime.state.KeyedStateBackend
+import org.apache.flink.streaming.api.functions.co.KeyedCoProcessFunction
+import org.apache.flink.streaming.api.operators.co.KeyedCoProcessOperator
+import org.apache.flink.streaming.api.watermark.Watermark
+import org.apache.flink.streaming.util.KeyedTwoInputStreamOperatorTestHarness
+import org.apache.flink.util.Collector
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.util
+import scala.collection.JavaConverters._
+
+class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
+  import GigaTileProcessFunctionTest._
+
+  "GigaTileProcessFunction" should "use processing time for current-value versions and eviction timers" in {
+    val testHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    val retainedLateEventTs = processingTs - 30 * 60 * 1000L
+    val carriedProcessingTs = processingTs - 10 * 60 * 1000L
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      testHarness.processElement1(
+        ProjectedEvent(Map(Constants.TimeColumn -> retainedLateEventTs, "num" -> 5L), carriedProcessingTs),
+        retainedLateEventTs)
+
+      val output = testHarness.extractOutputValues().get(0)
+      decodeSum(output) shouldEqual 5L
+      output.latestTsMillis shouldEqual processingTs
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+      testHarness.numEventTimeTimers() shouldEqual 0
+    } finally testHarness.close()
+  }
+
+  it should "evict small-window state on processing time" in {
+    val testHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    val windowMillis = new Window(1, TimeUnit.HOURS).millis
+    val justBeforeExpiry = eventTs + windowMillis - 1L
+    val afterExpiry = TsUtils.round(justBeforeExpiry, new Window(5, TimeUnit.MINUTES).millis) +
+      new Window(5, TimeUnit.MINUTES).millis
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(justBeforeExpiry)
+      testHarness.processElement1(event(eventTs, 5L), eventTs)
+      testHarness.setProcessingTime(afterExpiry)
+
+      val outputs = testHarness.extractOutputValues()
+      val evictionOutput = outputs.get(outputs.size() - 1)
+      decodeSum(evictionOutput) shouldBe null
+      evictionOutput.latestTsMillis shouldEqual afterExpiry
+      testHarness.numProcessingTimeTimers() shouldEqual 0
+    } finally testHarness.close()
+  }
+
+  it should "roll the current day on processing time while retaining an eligible late event" in {
+    val testHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    val dayMillis = new Window(1, TimeUnit.DAYS).millis
+    val beforeMidnightProcessingTs = dayMillis - 60 * 1000L
+    val afterMidnightProcessingTs = dayMillis + 60 * 1000L
+    val initialEventTs = dayMillis - 30 * 60 * 1000L
+    val delayedEventTs = dayMillis - 10 * 60 * 1000L
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(beforeMidnightProcessingTs)
+      testHarness.processElement1(event(initialEventTs, 5L), initialEventTs)
+      testHarness.setProcessingTime(afterMidnightProcessingTs)
+      // Zipline suppresses redundant timer writes. Crossing midnight must still leave the
+      // retained pre-midnight value available to the next event.
+      testHarness.extractOutputValues().size() shouldEqual 1
+
+      testHarness.processElement1(event(delayedEventTs, 7L), delayedEventTs)
+      val outputs = testHarness.extractOutputValues()
+      val delayedEventOutput = outputs.get(outputs.size() - 1)
+      decodeSum(delayedEventOutput) shouldEqual 12L
+      delayedEventOutput.latestTsMillis shouldEqual afterMidnightProcessingTs
+    } finally testHarness.close()
+  }
+
+  it should "use processing time for batch refresh versions" in {
+    val batchGroupBy = Builders.GroupBy(
+      metaData = Builders.MetaData(name = "gigatile-process-function-batch-test"),
+      aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(7, TimeUnit.DAYS)))))
+    val testHarness = harness(new GigaTileProcessFunction(batchGroupBy, inputSchema))
+    val batchCodec = new GigaTileCodec(batchGroupBy, inputSchema)
+    val batchEndTs = TsUtils.round(eventTs, new Window(1, TimeUnit.DAYS).millis)
+    val batchEventTs = batchEndTs - 60 * 1000L
+    val batchAggregator =
+      new SawtoothOnlineAggregator(batchEndTs, batchGroupBy.getAggregations.asScala.toSeq, inputSchema)
+    val batchIr = batchAggregator.update(
+      batchAggregator.init,
+      new ArrayRow(Array[Any](batchEventTs, 7L), batchEventTs))
+    val finalBatchIr = batchAggregator.denormalizeBatchIr(batchAggregator.normalizeBatchIr(batchIr))
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      testHarness.processElement2(
+        new BatchIrRow(entityKey(), batchCodec.encodeBatchIr(finalBatchIr), batchEndTs),
+        batchEndTs)
+
+      val output = testHarness.extractOutputValues().get(0)
+      decodeSum(output, batchGroupBy) shouldEqual 7L
+      output.latestTsMillis shouldEqual processingTs
+    } finally testHarness.close()
+  }
+
+  it should "schedule decay when a batch refresh leaves the current value unchanged" in {
+    val batchGroupBy = Builders.GroupBy(
+      metaData = Builders.MetaData(name = "gigatile-process-function-empty-batch-test"),
+      aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(7, TimeUnit.DAYS)))))
+    val testHarness = harness(new GigaTileProcessFunction(batchGroupBy, inputSchema))
+    val batchCodec = new GigaTileCodec(batchGroupBy, inputSchema)
+    val batchEndTs = TsUtils.round(eventTs, new Window(1, TimeUnit.DAYS).millis)
+    val batchAggregator =
+      new SawtoothOnlineAggregator(batchEndTs, batchGroupBy.getAggregations.asScala.toSeq, inputSchema)
+    val emptyBatchIr = batchAggregator.denormalizeBatchIr(batchAggregator.normalizeBatchIr(batchAggregator.init))
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      testHarness.processElement2(
+        new BatchIrRow(entityKey(), batchCodec.encodeBatchIr(emptyBatchIr), batchEndTs),
+        batchEndTs)
+
+      testHarness.extractOutputValues().asScala shouldBe empty
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+    } finally testHarness.close()
+  }
+
+  it should "migrate restored legacy event-time timers without publishing twice" in {
+    val firstLegacyTimer = eventTs + 1000L
+    val secondLegacyTimer = firstLegacyTimer + 1000L
+    val originalHarness = harness(new LegacyEventTimeTimerFunction(Seq(firstLegacyTimer, secondLegacyTimer)))
+    originalHarness.open()
+    originalHarness.processElement1(event(eventTs, 1L), eventTs)
+    originalHarness.numEventTimeTimers() shouldEqual 2
+    val snapshot = originalHarness.snapshot(7L, processingTs)
+    originalHarness.close()
+
+    val restoredHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(snapshot)
+      restoredHarness.open()
+      restoredHarness.setProcessingTime(processingTs)
+      restoredHarness.processWatermark1(new Watermark(secondLegacyTimer))
+      restoredHarness.processWatermark2(new Watermark(secondLegacyTimer))
+
+      restoredHarness.extractOutputValues().asScala shouldBe empty
+      restoredHarness.numEventTimeTimers() shouldEqual 0
+      restoredHarness.numProcessingTimeTimers() shouldEqual 1
+    } finally restoredHarness.close()
+  }
+
+  it should "restore and flush same-millisecond updates with a strictly newer version" in {
+    val originalHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    val firstEventTs = processingTs - 1000L
+    originalHarness.open()
+    originalHarness.setProcessingTime(processingTs)
+    originalHarness.processElement1(event(firstEventTs, 5L), firstEventTs)
+    originalHarness.processElement1(event(firstEventTs + 1L, 7L), firstEventTs + 1L)
+    originalHarness.processElement1(event(firstEventTs + 2L, 3L), firstEventTs + 2L)
+
+    val initialOutputs = originalHarness.extractOutputValues()
+    initialOutputs.size() shouldEqual 1
+    decodeSum(initialOutputs.get(0)) shouldEqual 5L
+    initialOutputs.get(0).latestTsMillis shouldEqual processingTs
+    // One timer keeps normal eviction cadence; the other flushes the version collision.
+    originalHarness.numProcessingTimeTimers() shouldEqual 2
+    val snapshot = originalHarness.snapshot(8L, processingTs)
+    originalHarness.close()
+
+    val restoredHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(snapshot)
+      restoredHarness.open()
+      // A delayed callback still uses the reserved strictly-newer version without moving
+      // aggregation time merely to flush the current snapshot.
+      restoredHarness.setProcessingTime(processingTs + 100L)
+
+      val outputs = restoredHarness.extractOutputValues()
+      outputs.size() shouldEqual 1
+      decodeSum(outputs.get(0)) shouldEqual 15L
+      outputs.get(0).latestTsMillis shouldEqual processingTs + 1L
+    } finally restoredHarness.close()
+  }
+
+  it should "repair collision and eviction markers after a state-blind timer consumer" in {
+    val firstEventTs = processingTs - 1000L
+    val evictionTs = nextEvictionHop(processingTs)
+    val originalFunction = new GigaTileProcessFunction(groupBy, inputSchema)
+    val originalHarness = harness(originalFunction)
+    originalHarness.open()
+    originalHarness.setProcessingTime(processingTs)
+    originalHarness.processElement1(event(firstEventTs, 5L), firstEventTs)
+    originalHarness.processElement1(event(firstEventTs + 1L, 7L), firstEventTs + 1L)
+    val originalSnapshot = originalHarness.snapshot(31L, processingTs)
+    originalHarness.close()
+
+    val legacyHarness = harness(new StateBlindProcessingTimerConsumer)
+    legacyHarness.setup()
+    legacyHarness.initializeState(originalSnapshot)
+    legacyHarness.open()
+    legacyHarness.setProcessingTime(processingTs)
+    legacyHarness.setProcessingTime(evictionTs)
+    legacyHarness.numProcessingTimeTimers() shouldEqual 0
+    val legacySnapshot = legacyHarness.snapshot(32L, evictionTs)
+    legacyHarness.close()
+
+    val restoredFunction = new GigaTileProcessFunction(groupBy, inputSchema)
+    val restoredHarness = harness(restoredFunction)
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(legacySnapshot)
+      restoredHarness.open()
+      restoredHarness.setProcessingTime(evictionTs)
+      // With no keyed callback, there is no way for open() to enumerate and repair this key.
+      restoredHarness.numProcessingTimeTimers() shouldEqual 0
+
+      restoredHarness.processElement1(event(firstEventTs + 2L, 3L), firstEventTs + 2L)
+      setCurrentKey(restoredHarness, entityKey())
+      val repairedEviction = valueState[java.lang.Long](restoredFunction,
+                                                        "nextProcessingEvictionTimerState").value().longValue()
+      val repairedCollision = valueState[java.lang.Long](restoredFunction,
+                                                         "pendingVersionCollisionState").value().longValue()
+      repairedEviction should be > evictionTs
+      repairedCollision shouldEqual repairedEviction
+      restoredHarness.numProcessingTimeTimers() shouldEqual 1
+
+      restoredHarness.setProcessingTime(repairedCollision)
+
+      val outputs = restoredHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldEqual 15L
+      outputs.get(0).latestTsMillis shouldEqual repairedCollision
+      valueState[java.lang.Long](restoredFunction, "pendingVersionCollisionState").value() shouldBe null
+      restoredHarness.numProcessingTimeTimers() shouldEqual 1
+    } finally restoredHarness.close()
+  }
+
+  it should "keep a later owned timer while draining an earlier due callback" in {
+    val windowMillis = new Window(1, TimeUnit.HOURS).millis
+    val justBeforeExpiry = eventTs + windowMillis - 1L
+    val injectedTimer = justBeforeExpiry + 1L
+    val evictionTimer = nextEvictionHop(justBeforeExpiry)
+    injectedTimer should be < evictionTimer
+
+    val originalHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    originalHarness.open()
+    originalHarness.setProcessingTime(justBeforeExpiry)
+    originalHarness.processElement1(event(eventTs, 5L), eventTs)
+    val originalSnapshot = originalHarness.snapshot(33L, justBeforeExpiry)
+    originalHarness.close()
+
+    val injectorHarness = harness(new ProcessingTimerInjector(injectedTimer))
+    injectorHarness.setup()
+    injectorHarness.initializeState(originalSnapshot)
+    injectorHarness.open()
+    injectorHarness.setProcessingTime(justBeforeExpiry)
+    injectorHarness.processElement1(event(eventTs, 0L), eventTs)
+    val injectedSnapshot = injectorHarness.snapshot(34L, justBeforeExpiry)
+    injectorHarness.close()
+
+    val restoredHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(injectedSnapshot)
+      restoredHarness.open()
+      // Flink reports this jump target while it first drains injectedTimer. That earlier
+      // callback must not steal ownership from the still-queued evictionTimer.
+      restoredHarness.setProcessingTime(evictionTimer)
+
+      val outputs = restoredHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldBe null
+      outputs.get(0).latestTsMillis shouldEqual evictionTimer
+      restoredHarness.numProcessingTimeTimers() shouldEqual 0
+    } finally restoredHarness.close()
+  }
+
+  it should "share a queued eviction while draining an earlier collision repair callback" in {
+    val firstEventTs = processingTs - 1000L
+    val consumedCollisionTimer = processingTs + 1L
+    val injectedTimer = processingTs + 2L
+    val evictionTimer = nextEvictionHop(processingTs)
+    injectedTimer should be < evictionTimer
+
+    val originalHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    originalHarness.open()
+    originalHarness.setProcessingTime(processingTs)
+    originalHarness.processElement1(event(firstEventTs, 5L), firstEventTs)
+    originalHarness.processElement1(event(firstEventTs + 1L, 7L), firstEventTs + 1L)
+    val originalSnapshot = originalHarness.snapshot(35L, processingTs)
+    originalHarness.close()
+
+    val legacyHarness = harness(new StateBlindProcessingTimerConsumer)
+    legacyHarness.setup()
+    legacyHarness.initializeState(originalSnapshot)
+    legacyHarness.open()
+    legacyHarness.setProcessingTime(processingTs)
+    legacyHarness.setProcessingTime(consumedCollisionTimer)
+    legacyHarness.numProcessingTimeTimers() shouldEqual 1
+    val legacySnapshot = legacyHarness.snapshot(36L, consumedCollisionTimer)
+    legacyHarness.close()
+
+    val injectorHarness = harness(new ProcessingTimerInjector(injectedTimer))
+    injectorHarness.setup()
+    injectorHarness.initializeState(legacySnapshot)
+    injectorHarness.open()
+    injectorHarness.setProcessingTime(consumedCollisionTimer)
+    injectorHarness.processElement1(event(firstEventTs, 0L), firstEventTs)
+    val injectedSnapshot = injectorHarness.snapshot(37L, consumedCollisionTimer)
+    injectorHarness.close()
+
+    val restoredFunction = new GigaTileProcessFunction(groupBy, inputSchema)
+    val restoredHarness = harness(restoredFunction)
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(injectedSnapshot)
+      restoredHarness.open()
+      restoredHarness.setProcessingTime(consumedCollisionTimer)
+      // The injected callback runs first while Flink already reports evictionTimer as the
+      // current processing time. The stale collision must join that still-queued eviction.
+      restoredHarness.setProcessingTime(evictionTimer)
+
+      val outputs = restoredHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldEqual 12L
+      outputs.get(0).latestTsMillis shouldEqual evictionTimer
+      setCurrentKey(restoredHarness, entityKey())
+      valueState[java.lang.Long](restoredFunction, "pendingVersionCollisionState").value() shouldBe null
+      restoredHarness.numProcessingTimeTimers() shouldEqual 1
+    } finally restoredHarness.close()
+  }
+
+  it should "retry the current snapshot when the first publication fails" in {
+    val function = new GigaTileProcessFunction(groupBy, inputSchema)
+    val testHarness = harness(function)
+    val firstEventTs = processingTs - 1000L
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      failNextEncode(function)
+      testHarness.processElement1(event(firstEventTs, 5L), firstEventTs)
+
+      testHarness.extractOutputValues() shouldBe empty
+      // Normal eviction and the failed-snapshot retry both remain live.
+      testHarness.numProcessingTimeTimers() shouldEqual 2
+
+      testHarness.setProcessingTime(processingTs + 1L)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs.size() shouldEqual 1
+      decodeSum(outputs.get(0)) shouldEqual 5L
+      outputs.get(0).latestTsMillis shouldEqual processingTs + 1L
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+    } finally testHarness.close()
+  }
+
+  it should "re-arm a version collision when snapshot construction fails" in {
+    val function = new GigaTileProcessFunction(groupBy, inputSchema)
+    val testHarness = harness(function)
+    val firstEventTs = processingTs - 1000L
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      testHarness.processElement1(event(firstEventTs, 5L), firstEventTs)
+      testHarness.processElement1(event(firstEventTs + 1L, 7L), firstEventTs + 1L)
+
+      testHarness.extractOutputValues().size() shouldEqual 1
+      failNextSnapshot(function)
+
+      testHarness.setProcessingTime(processingTs + 1L)
+
+      testHarness.extractOutputValues().size() shouldEqual 1
+      // The normal eviction timer and the re-armed collision timer must both remain live.
+      testHarness.numProcessingTimeTimers() shouldEqual 2
+
+      testHarness.setProcessingTime(processingTs + 2L)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs.size() shouldEqual 2
+      decodeSum(outputs.get(1)) shouldEqual 12L
+      outputs.get(1).latestTsMillis shouldEqual processingTs + 2L
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+    } finally testHarness.close()
+  }
+
+  it should "evict before flushing when version and eviction timers coincide" in {
+    val testHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    val hopMillis = new Window(5, TimeUnit.MINUTES).millis
+    val evictionTs = TsUtils.round(processingTs, hopMillis) + hopMillis
+    val collisionProcessingTs = evictionTs - 1L
+    val expiringEventTs = evictionTs - new Window(1, TimeUnit.HOURS).millis - 1L
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(collisionProcessingTs)
+      testHarness.processElement1(event(expiringEventTs, 5L), expiringEventTs)
+      testHarness.processElement1(event(expiringEventTs, 7L), expiringEventTs)
+
+      testHarness.setProcessingTime(evictionTs)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs.size() shouldEqual 2
+      decodeSum(outputs.get(1)) shouldBe null
+      outputs.get(1).latestTsMillis shouldEqual evictionTs
+      testHarness.numProcessingTimeTimers() shouldEqual 0
+    } finally testHarness.close()
+  }
+
+  it should "delay a shared collision until a failed eviction is retried" in {
+    val function = new GigaTileProcessFunction(groupBy, inputSchema)
+    val testHarness = harness(function)
+    val hopMillis = new Window(5, TimeUnit.MINUTES).millis
+    val evictionTs = TsUtils.round(processingTs, hopMillis) + hopMillis
+    val retryTs = evictionTs + hopMillis
+    val collisionProcessingTs = evictionTs - 1L
+    val expiringEventTs = retryTs - new Window(1, TimeUnit.HOURS).millis - 1L
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(collisionProcessingTs)
+      testHarness.processElement1(event(expiringEventTs, 5L), expiringEventTs)
+      testHarness.processElement1(event(expiringEventTs, 7L), expiringEventTs)
+      failNextScheduledEviction(function)
+
+      testHarness.setProcessingTime(evictionTs)
+
+      testHarness.extractOutputValues().size() shouldEqual 1
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+
+      testHarness.setProcessingTime(evictionTs + 1L)
+      testHarness.extractOutputValues().size() shouldEqual 1
+
+      testHarness.setProcessingTime(retryTs)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs.size() shouldEqual 2
+      decodeSum(outputs.get(1)) shouldBe null
+      outputs.get(1).latestTsMillis shouldEqual retryTs
+      testHarness.numProcessingTimeTimers() shouldEqual 0
+    } finally testHarness.close()
+  }
+
+  it should "isolate same-millisecond publication collisions by key" in {
+    val testHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    val firstEventTs = processingTs - 1000L
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      testHarness.processElement1(keyedEvent("campaign-1", firstEventTs, 5L), firstEventTs)
+      testHarness.processElement1(keyedEvent("campaign-1", firstEventTs + 1L, 7L), firstEventTs + 1L)
+      testHarness.processElement1(keyedEvent("campaign-2", firstEventTs, 11L), firstEventTs)
+      testHarness.processElement1(keyedEvent("campaign-2", firstEventTs + 1L, 13L), firstEventTs + 1L)
+
+      testHarness.extractOutputValues().size() shouldEqual 2
+      testHarness.setProcessingTime(processingTs + 1L)
+
+      val flushedByKey = testHarness.extractOutputValues().asScala
+        .filter(_.latestTsMillis == processingTs + 1L)
+        .map(tile => tile.keys.get(0).toString -> decodeSum(tile))
+        .toMap
+      flushedByKey shouldEqual Map("campaign-1" -> 12L, "campaign-2" -> 24L)
+    } finally testHarness.close()
+  }
+}
+
+object GigaTileProcessFunctionTest {
+  private val eventTs = 1000000L
+  private val processingTs = eventTs + new Window(2, TimeUnit.HOURS).millis
+  private val inputSchema: Seq[(String, DataType)] =
+    Seq(Constants.TimeColumn -> LongType, "num" -> LongType)
+  private val groupBy = Builders.GroupBy(
+    metaData = Builders.MetaData(name = "gigatile-process-function-test"),
+    aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(1, TimeUnit.HOURS)))))
+
+  private def harness(
+      function: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]
+  ): KeyedTwoInputStreamOperatorTestHarness[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile] =
+    new KeyedTwoInputStreamOperatorTestHarness[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile](
+      new KeyedCoProcessOperator(function),
+      new KeySelector[ProjectedEvent, util.List[Any]] {
+        override def getKey(value: ProjectedEvent): util.List[Any] =
+          entityKey(value.fields.getOrElse("entity", "campaign-1").toString)
+      },
+      new KeySelector[BatchIrRow, util.List[Any]] {
+        override def getKey(value: BatchIrRow): util.List[Any] = value.entityKeys
+      },
+      TypeInformation
+        .of(classOf[util.List[_]])
+        .asInstanceOf[TypeInformation[util.List[Any]]])
+
+  private def event(timestamp: Long, value: Long): ProjectedEvent =
+    ProjectedEvent(Map(Constants.TimeColumn -> timestamp, "num" -> value), timestamp)
+
+  private def keyedEvent(entity: String, timestamp: Long, value: Long): ProjectedEvent =
+    ProjectedEvent(Map("entity" -> entity, Constants.TimeColumn -> timestamp, "num" -> value), timestamp)
+
+  private def entityKey(entity: String = "campaign-1"): util.List[Any] = {
+    val result = new util.ArrayList[Any](1)
+    result.add(entity)
+    result
+  }
+
+  private def nextEvictionHop(timestamp: Long): Long = {
+    val hopMillis = new Window(5, TimeUnit.MINUTES).millis
+    TsUtils.round(timestamp, hopMillis) + hopMillis
+  }
+
+  private def setCurrentKey(
+      testHarness: KeyedTwoInputStreamOperatorTestHarness[
+        util.List[Any],
+        ProjectedEvent,
+        BatchIrRow,
+        TimestampedTile],
+      key: util.List[Any]
+  ): Unit =
+    testHarness.getOperator.getKeyedStateBackend
+      .asInstanceOf[KeyedStateBackend[util.List[Any]]]
+      .setCurrentKey(key)
+
+  private def valueState[T](function: GigaTileProcessFunction, fieldName: String): ValueState[T] = {
+    val field = classOf[GigaTileProcessFunction].getDeclaredField(fieldName)
+    field.setAccessible(true)
+    field.get(function).asInstanceOf[ValueState[T]]
+  }
+
+  private def decodeSum(tile: TimestampedTile, decodeGroupBy: GroupBy = groupBy): AnyRef = {
+    val outputCodec = new GigaTileCodec(decodeGroupBy, inputSchema)
+    val fieldName = outputCodec.outputSchema.fields.head.name
+    AvroCodec
+      .of(ai.chronon.online.serde.AvroConversions.fromChrononSchema(outputCodec.outputSchema).toString)
+      .decodeMap(tile.tileBytes)(fieldName)
+  }
+
+  private def failNextSnapshot(function: GigaTileProcessFunction): Unit = {
+    val processorField = classOf[GigaTileProcessFunction].getDeclaredField("processor")
+    processorField.setAccessible(true)
+    val delegate = processorField.get(function).asInstanceOf[GigaTileStreamProcessor]
+    processorField.set(
+      function,
+      new GigaTileStreamProcessor(
+        delegate.megaTileAgg,
+        delegate.store,
+        delegate.irEqual,
+        delegate.maxBatchStalenessDays
+      ) {
+        private var shouldFail = true
+
+        override private[chronon] def currentSnapshot: GigaEmitResult = {
+          if (shouldFail) {
+            shouldFail = false
+            throw new RuntimeException("expected snapshot failure")
+          }
+          delegate.currentSnapshot
+        }
+      }
+    )
+  }
+
+  private def failNextEncode(function: GigaTileProcessFunction): Unit = {
+    val codecField = classOf[GigaTileProcessFunction].getDeclaredField("gigaTileCodec")
+    codecField.setAccessible(true)
+    codecField.set(
+      function,
+      new GigaTileCodec(groupBy, inputSchema) {
+        private var shouldFail = true
+
+        override def encodeOutput(finalizedVector: Array[Any]): Array[Byte] = {
+          if (shouldFail) {
+            shouldFail = false
+            throw new RuntimeException("expected publication encoding failure")
+          }
+          super.encodeOutput(finalizedVector)
+        }
+      })
+  }
+
+  private def failNextScheduledEviction(function: GigaTileProcessFunction): Unit = {
+    val processorField = classOf[GigaTileProcessFunction].getDeclaredField("processor")
+    processorField.setAccessible(true)
+    val delegate = processorField.get(function).asInstanceOf[GigaTileStreamProcessor]
+    processorField.set(
+      function,
+      new GigaTileStreamProcessor(
+        delegate.megaTileAgg,
+        delegate.store,
+        delegate.irEqual,
+        delegate.maxBatchStalenessDays
+      ) {
+        private var shouldFail = true
+
+        override def onScheduledEviction(timerTs: Long): GigaEmitResult = {
+          if (shouldFail) {
+            shouldFail = false
+            throw new RuntimeException("expected scheduled eviction failure")
+          }
+          delegate.onScheduledEviction(timerTs)
+        }
+      }
+    )
+  }
+
+  private class LegacyEventTimeTimerFunction(timerTimestamps: Seq[Long])
+      extends KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile] {
+    override def processElement1(
+        event: ProjectedEvent,
+        ctx: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#Context,
+        out: Collector[TimestampedTile]
+    ): Unit =
+      timerTimestamps.foreach(ctx.timerService().registerEventTimeTimer)
+
+    override def processElement2(
+        batchRow: BatchIrRow,
+        ctx: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#Context,
+        out: Collector[TimestampedTile]
+    ): Unit = ()
+  }
+
+  /** Models a rollback binary that consumes physical timers without binding the additive
+    * collision and eviction ownership descriptors.
+    */
+  private class StateBlindProcessingTimerConsumer
+      extends KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile] {
+    override def processElement1(
+        event: ProjectedEvent,
+        ctx: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#Context,
+        out: Collector[TimestampedTile]
+    ): Unit = ()
+
+    override def processElement2(
+        batchRow: BatchIrRow,
+        ctx: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#Context,
+        out: Collector[TimestampedTile]
+    ): Unit = ()
+
+    override def onTimer(
+        timestamp: Long,
+        ctx: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#OnTimerContext,
+        out: Collector[TimestampedTile]
+    ): Unit = ()
+  }
+
+  private class ProcessingTimerInjector(timerTimestamp: Long)
+      extends KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile] {
+    override def processElement1(
+        event: ProjectedEvent,
+        ctx: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#Context,
+        out: Collector[TimestampedTile]
+    ): Unit = ctx.timerService().registerProcessingTimeTimer(timerTimestamp)
+
+    override def processElement2(
+        batchRow: BatchIrRow,
+        ctx: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#Context,
+        out: Collector[TimestampedTile]
+    ): Unit = ()
+  }
+}


### PR DESCRIPTION
## Summary

Layer 1 of 5 for `nikhil/gigatile`, based on [openai/chronon-private#109](https://github.com/openai/chronon-private/pull/109).

GigaTile now ages PUSH materialization and handles day rollover with processing time while retaining event time as the aggregation clock.

Stack: #2022 → #2023 → #2024 → #2025 → #2026.

## Changes

- Move eviction and materialized day advancement to processing-time timers.
- Keep same-millisecond PUSH versions strictly increasing.
- Checkpoint timer ownership and repair stale additive timer state after restore.
- Preserve compatibility with checkpoints written before the new state existed.

## Safety

This layer is not replay-safe by itself because processing time can outrun replayed event time. Do not enable replay until #2024 adds the publication fence.

## Validation

- At the final stack head, 164 focused GigaTile tests pass on Scala 2.12.18 and 164 pass on Scala 2.13.17 (328 total).
- `git diff --check` passes, as do formatting checks for all files changed by this stack.

## Checklist

- [x] Added Unit Tests
- [ ] Covered by existing CI
- [x] Integration tested
- [ ] Documentation update
