### PR TITLE
Add opt-in grace for batch-absent GigaTile keys

### DIFF
--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStore.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStore.scala
@@ -16,6 +16,14 @@ trait GigaTileStore extends TileStore {
   def getRunningLargeIr: Array[Any]
   def putRunningLargeIr(ir: Array[Any]): Unit
 
+  /** Hop-aligned as-of timestamp represented by the cached small-window IR. */
+  def getCachedSmallWindowAsOfTs: Long
+  def putCachedSmallWindowAsOfTs(ts: Long): Unit
+
+  /** As-of timestamp used by the last full running-large IR recomputation. */
+  def getLastLargeRecomputeAsOfTs: Long
+  def putLastLargeRecomputeAsOfTs(ts: Long): Unit
+
   // Per-day large-window IR state. One slot per day with streaming events between
   // batchEndDay and the current watermark day; pruned on batch advance.
   def getDailyLargeIr(dayStart: Long): Array[Any]

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStore.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStore.scala
@@ -25,7 +25,7 @@ trait GigaTileStore extends TileStore {
   def putLastLargeRecomputeAsOfTs(ts: Long): Unit
 
   // Per-day large-window IR state. One slot per day with streaming events between
-  // batchEndDay and the current watermark day; pruned on batch advance.
+  // batchEndDay and the current materialized day; pruned on batch advance.
   def getDailyLargeIr(dayStart: Long): Array[Any]
   def putDailyLargeIr(dayStart: Long, ir: Array[Any]): Unit
   def removeDailyLargeIr(dayStart: Long): Unit

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStreamProcessor.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStreamProcessor.scala
@@ -5,6 +5,8 @@ import ai.chronon.api.TsUtils
 
 import scala.collection.mutable
 
+private[chronon] final case class EvictionTimes(timerTs: Long, smallWindowAsOfTs: Long)
+
 /** Pure Scala state manager for the GigaTile streaming pipeline.
   *
   * Flink holds the FinalBatchIr in state (loaded from Iceberg) and one daily large-window
@@ -39,6 +41,11 @@ class GigaTileStreamProcessor(
   private val baseAgg = megaTileAgg.baseAggregator
   private val isNoBatch = megaTileAgg.isNoBatch
   private val columnHopSize = megaTileAgg.columnHopSize
+  private val isFiniteLargeWindow: Array[Boolean] = megaTileAgg.windowMappings.zipWithIndex.map { case (mapping, col) =>
+    val window = mapping.aggregationPart.window
+    !isNoBatch(col) && window != null && window.length > 0 && window.length < Int.MaxValue
+  }
+  private val hasFiniteLargeWindows = isFiniteLargeWindow.contains(true)
 
   val smallWindowTiers: Set[Long] = {
     val tiers = mutable.Set.empty[Long]
@@ -93,7 +100,18 @@ class GigaTileStreamProcessor(
     * rebuild correctly), but only events inside each column's effective horizon contribute
     * to the live cached IR that gets emitted.
     */
-  def onEvent(row: Row, eventTs: Long, smallWindowAsOfTs: Long): GigaEmitResult = {
+  def onEvent(row: Row, eventTs: Long, smallWindowAsOfTs: Long): GigaEmitResult =
+    onEvent(row, eventTs, largeWindowAsOfTs = smallWindowAsOfTs, smallWindowAsOfTs = smallWindowAsOfTs)
+
+  /** Separate horizons keep the small-window exclusive upper bound from shifting the
+    * large-window query time at an exact hop boundary.
+    */
+  private[chronon] def onEvent(
+      row: Row,
+      eventTs: Long,
+      largeWindowAsOfTs: Long,
+      smallWindowAsOfTs: Long
+  ): GigaEmitResult = {
     var currentDayStart = store.getCurrentDayStart
     if (currentDayStart == -1L) {
       currentDayStart = TsUtils.round(eventTs, DayMillis)
@@ -105,6 +123,19 @@ class GigaTileStreamProcessor(
     // --- Small windows: update tiles, then update cached IR only for columns whose
     // tile lies inside the smallWindowAsOfTs horizon. ---
     if (hasSmallWindows) {
+      val targetHop = TsUtils.round(smallWindowAsOfTs, minSmallWindowTileSize)
+      val cachedHop = store.getCachedSmallWindowAsOfTs
+      // An older or delayed callback can arrive after this cache has advanced. Keep the live
+      // horizon monotonic instead of rebuilding or gating the event against an older range
+      // and resurrecting an expired tile.
+      val effectiveSmallWindowAsOfTs = if (cachedHop > targetHop) cachedHop else smallWindowAsOfTs
+      // A delayed callback can advance to a new hop before the scheduled eviction runs.
+      // Rebuild first so this event cannot publish an expired tile from the previous hop.
+      if (store.getEarliestTileStart != Long.MaxValue && cachedHop < targetHop) {
+        rebuildCachedSmallWindowIr(smallWindowAsOfTs, currentDayStart)
+        dirty = true
+      }
+
       val acceptedTileStarts = mutable.Map.empty[Long, Long]
       val tileStarts = megaTileAgg.tileStartsForEvent(eventTs)
       for ((hopSize, tileStart) <- tileStarts) {
@@ -131,10 +162,10 @@ class GigaTileStreamProcessor(
           if (isNoBatch(col)) {
             val hopSize = columnHopSize(col)
             acceptedTileStarts.get(hopSize).foreach { tileStart =>
-              val effStart = megaTileAgg.effectiveStart(col, smallWindowAsOfTs, currentDayStart)
+              val effStart = megaTileAgg.effectiveStart(col, effectiveSmallWindowAsOfTs, currentDayStart)
               // Retained late events: keep the base tile but skip cached-IR update so the live
               // emit reflects only events inside the as-of horizon for this column's window.
-              if (tileStart >= effStart && tileStart < smallWindowAsOfTs) {
+              if (tileStart >= effStart && tileStart < effectiveSmallWindowAsOfTs) {
                 if (cachedIr == null) cachedIr = store.getCachedSmallWindowIr
                 windowedAgg.columnAggregators(col).update(cachedIr, row)
                 cachedIrUpdated = true
@@ -145,17 +176,22 @@ class GigaTileStreamProcessor(
         }
         if (cachedIrUpdated) {
           store.putCachedSmallWindowIr(cachedIr)
+          store.putCachedSmallWindowAsOfTs(math.max(cachedHop, targetHop))
           dirty = true
         }
       }
     }
 
+    // A delayed callback can cross one or more large-window boundaries before its
+    // scheduled eviction runs. Track the last full recompute per key so the event path
+    // repairs a stale large view once per hop without coupling it to the small horizon.
+    if (recomputeRunningLargeIrForEventIfNeeded(largeWindowAsOfTs, currentDayStart)) dirty = true
+
     // --- Large windows: route to the per-day slot for round(eventTs, DayMillis) ---
-    // Accept events as far back as the staleness bound. Events whose dayStart is already
-    // covered by batch are still accepted for the incremental running IR (so onEvent emits
-    // see them immediately), and recomputeRunningLargeIr will drop their daily slot at the
-    // next eviction — matching the original "incremental shows it, eviction may drop it"
-    // trade-off when the late event was not in the prior batch's source data.
+    // Accept events as far back as the staleness bound. The daily slot retains the event for
+    // every large column, but the incremental running view only updates columns whose daily
+    // slot overlaps the monotonic materialized horizon. This prevents an out-of-order event
+    // from resurrecting an already-expired shorter window before the next eviction.
     //
     // Daily slot IRs are sized to the BASE aggregator (one column per (op, input)) — not
     // the windowed aggregator. The same SUM(num) value covers every windowed SUM(num, W)
@@ -171,7 +207,11 @@ class GigaTileStreamProcessor(
       store.putDailyLargeIr(eventDayStart, dayIr)
 
       val runningIr = store.getRunningLargeIr
-      updateLargeWindowColumns(runningIr, row)
+      val lastLargeRecomputeAsOfTs = store.getLastLargeRecomputeAsOfTs
+      val effectiveLargeAsOfTs =
+        if (lastLargeRecomputeAsOfTs == Long.MinValue) largeWindowAsOfTs
+        else math.max(lastLargeRecomputeAsOfTs, largeWindowAsOfTs)
+      updateLargeWindowColumns(runningIr, row, eventDayStart, effectiveLargeAsOfTs)
       store.putRunningLargeIr(runningIr)
       dirty = true
     } else {
@@ -182,25 +222,23 @@ class GigaTileStreamProcessor(
     else GigaEmitResult(null, droppedStaleEvent = droppedStaleEvent)
   }
 
-  /** As-of-driven day transition. Updates currentDayStart and rebuilds the small-window
-    * cache because each column's effectiveStart shifts with the new as-of horizon. Daily
-    * large-IR slots are unaffected — they're keyed by day-start and persist across rollovers
-    * until batch covers them.
+  /** As-of-driven day transition. Finite day jumps rebuild both views so the next callback
+    * cannot combine a corrected small-window cache with stale large-window state.
     */
   def advanceWatermark(watermarkTs: Long): GigaEmitResult = {
     val currentDayStart = store.getCurrentDayStart
     if (currentDayStart == -1L) return GigaEmitResult(null)
     val wmDay = TsUtils.round(watermarkTs, DayMillis)
     if (wmDay > currentDayStart) {
-      val isAdjacentRollover = wmDay == currentDayStart + DayMillis
+      val previousPackedIr = windowedAgg.clone(pack())
       store.putCurrentDayStart(wmDay)
-      // Rebuild only on an adjacent-day transition. Multi-day jumps and end-of-stream
-      // (watermark = MAX) push the as-of so far past retained tiles that everything would be
-      // marked stale and the cache cleared — emitting a spurious null that would overwrite the
-      // PUSH KV row. Leave those cases to the next eviction at a sane timer timestamp.
-      if (isAdjacentRollover && hasSmallWindows) {
-        val previousPackedIr = windowedAgg.clone(pack())
+      // A terminal MAX watermark is not a serving horizon. Rebuilding at MAX would expire
+      // every retained value and publish a synthetic all-null row when a bounded input ends.
+      if (watermarkTs != Long.MaxValue) {
         rebuildCachedSmallWindowIr(watermarkTs, wmDay)
+        // A future batch row is retained but must not become active until its boundary.
+        // Small-window time can still advance while the prior large view remains serving.
+        if (!largeRecomputeDeferred(wmDay)) recomputeRunningLargeIr(watermarkTs, wmDay)
         val packed = pack()
         val packedIsEmpty = isAllNull(packed)
         val previousWasEmpty = isAllNull(previousPackedIr)
@@ -209,33 +247,35 @@ class GigaTileStreamProcessor(
         }
       }
     }
-    GigaEmitResult(null)
+    GigaEmitResult(null, isEmpty = isAllNull(pack()))
   }
 
   /** Direct eviction/serve-as-of: corrects small window sawtooth and large window tail selection. */
   def onEviction(timerTs: Long): GigaEmitResult =
-    runEviction(timerTs, force = true)
+    onEviction(EvictionTimes(timerTs = timerTs, smallWindowAsOfTs = timerTs))
 
-  /** Scheduled eviction used by Flink timers. Timer cadence stays fixed, but a timer that does
-    * not cross a real small or large boundary skips the expensive state rebuilds.
-    */
-  def onScheduledEviction(timerTs: Long): GigaEmitResult =
-    runEviction(timerTs, force = false)
-
-  private def runEviction(timerTs: Long, force: Boolean): GigaEmitResult = {
+  private[chronon] def onEviction(evictionTimes: EvictionTimes): GigaEmitResult = {
     val currentDayStart = store.getCurrentDayStart
     if (currentDayStart == -1L) return GigaEmitResult(null)
 
-    val smallMayChange = force || smallWindowMayChangeAt(timerTs, currentDayStart)
-    val largeMayChange = force || largeIrMayChangeAt(timerTs)
+    val cachedSmallWindowHop = store.getCachedSmallWindowAsOfTs
+    val requestedSmallWindowHop = TsUtils.round(evictionTimes.smallWindowAsOfTs, minSmallWindowTileSize)
+    val cachedSmallWindowHopUnknown = cachedSmallWindowHop < 0L
+    val smallWindowCanAdvance = hasSmallWindows &&
+      (cachedSmallWindowHopUnknown || requestedSmallWindowHop >= cachedSmallWindowHop)
+    val smallMayChange = smallWindowCanAdvance
+    val largeRecomputeIsDeferred = largeRecomputeDeferred(currentDayStart)
+    val largeMayChange = !largeRecomputeIsDeferred
     if (!smallMayChange && !largeMayChange) {
-      return GigaEmitResult(null, isEmpty = isAllNull(pack()))
+      // Do not advance the large recompute marker. A later callback checks the entire gap
+      // from the last materialized horizon, including boundaries skipped by delayed timers.
+      return GigaEmitResult(null, needsEvictionTimer = largeRecomputeIsDeferred, isEmpty = isAllNull(pack()))
     }
 
     val previousPackedIr = windowedAgg.clone(pack())
 
-    if (smallMayChange) rebuildCachedSmallWindowIr(timerTs, currentDayStart)
-    if (largeMayChange) recomputeRunningLargeIr(timerTs, currentDayStart)
+    if (smallMayChange) rebuildCachedSmallWindowIr(evictionTimes.smallWindowAsOfTs, currentDayStart)
+    if (largeMayChange) recomputeRunningLargeIr(evictionTimes.timerTs, currentDayStart)
 
     val packed = pack()
     val packedIsEmpty = isAllNull(packed)
@@ -243,9 +283,11 @@ class GigaTileStreamProcessor(
     if ((packedIsEmpty && previousWasEmpty) || irEqual(previousPackedIr, packed)) {
       // Nothing changed for this key. Suppress redundant KV writes, including fully-decayed
       // idle entities where the previous and current packed IR are both all-null.
-      GigaEmitResult(null, isEmpty = packedIsEmpty)
+      GigaEmitResult(null, needsEvictionTimer = largeRecomputeIsDeferred, isEmpty = packedIsEmpty)
     } else {
-      GigaEmitResult(windowedAgg.finalize(packed), isEmpty = packedIsEmpty)
+      GigaEmitResult(windowedAgg.finalize(packed),
+                     needsEvictionTimer = largeRecomputeIsDeferred,
+                     isEmpty = packedIsEmpty)
     }
   }
 
@@ -296,7 +338,7 @@ class GigaTileStreamProcessor(
   }
 
   /** True when every column in the packed pre-finalize IR is null. Used by the eviction
-    * suppress path and surfaced on GigaEmitResult so the Flink writer can DELETE the KV row.
+    * suppress path and surfaced so Flink can stop scheduling further decay callbacks.
     */
   private def isAllNull(packed: Array[Any]): Boolean = {
     var i = 0
@@ -313,10 +355,19 @@ class GigaTileStreamProcessor(
     * @param newBatchEnd batch upload boundary timestamp (midnight-aligned)
     * @param currentWatermark Flink's current watermark (for tail hop selection as queryTs)
     */
-  def onBatchUpdate(newBatchIr: FinalBatchIr, newBatchEnd: Long, currentWatermark: Long): GigaEmitResult = {
+  def onBatchUpdate(newBatchIr: FinalBatchIr, newBatchEnd: Long, currentWatermark: Long): GigaEmitResult =
+    onBatchUpdate(newBatchIr, newBatchEnd, largeWindowAsOfTs = currentWatermark, smallWindowAsOfTs = currentWatermark)
+
+  private[chronon] def onBatchUpdate(
+      newBatchIr: FinalBatchIr,
+      newBatchEnd: Long,
+      largeWindowAsOfTs: Long,
+      smallWindowAsOfTs: Long
+  ): GigaEmitResult = {
     val oldBatchEnd = store.getBatchEndTs
     if (newBatchEnd <= oldBatchEnd) return GigaEmitResult(null)
 
+    val previousPackedIr = windowedAgg.clone(pack())
     val strippedBatchIr = stripSmallWindowHops(newBatchIr)
     store.putBatchIr(strippedBatchIr)
     store.putBatchEndTs(newBatchEnd)
@@ -330,7 +381,8 @@ class GigaTileStreamProcessor(
         store.putCurrentDayStart(currentDayStart)
       } else {
         // Defer until watermark advances past batchEnd. Daily slots between currentDayStart
-        // and batchEnd would otherwise overlap with batch and double-count.
+        // and batchEnd would otherwise overlap with batch and double-count. Event, timer, and
+        // day-roll recomputation paths all honor largeRecomputeDeferred.
         return GigaEmitResult(null, needsEvictionTimer = true)
       }
     }
@@ -346,116 +398,53 @@ class GigaTileStreamProcessor(
     }
     toRemove.foreach(store.removeDailyLargeIr)
 
-    val oldRunningIr = store.getRunningLargeIr
-    recomputeRunningLargeIr(currentWatermark, currentDayStart)
+    rebuildCachedSmallWindowIr(smallWindowAsOfTs, currentDayStart)
+    recomputeRunningLargeIr(largeWindowAsOfTs, currentDayStart)
+    val packed = pack()
+    val packedIsEmpty = isAllNull(packed)
 
-    val newRunningIr = store.getRunningLargeIr
-
-    if (!irEqual(oldRunningIr, newRunningIr)) {
-      GigaEmitResult(packAndFinalize(), needsEvictionTimer = true)
+    if (!irEqual(previousPackedIr, packed)) {
+      GigaEmitResult(windowedAgg.finalize(packed), needsEvictionTimer = true, isEmpty = packedIsEmpty)
     } else {
-      GigaEmitResult(null, needsEvictionTimer = true)
+      GigaEmitResult(null, needsEvictionTimer = true, isEmpty = packedIsEmpty)
     }
   }
 
   // --- Private helpers ---
 
-  private def previousTimerTs(queryTs: Long): Long =
-    if (queryTs <= Long.MinValue + minEvictionInterval) Long.MinValue else queryTs - minEvictionInterval
+  private def recomputeRunningLargeIrForEventIfNeeded(queryTs: Long, currentDayStart: Long): Boolean = {
+    if (!hasFiniteLargeWindows || largeRecomputeDeferred(currentDayStart)) return false
 
-  private def crossedSincePreviousTimer(queryTs: Long, boundaryTs: Long): Boolean =
-    boundaryTs > previousTimerTs(queryTs) && boundaryTs <= queryTs
-
-  private def smallWindowMayChangeAt(queryTs: Long, currentDayStart: Long): Boolean = {
-    if (!hasSmallWindows || store.getEarliestTileStart == Long.MaxValue) return false
-
-    var col = 0
-    while (col < windowedAgg.length) {
-      val windowMillis = megaTileAgg.columnWindowMillis(col)
-      if (isNoBatch(col) && windowMillis > 0) {
-        val hopSize = columnHopSize(col)
-        val effectiveStart = megaTileAgg.effectiveStart(col, queryTs, currentDayStart)
-        if (effectiveStart >= Long.MinValue + hopSize) {
-          val expiredTileStart = effectiveStart - hopSize
-          if (store.getTile(hopSize, expiredTileStart) != null) return true
-        }
-      }
-      col += 1
+    if (largeIrMayChangeSinceLastRecompute(queryTs)) {
+      recomputeRunningLargeIr(queryTs, currentDayStart)
+      true
+    } else {
+      false
     }
-
-    false
   }
 
-  private def largeIrMayChangeAt(queryTs: Long): Boolean = {
-    val batchIr = store.getBatchIr
-    val batchEndTs = store.getBatchEndTs
-    val batchEndDay = if (batchEndTs > 0) TsUtils.round(batchEndTs, DayMillis) else Long.MinValue
+  private def largeRecomputeDeferred(currentDayStart: Long): Boolean =
+    currentDayStart >= 0L && store.getBatchEndTs > currentDayStart
 
-    if (batchEndDay != Long.MinValue) {
-      val iter = store.dailyLargeIrIterator
-      while (iter.hasNext) {
-        val (dayStart, _) = iter.next()
-        if (dayStart < batchEndDay) return true
-      }
-    }
+  /** True when a finite large-window start crossed its own tail-hop boundary since the exact
+    * prior materialized horizon. Batch ends and daily slots are midnight-aligned, and every
+    * tail hop divides a day, so the same boundary covers collapsed, tail, and daily expiry.
+    * This stays O(columns) on the event path; iterating retained daily state here would decode
+    * every slot for every event until the next real boundary.
+    */
+  private def largeIrMayChangeSinceLastRecompute(queryTs: Long): Boolean = {
+    val previousAsOfTs = store.getLastLargeRecomputeAsOfTs
+    if (previousAsOfTs == Long.MinValue) return true
+    if (queryTs <= previousAsOfTs) return false
 
-    if (batchIr != null && batchEndTs > 0L) {
-      var col = 0
-      while (col < windowedAgg.length) {
-        val windowMillis = megaTileAgg.columnWindowMillis(col)
-        if (!isNoBatch(col) && windowMillis > 0) {
-          val collapsedExpiry = addIfNoOverflow(batchEndTs, windowMillis)
-          if (
-            batchIr.collapsed != null && col < batchIr.collapsed.length &&
-            batchIr.collapsed(col) != null && crossedSincePreviousTimer(queryTs, collapsedExpiry)
-          ) {
-            return true
-          }
-
-          val hopIndex = megaTileAgg.tailHopIndicesArray(col)
-          if (batchIr.tailHops != null && hopIndex < batchIr.tailHops.length && batchIr.tailHops(hopIndex) != null) {
-            val hopSize = megaTileAgg.hopSizesArray(hopIndex)
-            val prevTs = previousTimerTs(queryTs)
-            val previousTail =
-              if (prevTs == Long.MinValue) Long.MinValue
-              else TsUtils.round(subtractIfNoUnderflow(prevTs, windowMillis), hopSize)
-            val queryTail = TsUtils.round(subtractIfNoUnderflow(queryTs, windowMillis), hopSize)
-            if (queryTail > previousTail) {
-              val baseIrIndex = megaTileAgg.baseIrIndicesArray(col)
-              val hopIrs = batchIr.tailHops(hopIndex)
-              var idx = 0
-              while (idx < hopIrs.length) {
-                val hopIr = hopIrs(idx)
-                if (hopIr != null && baseIrIndex < hopIr.length - 1) {
-                  val hopStart = hopIr.last.asInstanceOf[Long]
-                  if (hopStart >= previousTail && hopStart < queryTail && hopIr(baseIrIndex) != null) {
-                    return true
-                  }
-                }
-                idx += 1
-              }
-            }
-          }
-        }
-        col += 1
-      }
-    }
-
-    val columnWindowMillis = megaTileAgg.columnWindowMillis
-    val baseIrIndices = megaTileAgg.baseIrIndicesArray
     var col = 0
     while (col < windowedAgg.length) {
-      val windowMillis = columnWindowMillis(col)
-      if (!isNoBatch(col) && windowMillis > 0 && queryTs >= windowMillis + DayMillis) {
-        val dayStart = TsUtils.round(queryTs - windowMillis - DayMillis, DayMillis)
-        val expiryTs = addIfNoOverflow(addIfNoOverflow(dayStart, DayMillis), windowMillis)
-        if (crossedSincePreviousTimer(queryTs, expiryTs)) {
-          val dayIr = store.getDailyLargeIr(dayStart)
-          val baseIrIndex = baseIrIndices(col)
-          if (dayIr != null && baseIrIndex < dayIr.length && dayIr(baseIrIndex) != null) {
-            return true
-          }
-        }
+      if (isFiniteLargeWindow(col)) {
+        val windowMillis = megaTileAgg.columnWindowMillis(col)
+        val hopSize = columnHopSize(col)
+        val previousStart = TsUtils.round(subtractIfNoUnderflow(previousAsOfTs, windowMillis), hopSize)
+        val queryStart = TsUtils.round(subtractIfNoUnderflow(queryTs, windowMillis), hopSize)
+        if (queryStart > previousStart) return true
       }
       col += 1
     }
@@ -493,7 +482,7 @@ class GigaTileStreamProcessor(
     // windowed column via baseIrIndices, but only for columns whose own window overlaps the
     // slot's date range. Otherwise we'd over-count smaller-window columns by an entire day's
     // worth of out-of-window events.
-    val batchEndDay = if (batchEndTs > 0) TsUtils.round(batchEndTs, DayMillis) else Long.MinValue
+    val batchEndDay = if (batchEndTs >= 0L) TsUtils.round(batchEndTs, DayMillis) else Long.MinValue
     val maxWindowMillis = megaTileAgg.maxWindowMillis
     val columnWindowMillis = megaTileAgg.columnWindowMillis
     val baseIrIndices = megaTileAgg.baseIrIndicesArray
@@ -534,11 +523,12 @@ class GigaTileStreamProcessor(
     // aliased to cached tail-hop or daily-slot IRs; subsequent in-place onEvent updates would
     // then mutate that shared state and corrupt future serves.
     store.putRunningLargeIr(windowedAgg.clone(runningIr))
+    store.putLastLargeRecomputeAsOfTs(queryTs)
   }
 
   /** Rebuild cachedSmallWindowIr from retained tiles using the supplied as-of horizon.
-    * Called from advanceWatermark on day rollover (effective starts shift) and from
-    * onEviction (sawtooth correction at hop boundaries).
+    * Used for day-roll and hop-boundary correction, and before event publication whenever
+    * the cached as-of marker is stale.
     */
   private def rebuildCachedSmallWindowIr(asOfTs: Long, currentDayStart: Long): Unit = {
     if (!hasSmallWindows) return
@@ -569,13 +559,23 @@ class GigaTileStreamProcessor(
 
     val rebuiltIr = megaTileAgg.buildMegaTileIr(tiles, now = asOfTs, batchEnd = currentDayStart)
     store.putCachedSmallWindowIr(rebuiltIr)
+    store.putCachedSmallWindowAsOfTs(TsUtils.round(asOfTs, minSmallWindowTileSize))
   }
 
-  private def updateLargeWindowColumns(ir: Array[Any], row: Row): Unit = {
+  private def updateLargeWindowColumns(
+      ir: Array[Any],
+      row: Row,
+      eventDayStart: Long,
+      effectiveAsOfTs: Long
+  ): Unit = {
+    val slotEnd = addIfNoOverflow(eventDayStart, DayMillis)
     var col = 0
     while (col < windowedAgg.length) {
       if (!isNoBatch(col)) {
-        windowedAgg.columnAggregators(col).update(ir, row)
+        val include =
+          !isFiniteLargeWindow(col) ||
+            slotEnd > subtractIfNoUnderflow(effectiveAsOfTs, megaTileAgg.columnWindowMillis(col))
+        if (include) windowedAgg.columnAggregators(col).update(ir, row)
       }
       col += 1
     }
@@ -626,13 +626,11 @@ class GigaTileStreamProcessor(
 
 case class GigaEmitResult(
     finalizedVector: Array[Any],
-    // True when a non-timer path, such as batch update, wants the next fixed-cadence
-    // eviction timer registered.
+    // True when this key must keep its fixed-cadence eviction timer registered. Batch
+    // updates start the cadence; deferred future batches keep it live even for empty keys.
     needsEvictionTimer: Boolean = false,
-    // True when the packed pre-finalize IR has every column null. The Flink wiring uses this
-    // to (a) DELETE the PUSH KV row instead of writing a row of nulls and (b) decide whether
-    // to keep re-registering decay timers — once a key is fully empty, no further decay is
-    // possible until a new event arrives.
+    // True when the packed pre-finalize IR has every column null. Flink can emit the encoded
+    // all-null correction and stop decay timers; the current sink does not issue a DELETE.
     isEmpty: Boolean = false,
     // True when this onEvent call dropped its event because eventTs was older than the
     // staleness bound. Surfaced so the Flink wiring can bump a metric / log instead of

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStreamProcessor.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStreamProcessor.scala
@@ -182,24 +182,34 @@ class GigaTileStreamProcessor(
     else GigaEmitResult(null, droppedStaleEvent = droppedStaleEvent)
   }
 
-  /** Watermark-driven day transition. Updates currentDayStart and rebuilds the small-window
+  /** As-of-driven day transition. Updates currentDayStart and rebuilds the small-window
     * cache because each column's effectiveStart shifts with the new as-of horizon. Daily
     * large-IR slots are unaffected — they're keyed by day-start and persist across rollovers
     * until batch covers them.
     */
-  def advanceWatermark(watermarkTs: Long): Unit = {
+  def advanceWatermark(watermarkTs: Long): GigaEmitResult = {
     val currentDayStart = store.getCurrentDayStart
-    if (currentDayStart == -1L) return
+    if (currentDayStart == -1L) return GigaEmitResult(null)
     val wmDay = TsUtils.round(watermarkTs, DayMillis)
     if (wmDay > currentDayStart) {
       val isAdjacentRollover = wmDay == currentDayStart + DayMillis
       store.putCurrentDayStart(wmDay)
-      // Rebuild only on the adjacent-day case Bug B targets. Multi-day jumps and end-of-stream
+      // Rebuild only on an adjacent-day transition. Multi-day jumps and end-of-stream
       // (watermark = MAX) push the as-of so far past retained tiles that everything would be
       // marked stale and the cache cleared — emitting a spurious null that would overwrite the
-      // PUSH KV row. Leave those cases to the next event-time eviction at a sane timer ts.
-      if (isAdjacentRollover) rebuildCachedSmallWindowIr(watermarkTs, wmDay)
+      // PUSH KV row. Leave those cases to the next eviction at a sane timer timestamp.
+      if (isAdjacentRollover && hasSmallWindows) {
+        val previousPackedIr = windowedAgg.clone(pack())
+        rebuildCachedSmallWindowIr(watermarkTs, wmDay)
+        val packed = pack()
+        val packedIsEmpty = isAllNull(packed)
+        val previousWasEmpty = isAllNull(previousPackedIr)
+        if (!((packedIsEmpty && previousWasEmpty) || irEqual(previousPackedIr, packed))) {
+          return GigaEmitResult(windowedAgg.finalize(packed), isEmpty = packedIsEmpty)
+        }
+      }
     }
+    GigaEmitResult(null)
   }
 
   /** Direct eviction/serve-as-of: corrects small window sawtooth and large window tail selection. */
@@ -395,8 +405,10 @@ class GigaTileStreamProcessor(
         val windowMillis = megaTileAgg.columnWindowMillis(col)
         if (!isNoBatch(col) && windowMillis > 0) {
           val collapsedExpiry = addIfNoOverflow(batchEndTs, windowMillis)
-          if (batchIr.collapsed != null && col < batchIr.collapsed.length &&
-              batchIr.collapsed(col) != null && crossedSincePreviousTimer(queryTs, collapsedExpiry)) {
+          if (
+            batchIr.collapsed != null && col < batchIr.collapsed.length &&
+            batchIr.collapsed(col) != null && crossedSincePreviousTimer(queryTs, collapsedExpiry)
+          ) {
             return true
           }
 
@@ -590,6 +602,12 @@ class GigaTileStreamProcessor(
   }
 
   private[windowing] def packAndFinalize(): Array[Any] = windowedAgg.finalize(pack())
+
+  /** Snapshot the current value without moving either aggregation clock. */
+  private[chronon] def currentSnapshot: GigaEmitResult = {
+    val packed = pack()
+    GigaEmitResult(windowedAgg.finalize(packed), isEmpty = isAllNull(packed))
+  }
 
   /** Strip tail hops that are only used by small windows to reduce state size.
     * 5-min hops for ≤12h windows are never consumed by mergeTailHopsForBatchColumns.

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStreamProcessor.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStreamProcessor.scala
@@ -59,6 +59,8 @@ class GigaTileStreamProcessor(
 
   val hasSmallWindows: Boolean = smallWindowTiers.nonEmpty
 
+  val hasBatchBackedColumns: Boolean = isNoBatch.contains(false)
+
   // Eviction cadence: smallest hop across ALL windows (not just small).
   // Large-window-only GroupBys need eviction for tail hop correction.
   val minEvictionInterval: Long = megaTileAgg.activeTiers.min
@@ -411,6 +413,26 @@ class GigaTileStreamProcessor(
     } else {
       GigaEmitResult(null, needsEvictionTimer = true, isEmpty = packedIsEmpty)
     }
+  }
+
+  /** Treat a first-seen key as having no historical batch contribution.
+    *
+    * This only installs the empty baseline. It deliberately leaves batchEndTs unchanged so a
+    * later real batch row remains authoritative and retained live slots are not pruned early.
+    */
+  private[chronon] def initializeEmptyBatchIr(
+      largeWindowAsOfTs: Long,
+      installEmptyBatchIr: FinalBatchIr => Unit
+  ): GigaEmitResult = {
+    if (store.getBatchIr != null) return GigaEmitResult(null)
+
+    installEmptyBatchIr(megaTileAgg.finalizeSnapshot(megaTileAgg.init))
+    val currentDayStart = store.getCurrentDayStart
+    if (currentDayStart >= 0L) recomputeRunningLargeIr(largeWindowAsOfTs, currentDayStart)
+
+    val packed = pack()
+    val packedIsEmpty = isAllNull(packed)
+    GigaEmitResult(windowedAgg.finalize(packed), needsEvictionTimer = true, isEmpty = packedIsEmpty)
   }
 
   // --- Private helpers ---

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStreamProcessor.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStreamProcessor.scala
@@ -10,7 +10,7 @@ private[chronon] final case class EvictionTimes(timerTs: Long, smallWindowAsOfTs
 /** Pure Scala state manager for the GigaTile streaming pipeline.
   *
   * Flink holds the FinalBatchIr in state (loaded from Iceberg) and one daily large-window
-  * IR slot per day with streaming events between batchEndDay and the watermark day. The
+  * IR slot per day with streaming events between batchEndDay and the current materialized day. The
   * runningLargeIr cache is the merged batch + every retained daily slot, refreshed on
   * eviction and on batch update.
   *
@@ -225,20 +225,20 @@ class GigaTileStreamProcessor(
   /** As-of-driven day transition. Finite day jumps rebuild both views so the next callback
     * cannot combine a corrected small-window cache with stale large-window state.
     */
-  def advanceWatermark(watermarkTs: Long): GigaEmitResult = {
+  def advanceDayAsOf(asOfTs: Long): GigaEmitResult = {
     val currentDayStart = store.getCurrentDayStart
     if (currentDayStart == -1L) return GigaEmitResult(null)
-    val wmDay = TsUtils.round(watermarkTs, DayMillis)
-    if (wmDay > currentDayStart) {
+    val asOfDay = TsUtils.round(asOfTs, DayMillis)
+    if (asOfDay > currentDayStart) {
       val previousPackedIr = windowedAgg.clone(pack())
-      store.putCurrentDayStart(wmDay)
-      // A terminal MAX watermark is not a serving horizon. Rebuilding at MAX would expire
-      // every retained value and publish a synthetic all-null row when a bounded input ends.
-      if (watermarkTs != Long.MaxValue) {
-        rebuildCachedSmallWindowIr(watermarkTs, wmDay)
+      store.putCurrentDayStart(asOfDay)
+      // A terminal Long.MaxValue horizon from a bounded watermark is not a serving horizon.
+      // Rebuilding there would expire every retained value and publish a synthetic all-null row.
+      if (asOfTs != Long.MaxValue) {
+        rebuildCachedSmallWindowIr(asOfTs, asOfDay)
         // A future batch row is retained but must not become active until its boundary.
         // Small-window time can still advance while the prior large view remains serving.
-        if (!largeRecomputeDeferred(wmDay)) recomputeRunningLargeIr(watermarkTs, wmDay)
+        if (!largeRecomputeDeferred(asOfDay)) recomputeRunningLargeIr(asOfTs, asOfDay)
         val packed = pack()
         val packedIsEmpty = isAllNull(packed)
         val previousWasEmpty = isAllNull(previousPackedIr)
@@ -249,6 +249,9 @@ class GigaTileStreamProcessor(
     }
     GigaEmitResult(null, isEmpty = isAllNull(pack()))
   }
+
+  // Compatibility wrapper for callers that still pass an event-time watermark directly.
+  def advanceWatermark(watermarkTs: Long): GigaEmitResult = advanceDayAsOf(watermarkTs)
 
   /** Direct eviction/serve-as-of: corrects small window sawtooth and large window tail selection. */
   def onEviction(timerTs: Long): GigaEmitResult =
@@ -380,9 +383,9 @@ class GigaTileStreamProcessor(
         currentDayStart = newBatchEnd
         store.putCurrentDayStart(currentDayStart)
       } else {
-        // Defer until watermark advances past batchEnd. Daily slots between currentDayStart
-        // and batchEnd would otherwise overlap with batch and double-count. Event, timer, and
-        // day-roll recomputation paths all honor largeRecomputeDeferred.
+        // Defer until the selected large-window as-of day reaches batchEnd. Daily slots between
+        // currentDayStart and batchEnd would otherwise overlap with batch and double-count. Event,
+        // timer, and day-roll recomputation paths all honor largeRecomputeDeferred.
         return GigaEmitResult(null, needsEvictionTimer = true)
       }
     }
@@ -494,7 +497,7 @@ class GigaTileStreamProcessor(
       // Slot entirely outside the largest window — useful to no column. Drop from state.
       if (dayStart < batchEndDay) {
         toEvict += dayStart
-      } else if (maxWindowMillis > 0 && slotEnd <= queryTs - maxWindowMillis) {
+      } else if (maxWindowMillis > 0 && maxWindowMillis < Long.MaxValue && slotEnd <= queryTs - maxWindowMillis) {
         toEvict += dayStart
       } else if (dayStart >= batchEndDay && dayIr != null) {
         var col = 0
@@ -606,7 +609,9 @@ class GigaTileStreamProcessor(
   /** Snapshot the current value without moving either aggregation clock. */
   private[chronon] def currentSnapshot: GigaEmitResult = {
     val packed = pack()
-    GigaEmitResult(windowedAgg.finalize(packed), isEmpty = isAllNull(packed))
+    GigaEmitResult(windowedAgg.finalize(packed),
+                   needsEvictionTimer = largeRecomputeDeferred(store.getCurrentDayStart),
+                   isEmpty = isAllNull(packed))
   }
 
   /** Strip tail hops that are only used by small windows to reduce state size.

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStreamProcessor.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/GigaTileStreamProcessor.scala
@@ -604,7 +604,7 @@ class GigaTileStreamProcessor(
     packed
   }
 
-  private[windowing] def packAndFinalize(): Array[Any] = windowedAgg.finalize(pack())
+  private[chronon] def packAndFinalize(): Array[Any] = windowedAgg.finalize(pack())
 
   /** Snapshot the current value without moving either aggregation clock. */
   private[chronon] def currentSnapshot: GigaEmitResult = {

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/InMemoryGigaTileStore.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/InMemoryGigaTileStore.scala
@@ -8,6 +8,8 @@ class InMemoryGigaTileStore(windowedAgg: RowAggregator) extends InMemoryTileStor
   private var _batchIr: FinalBatchIr = _
   private var _batchEndTs: Long = -1L
   private var _runningLargeIr: Array[Any] = windowedAgg.init
+  private var _cachedSmallWindowAsOfTs: Long = -1L
+  private var _lastLargeRecomputeAsOfTs: Long = Long.MinValue
   private val _dailyLargeIrs: mutable.Map[Long, Array[Any]] = mutable.Map.empty
 
   override def getBatchIr: FinalBatchIr = _batchIr
@@ -18,6 +20,12 @@ class InMemoryGigaTileStore(windowedAgg: RowAggregator) extends InMemoryTileStor
 
   override def getRunningLargeIr: Array[Any] = _runningLargeIr
   override def putRunningLargeIr(ir: Array[Any]): Unit = _runningLargeIr = ir
+
+  override def getCachedSmallWindowAsOfTs: Long = _cachedSmallWindowAsOfTs
+  override def putCachedSmallWindowAsOfTs(ts: Long): Unit = _cachedSmallWindowAsOfTs = ts
+
+  override def getLastLargeRecomputeAsOfTs: Long = _lastLargeRecomputeAsOfTs
+  override def putLastLargeRecomputeAsOfTs(ts: Long): Unit = _lastLargeRecomputeAsOfTs = ts
 
   override def getDailyLargeIr(dayStart: Long): Array[Any] = _dailyLargeIrs.getOrElse(dayStart, null)
   override def putDailyLargeIr(dayStart: Long, ir: Array[Any]): Unit = _dailyLargeIrs(dayStart) = ir

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/MegaTileAggregator.scala
@@ -118,19 +118,21 @@ class MegaTileAggregator(aggregations: Seq[Aggregation],
   val hopSizesArray: Array[Long] = hopSizes
   val baseIrIndicesArray: Array[Int] = baseIrIndices
 
-  /** Largest window across all windowed columns, in millis. Used by GigaTile to bound daily-
-    * slot retention: any slot whose dayStart + DayMillis is older than (queryTs - maxWindowMillis)
-    * cannot contribute to any column and can be evicted from state.
+  /** Largest retention horizon across all columns, in millis. Used by GigaTile to bound daily-
+    * slot retention. Unwindowed columns retain uncovered slots until a later batch includes them,
+    * so their horizon is intentionally unbounded.
     */
   val maxWindowMillis: Long = {
     var m: Long = 0L
+    var hasUnwindowedColumn = false
     var i = 0
     while (i < windowMappings.length) {
       val w = windowMappings(i).aggregationPart.window
-      if (w != null && w.millis > m) m = w.millis
+      if (w == null) hasUnwindowedColumn = true
+      else if (w.millis > m) m = w.millis
       i += 1
     }
-    m
+    if (hasUnwindowedColumn) Long.MaxValue else m
   }
 
   /** Per-windowed-column window in millis. -1 for unwindowed columns (which always include the slot). */

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileBugRegressionTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileBugRegressionTest.scala
@@ -281,7 +281,9 @@ class GigaTileBugRegressionTest extends AnyFlatSpec {
 
     // Roll over — wall clock has moved to day+1, three hours past midnight.
     val day1_3h = baseDay + DayMillis + 3 * HourMillis
-    processor.advanceWatermark(day1_3h)
+    val rollover = processor.advanceWatermark(day1_3h)
+    assertNotNull("day rollover should surface the cache correction", rollover.finalizedVector)
+    assertNull("expired values should be removed at rollover", rollover.finalizedVector(0))
 
     // Single fresh event 55 minutes later. Only this event lies inside the 1h horizon now.
     val day1_3h_55m = day1_3h + 55 * MinuteMillis

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileBugRegressionTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileBugRegressionTest.scala
@@ -48,6 +48,10 @@ class GigaTileBugRegressionTest extends AnyFlatSpec {
 
     override def getCachedSmallWindowIr: Array[Any] = currentStore.getCachedSmallWindowIr
     override def putCachedSmallWindowIr(ir: Array[Any]): Unit = currentStore.putCachedSmallWindowIr(ir)
+    override def getCachedSmallWindowAsOfTs: Long = currentStore.getCachedSmallWindowAsOfTs
+    override def putCachedSmallWindowAsOfTs(ts: Long): Unit = currentStore.putCachedSmallWindowAsOfTs(ts)
+    override def getLastLargeRecomputeAsOfTs: Long = currentStore.getLastLargeRecomputeAsOfTs
+    override def putLastLargeRecomputeAsOfTs(ts: Long): Unit = currentStore.putLastLargeRecomputeAsOfTs(ts)
 
     override def getLargeTodayIr: Array[Any] = currentStore.getLargeTodayIr
     override def putLargeTodayIr(ir: Array[Any]): Unit = currentStore.putLargeTodayIr(ir)
@@ -72,21 +76,6 @@ class GigaTileBugRegressionTest extends AnyFlatSpec {
     override def removeDailyLargeIr(dayStart: Long): Unit = currentStore.removeDailyLargeIr(dayStart)
     override def dailyLargeIrIterator: Iterator[(Long, Array[Any])] = currentStore.dailyLargeIrIterator
 
-  }
-
-  private class CountingGigaTileStore(windowedAgg: RowAggregator) extends InMemoryGigaTileStore(windowedAgg) {
-    var runningLargeWrites: Int = 0
-    var tileScans: Int = 0
-
-    override def putRunningLargeIr(ir: Array[Any]): Unit = {
-      runningLargeWrites += 1
-      super.putRunningLargeIr(ir)
-    }
-
-    override def tileIterator: Iterator[(Long, Long, Array[Any])] = {
-      tileScans += 1
-      super.tileIterator
-    }
   }
 
   private def mixedBoundaryAggregations: Seq[Aggregation] =
@@ -129,8 +118,9 @@ class GigaTileBugRegressionTest extends AnyFlatSpec {
     def loadStreamingKey(key: String): Unit = {
       store.bind(key)
       processor.onBatchUpdate(emptyBatch, baseDay, baseDay)
-      processor.advanceWatermark(queryTs - 2 * HourMillis)
-      processor.onEvent(new TestRow(queryTs - 2 * HourMillis, 5L)(0), queryTs - 2 * HourMillis)
+      val expiringEventTs = queryTs - HourMillis - 1L
+      processor.advanceWatermark(expiringEventTs)
+      processor.onEvent(new TestRow(expiringEventTs, 5L)(0), expiringEventTs)
       processor.advanceWatermark(queryTs - 30 * MinuteMillis)
       processor.onEvent(new TestRow(queryTs - 30 * MinuteMillis, 7L)(0), queryTs - 30 * MinuteMillis)
     }
@@ -185,36 +175,6 @@ class GigaTileBugRegressionTest extends AnyFlatSpec {
     assertNull(bLargeBoundary.finalizedVector(0))
     assertNull(bLargeBoundary.finalizedVector(1))
     assertEquals(12L, bLargeBoundary.finalizedVector(2))
-  }
-
-  it should "FAIL: scheduled eviction before the next real boundary must not scan or rewrite full state" in {
-    val aggregations = mixedBoundaryAggregations
-    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
-    val store = new CountingGigaTileStore(megaTileAgg.windowedAggregator)
-    val processor = new GigaTileStreamProcessor(megaTileAgg, store, irEqual)
-    val baseDay = TsUtils.round(1700000000000L, DayMillis)
-    val eventTs = baseDay + 10 * HourMillis + 30 * MinuteMillis
-    val earlyTimer = eventTs + 5 * MinuteMillis
-    val expiryTimer = TsUtils.round(eventTs, 5 * MinuteMillis) + HourMillis + 5 * MinuteMillis
-
-    processor.onBatchUpdate(emptyBatchIr(baseDay, aggregations), baseDay, baseDay)
-    processor.advanceWatermark(eventTs)
-    processor.onEvent(new TestRow(eventTs, 3L)(0), eventTs)
-    val writesAfterEvent = store.runningLargeWrites
-    val scansAfterEvent = store.tileScans
-
-    val earlyEviction = processor.onScheduledEviction(earlyTimer)
-    assertNull("timer before any small/large boundary should not emit", earlyEviction.finalizedVector)
-    assertEquals("timer before a real boundary should not rewrite runningLargeIr",
-                 writesAfterEvent,
-                 store.runningLargeWrites)
-    assertEquals("timer before a real boundary should not scan tile state", scansAfterEvent, store.tileScans)
-
-    val boundaryEviction = processor.onEviction(expiryTimer)
-    assertNotNull("timer at the 1h small-window expiry should recompute and emit", boundaryEviction.finalizedVector)
-    assertNull(boundaryEviction.finalizedVector(0))
-    assertEquals(3L, boundaryEviction.finalizedVector(1))
-    assertEquals(3L, boundaryEviction.finalizedVector(2))
   }
 
   // -----------------------------------------------------------------

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileBugRegressionTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileBugRegressionTest.scala
@@ -713,6 +713,34 @@ class GigaTileBugRegressionTest extends AnyFlatSpec {
     )
   }
 
+  it should "retain uncovered daily slots required by an unwindowed column" in {
+    val aggregations = mixedBoundaryAggregations
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val store = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, store)
+    val day0 = TsUtils.round(1700000000000L, DayMillis)
+    val event = new TestRow(day0 + HourMillis, 5L)(0)
+
+    processor.onBatchUpdate(emptyBatchIr(day0, aggregations), day0, day0)
+    processor.advanceWatermark(event.ts)
+    processor.onEvent(event, event.ts)
+
+    val queryTs = day0 + 10 * DayMillis
+    processor.advanceWatermark(queryTs)
+    val beforeBatchCoverage = processor.onEviction(queryTs)
+
+    assertNotNull("the uncovered day must remain available to the unwindowed column",
+                  store.getDailyLargeIr(day0))
+    assertEquals(5L, beforeBatchCoverage.finalizedVector(2))
+
+    val coveringBatchEnd = day0 + DayMillis
+    val coveringBatch = batchIrFromEvents(Array(event), coveringBatchEnd, aggregations)
+    val afterBatchCoverage = processor.onBatchUpdate(coveringBatch, coveringBatchEnd, queryTs)
+
+    assertNull("the daily slot can be removed once batch state covers it", store.getDailyLargeIr(day0))
+    assertEquals(5L, afterBatchCoverage.finalizedVector(2))
+  }
+
   it should "FAIL: consecutive all-empty eviction emits must be suppressed even under default irEqual" in {
     val window = new Window(1, TimeUnit.HOURS)
     val aggregations: Seq[Aggregation] = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(window)))

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileStreamProcessorTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/GigaTileStreamProcessorTest.scala
@@ -524,11 +524,12 @@ class GigaTileStreamProcessorTest extends AnyFlatSpec {
       processor.onEvent(event, event.ts)
     }
 
-    // First eviction at an hour boundary — should emit
+    // Event-path recomputes already kept the large view current. Both forced evictions
+    // must suppress their write because recomputing produces the same packed IR.
     val evictionTs = TsUtils.round(batchEnd + 12 * 3600 * 1000L, 3600 * 1000L)
     processor.advanceWatermark(evictionTs)
     val result1 = processor.onEviction(evictionTs)
-    assertNotNull("first eviction should emit", result1.finalizedVector)
+    assertNull("an already-current eviction should not emit", result1.finalizedVector)
 
     // Second eviction 5 min later — same hour boundary, no events, nothing changed
     val nextEviction = evictionTs + 5 * 60 * 1000L
@@ -963,5 +964,452 @@ class GigaTileStreamProcessorTest extends AnyFlatSpec {
     if (!approxEqual(result.finalizedVector, naive(0))) {
       fail(s"all_small_windows: expected ${gson.toJson(naive(0))} got ${gson.toJson(result.finalizedVector)}")
     }
+  }
+
+  it should "exclude an expired small-window tile when a hop timer callback is delayed" in {
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+    val aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(1, TimeUnit.HOURS))))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, new InMemoryGigaTileStore(megaTileAgg.windowedAggregator))
+    val hopMillis = 5 * 60 * 1000L
+    val expiredTileEventTs = 10 * hopMillis
+    val previousHopTs = expiredTileEventTs + 12 * hopMillis + 1L
+    val delayedEventTs = previousHopTs + hopMillis + 9 * 1000L
+
+    // Seed the left-edge 1h tile, then stop before the next hop eviction fires.
+    // The delayed event path must rebuild the stale cache before adding the fresh 7.
+    processor.onEvent(row(expiredTileEventTs, 5L, 1.0), expiredTileEventTs + 1L)
+    processor.onEviction(previousHopTs)
+
+    val result = processor.onEvent(row(delayedEventTs, 7L, 1.0), delayedEventTs)
+    assertEquals("expired left-edge tile must not survive a delayed hop timer", 7L, result.finalizedVector(0))
+  }
+
+  it should "rebuild a sparse small window when a timer skips multiple hops" in {
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+    val aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(1, TimeUnit.HOURS))))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val store = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, store)
+    val hopMillis = processor.minSmallWindowTileSize
+
+    processor.onEvent(row(0L, 5L, 1.0), 0L, hopMillis + 1L)
+    assertEquals(hopMillis, store.getCachedSmallWindowAsOfTs)
+
+    // The 0-minute tile expires before this callback, but the immediately preceding
+    // hop tile is empty. The full skipped range still has to trigger a rebuild.
+    val delayedCallbackTs = 14 * hopMillis + 1L
+    val result = processor.onEviction(delayedCallbackTs)
+
+    assertNotNull("the delayed timer must publish the sparse-key correction", result.finalizedVector)
+    assertNull("the old sparse tile must not survive the skipped hops", result.finalizedVector(0))
+    assertTrue("the corrected sparse key must be empty", result.isEmpty)
+
+    // A +1 exclusive bound can cache the tile that starts exactly at the rounded marker.
+    // The bounded gap scan must include that marker tile as well.
+    val markerStore = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator)
+    val markerProcessor = new GigaTileStreamProcessor(megaTileAgg, markerStore)
+    markerProcessor.onEvent(row(hopMillis, 7L, 1.0), hopMillis, hopMillis + 1L)
+    assertEquals(hopMillis, markerStore.getCachedSmallWindowAsOfTs)
+
+    val markerResult = markerProcessor.onEviction(delayedCallbackTs)
+    assertNotNull("the delayed timer must publish the exact-marker correction", markerResult.finalizedVector)
+    assertNull("the exact-marker tile must expire across the skipped hops", markerResult.finalizedVector(0))
+    assertTrue("the corrected exact-marker key must be empty", markerResult.isEmpty)
+  }
+
+  it should "exclude an expired batch tail for a large-window-only delayed callback" in {
+    val batchEnd = 10 * DayMillis
+    val hourMillis = 60 * 60 * 1000L
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+    val aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(49, TimeUnit.HOURS))))
+    val batchEvents = Array(row(batchEnd - 48 * hourMillis, 5L, 1.0))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val store = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator) {
+      var runningLargeWrites: Int = 0
+
+      override def putRunningLargeIr(ir: Array[Any]): Unit = {
+        runningLargeWrites += 1
+        super.putRunningLargeIr(ir)
+      }
+    }
+    val processor = new GigaTileStreamProcessor(megaTileAgg, store)
+    val batchIr = denormalizeBatchIr(buildBatchIr(batchEvents, batchEnd, aggregations, schema),
+                                     aggregations,
+                                     schema,
+                                     batchEnd)
+    val beforeExpiry = batchEnd + 59 * 60 * 1000L
+    // Skip past the +2h boundary where the -48h tail hop leaves this 49h sawtooth.
+    val delayedCallbackTs = batchEnd + 3 * hourMillis + 60 * 1000L
+    val freshEvent = row(delayedCallbackTs - 1L, 7L, 1.0)
+
+    processor.onBatchUpdate(batchIr, batchEnd, batchEnd)
+    processor.onEviction(beforeExpiry)
+    val delayedTimerResult = processor.onEviction(delayedCallbackTs)
+    assertNull("the delayed timer must remove the expired batch tail", delayedTimerResult.finalizedVector(0))
+    assertEquals(delayedCallbackTs, store.getLastLargeRecomputeAsOfTs)
+
+    val writesBeforeDelayedCallback = store.runningLargeWrites
+    val result = processor.onEvent(freshEvent,
+                                   freshEvent.ts,
+                                   largeWindowAsOfTs = delayedCallbackTs,
+                                   smallWindowAsOfTs = delayedCallbackTs)
+
+    assertEquals("the expired batch tail must be removed before adding the fresh event",
+                 7L,
+                 result.finalizedVector(0))
+    assertEquals("the event must reuse the timer-corrected horizon and then apply once",
+                 writesBeforeDelayedCallback + 1,
+                 store.runningLargeWrites)
+    assertEquals(delayedCallbackTs, store.getLastLargeRecomputeAsOfTs)
+
+    val writesAfterRebuild = store.runningLargeWrites
+    val sameHopCallbackTs = delayedCallbackTs + 30 * 60 * 1000L
+    val sameHopEvent = row(sameHopCallbackTs - 1L, 3L, 1.0)
+    val sameHopResult = processor.onEvent(sameHopEvent,
+                                         sameHopEvent.ts,
+                                         largeWindowAsOfTs = sameHopCallbackTs,
+                                         smallWindowAsOfTs = sameHopCallbackTs)
+
+    assertEquals(10L, sameHopResult.finalizedVector(0))
+    assertEquals("a second event in the same large-window hop must not rebuild again",
+                 writesAfterRebuild + 1,
+                 store.runningLargeWrites)
+    assertEquals("the last recompute marker must remain at the first callback in the hop",
+                 delayedCallbackTs,
+                 store.getLastLargeRecomputeAsOfTs)
+  }
+
+  it should "rebuild at an offset tail boundary inside one eviction hop" in {
+    val batchEnd = 10 * DayMillis
+    val hourMillis = 60 * 60 * 1000L
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+    val window = new Window(49 * 60 + 20, TimeUnit.MINUTES)
+    val aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(window)))
+    val batchEvents = Array(row(batchEnd - 48 * hourMillis, 5L, 1.0))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val store = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator) {
+      var runningLargeWrites: Int = 0
+
+      override def putRunningLargeIr(ir: Array[Any]): Unit = {
+        runningLargeWrites += 1
+        super.putRunningLargeIr(ir)
+      }
+    }
+    val processor = new GigaTileStreamProcessor(megaTileAgg, store)
+    val batchIr = denormalizeBatchIr(buildBatchIr(batchEvents, batchEnd, aggregations, schema),
+                                     aggregations,
+                                     schema,
+                                     batchEnd)
+    val beforeOffsetBoundary = batchEnd + 2 * hourMillis + 5 * 60 * 1000L
+    val afterOffsetBoundary = batchEnd + 2 * hourMillis + 30 * 60 * 1000L
+
+    processor.onBatchUpdate(batchIr, batchEnd, batchEnd)
+    processor.onEviction(beforeOffsetBoundary)
+    assertEquals(5L, processor.currentSnapshot.finalizedVector(0))
+
+    val writesBeforeEvent = store.runningLargeWrites
+    val result = processor.onEvent(row(afterOffsetBoundary - 1L, 7L, 1.0),
+                                   afterOffsetBoundary - 1L,
+                                   largeWindowAsOfTs = afterOffsetBoundary,
+                                   smallWindowAsOfTs = afterOffsetBoundary)
+
+    assertEquals("the tail that expired at +2h20 must be removed before the event", 7L, result.finalizedVector(0))
+    assertEquals("the callback must rebuild once and then apply the event",
+                 writesBeforeEvent + 2,
+                 store.runningLargeWrites)
+    assertEquals(afterOffsetBoundary, store.getLastLargeRecomputeAsOfTs)
+  }
+
+  it should "rebuild at an offset daily-slot boundary inside one eviction hop" in {
+    val hourMillis = 60 * 60 * 1000L
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+    val window = new Window(49 * 60 + 20, TimeUnit.MINUTES)
+    val aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(window)))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val store = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, store)
+    val emptyBatch = denormalizeBatchIr(buildBatchIr(Array.empty[TestRow], 0L, aggregations, schema),
+                                        aggregations,
+                                        schema,
+                                        0L)
+    val oldEventTs = hourMillis
+    val beforeOffsetBoundary = 3 * DayMillis + hourMillis + 5 * 60 * 1000L
+    val afterOffsetBoundary = 3 * DayMillis + hourMillis + 30 * 60 * 1000L
+
+    processor.onBatchUpdate(emptyBatch, 0L, 0L)
+    processor.onEvent(row(oldEventTs, 5L, 1.0), oldEventTs)
+    processor.onEviction(beforeOffsetBoundary)
+    assertEquals(5L, processor.currentSnapshot.finalizedVector(0))
+
+    val result = processor.onEvent(row(afterOffsetBoundary - 1L, 7L, 1.0),
+                                   afterOffsetBoundary - 1L,
+                                   largeWindowAsOfTs = afterOffsetBoundary,
+                                   smallWindowAsOfTs = afterOffsetBoundary)
+
+    assertEquals("the expired day slot must be removed before the fresh event", 7L, result.finalizedVector(0))
+    assertEquals(afterOffsetBoundary, store.getLastLargeRecomputeAsOfTs)
+  }
+
+  it should "keep an out-of-order daily slot out of an expired shorter window" in {
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+    val aggregations = Seq(
+      Builders.Aggregation(Operation.SUM,
+                           "num",
+                           Seq(new Window(3, TimeUnit.DAYS), new Window(7, TimeUnit.DAYS))))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, new InMemoryGigaTileStore(megaTileAgg.windowedAggregator))
+    val materializedAsOfTs = 10 * DayMillis
+    val oldEventTs = 4 * DayMillis + 60 * 60 * 1000L
+    val emptyBatch = denormalizeBatchIr(buildBatchIr(Array.empty[TestRow], 0L, aggregations, schema),
+                                        aggregations,
+                                        schema,
+                                        0L)
+
+    processor.onBatchUpdate(emptyBatch, 0L, 0L)
+    processor.advanceWatermark(materializedAsOfTs)
+    val result = processor.onEvent(row(oldEventTs, 5L, 1.0),
+                                   oldEventTs,
+                                   largeWindowAsOfTs = oldEventTs,
+                                   smallWindowAsOfTs = oldEventTs)
+
+    assertNull("the old slot must not re-inflate the already-expired 3d window", result.finalizedVector(0))
+    assertEquals("the same slot remains eligible for the 7d window", 5L, result.finalizedVector(1))
+    assertEquals(materializedAsOfTs, processor.store.getLastLargeRecomputeAsOfTs)
+  }
+
+  it should "keep a deferred future batch inactive until its day" in {
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+    val aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(7, TimeUnit.DAYS))))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, new InMemoryGigaTileStore(megaTileAgg.windowedAggregator))
+    val futureBatchEnd = 2 * DayMillis
+    val oldBatch = denormalizeBatchIr(
+      buildBatchIr(Array(row(-60 * 60 * 1000L, 5L, 1.0)), 0L, aggregations, schema),
+      aggregations,
+      schema,
+      0L)
+    val futureBatch = denormalizeBatchIr(
+      buildBatchIr(Array(row(futureBatchEnd - 60 * 60 * 1000L, 50L, 1.0)),
+                   futureBatchEnd,
+                   aggregations,
+                   schema),
+      aggregations,
+      schema,
+      futureBatchEnd)
+
+    processor.onBatchUpdate(oldBatch, 0L, 0L)
+    val deferred = processor.onBatchUpdate(futureBatch,
+                                           futureBatchEnd,
+                                           largeWindowAsOfTs = DayMillis,
+                                           smallWindowAsOfTs = DayMillis)
+    assertNull(deferred.finalizedVector)
+
+    val beforeActivation = processor.onEvent(row(DayMillis + 60 * 60 * 1000L, 7L, 1.0),
+                                             DayMillis + 60 * 60 * 1000L)
+    assertEquals("the event path must retain the prior large view", 12L, beforeActivation.finalizedVector(0))
+    assertNull(processor.onEviction(DayMillis + 2 * 60 * 60 * 1000L).finalizedVector)
+    processor.advanceWatermark(DayMillis + 2 * 60 * 60 * 1000L)
+    assertEquals(12L, processor.currentSnapshot.finalizedVector(0))
+
+    processor.advanceWatermark(futureBatchEnd + 60 * 60 * 1000L)
+    assertEquals("the deferred batch becomes active only once its day is current",
+                 50L,
+                 processor.currentSnapshot.finalizedVector(0))
+  }
+
+  it should "keep eviction live for an empty view with a deferred future batch" in {
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+    val aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(7, TimeUnit.DAYS))))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, new InMemoryGigaTileStore(megaTileAgg.windowedAggregator))
+    val currentBatchEnd = 10 * DayMillis
+    val futureBatchEnd = currentBatchEnd + DayMillis
+    val emptyBatch = denormalizeBatchIr(buildBatchIr(Array.empty[TestRow], currentBatchEnd, aggregations, schema),
+                                        aggregations,
+                                        schema,
+                                        currentBatchEnd)
+    val futureBatch = denormalizeBatchIr(
+      buildBatchIr(Array(row(futureBatchEnd - 60 * 60 * 1000L, 50L, 1.0)),
+                   futureBatchEnd,
+                   aggregations,
+                   schema),
+      aggregations,
+      schema,
+      futureBatchEnd)
+
+    processor.onBatchUpdate(emptyBatch,
+                            currentBatchEnd,
+                            largeWindowAsOfTs = currentBatchEnd,
+                            smallWindowAsOfTs = currentBatchEnd)
+    processor.onBatchUpdate(futureBatch,
+                            futureBatchEnd,
+                            largeWindowAsOfTs = currentBatchEnd + 60 * 60 * 1000L,
+                            smallWindowAsOfTs = currentBatchEnd + 60 * 60 * 1000L)
+
+    val waiting = processor.onEviction(currentBatchEnd + 2 * 60 * 60 * 1000L)
+    assertNull(waiting.finalizedVector)
+    assertTrue("the empty key must retain a timer until its future batch activates", waiting.needsEvictionTimer)
+    assertTrue(waiting.isEmpty)
+
+    val activated = processor.advanceWatermark(futureBatchEnd + 60 * 60 * 1000L)
+    assertEquals(50L, activated.finalizedVector(0))
+  }
+
+  it should "not rewind the cached small-window horizon for an older event" in {
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+    val aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(1, TimeUnit.HOURS))))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val store = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, store)
+    val hopMillis = 5 * 60 * 1000L
+    val expiredEventTs = 0L
+    val liveAsOfTs = 13 * hopMillis + 1L
+
+    processor.onEvent(row(expiredEventTs, 5L, 1.0), expiredEventTs + 1L)
+    val eviction = processor.onEviction(liveAsOfTs)
+    assertNull("the original tile must be expired at the live horizon", eviction.finalizedVector(0))
+
+    val result = processor.onEvent(row(expiredEventTs, 7L, 1.0), expiredEventTs)
+    assertNull("an older event must not resurrect the expired tile", result.finalizedVector(0))
+    assertEquals("the cache marker must not move backwards", 13 * hopMillis, store.getCachedSmallWindowAsOfTs)
+  }
+
+  it should "surface a cache-only correction from an adjacent day rollover" in {
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+    val aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(1, TimeUnit.HOURS))))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, new InMemoryGigaTileStore(megaTileAgg.windowedAggregator))
+    val eventTs = DayMillis - 90 * 60 * 1000L
+
+    processor.onEvent(row(eventTs, 5L, 1.0), eventTs + 1L)
+    val rollover = processor.advanceWatermark(DayMillis + 60 * 1000L)
+
+    assertNotNull("the rollover correction must be publishable", rollover.finalizedVector)
+    assertNull("the event must expire from the 1h window", rollover.finalizedVector(0))
+    assertTrue("the corrected vector must be marked empty", rollover.isEmpty)
+  }
+
+  it should "publish a stale-cache correction when a delayed event is fully dropped" in {
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+    val aggregations =
+      Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(1, TimeUnit.HOURS), new Window(7, TimeUnit.DAYS))))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, new InMemoryGigaTileStore(megaTileAgg.windowedAggregator))
+    val hopMillis = 5 * 60 * 1000L
+    val baseDay = 40 * DayMillis
+    val oldLargeWindowEventTs = baseDay - 8 * DayMillis + 60 * 60 * 1000L
+    val expiredTileEventTs = baseDay + 10 * hopMillis
+    val delayedProcessingTs = expiredTileEventTs + 13 * hopMillis + 9 * 1000L
+    val droppedEventTs = baseDay - 33 * DayMillis
+    val emptyBatchIr =
+      denormalizeBatchIr(buildBatchIr(Array.empty[TestRow], 0L, aggregations, schema), aggregations, schema, 0L)
+
+    // Keep a 7d value live while the 1h tile expires, then trigger the stale-cache rebuild
+    // with an event so old that it is dropped. The rebuild still changed the PUSH value.
+    processor.onBatchUpdate(emptyBatchIr, 0L, 0L)
+    processor.advanceWatermark(baseDay)
+    processor.onEvent(row(oldLargeWindowEventTs, 5L, 1.0), oldLargeWindowEventTs)
+    processor.onEvent(row(expiredTileEventTs, 11L, 1.0), expiredTileEventTs + 1L)
+
+    val result = processor.onEvent(row(droppedEventTs, 7L, 1.0), droppedEventTs, delayedProcessingTs)
+    assertTrue("event outside the retained daily range must be reported as dropped", result.droppedStaleEvent)
+    assertNotNull("stale-cache correction must publish even when the triggering event is dropped",
+                  result.finalizedVector)
+    assertNull("expired left-edge tile must not survive a fully dropped delayed event", result.finalizedVector(0))
+    assertEquals("the correction must also expire the stale large-window tail", 11L, result.finalizedVector(1))
+  }
+
+  it should "retain an exact-hop event when a delayed scheduled eviction rebuilds the cache" in {
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+    val aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(1, TimeUnit.HOURS))))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, new InMemoryGigaTileStore(megaTileAgg.windowedAggregator))
+    val hopMillis = 5 * 60 * 1000L
+    val exactHopTs = 20 * hopMillis
+    val expiredBufferTileTs = exactHopTs - 13 * hopMillis
+
+    processor.onEvent(row(expiredBufferTileTs, 3L, 1.0), expiredBufferTileTs + 1L)
+    processor.onEvent(row(exactHopTs - 1L, 0L, 1.0), exactHopTs - 1L, exactHopTs + 1L)
+    processor.onEvent(row(exactHopTs, 5L, 1.0), exactHopTs, exactHopTs + 1L)
+
+    val result = processor.onEviction(EvictionTimes(timerTs = exactHopTs, smallWindowAsOfTs = exactHopTs + 1L))
+    assertNotNull("the scheduled boundary rebuild should emit", result.finalizedVector)
+    assertEquals("the just-opened exact-hop tile must remain visible", 5L, result.finalizedVector(0))
+  }
+
+  it should "rebuild mixed small and large state across a day rollover" in {
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+    val aggregations =
+      Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(1, TimeUnit.HOURS), new Window(7, TimeUnit.DAYS))))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, new InMemoryGigaTileStore(megaTileAgg.windowedAggregator))
+    val rolloverDay = 10 * DayMillis
+    val beforeRollover = rolloverDay - 60 * 1000L
+    val afterRollover = rolloverDay + 60 * 1000L
+    val oldLargeEventTs = rolloverDay - 8 * DayMillis + 60 * 60 * 1000L
+    val recentEventTs = rolloverDay - 30 * 60 * 1000L
+    val emptyBatchIr =
+      denormalizeBatchIr(buildBatchIr(Array.empty[TestRow], 0L, aggregations, schema), aggregations, schema, 0L)
+
+    processor.onBatchUpdate(emptyBatchIr, 0L, 0L)
+    processor.advanceWatermark(beforeRollover)
+    processor.onEvent(row(oldLargeEventTs, 5L, 1.0), oldLargeEventTs, beforeRollover)
+    processor.onEvent(row(recentEventTs, 7L, 1.0), recentEventTs, beforeRollover)
+
+    val rollover = processor.advanceWatermark(afterRollover)
+    assertNotNull("the mixed-window correction must be publishable", rollover.finalizedVector)
+    assertEquals("the recent value remains in the 1h window", 7L, rollover.finalizedVector(0))
+    assertEquals("the expired daily slot must leave the 7d window", 7L, rollover.finalizedVector(1))
+  }
+
+  it should "keep the large-window horizon separate from the small-window boundary" in {
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+    val aggregations =
+      Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(1, TimeUnit.HOURS), new Window(7, TimeUnit.DAYS))))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, new InMemoryGigaTileStore(megaTileAgg.windowedAggregator))
+    val baseDay = 40 * DayMillis
+    val largeWindowAsOfTs = baseDay + 7 * DayMillis
+    val smallWindowAsOfTs = largeWindowAsOfTs + DayMillis
+    val oldLargeEventTs = baseDay + 60 * 60 * 1000L
+    val recentEventTs = largeWindowAsOfTs - 30 * 60 * 1000L
+    val droppedEventTs = largeWindowAsOfTs - 33 * DayMillis
+    val emptyBatchIr =
+      denormalizeBatchIr(buildBatchIr(Array.empty[TestRow], 0L, aggregations, schema), aggregations, schema, 0L)
+
+    processor.onBatchUpdate(emptyBatchIr, 0L, 0L)
+    processor.advanceWatermark(largeWindowAsOfTs)
+    processor.onEvent(row(oldLargeEventTs, 5L, 1.0), oldLargeEventTs, largeWindowAsOfTs)
+    processor.onEvent(row(recentEventTs, 11L, 1.0), recentEventTs, largeWindowAsOfTs)
+
+    val result = processor.onEvent(row(droppedEventTs, 7L, 1.0),
+                                   droppedEventTs,
+                                   largeWindowAsOfTs = largeWindowAsOfTs,
+                                   smallWindowAsOfTs = smallWindowAsOfTs)
+    assertTrue("the trigger must be outside retained history", result.droppedStaleEvent)
+    assertNull("the small horizon should expire both streaming tiles", result.finalizedVector(0))
+    assertEquals("the large horizon must retain both 7d contributions", 16L, result.finalizedVector(1))
+  }
+
+  it should "rebuild stale small state when a batch row is the next callback" in {
+    val schema: Seq[(String, DataType)] = Seq(("ts", LongType), ("num", LongType), ("amount", DoubleType))
+    val aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(1, TimeUnit.HOURS))))
+    val megaTileAgg = new MegaTileAggregator(aggregations, schema, tailBufferMillis = TailBufferMillis)
+    val processor = new GigaTileStreamProcessor(megaTileAgg, new InMemoryGigaTileStore(megaTileAgg.windowedAggregator))
+    val eventTs = 4 * DayMillis + 60 * 60 * 1000L
+    val batchCallbackTs = eventTs + 2 * 60 * 60 * 1000L
+    val emptyBatchIr =
+      denormalizeBatchIr(buildBatchIr(Array.empty[TestRow], 0L, aggregations, schema), aggregations, schema, 0L)
+
+    processor.onEvent(row(eventTs, 5L, 1.0), eventTs, eventTs + 1L)
+    val result = processor.onBatchUpdate(emptyBatchIr,
+                                         newBatchEnd = 0L,
+                                         largeWindowAsOfTs = batchCallbackTs,
+                                         smallWindowAsOfTs = batchCallbackTs)
+
+    assertNotNull("the batch callback must surface the stale-cache correction", result.finalizedVector)
+    assertNull("the expired 1h value must not remain published", result.finalizedVector(0))
+    assertTrue("the correction is an encoded all-null value", result.isEmpty)
   }
 }

--- a/docs/source/gigatile.md
+++ b/docs/source/gigatile.md
@@ -421,12 +421,14 @@ Mar 26 06:00  events continue        runningLargeIr updated incrementally.
 
 ### Emit strategy
 
-No suppress logic inside Flink. Flink always emits when it has something to emit.
-The serving layer doesn't route traffic until the orchestrator signals "ready."
+Flink continues rebuilding state during replay, but PUSH writes are fenced until the connected
+watermark is near wall clock. A batch source that is still active can hold that watermark at
+`MIN`; source idleness lets it advance but does not prove the initial scan completed. An optional
+write cadence can further coalesce hot-key updates after the fence opens.
 
 **Emit triggers:**
-- **Event arrival**: emit on every event (existing mega tile behavior).
-- **Eviction timer**: emit on periodic eviction (existing).
+- **Event arrival**: update state and publish only when the replay fence is open.
+- **Eviction timer**: rebuild expired state and publish a changed or deferred snapshot.
 - **Batch IR update**: emit if `runningLargeIr` changed. Single rule covers
   null→value (first batch load), batch correction, tail shift, no-change skip.
 
@@ -441,47 +443,33 @@ def onBatchUpdate(newBatchIr, newBatchEnd):
     emit(finalize(pack(cachedSmallWindowIr, runningLargeIr)))
 ```
 
-### Readiness signal
+### Readiness
 
-The Flink job exposes a readiness condition: **initial Iceberg scan complete AND watermark
-caught up** (within configurable `maxLag` of wall clock). The orchestrator checks this
-before routing model traffic to the giga tile KV dataset.
-
-```
-isReady = icebergInitialScanComplete
-          AND currentWatermark >= System.currentTimeMillis() - maxLag
-```
-
-This is a metric/health endpoint — not part of the emit logic. Flink doesn't gate emits
-on readiness. It writes to KV freely. The orchestrator decides when to trust the output.
+The implementation has no positive initial-Iceberg-scan-complete signal. A near-live connected
+watermark proves Kafka catch-up, not batch coverage. Rollout tooling must validate batch input and
+serving output separately before routing traffic.
 
 ### Kafka replay on cold start
 
-On cold start (no checkpoint), Flink replays Kafka from `batchEndTs` to reconstruct
-streaming state. During replay, Flink emits progressively-building vectors. This is fine
-because the orchestrator hasn't signaled "ready" yet — no traffic is routed.
+On cold start (no checkpoint), Flink rebuilds batch and streaming state from the configured
+sources. Serving writes remain fenced until the connected watermark reaches `Live`.
 
 ```
 Cold start / first startup:
 1. Flink starts with no state
 2. Iceberg source scans upload table (latest ds partition)
-   → all entities get batch IR via onBatchUpdate
-   → null→value trigger: each entity emits batch-only vector
-3. Kafka consumer starts from batchEndTs offset
-   → replays events from [batchEnd, now)
-   → each event emits updated vector (progressively improving)
-4. Watermark catches up + Iceberg scan done → isReady = true
-5. Orchestrator routes traffic → fetcher reads correct vectors
+   → rows populate batch state as they arrive
+3. Kafka replay rebuilds retained streaming state
+4. Connected watermark reaches `Live`
+   → the latest deferred snapshot can publish (subject to optional cadence)
+5. Rollout tooling validates batch coverage and serving output before routing traffic
 ```
-
-During replay (steps 2-3), the KV store has intermediate vectors. Nobody reads them
-because readiness hasn't been signaled.
 
 ### Kafka retention requirement
 
-Kafka topic retention must be ≥ max batch staleness (typically 2 days). This ensures
-events from `[batchEnd, now)` are available for replay. For GroupBys with only small
-windows (≤ 2d), retention must cover the max window size.
+Kafka retention must cover the actual gap from `batchEnd` through replay plus the required
+correctness horizon. For GroupBys with only small windows, it must also cover the maximum
+window size.
 
 ### Key completeness
 
@@ -489,91 +477,38 @@ windows (≤ 2d), retention must cover the max window size.
 
 Yes, for all temporal entities:
 - **Inactive entities** (in batch table, no recent streaming events): Iceberg source
-  emits their batch IR → null→value trigger → batch-only vector emitted to KV.
-- **Active entities**: batch-only vector first (Iceberg), then corrected with streaming
-  during Kafka replay.
-- **New entities (in Kafka, not in batch)**: first event creates Flink state. `batchIr`
-  is null → streaming-only vector emitted. Correct for entities with no history.
-  Next batch run picks them up via onBatchUpdate (null→value trigger).
+  loads their batch IR; the batch-only vector can publish after the live fence opens.
+- **Active entities**: Iceberg and Kafka replay rebuild one deferred snapshot, which can
+  publish after the live fence opens.
+- **New entities (in Kafka, not in batch)**: first event creates Flink state. Columns that
+  require batch history remain unset until a batch row arrives, unless the batch-absent
+  fallback below is explicitly enabled.
+
+`gigatile_first_seen_key_grace_millis` enables the batch-absent fallback when set to a
+positive value; it is disabled by default. The operator-local grace starts on the first keyed
+callback after open or restore. Its deadline is a lower bound: the fallback installs on the next
+eligible keyed callback, which may be the next 5m, 1h, or 1d eviction for a sparse key. A missing
+row may then be treated as empty history, while a later real batch row remains authoritative.
+The grace is an operational assertion, not proof that the initial Iceberg scan completed.
+Enabling it therefore requires a configured Iceberg source and fails the job on source
+construction or entity-row decode/update errors; the serving-info metadata row is ignored.
+
+To roll back this option, fence serving first, disable it on the current binary, and keep serving
+fenced until null corrections are verified in KV and a later checkpoint completes. Only then
+roll back the binary or unfence. Correction waits for a live watermark and the affected key's
+next eviction callback (5m, 1h, or 1d), so binary rollback alone is not an immediate retraction.
 
 **Note:** Giga tile only applies to `Accuracy.TEMPORAL` GroupBys (with a streaming topic).
 `SNAPSHOT` GroupBys bypass Flink — they use the traditional `bulkPut` from Spark to KV.
 
-### Startup timeline
+## Entity behavior
 
-```
-Time          KV state                              isReady
-──────────    ──────────────────────────────────     ───────
-T+0           Empty                                  false
-T+1 min       Batch-only vectors appearing           false
-              (Iceberg scan in progress)
-T+5 min       All batch entities in KV               false
-              (Iceberg scan complete)
-              Streaming entities: partial
-              (Kafka replay in progress)
-T+10 min      All entities fully correct             true
-              (watermark caught up)
-              Orchestrator routes traffic
-```
+- **Active:** combine batch state with replayed and live events; publish after the live fence opens.
+- **Batch-only:** load and publish batch state after the fence opens; no per-key event is required.
+- **New:** retain streaming state, but leave batch-backed values unset until a real batch row arrives
+  or the explicit grace installs an empty baseline.
 
-### State transitions
-
-```
-┌──────────────────────────────────────────────┐
-│   First startup / cold restart                │
-│                                              │
-│   1. Iceberg scan: batch IRs → KV           │
-│   2. Kafka replay: streaming → KV           │
-│   3. Both complete → isReady = true          │
-│   4. Orchestrator routes traffic             │
-└──────────────────────────────────────────────┘
-
-┌──────────────────────────────────────────────┐
-│   Checkpoint restore (normal)                 │
-│                                              │
-│   1. Restore state from checkpoint           │
-│   2. Resume Kafka from checkpointed offsets  │
-│   3. Iceberg re-scan for batch updates       │
-│   4. isReady = true immediately              │
-└──────────────────────────────────────────────┘
-```
-
-## Entity Scenario Matrix
-
-Each entity falls into one of these categories. The matrix traces through startup, steady state,
-and edge cases for each, showing which code paths fire and what gets emitted.
-
-### Entity types
-
-| Type | Description | Has batch IR? | Has Kafka events? |
-|------|-------------|---------------|-------------------|
-| **A: Active** | In batch table AND streaming topic | Yes | Yes |
-| **B: Inactive** | In batch table, no recent events | Yes | No |
-| **C: New** | Not in batch yet, has streaming events | No | Yes |
-
-### Startup (first deploy or cold restart)
-
-| Entity | Iceberg scan | Kafka replay | First emit | Fully correct at |
-|--------|-------------|-------------|------------|------------------|
-| **A** | batch IR loaded → `currentDayStart` init'd from `batchEnd` → `runningLargeIr` computed → emit batch-only vector | Events replay from `batchEnd` → `onEvent` merges into `runningLargeIr` → emit on each event | On batch IR load (Iceberg) | Watermark caught up (~minutes) |
-| **B** | batch IR loaded → same as A → emit batch-only vector | No events → no Kafka processing | On batch IR load (Iceberg) | Immediately (batch is the full answer) |
-| **C** | No row in Iceberg → no `onBatchUpdate` | Events arrive → `batchIr = null` → `onEvent` emits streaming-only vector | On first Kafka event | Next batch run picks it up |
-
-### Steady state (job running, daily batch refresh)
-
-| Entity | On event | On eviction | On batch refresh |
-|--------|----------|-------------|------------------|
-| **A** | Update tiles + `cachedSmallWindowIr` + `largeTodayIr` + `runningLargeIr` → emit | Rebuild small windows from tiles. Recompute `runningLargeIr` from batch hops + streaming → emit | Store new `batchIr`. Recompute `runningLargeIr`. Emit on mismatch. |
-| **B** | No events → nothing | Timer fires (registered by `onBatchUpdate`). Recompute `runningLargeIr` from batch hops → emit if tail shifted. | Store new `batchIr`. Recompute. Emit on mismatch. |
-| **C** | Same as A but `batchIr = null` → `runningLargeIr` = streaming only → emit | Rebuild small windows. `batchIr = null` → `runningLargeIr` = streaming only → emit | **Transition to type A:** `batchIr` goes null→value. Recompute includes batch. Mismatch → emit. |
-
-### Day transition (advanceWatermark crosses midnight)
-
-| Entity | What happens |
-|--------|-------------|
-| **A** | `largeYesterdayIr = largeTodayIr`, `largeTodayIr = init`, `currentDayStart` advances. `runningLargeIr` NOT reset (cumulative). Eviction corrects tail within one interval. |
-| **B** | `advanceWatermark` fires from global watermark advancement. Same rotation. No events → `largeTodayIr` stays init. Eviction timer recomputes `runningLargeIr` with shifted tail hops. |
-| **C** | Same as A but no batch component. Rotation is streaming-only. |
+Daily state remains keyed by day and is pruned once covered by batch or outside every finite window.
 
 ### Batch refresh (onBatchUpdate) edge cases
 
@@ -581,16 +516,16 @@ and edge cases for each, showing which code paths fire and what gets emitted.
 |----------|-------|----------|
 | `newBatchEnd <= oldBatchEnd` | Early return | Skip (same or older batch) |
 | `currentDayStart < 0` (uninitialized, no events) | Init `currentDayStart = newBatchEnd` | Safe: no events → no overlap. Recompute and emit. |
-| `newBatchEnd > currentDayStart` (watermark lag) | Defer (return) | Store `batchIr` but don't recompute. Next eviction handles it after watermark advances. |
-| `newBatchEnd >= currentDayStart` (normal) | Clear `largeYesterdayIr` | Batch covers through yesterday. Recompute without yesterday. |
-| `newBatchEnd < currentDayStart` (stale batch catch-up) | Keep `largeYesterdayIr` | Batch doesn't cover yesterday. Include yesterday in recomputation. |
+| `newBatchEnd > currentDayStart` (batch ahead of the materialized horizon) | Defer (return) | Store `batchIr` but don't recompute. The next callback retries after the selected horizon advances. |
+| `newBatchEnd <= currentDayStart` (normal) | Prune slots with `dayStart < batchEndDay` | Recompute from the new batch plus uncovered daily slots. |
+| Stale batch catch-up | Retain slots at or after `batchEndDay` | Uncovered streaming days remain in the recomputed running view. |
 
 ### Eviction edge cases
 
 | Scenario | Behavior |
 |----------|----------|
-| `batchIr = null` (new entity, type C) | `runningLargeIr = init + streaming`. No NPE. |
-| `batchIr != null` (types A, B) | `runningLargeIr = clone(collapsed) + mergeTailHops + streaming` |
+| `batchIr = null` (new entity, type C) | Retain streaming state, but keep batch-backed output unset unless the explicit grace is active. |
+| `batchIr != null` (types A, B) | Rebuild `runningLargeIr` from batch collapsed/tail hops plus retained daily slots. |
 | `earliestTileStart = MaxValue` (no tiles, large-windows-only) | Skip tile eviction. Still recompute `runningLargeIr` from batch hops. |
 | Batch-only entity (type B), no `hasSmallWindows` | Timer registered unconditionally by `onBatchUpdate`. Eviction fires at `minEvictionInterval`. |
 

--- a/flink/src/main/scala/ai/chronon/flink/FlinkGroupByStreamingJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkGroupByStreamingJob.scala
@@ -56,6 +56,8 @@ class FlinkGroupByStreamingJob(eventSrc: FlinkSource[ProjectedEvent],
       .getProperty("buffering_output_policy", props, topicInfo)
       .map(MegaTileEmissionPolicy.fromString)
       .getOrElse(MegaTileEmissionPolicy.Default)
+  private val gigaTileBufferingOutputTimeMillis =
+    FlinkUtils.gigaTileBufferingOutputTimeMillis(bufferingOutputTimeMillis, bufferingOutputPolicy)
 
   // The source of our Flink application is a  topic
   val topic: String = groupByServingInfoParsed.groupBy.streamingSource.get.topic
@@ -152,7 +154,14 @@ class FlinkGroupByStreamingJob(eventSrc: FlinkSource[ProjectedEvent],
     logger.info(f"Running Giga Tiled (push) Flink job for groupByName=${groupByName}, Topic=${topic}.")
     val preparedStream = buildSourceStream(env)
     val batchIrStream = BatchIrSourceBuilder.build(env, groupByServingInfoParsed, props)
-    buildGigaTiledTail(preparedStream, batchIrStream, inputSchema, parallelism, sinkFn, kvStoreCapacity, enableDebug)
+    buildGigaTiledTail(preparedStream,
+                       batchIrStream,
+                       inputSchema,
+                       parallelism,
+                       sinkFn,
+                       kvStoreCapacity,
+                       enableDebug,
+                       gigaTileBufferingOutputTimeMillis)
   }
 
   private def buildSourceStream(env: StreamExecutionEnvironment): DataStream[ProjectedEvent] = {

--- a/flink/src/main/scala/ai/chronon/flink/FlinkGroupByStreamingJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkGroupByStreamingJob.scala
@@ -7,7 +7,7 @@ import ai.chronon.flink.deser.ProjectedEvent
 import ai.chronon.flink.source.FlinkSource
 import ai.chronon.flink.source.BatchIrSourceBuilder
 import ai.chronon.flink.types.{AvroCodecOutput, WriteResponse}
-import ai.chronon.flink.window.MegaTileEmissionPolicy
+import ai.chronon.flink.window.{GigaTileProcessFunction, MegaTileEmissionPolicy}
 import ai.chronon.online.{GroupByServingInfoParsed, TopicInfo}
 import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
@@ -51,6 +51,8 @@ class FlinkGroupByStreamingJob(eventSrc: FlinkSource[ProjectedEvent],
     FlinkUtils.getNonNegativeLongProperty("buffering_output_time_millis", props, topicInfo)
   private val bufferingOutputJitterMillis =
     FlinkUtils.getNonNegativeLongProperty("buffering_output_jitter_millis", props, topicInfo)
+  private val firstSeenKeyGraceMillis =
+    FlinkUtils.getNonNegativeLongProperty(GigaTileProcessFunction.FirstSeenKeyGraceMillisConfig, props, topicInfo)
   private val bufferingOutputPolicy =
     FlinkUtils
       .getProperty("buffering_output_policy", props, topicInfo)
@@ -153,7 +155,10 @@ class FlinkGroupByStreamingJob(eventSrc: FlinkSource[ProjectedEvent],
   override def runGigaTiledGroupByJob(env: StreamExecutionEnvironment): DataStream[WriteResponse] = {
     logger.info(f"Running Giga Tiled (push) Flink job for groupByName=${groupByName}, Topic=${topic}.")
     val preparedStream = buildSourceStream(env)
-    val batchIrStream = BatchIrSourceBuilder.build(env, groupByServingInfoParsed, props)
+    val batchIrStream = BatchIrSourceBuilder.build(env,
+                                                   groupByServingInfoParsed,
+                                                   props,
+                                                   requireConfiguredBatchSource = firstSeenKeyGraceMillis > 0L)
     buildGigaTiledTail(preparedStream,
                        batchIrStream,
                        inputSchema,
@@ -161,7 +166,8 @@ class FlinkGroupByStreamingJob(eventSrc: FlinkSource[ProjectedEvent],
                        sinkFn,
                        kvStoreCapacity,
                        enableDebug,
-                       gigaTileBufferingOutputTimeMillis)
+                       gigaTileBufferingOutputTimeMillis,
+                       firstSeenKeyGraceMillis)
   }
 
   private def buildSourceStream(env: StreamExecutionEnvironment): DataStream[ProjectedEvent] = {

--- a/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
@@ -275,6 +275,12 @@ object FlinkJob {
 
   val CatchupWatermarkLagSlackMillis: Long = 30 * 1000L
 
+  // The event-source watermark intentionally trails the newest observed event by
+  // AllowedOutOfOrderness. Publication is safe once only that expected lag plus a small
+  // operational slack remains; aggregation hop sizes do not describe source readiness.
+  val LiveWatermarkLagToleranceMillis: Long =
+    AllowedOutOfOrderness.toMillis + CatchupWatermarkLagSlackMillis
+
   // Set an idleness timeout to keep time moving in case of very low traffic event streams as well as late events during
   // large backlog catchups
   val IdlenessTimeout: Duration = Duration.ofSeconds(30)

--- a/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
@@ -196,7 +196,8 @@ abstract class BaseFlinkJob {
       sinkFn: RichAsyncFunction[AvroCodecOutput, WriteResponse],
       kvStoreCapacity: Int,
       enableDebug: Boolean,
-      bufferingOutputTimeMillis: Long
+      bufferingOutputTimeMillis: Long,
+      firstSeenKeyGraceMillis: Long
   ): DataStream[WriteResponse] = {
     val eventKeySelector = KeySelectorBuilder.build(groupByServingInfoParsed.groupBy)
     val batchKeySelector = new org.apache.flink.api.java.functions.KeySelector[BatchIrRow, java.util.List[Any]] {
@@ -206,11 +207,13 @@ abstract class BaseFlinkJob {
     val gigaTileDS = preparedStream
       .connect(batchIrStream)
       .keyBy(eventKeySelector, batchKeySelector)
-      .process(
-        new GigaTileProcessFunction(groupByServingInfoParsed.groupBy,
-                                    schema,
-                                    enableDebug = enableDebug,
-                                    bufferingOutputTimeMillis = bufferingOutputTimeMillis))
+      .process(new GigaTileProcessFunction(
+        groupByServingInfoParsed.groupBy,
+        schema,
+        enableDebug = enableDebug,
+        bufferingOutputTimeMillis = bufferingOutputTimeMillis,
+        firstSeenKeyGraceMillis = firstSeenKeyGraceMillis
+      ))
       .uid(s"giga-tiling-$groupByName")
       .name(s"Giga Tiling for $groupByName")
       .setParallelism(parallelism)

--- a/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
@@ -195,7 +195,8 @@ abstract class BaseFlinkJob {
       parallelism: Int,
       sinkFn: RichAsyncFunction[AvroCodecOutput, WriteResponse],
       kvStoreCapacity: Int,
-      enableDebug: Boolean
+      enableDebug: Boolean,
+      bufferingOutputTimeMillis: Long
   ): DataStream[WriteResponse] = {
     val eventKeySelector = KeySelectorBuilder.build(groupByServingInfoParsed.groupBy)
     val batchKeySelector = new org.apache.flink.api.java.functions.KeySelector[BatchIrRow, java.util.List[Any]] {
@@ -205,7 +206,11 @@ abstract class BaseFlinkJob {
     val gigaTileDS = preparedStream
       .connect(batchIrStream)
       .keyBy(eventKeySelector, batchKeySelector)
-      .process(new GigaTileProcessFunction(groupByServingInfoParsed.groupBy, schema, enableDebug))
+      .process(
+        new GigaTileProcessFunction(groupByServingInfoParsed.groupBy,
+                                    schema,
+                                    enableDebug = enableDebug,
+                                    bufferingOutputTimeMillis = bufferingOutputTimeMillis))
       .uid(s"giga-tiling-$groupByName")
       .name(s"Giga Tiling for $groupByName")
       .setParallelism(parallelism)

--- a/flink/src/main/scala/ai/chronon/flink/FlinkUtils.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkUtils.scala
@@ -1,5 +1,6 @@
 package ai.chronon.flink
 
+import ai.chronon.flink.window.MegaTileEmissionPolicy
 import ai.chronon.online.TopicInfo
 
 import scala.concurrent.ExecutionContext
@@ -63,6 +64,12 @@ object FlinkUtils {
       }
       .getOrElse(0L)
   }
+
+  def gigaTileBufferingOutputTimeMillis(
+      configuredMillis: Long,
+      emissionPolicy: MegaTileEmissionPolicy
+  ): Long =
+    if (emissionPolicy == MegaTileEmissionPolicy.WallClockCadence) configuredMillis else 0L
 }
 
 /** This was moved to flink-rpc-akka in Flink 1.16 and made private, so we reproduce the direct execution context here

--- a/flink/src/main/scala/ai/chronon/flink/chaining/ChainedGroupByJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/chaining/ChainedGroupByJob.scala
@@ -76,6 +76,8 @@ class ChainedGroupByJob(eventSrc: FlinkSource[ProjectedEvent],
       .getProperty("buffering_output_policy", props, topicInfo)
       .map(MegaTileEmissionPolicy.fromString)
       .getOrElse(MegaTileEmissionPolicy.Default)
+  private val gigaTileBufferingOutputTimeMillis =
+    FlinkUtils.gigaTileBufferingOutputTimeMillis(bufferingOutputTimeMillis, bufferingOutputPolicy)
 
   /** Build the tiled version of the Flink GroupBy job that chains features using a JoinSource.
     *  The operators are structured as follows:
@@ -116,7 +118,14 @@ class ChainedGroupByJob(eventSrc: FlinkSource[ProjectedEvent],
         s"${joinSource.getJoin.getMetaData.getName} using topic: $topic")
     val (processedStream, schema) = buildEnrichedStream(env)
     val batchIrStream = BatchIrSourceBuilder.build(env, groupByServingInfoParsed, props)
-    buildGigaTiledTail(processedStream, batchIrStream, schema, parallelism, sinkFn, kvStoreCapacity, enableDebug)
+    buildGigaTiledTail(processedStream,
+                       batchIrStream,
+                       schema,
+                       parallelism,
+                       sinkFn,
+                       kvStoreCapacity,
+                       enableDebug,
+                       gigaTileBufferingOutputTimeMillis)
   }
 
   /** Build the source → watermark → enrichment → query transform pipeline.

--- a/flink/src/main/scala/ai/chronon/flink/chaining/ChainedGroupByJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/chaining/ChainedGroupByJob.scala
@@ -8,7 +8,7 @@ import ai.chronon.flink.FlinkJob.watermarkStrategy
 import ai.chronon.flink.deser.ProjectedEvent
 import ai.chronon.flink.source.{BatchIrSourceBuilder, FlinkSource}
 import ai.chronon.flink.types.{AvroCodecOutput, WriteResponse}
-import ai.chronon.flink.window.MegaTileEmissionPolicy
+import ai.chronon.flink.window.{GigaTileProcessFunction, MegaTileEmissionPolicy}
 import ai.chronon.online.{Api, GroupByServingInfoParsed, TopicInfo}
 
 import java.util.concurrent.TimeUnit
@@ -71,6 +71,8 @@ class ChainedGroupByJob(eventSrc: FlinkSource[ProjectedEvent],
     FlinkUtils.getNonNegativeLongProperty("buffering_output_time_millis", props, topicInfo)
   private val bufferingOutputJitterMillis =
     FlinkUtils.getNonNegativeLongProperty("buffering_output_jitter_millis", props, topicInfo)
+  private val firstSeenKeyGraceMillis =
+    FlinkUtils.getNonNegativeLongProperty(GigaTileProcessFunction.FirstSeenKeyGraceMillisConfig, props, topicInfo)
   private val bufferingOutputPolicy =
     FlinkUtils
       .getProperty("buffering_output_policy", props, topicInfo)
@@ -117,7 +119,10 @@ class ChainedGroupByJob(eventSrc: FlinkSource[ProjectedEvent],
       s"Building giga tiled (push) Flink streaming job for groupBy: $groupByName that chains join: " +
         s"${joinSource.getJoin.getMetaData.getName} using topic: $topic")
     val (processedStream, schema) = buildEnrichedStream(env)
-    val batchIrStream = BatchIrSourceBuilder.build(env, groupByServingInfoParsed, props)
+    val batchIrStream = BatchIrSourceBuilder.build(env,
+                                                   groupByServingInfoParsed,
+                                                   props,
+                                                   requireConfiguredBatchSource = firstSeenKeyGraceMillis > 0L)
     buildGigaTiledTail(processedStream,
                        batchIrStream,
                        schema,
@@ -125,7 +130,8 @@ class ChainedGroupByJob(eventSrc: FlinkSource[ProjectedEvent],
                        sinkFn,
                        kvStoreCapacity,
                        enableDebug,
-                       gigaTileBufferingOutputTimeMillis)
+                       gigaTileBufferingOutputTimeMillis,
+                       firstSeenKeyGraceMillis)
   }
 
   /** Build the source → watermark → enrichment → query transform pipeline.

--- a/flink/src/main/scala/ai/chronon/flink/source/BatchIrSourceBuilder.scala
+++ b/flink/src/main/scala/ai/chronon/flink/source/BatchIrSourceBuilder.scala
@@ -1,6 +1,7 @@
 package ai.chronon.flink.source
 
 import ai.chronon.api.Extensions.{GroupByOps, MetadataOps}
+import ai.chronon.api.Constants
 import ai.chronon.flink.types.BatchIrRow
 import ai.chronon.online.GroupByServingInfoParsed
 import ai.chronon.online.serde.AvroConversions
@@ -12,6 +13,7 @@ import org.apache.flink.table.data.RowData
 import org.apache.flink.util.Collector
 import org.slf4j.LoggerFactory
 
+import java.text.{ParseException, ParsePosition}
 import java.time.Duration
 
 /** Builds a DataStream[BatchIrRow] from the GroupBy's upload Iceberg table.
@@ -24,7 +26,8 @@ import java.time.Duration
   *   - `iceberg.catalog.uri`: metastore URI (for hive catalog)
   *   - `iceberg.monitor.interval.minutes`: snapshot monitor interval (default: 30)
   *
-  * Falls back to an idle (empty) stream if Iceberg is not configured.
+  * Falls back to an idle (empty) stream if Iceberg is not configured unless the caller has
+  * explicitly enabled behavior that depends on distinguishing an absent batch row.
   */
 object BatchIrSourceBuilder {
 
@@ -32,31 +35,46 @@ object BatchIrSourceBuilder {
 
   def build(env: StreamExecutionEnvironment,
             servingInfo: GroupByServingInfoParsed,
-            props: Map[String, String]): DataStream[BatchIrRow] = {
+            props: Map[String, String],
+            requireConfiguredBatchSource: Boolean = false): DataStream[BatchIrRow] = {
 
     val warehouse = props.getOrElse("iceberg.catalog.warehouse", "")
-    val monitorIntervalMin = props.getOrElse("iceberg.monitor.interval.minutes", "30").toLong
+    val groupByName = servingInfo.groupByOps.metaData.getName
 
     if (warehouse.isEmpty) {
-      logger.warn(s"No iceberg.catalog.warehouse configured for ${servingInfo.groupByOps.metaData.getName}. " +
-        s"Returning idle batch IR stream (batch loading disabled).")
-      return buildIdleStream(env, servingInfo.groupByOps.metaData.getName)
+      val message = s"No iceberg.catalog.warehouse configured for $groupByName"
+      if (requireConfiguredBatchSource) {
+        throw new IllegalArgumentException(
+          s"$message; a configured batch source is required when gigatile_first_seen_key_grace_millis is enabled")
+      }
+      logger.warn(s"$message. Returning idle batch IR stream (batch loading disabled).")
+      return buildIdleStream(env, groupByName)
     }
 
     try {
-      buildIcebergStream(env, servingInfo, props, warehouse, monitorIntervalMin)
+      val monitorIntervalMin = props.getOrElse("iceberg.monitor.interval.minutes", "30").toLong
+      buildIcebergStream(env,
+                         servingInfo,
+                         props,
+                         warehouse,
+                         monitorIntervalMin,
+                         failOnDecodeError = requireConfiguredBatchSource)
     } catch {
       case e: Exception =>
-        logger.error(s"Failed to create Iceberg source. Falling back to idle stream.", e)
-        buildIdleStream(env, servingInfo.groupByOps.metaData.getName)
+        if (requireConfiguredBatchSource) {
+          throw new IllegalStateException(s"Failed to create required Iceberg source for $groupByName", e)
+        }
+        logger.error(s"Failed to create Iceberg source for $groupByName. Falling back to idle stream.", e)
+        buildIdleStream(env, groupByName)
     }
   }
 
   private def buildIcebergStream(env: StreamExecutionEnvironment,
-                                  servingInfo: GroupByServingInfoParsed,
-                                  props: Map[String, String],
-                                  warehouse: String,
-                                  monitorIntervalMin: Long): DataStream[BatchIrRow] = {
+                                 servingInfo: GroupByServingInfoParsed,
+                                 props: Map[String, String],
+                                 warehouse: String,
+                                 monitorIntervalMin: Long,
+                                 failOnDecodeError: Boolean): DataStream[BatchIrRow] = {
     import org.apache.iceberg.catalog.TableIdentifier
     import org.apache.iceberg.flink.{CatalogLoader, TableLoader}
     import org.apache.iceberg.flink.source.IcebergSource
@@ -68,8 +86,8 @@ object BatchIrSourceBuilder {
     catalogProps.put("warehouse", warehouse)
     props.get("iceberg.catalog.uri").foreach(catalogProps.put("uri", _))
 
-    val catalogLoader = CatalogLoader.hadoop("chronon_catalog",
-      new org.apache.hadoop.conf.Configuration(), catalogProps)
+    val catalogLoader =
+      CatalogLoader.hadoop("chronon_catalog", new org.apache.hadoop.conf.Configuration(), catalogProps)
     val tableId = TableIdentifier.parse(uploadTable)
     val tableLoader = TableLoader.fromCatalog(catalogLoader, tableId)
 
@@ -91,7 +109,7 @@ object BatchIrSourceBuilder {
       .setParallelism(1)
 
     rawStream
-      .flatMap(new BatchIrRowDecoder(servingInfo))
+      .flatMap(new BatchIrRowDecoder(servingInfo, failOnDecodeError))
       .uid(s"batch-ir-decode-$groupByName")
       .name(s"Decode batch IR for $groupByName")
       .setParallelism(1)
@@ -113,7 +131,7 @@ object BatchIrSourceBuilder {
   * batchEnd is derived from the ds partition column — NOT from the static servingInfo.batchEndTsMillis.
   * Each new partition (ds=2026-03-29) produces a fresh batchEnd, ensuring onBatchUpdate accepts it.
   */
-class BatchIrRowDecoder(servingInfo: GroupByServingInfoParsed)
+class BatchIrRowDecoder(servingInfo: GroupByServingInfoParsed, failOnDecodeError: Boolean = false)
     extends RichFlatMapFunction[RowData, BatchIrRow] {
 
   @transient private lazy val logger = LoggerFactory.getLogger(getClass)
@@ -134,17 +152,37 @@ class BatchIrRowDecoder(servingInfo: GroupByServingInfoParsed)
   @transient private lazy val dsParser: String => Long = {
     val fmt = new java.text.SimpleDateFormat(servingInfo.groupByServingInfo.getDateFormat)
     fmt.setTimeZone(java.util.TimeZone.getTimeZone("UTC"))
-    ds: String => fmt.parse(ds).getTime
+    fmt.setLenient(false)
+    ds: String => {
+      val position = new ParsePosition(0)
+      val parsed = fmt.parse(ds, position)
+      if (parsed == null || position.getIndex != ds.length) {
+        val errorOffset = math.max(position.getErrorIndex, position.getIndex)
+        throw new ParseException(s"Invalid ds partition value: $ds", errorOffset)
+      }
+      parsed.getTime
+    }
   }
 
   // Upload table columns: key_bytes(0), value_bytes(1), key_json(2), value_json(3), ds(4)
+  private val KeyJsonColumnIndex = 2
   private val DsColumnIndex = 4
 
   override def flatMap(row: RowData, out: Collector[BatchIrRow]): Unit = {
     try {
+      // GroupByUpload appends one metadata row to every upload partition and filters it by
+      // key_json in its own reload path. It is not an entity BatchIrRow, even in strict mode.
+      if (
+        row.getArity > KeyJsonColumnIndex && !row.isNullAt(KeyJsonColumnIndex) &&
+        row.getString(KeyJsonColumnIndex).toString == Constants.GroupByServingInfoKey
+      ) return
+
       val keyBytes = row.getBinary(0)
       val valueBytes = row.getBinary(1)
-      if (keyBytes == null || valueBytes == null) return
+      if (keyBytes == null || valueBytes == null) {
+        if (failOnDecodeError) throw new IllegalArgumentException("Batch IR row has null key_bytes or value_bytes")
+        return
+      }
 
       val entityKeys = keyDecoder(keyBytes)
 
@@ -153,16 +191,20 @@ class BatchIrRowDecoder(servingInfo: GroupByServingInfoParsed)
       // [Mar 28 00:00, Mar 29 00:00), so batchEnd = Mar 29 00:00.
       // See GroupByUpload: batchEndDate = partitionSpec.after(endDs).
       val DayMillis = 24 * 3600 * 1000L
-      val batchEnd = if (row.getArity > DsColumnIndex && !row.isNullAt(DsColumnIndex)) {
-        dsParser(row.getString(DsColumnIndex).toString) + DayMillis
-      } else {
-        servingInfo.batchEndTsMillis
-      }
+      val batchEnd =
+        if (row.getArity > DsColumnIndex && !row.isNullAt(DsColumnIndex)) {
+          Math.addExact(dsParser(row.getString(DsColumnIndex).toString), DayMillis)
+        } else if (failOnDecodeError) {
+          throw new IllegalArgumentException("Batch IR row is missing required ds partition value")
+        } else {
+          servingInfo.batchEndTsMillis
+        }
 
       out.collect(new BatchIrRow(entityKeys, valueBytes, batchEnd))
     } catch {
       case e: Exception =>
         logger.error("Error decoding batch IR row from Iceberg", e)
+        if (failOnDecodeError) throw e
     }
   }
 }

--- a/flink/src/main/scala/ai/chronon/flink/window/ChrononClockMode.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/ChrononClockMode.scala
@@ -1,0 +1,113 @@
+package ai.chronon.flink.window
+
+import ai.chronon.api.TsUtils
+
+/** Chooses replay-safe aggregation horizons for the GigaTile operator. */
+private[flink] object ChrononClockMode {
+  sealed trait Mode
+  case object NoWatermark extends Mode
+  case object Catchup extends Mode
+  case object Live extends Mode
+
+  final case class Horizons(largeWindowAsOfMillis: Long, smallWindowAsOfMillis: Long)
+
+  def classify(
+      processingTimeMillis: Long,
+      eventTimeWatermarkMillis: Long,
+      sourceOutOfOrdernessMillis: Long,
+      liveWatermarkLagToleranceMillis: Long
+  ): Mode = {
+    require(sourceOutOfOrdernessMillis >= 0L, "source out-of-orderness must be non-negative")
+    require(liveWatermarkLagToleranceMillis >= sourceOutOfOrdernessMillis,
+            "live watermark tolerance must cover source out-of-orderness")
+    if (eventTimeWatermarkMillis == Long.MinValue) NoWatermark
+    // Flink emits bounded-out-of-order watermarks as maxEventTs - outOfOrderness - 1.
+    // Equality therefore implies that the source has already observed a future event.
+    else if (watermarkImpliesFutureEvent(processingTimeMillis, eventTimeWatermarkMillis, sourceOutOfOrdernessMillis))
+      NoWatermark
+    else if (watermarkIsBehind(processingTimeMillis, eventTimeWatermarkMillis, liveWatermarkLagToleranceMillis)) Catchup
+    else Live
+  }
+
+  def allowsPublication(mode: Mode): Boolean = mode == Live
+
+  def dayAdvanceAsOfMillis(
+      mode: Mode,
+      processingTimeMillis: Long,
+      eventTimeWatermarkMillis: Long
+  ): Option[Long] =
+    mode match {
+      case NoWatermark => None
+      case Catchup     => Some(eventTimeWatermarkMillis)
+      case Live        => Some(processingTimeMillis)
+    }
+
+  def streamEventHorizons(
+      mode: Mode,
+      eventTimeMillis: Long,
+      processingTimeMillis: Long,
+      eventTimeWatermarkMillis: Long,
+      smallestHopMillis: Long
+  ): Horizons = {
+    val asOfMillis = mode match {
+      case NoWatermark => eventTimeMillis
+      case Catchup     => eventTimeWatermarkMillis
+      case Live        => processingTimeMillis
+    }
+    horizons(asOfMillis, smallestHopMillis)
+  }
+
+  def batchUpdateHorizons(
+      mode: Mode,
+      batchEndMillis: Long,
+      currentDayStartMillis: Long,
+      processingTimeMillis: Long,
+      eventTimeWatermarkMillis: Long,
+      smallestHopMillis: Long
+  ): Horizons = {
+    val asOfMillis = mode match {
+      case NoWatermark => if (currentDayStartMillis >= 0L) currentDayStartMillis else batchEndMillis
+      case Catchup     => eventTimeWatermarkMillis
+      case Live        => processingTimeMillis
+    }
+    horizons(asOfMillis, smallestHopMillis)
+  }
+
+  def processingTimerHorizons(
+      mode: Mode,
+      processingTimeMillis: Long,
+      eventTimeWatermarkMillis: Long,
+      smallestHopMillis: Long
+  ): Option[Horizons] =
+    mode match {
+      case NoWatermark => None
+      case Catchup     => Some(horizons(eventTimeWatermarkMillis, smallestHopMillis))
+      case Live        => Some(horizons(processingTimeMillis, smallestHopMillis))
+    }
+
+  private def horizons(asOfMillis: Long, smallestHopMillis: Long): Horizons =
+    Horizons(asOfMillis, adjustExclusiveUpperBound(asOfMillis, smallestHopMillis))
+
+  private def adjustExclusiveUpperBound(asOfMillis: Long, hopMillis: Long): Long =
+    if (asOfMillis < Long.MaxValue && asOfMillis == TsUtils.round(asOfMillis, hopMillis)) asOfMillis + 1L
+    else asOfMillis
+
+  private def watermarkIsBehind(
+      processingTimeMillis: Long,
+      eventTimeWatermarkMillis: Long,
+      liveWatermarkLagToleranceMillis: Long
+  ): Boolean =
+    processingTimeMillis > saturatingAdd(eventTimeWatermarkMillis, liveWatermarkLagToleranceMillis)
+
+  private def watermarkImpliesFutureEvent(
+      processingTimeMillis: Long,
+      eventTimeWatermarkMillis: Long,
+      sourceOutOfOrdernessMillis: Long
+  ): Boolean =
+    saturatingAdd(eventTimeWatermarkMillis, sourceOutOfOrdernessMillis) >= processingTimeMillis
+
+  private def saturatingAdd(value: Long, nonNegativeDelta: Long): Long = {
+    require(nonNegativeDelta >= 0L, "clock delta must be non-negative")
+    if (value > Long.MaxValue - nonNegativeDelta) Long.MaxValue else value + nonNegativeDelta
+  }
+}

--- a/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
@@ -26,6 +26,11 @@ import org.slf4j.{Logger, LoggerFactory}
 
 import scala.util.Try
 
+object GigaTileProcessFunction {
+  val FirstSeenKeyGraceMillisConfig: String = "gigatile_first_seen_key_grace_millis"
+  val DefaultFirstSeenKeyGraceMillis: Long = 0L
+}
+
 /** Flink CoProcessFunction for the GigaTile pipeline.
   *
   * Two inputs:
@@ -39,10 +44,12 @@ class GigaTileProcessFunction(
     groupBy: GroupBy,
     inputSchema: Seq[(String, DataType)],
     enableDebug: Boolean = false,
-    bufferingOutputTimeMillis: Long = 0L
+    bufferingOutputTimeMillis: Long = 0L,
+    firstSeenKeyGraceMillis: Long = GigaTileProcessFunction.DefaultFirstSeenKeyGraceMillis
 ) extends KeyedCoProcessFunction[java.util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile] {
 
   require(bufferingOutputTimeMillis >= 0L, "GigaTile output buffer must be non-negative")
+  require(firstSeenKeyGraceMillis >= 0L, "GigaTile first-seen key grace must be non-negative")
 
   @transient lazy val logger: Logger = LoggerFactory.getLogger(getClass)
 
@@ -55,6 +62,9 @@ class GigaTileProcessFunction(
   @transient private var batchUpdateCounter: Counter = _
   @transient private var futureEventDropCounter: Counter = _
   @transient private var lastKey: java.util.List[Any] = _
+  // Deliberately operator-local and not checkpointed. Recovery starts a fresh delay on its first
+  // keyed callback before an unseen batch row can be treated as empty history.
+  @transient private var emptyBatchBaselineSafeAfterMillis: java.lang.Long = _
 
   private val valueColumns: Array[String] = inputSchema.map(_._1).toArray
   private val timeColumnAlias: String = Constants.TimeColumn
@@ -78,6 +88,9 @@ class GigaTileProcessFunction(
   private var pendingPublicationActivationTimerState: ValueState[java.lang.Long] = _
   private var bufferedWriteLatestTsState: ValueState[java.lang.Long] = _
   private var nextBufferedWriteTimerState: ValueState[java.lang.Long] = _
+  private var pendingEmptyBatchBaselineState: ValueState[java.lang.Boolean] = _
+  private var syntheticEmptyBatchBaselineState: ValueState[java.lang.Boolean] = _
+  private var syntheticRollbackCorrectionState: ValueState[java.lang.Boolean] = _
 
   private val publicationRetryDelayMillis = math.max(1L, 2L * FlinkJob.AutoWatermarkInterval)
   private val activationCooldownDelayMillis =
@@ -132,6 +145,13 @@ class GigaTileProcessFunction(
       new ValueStateDescriptor[java.lang.Long]("giga-tile-buffered-write-latest-ts", classOf[java.lang.Long]))
     nextBufferedWriteTimerState = getRuntimeContext.getState(
       new ValueStateDescriptor[java.lang.Long]("giga-tile-next-emit-pt-timer", classOf[java.lang.Long]))
+    pendingEmptyBatchBaselineState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Boolean]("giga-tile-pending-empty-batch", classOf[java.lang.Boolean]))
+    syntheticEmptyBatchBaselineState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Boolean]("giga-tile-synthetic-empty-batch", classOf[java.lang.Boolean]))
+    syntheticRollbackCorrectionState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Boolean]("giga-tile-synthetic-rollback-correction",
+                                                  classOf[java.lang.Boolean]))
 
     initializeTransients()
   }
@@ -163,7 +183,8 @@ class GigaTileProcessFunction(
         batchEndTsState,
         runningLargeIrState,
         cachedSmallWindowAsOfTsState,
-        lastLargeRecomputeAsOfTsState
+        lastLargeRecomputeAsOfTsState,
+        syntheticEmptyBatchBaselineState
       )
     }
   }
@@ -173,6 +194,65 @@ class GigaTileProcessFunction(
                               eventTimeWatermark,
                               FlinkJob.AllowedOutOfOrderness.toMillis,
                               FlinkJob.LiveWatermarkLagToleranceMillis)
+
+  private def firstSeenKeyGraceEnabled: Boolean = firstSeenKeyGraceMillis > 0L
+
+  private def startEmptyBatchGrace(currentProcessingTime: Long): Unit = {
+    if (!firstSeenKeyGraceEnabled) {
+      // Synthetic availability lives outside the legacy batch-IR descriptor so both a config
+      // rollback and an older binary return to the normal null fence. Keep the legacy pending
+      // publication marker armed so the next callback retracts any synthetic value already
+      // handed to KV.
+      emptyBatchBaselineSafeAfterMillis = null
+      pendingEmptyBatchBaselineState.clear()
+      flinkStore.clearSyntheticBatchIr()
+      syntheticRollbackCorrectionState.clear()
+    } else if (emptyBatchBaselineSafeAfterMillis == null) {
+      // A pre-fallback binary understands pendingPublicationState but not the two synthetic
+      // markers. If it cleared pending state, it already handed off the null-fenced correction;
+      // do not resurrect synthetic availability when rolling forward again. The correction
+      // marker may itself be clear when the rollback checkpoint captured a newer fenced update.
+      if (flinkStore.hasSyntheticBatchIr && !hasRawPendingPublication) {
+        flinkStore.clearSyntheticBatchIr()
+        syntheticRollbackCorrectionState.clear()
+      }
+      emptyBatchBaselineSafeAfterMillis =
+        if (currentProcessingTime > Long.MaxValue - firstSeenKeyGraceMillis) Long.MaxValue
+        else currentProcessingTime + firstSeenKeyGraceMillis
+    }
+  }
+
+  private def hasPendingEmptyBatchBaseline: Boolean =
+    firstSeenKeyGraceEnabled && java.lang.Boolean.TRUE.equals(pendingEmptyBatchBaselineState.value())
+
+  private def markEmptyBatchBaselinePendingIfNeeded(): Unit = {
+    if (firstSeenKeyGraceEnabled && processor.hasBatchBackedColumns && flinkStore.getBatchIr == null) {
+      pendingEmptyBatchBaselineState.update(java.lang.Boolean.TRUE)
+    }
+  }
+
+  private def initializeEmptyBatchBaselineIfReady(
+      currentProcessingTime: Long,
+      largeWindowAsOfMillis: Long
+  ): Option[GigaEmitResult] = {
+    if (!firstSeenKeyGraceEnabled) {
+      pendingEmptyBatchBaselineState.clear()
+      return None
+    }
+
+    val safeAfterMillis = emptyBatchBaselineSafeAfterMillis
+    if (
+      !hasPendingEmptyBatchBaseline || safeAfterMillis == null ||
+      currentProcessingTime < safeAfterMillis.longValue()
+    ) {
+      None
+    } else {
+      val result = processor.initializeEmptyBatchIr(largeWindowAsOfMillis,
+                                                    emptyBatchIr => flinkStore.putSyntheticBatchIr(emptyBatchIr))
+      pendingEmptyBatchBaselineState.clear()
+      if (result.finalizedVector != null) Some(result) else None
+    }
+  }
 
   private def bufferingEnabled: Boolean = bufferingOutputTimeMillis > 0L
 
@@ -191,7 +271,7 @@ class GigaTileProcessFunction(
     ) {
       // An older binary can consume a cadence timer without understanding these keyed
       // markers. Recreate logical/physical ownership on the first later callback.
-      pendingPublicationState.update(java.lang.Boolean.TRUE)
+      markPublicationPending()
       nextBufferedWriteTimestamp(lastKey, currentProcessingTime) match {
         case Some(nextEmit) =>
           // Register the replacement before moving the keyed marker. If registration
@@ -252,8 +332,32 @@ class GigaTileProcessFunction(
   private def isFutureEvent(eventTime: Long, currentProcessingTime: Long): Boolean =
     eventTime > currentProcessingTime
 
+  private def hasRawPendingPublication: Boolean =
+    java.lang.Boolean.TRUE.equals(pendingPublicationState.value())
+
+  private def hasSyntheticRollbackCorrection: Boolean =
+    java.lang.Boolean.TRUE.equals(syntheticRollbackCorrectionState.value())
+
   private def hasPendingPublication: Boolean =
-    java.lang.Boolean.TRUE.equals(pendingPublicationState.value()) && pendingVersionCollisionState.value() == null
+    hasRawPendingPublication && !hasSyntheticRollbackCorrection && pendingVersionCollisionState.value() == null
+
+  private def markPublicationPending(): Unit = {
+    syntheticRollbackCorrectionState.clear()
+    pendingPublicationState.update(java.lang.Boolean.TRUE)
+  }
+
+  private def completePublicationHandoff(): Unit = {
+    if (flinkStore.hasSyntheticBatchIr) {
+      // A marker-blind binary still understands pendingPublicationState. Keeping that legacy
+      // marker armed lets its next eligible callback hand off the null-fenced rollback value.
+      // Rollback must remain serving-fenced until that correction is verified.
+      pendingPublicationState.update(java.lang.Boolean.TRUE)
+      syntheticRollbackCorrectionState.update(java.lang.Boolean.TRUE)
+    } else {
+      pendingPublicationState.clear()
+      syntheticRollbackCorrectionState.clear()
+    }
+  }
 
   private def hasDeferredPublication: Boolean =
     hasPendingPublication &&
@@ -462,7 +566,7 @@ class GigaTileProcessFunction(
     if (!shouldPublish(mode, horizons, currentProcessingTime)) {
       val publicationPending = result.finalizedVector != null || result.needsEvictionTimer || hasPendingPublication
       if (publicationPending) {
-        pendingPublicationState.update(java.lang.Boolean.TRUE)
+        markPublicationPending()
         if (scheduleWatermarkRetry) schedulePublicationRetryIfNeeded(timerService, currentProcessingTime)
       }
       return
@@ -477,13 +581,13 @@ class GigaTileProcessFunction(
       // This tracks ownership through cadence buffering, encoding, and Collector handoff. The
       // downstream async KV result is outside this keyed operator and cannot acknowledge or
       // retry through this state.
-      pendingPublicationState.update(java.lang.Boolean.TRUE)
+      markPublicationPending()
       try {
         emitOrBuffer(finalizedVector, currentKey, currentProcessingTime, startProcessingTime, timerService, out)
         // A buffered value has not reached the collector yet. Keep the legacy pending
         // marker until cadence/collision publication succeeds so an older binary restored
         // from this checkpoint can rebuild it on the normal eviction timer.
-        if (!hasBufferedWrite && pendingVersionCollisionState.value() == null) pendingPublicationState.clear()
+        if (!hasBufferedWrite && pendingVersionCollisionState.value() == null) completePublicationHandoff()
         // Cadence or collision state owns any deferred write from here.
         clearPublicationWakeupMarkers()
       } catch {
@@ -683,7 +787,7 @@ class GigaTileProcessFunction(
       // cannot schedule and publish the same value again.
       bufferedWriteLatestTsState.clear()
       nextBufferedWriteTimerState.clear()
-      pendingPublicationState.clear()
+      completePublicationHandoff()
       clearPublicationWakeupMarkers()
     } catch {
       case e: Exception =>
@@ -698,7 +802,7 @@ class GigaTileProcessFunction(
   private def parkBufferedWrite(): Unit = {
     nextBufferedWriteTimerState.clear()
     if (hasBufferedWrite) {
-      pendingPublicationState.update(java.lang.Boolean.TRUE)
+      markPublicationPending()
     }
   }
 
@@ -712,7 +816,7 @@ class GigaTileProcessFunction(
     nextBufferedWriteTimerState.clear()
     if (bufferedVersion == null) return
 
-    pendingPublicationState.update(java.lang.Boolean.TRUE)
+    markPublicationPending()
     try {
       emitOrCoalesceVersionCollision(timerService,
                                      processor.packAndFinalize(),
@@ -721,7 +825,7 @@ class GigaTileProcessFunction(
                                      System.currentTimeMillis(),
                                      out)
       bufferedWriteLatestTsState.clear()
-      if (pendingVersionCollisionState.value() == null) pendingPublicationState.clear()
+      if (pendingVersionCollisionState.value() == null) completePublicationHandoff()
       clearPublicationWakeupMarkers()
     } catch {
       case e: Exception =>
@@ -751,6 +855,7 @@ class GigaTileProcessFunction(
       ensureStateBound(ctx.getCurrentKey)
       val timerService = ctx.timerService()
       val currentProcessingTime = timerService.currentProcessingTime()
+      startEmptyBatchGrace(currentProcessingTime)
       repairExpiredProcessingTimerMarkers(timerService, currentProcessingTime, None)
       repairStaleBufferedWriteTimerIfNeeded(timerService, currentProcessingTime, None)
       if (isFutureEvent(tsMills, currentProcessingTime)) {
@@ -758,6 +863,7 @@ class GigaTileProcessFunction(
         return
       }
       clearExpiredPublicationRetryMarker(currentProcessingTime, None)
+      markEmptyBatchBaselinePendingIfNeeded()
       val eventTimeWatermark = timerService.currentWatermark()
       val mode = currentClockMode(currentProcessingTime, eventTimeWatermark)
       val horizons = ChrononClockMode.streamEventHorizons(mode,
@@ -774,7 +880,13 @@ class GigaTileProcessFunction(
                                           tsMills,
                                           largeWindowAsOfTs = horizons.largeWindowAsOfMillis,
                                           smallWindowAsOfTs = horizons.smallWindowAsOfMillis)
-      val result = preferLatestResult(eventResult, pendingRebuild.getOrElse(rolloverResult))
+      val callbackResult = preferLatestResult(eventResult, pendingRebuild.getOrElse(rolloverResult))
+      val result =
+        if (mode == NoWatermark) callbackResult
+        else
+          initializeEmptyBatchBaselineIfReady(currentProcessingTime, horizons.largeWindowAsOfMillis)
+            .map(preferLatestResult(_, callbackResult))
+            .getOrElse(callbackResult)
 
       scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
       emitOrDefer(mode,
@@ -806,6 +918,7 @@ class GigaTileProcessFunction(
       ensureStateBound(ctx.getCurrentKey)
       val timerService = ctx.timerService()
       val currentProcessingTime = timerService.currentProcessingTime()
+      startEmptyBatchGrace(currentProcessingTime)
       repairExpiredProcessingTimerMarkers(timerService, currentProcessingTime, None)
       repairStaleBufferedWriteTimerIfNeeded(timerService, currentProcessingTime, None)
       clearExpiredPublicationRetryMarker(currentProcessingTime, None)
@@ -825,6 +938,10 @@ class GigaTileProcessFunction(
                                                 batchRow.batchEndTs,
                                                 largeWindowAsOfTs = horizons.largeWindowAsOfMillis,
                                                 smallWindowAsOfTs = horizons.smallWindowAsOfMillis)
+      // A real row supersedes the synthetic rollback assertion. If that assertion kept the
+      // legacy pending marker armed, let this callback publish and clear it normally.
+      syntheticRollbackCorrectionState.clear()
+      pendingEmptyBatchBaselineState.clear()
       val result = preferLatestResult(batchResult, pendingRebuild.getOrElse(rolloverResult))
 
       batchUpdateCounter.inc()
@@ -846,6 +963,7 @@ class GigaTileProcessFunction(
       case e: Exception =>
         logger.error(s"Error processing batch IR for groupBy=${groupBy.getMetaData.getName}", e)
         eventProcessingErrorCounter.inc()
+        if (firstSeenKeyGraceEnabled) throw e
     }
   }
 
@@ -871,6 +989,7 @@ class GigaTileProcessFunction(
       val currentTimerCallback = Some(ctx.timeDomain() -> timestamp)
       timerServiceOnFailure = timerService
       processingTimeOnFailure = currentProcessingTime
+      startEmptyBatchGrace(currentProcessingTime)
       repairExpiredProcessingTimerMarkers(timerService, currentProcessingTime, currentTimerCallback)
 
       // Checkpoints written by the former event-time implementation may still contain
@@ -880,6 +999,7 @@ class GigaTileProcessFunction(
         val isPublicationActivationTimer = isCurrentPublicationActivationTimer(timestamp)
         publicationActivationTimerFired = isPublicationActivationTimer
         if (isPublicationActivationTimer) pendingPublicationActivationTimerState.clear()
+        markEmptyBatchBaselinePendingIfNeeded()
         scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
         if (isPublicationActivationTimer) {
           if (hasDeferredPublication) {
@@ -895,7 +1015,10 @@ class GigaTileProcessFunction(
                 val rolloverResult = advanceDayForMode(Live, currentProcessingTime, eventTimeWatermark)
                 val retryResult = rebuildPendingAtCurrentTime(Live, horizons, currentProcessingTime)
                   .getOrElse(GigaEmitResult(null))
-                val result = preferLatestResult(retryResult, rolloverResult)
+                val callbackResult = preferLatestResult(retryResult, rolloverResult)
+                val result = initializeEmptyBatchBaselineIfReady(currentProcessingTime, horizons.largeWindowAsOfMillis)
+                  .map(preferLatestResult(_, callbackResult))
+                  .getOrElse(callbackResult)
                 emitOrDefer(Live,
                             horizons,
                             result,
@@ -949,6 +1072,8 @@ class GigaTileProcessFunction(
         !expiredPublicationRetryMarkerCleared
       ) return
 
+      markEmptyBatchBaselinePendingIfNeeded()
+
       // The physical retry timer has fired. Clear only its logical role before running all
       // coincident roles, then arm one watermark-driven wake-up if publication remains fenced.
       if (isPublicationRetryTimer) clearPublicationRetryMarker()
@@ -968,7 +1093,7 @@ class GigaTileProcessFunction(
             // The active batch input holds the connected watermark at MIN while it scans.
             // Keep consuming records, but do not age or roll keyed state from wall clock.
             val snapshot = processor.currentSnapshot
-            if (!snapshot.isEmpty) pendingPublicationState.update(java.lang.Boolean.TRUE)
+            if (!snapshot.isEmpty) markPublicationPending()
             GigaEmitResult(null, needsEvictionTimer = snapshot.needsEvictionTimer, isEmpty = snapshot.isEmpty)
           case _ =>
             val horizons = timerHorizons.get
@@ -978,13 +1103,19 @@ class GigaTileProcessFunction(
             val evictionResult = pendingRebuild.getOrElse(
               processor.onEviction(EvictionTimes(timerTs = horizons.largeWindowAsOfMillis,
                                                  smallWindowAsOfTs = horizons.smallWindowAsOfMillis)))
-            preferLatestResult(evictionResult, rolloverResult)
+            val callbackResult = preferLatestResult(evictionResult, rolloverResult)
+            initializeEmptyBatchBaselineIfReady(currentProcessingTime, horizons.largeWindowAsOfMillis)
+              .map(preferLatestResult(_, callbackResult))
+              .getOrElse(callbackResult)
         }
         timerResult = Some(result)
 
         // Keep normal decay live while state or a deferred publication remains. A coincident
         // collision flush rearms itself on failure, so it does not need a speculative timer.
-        if (!result.isEmpty || result.needsEvictionTimer || hasPendingPublication || hasBufferedWrite) {
+        if (
+          !result.isEmpty || result.needsEvictionTimer || hasPendingPublication || hasBufferedWrite ||
+          hasPendingEmptyBatchBaseline
+        ) {
           scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
         }
       }
@@ -1011,7 +1142,7 @@ class GigaTileProcessFunction(
         }
       }
 
-      if (hasPendingPublication) {
+      if (hasPendingPublication || hasPendingEmptyBatchBaseline) {
         scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
       }
 
@@ -1049,10 +1180,10 @@ class GigaTileProcessFunction(
           case Some(horizons) if shouldPublish(mode, horizons, currentProcessingTime) =>
             // Eviction runs first when both markers share a timestamp, so this is one
             // post-eviction snapshot with a strictly newer version.
-            pendingPublicationState.update(java.lang.Boolean.TRUE)
+            markPublicationPending()
             flushVersionCollision(timerService, currentProcessingTime, currentTimerCallback, ctx.getCurrentKey, out)
           case _ =>
-            pendingPublicationState.update(java.lang.Boolean.TRUE)
+            markPublicationPending()
             scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
             postponeVersionCollision(timerService, currentProcessingTime, currentTimerCallback)
         }
@@ -1167,6 +1298,7 @@ class FlinkGigaTileStore(megaTileAgg: MegaTileAggregator, codec: MegaTileCodec, 
   private var runningLargeIrState: ValueState[Array[Byte]] = _
   private var cachedSmallWindowAsOfTsState: ValueState[java.lang.Long] = _
   private var lastLargeRecomputeAsOfTsState: ValueState[java.lang.Long] = _
+  private var syntheticEmptyBatchBaselineState: ValueState[java.lang.Boolean] = _
 
   // Decode cache invalidated on key switch. Keeping per-day decoded values in an off-heap
   // mutable map would defeat the idea of per-key Flink state, so we just memoize the values
@@ -1187,7 +1319,8 @@ class FlinkGigaTileStore(megaTileAgg: MegaTileAggregator, codec: MegaTileCodec, 
                      batchEndTs: ValueState[java.lang.Long],
                      runningLarge: ValueState[Array[Byte]],
                      cachedSmallWindowAsOfTs: ValueState[java.lang.Long],
-                     lastLargeRecomputeAsOfTs: ValueState[java.lang.Long]): Unit = {
+                     lastLargeRecomputeAsOfTs: ValueState[java.lang.Long],
+                     syntheticEmptyBatchBaseline: ValueState[java.lang.Boolean]): Unit = {
     tileState = tiles
     megaTileIrState = megaTileIr
     dailyLargeIrState = dailyLargeIr
@@ -1198,6 +1331,7 @@ class FlinkGigaTileStore(megaTileAgg: MegaTileAggregator, codec: MegaTileCodec, 
     runningLargeIrState = runningLarge
     cachedSmallWindowAsOfTsState = cachedSmallWindowAsOfTs
     lastLargeRecomputeAsOfTsState = lastLargeRecomputeAsOfTs
+    syntheticEmptyBatchBaselineState = syntheticEmptyBatchBaseline
     cachedSmallValid = false
     batchIrValid = false
     runningLargeValid = false
@@ -1286,15 +1420,35 @@ class FlinkGigaTileStore(megaTileAgg: MegaTileAggregator, codec: MegaTileCodec, 
   override def getBatchIr: FinalBatchIr = {
     if (!batchIrValid) {
       val bytes = batchIrState.value()
-      batchIrDecoded = if (bytes != null) gigaCodec.decodeBatchIr(bytes) else null
+      batchIrDecoded =
+        if (bytes != null) gigaCodec.decodeBatchIr(bytes)
+        else if (java.lang.Boolean.TRUE.equals(syntheticEmptyBatchBaselineState.value()))
+          megaTileAgg.finalizeSnapshot(megaTileAgg.init)
+        else null
       batchIrValid = true
     }
     batchIrDecoded
   }
   override def putBatchIr(ir: FinalBatchIr): Unit = {
     batchIrState.update(gigaCodec.encodeBatchIr(ir))
+    syntheticEmptyBatchBaselineState.clear()
     batchIrDecoded = ir; batchIrValid = true
   }
+
+  def putSyntheticBatchIr(ir: FinalBatchIr): Unit = {
+    syntheticEmptyBatchBaselineState.update(java.lang.Boolean.TRUE)
+    batchIrDecoded = ir; batchIrValid = true
+  }
+
+  def clearSyntheticBatchIr(): Unit = {
+    if (java.lang.Boolean.TRUE.equals(syntheticEmptyBatchBaselineState.value())) {
+      syntheticEmptyBatchBaselineState.clear()
+      batchIrDecoded = null; batchIrValid = false
+    }
+  }
+
+  def hasSyntheticBatchIr: Boolean =
+    java.lang.Boolean.TRUE.equals(syntheticEmptyBatchBaselineState.value())
 
   override def getBatchEndTs: Long = Option(batchEndTsState.value()).map(_.longValue()).getOrElse(-1L)
   override def putBatchEndTs(ts: Long): Unit = batchEndTsState.update(ts)

--- a/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
@@ -38,8 +38,11 @@ import scala.util.Try
 class GigaTileProcessFunction(
     groupBy: GroupBy,
     inputSchema: Seq[(String, DataType)],
-    enableDebug: Boolean = false
+    enableDebug: Boolean = false,
+    bufferingOutputTimeMillis: Long = 0L
 ) extends KeyedCoProcessFunction[java.util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile] {
+
+  require(bufferingOutputTimeMillis >= 0L, "GigaTile output buffer must be non-negative")
 
   @transient lazy val logger: Logger = LoggerFactory.getLogger(getClass)
 
@@ -73,6 +76,8 @@ class GigaTileProcessFunction(
   private var pendingPublicationState: ValueState[java.lang.Boolean] = _
   private var pendingPublicationRetryTimerState: ValueState[java.lang.Long] = _
   private var pendingPublicationActivationTimerState: ValueState[java.lang.Long] = _
+  private var bufferedWriteLatestTsState: ValueState[java.lang.Long] = _
+  private var nextBufferedWriteTimerState: ValueState[java.lang.Long] = _
 
   private val publicationRetryDelayMillis = math.max(1L, 2L * FlinkJob.AutoWatermarkInterval)
   private val activationCooldownDelayMillis =
@@ -123,6 +128,10 @@ class GigaTileProcessFunction(
     pendingPublicationActivationTimerState = getRuntimeContext.getState(
       new ValueStateDescriptor[java.lang.Long]("giga-tile-pending-publication-activation-et-timer",
                                                classOf[java.lang.Long]))
+    bufferedWriteLatestTsState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Long]("giga-tile-buffered-write-latest-ts", classOf[java.lang.Long]))
+    nextBufferedWriteTimerState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Long]("giga-tile-next-emit-pt-timer", classOf[java.lang.Long]))
 
     initializeTransients()
   }
@@ -165,11 +174,90 @@ class GigaTileProcessFunction(
                               FlinkJob.AllowedOutOfOrderness.toMillis,
                               FlinkJob.LiveWatermarkLagToleranceMillis)
 
+  private def bufferingEnabled: Boolean = bufferingOutputTimeMillis > 0L
+
+  private def hasBufferedWrite: Boolean = bufferedWriteLatestTsState.value() != null
+
+  private def repairStaleBufferedWriteTimerIfNeeded(
+      timerService: TimerService,
+      currentProcessingTime: Long,
+      currentTimerCallback: Option[(TimeDomain, Long)]
+  ): Unit = {
+    val bufferedVersion = bufferedWriteLatestTsState.value()
+    val bufferedTimer = nextBufferedWriteTimerState.value()
+    if (
+      bufferedVersion != null && bufferedTimer != null &&
+      processingTimerMarkerIsExpired(bufferedTimer.longValue(), currentProcessingTime, currentTimerCallback)
+    ) {
+      // An older binary can consume a cadence timer without understanding these keyed
+      // markers. Recreate logical/physical ownership on the first later callback.
+      pendingPublicationState.update(java.lang.Boolean.TRUE)
+      nextBufferedWriteTimestamp(lastKey, currentProcessingTime) match {
+        case Some(nextEmit) =>
+          // Register the replacement before moving the keyed marker. If registration
+          // fails, the restored stale marker remains visible for a later repair attempt.
+          timerService.registerProcessingTimeTimer(nextEmit)
+          nextBufferedWriteTimerState.update(nextEmit)
+        case None =>
+          nextBufferedWriteTimerState.clear()
+      }
+    }
+  }
+
+  private def stableBufferedWritePhaseMillis(key: java.util.List[Any]): Long =
+    Math.floorMod((groupBy.getMetaData.getName :: key.iterator().toScala.toList).hashCode().toLong,
+                  bufferingOutputTimeMillis)
+
+  private def nextBufferedWriteTimestamp(
+      key: java.util.List[Any],
+      currentProcessingTime: Long
+  ): Option[Long] = {
+    if (!bufferingEnabled) return None
+
+    val phase = stableBufferedWritePhaseMillis(key)
+    val currentPhase = Math.floorMod(currentProcessingTime, bufferingOutputTimeMillis)
+    val elapsedSincePhase = Math.floorMod(currentPhase - phase, bufferingOutputTimeMillis)
+    val delay =
+      if (elapsedSincePhase == 0L) bufferingOutputTimeMillis
+      else bufferingOutputTimeMillis - elapsedSincePhase
+    if (currentProcessingTime <= Long.MaxValue - delay) Some(currentProcessingTime + delay) else None
+  }
+
+  private def scheduleBufferedWriteTimerIfNeeded(
+      timerService: TimerService,
+      currentProcessingTime: Long
+  ): Unit = {
+    if (bufferingEnabled && nextBufferedWriteTimerState.value() == null) {
+      nextBufferedWriteTimestamp(lastKey, currentProcessingTime).foreach { nextEmit =>
+        timerService.registerProcessingTimeTimer(nextEmit)
+        nextBufferedWriteTimerState.update(nextEmit)
+      }
+    }
+  }
+
+  private def isCurrentBufferedWriteTimer(timestamp: Long): Boolean =
+    Option(nextBufferedWriteTimerState.value()).exists(_.longValue() == timestamp)
+
+  private def bufferLatestWrite(
+      timerService: TimerService,
+      versionMillis: Long
+  ): Unit = {
+    val previousVersion = bufferedWriteLatestTsState.value()
+    if (previousVersion == null || versionMillis > previousVersion.longValue()) {
+      bufferedWriteLatestTsState.update(versionMillis)
+    }
+    scheduleBufferedWriteTimerIfNeeded(timerService, versionMillis)
+  }
+
   private def isFutureEvent(eventTime: Long, currentProcessingTime: Long): Boolean =
     eventTime > currentProcessingTime
 
   private def hasPendingPublication: Boolean =
     java.lang.Boolean.TRUE.equals(pendingPublicationState.value()) && pendingVersionCollisionState.value() == null
+
+  private def hasDeferredPublication: Boolean =
+    hasPendingPublication &&
+      (!hasBufferedWrite || nextBufferedWriteTimerState.value() == null)
 
   private def schedulePublicationRetryIfNeeded(
       timerService: TimerService,
@@ -182,7 +270,7 @@ class GigaTileProcessFunction(
       currentProcessingTime: Long,
       delayMillis: Long
   ): Unit = {
-    if (!hasPublicationWakeupTimer && currentProcessingTime <= Long.MaxValue - delayMillis) {
+    if (hasDeferredPublication && !hasPublicationWakeupTimer && currentProcessingTime <= Long.MaxValue - delayMillis) {
       val retryTimestamp = currentProcessingTime + delayMillis
       timerService.registerProcessingTimeTimer(retryTimestamp)
       pendingPublicationRetryTimerState.update(retryTimestamp)
@@ -194,7 +282,7 @@ class GigaTileProcessFunction(
       currentProcessingTime: Long,
       retryTimestamp: Long
   ): Unit = {
-    if (!hasPublicationWakeupTimer && retryTimestamp > currentProcessingTime) {
+    if (hasDeferredPublication && !hasPublicationWakeupTimer && retryTimestamp > currentProcessingTime) {
       timerService.registerProcessingTimeTimer(retryTimestamp)
       pendingPublicationRetryTimerState.update(retryTimestamp)
     }
@@ -223,7 +311,7 @@ class GigaTileProcessFunction(
       currentProcessingTime: Long,
       eventTimeWatermark: Long
   ): Unit = {
-    if (!hasPublicationWakeupTimer) {
+    if (hasDeferredPublication && !hasPublicationWakeupTimer) {
       nextPublicationActivationWatermark(currentProcessingTime)
         .filter(_ > eventTimeWatermark)
         .foreach { activationWatermark =>
@@ -314,13 +402,51 @@ class GigaTileProcessFunction(
       horizons: Horizons,
       currentProcessingTime: Long
   ): Option[GigaEmitResult] =
-    if (hasPendingPublication && shouldPublish(mode, horizons, currentProcessingTime)) {
+    if (hasDeferredPublication && shouldPublish(mode, horizons, currentProcessingTime)) {
       Some(
         processor.onEviction(
           EvictionTimes(timerTs = horizons.largeWindowAsOfMillis, smallWindowAsOfTs = horizons.smallWindowAsOfMillis)))
     } else {
       None
     }
+
+  private def emitOrBuffer(
+      finalizedVector: Array[Any],
+      currentKey: java.util.List[Any],
+      currentProcessingTime: Long,
+      startProcessingTime: Long,
+      timerService: TimerService,
+      out: Collector[TimestampedTile]
+  ): Unit = {
+    if (!bufferingEnabled) {
+      // A checkpoint may have been written with buffering enabled. The first immediate
+      // callback supersedes that buffered snapshot; leave its physical timer in Flink and
+      // clear only the logical markers so the restored callback becomes a no-op.
+      bufferedWriteLatestTsState.clear()
+      nextBufferedWriteTimerState.clear()
+      emitOrCoalesceVersionCollision(timerService,
+                                     finalizedVector,
+                                     currentKey,
+                                     currentProcessingTime,
+                                     startProcessingTime,
+                                     out)
+      return
+    }
+
+    bufferLatestWrite(timerService, currentProcessingTime)
+    // Only the timestamp is buffered; the value is rebuilt from keyed state at the cadence
+    // boundary. If no later timestamp can be represented, fall back to the normal path so a
+    // value is not stranded at the end of the processing-time range.
+    if (nextBufferedWriteTimerState.value() == null) {
+      emitOrCoalesceVersionCollision(timerService,
+                                     finalizedVector,
+                                     currentKey,
+                                     currentProcessingTime,
+                                     startProcessingTime,
+                                     out)
+      bufferedWriteLatestTsState.clear()
+    }
+  }
 
   private def emitOrDefer(
       mode: Mode,
@@ -344,21 +470,21 @@ class GigaTileProcessFunction(
 
     val finalizedVector =
       if (result.finalizedVector != null) result.finalizedVector
-      else if (hasPendingPublication) processor.currentSnapshot.finalizedVector
+      else if (hasDeferredPublication) processor.currentSnapshot.finalizedVector
       else null
 
     if (finalizedVector != null) {
-      // This covers encoding and Collector handoff only. The downstream async KV result is
-      // outside this keyed operator and cannot acknowledge or retry through this state.
+      // This tracks ownership through cadence buffering, encoding, and Collector handoff. The
+      // downstream async KV result is outside this keyed operator and cannot acknowledge or
+      // retry through this state.
       pendingPublicationState.update(java.lang.Boolean.TRUE)
       try {
-        emitOrCoalesceVersionCollision(timerService,
-                                       finalizedVector,
-                                       currentKey,
-                                       currentProcessingTime,
-                                       startProcessingTime,
-                                       out)
-        if (pendingVersionCollisionState.value() == null) pendingPublicationState.clear()
+        emitOrBuffer(finalizedVector, currentKey, currentProcessingTime, startProcessingTime, timerService, out)
+        // A buffered value has not reached the collector yet. Keep the legacy pending
+        // marker until cadence/collision publication succeeds so an older binary restored
+        // from this checkpoint can rebuild it on the normal eviction timer.
+        if (!hasBufferedWrite && pendingVersionCollisionState.value() == null) pendingPublicationState.clear()
+        // Cadence or collision state owns any deferred write from here.
         clearPublicationWakeupMarkers()
       } catch {
         case e: Exception =>
@@ -545,9 +671,18 @@ class GigaTileProcessFunction(
 
       val snapshot = processor.currentSnapshot
       val encoded = gigaTileCodec.encodeOutput(snapshot.finalizedVector)
-      out.collect(new TimestampedTile(currentKey, encoded, pendingVersion.longValue(), System.currentTimeMillis()))
-      lastEmittedVersionState.update(pendingVersion)
+      val bufferedVersion = bufferedWriteLatestTsState.value()
+      val outputVersion =
+        if (bufferedVersion != null && bufferedVersion.longValue() > pendingVersion.longValue()) bufferedVersion
+        else pendingVersion
+      out.collect(new TimestampedTile(currentKey, encoded, outputVersion.longValue(), System.currentTimeMillis()))
+      lastEmittedVersionState.update(outputVersion)
       pendingVersionCollisionState.clear()
+      // The collision snapshot includes every mutation represented by the buffered
+      // cadence state. Relinquish that logical timer ownership so its physical callback
+      // cannot schedule and publish the same value again.
+      bufferedWriteLatestTsState.clear()
+      nextBufferedWriteTimerState.clear()
       pendingPublicationState.clear()
       clearPublicationWakeupMarkers()
     } catch {
@@ -556,6 +691,44 @@ class GigaTileProcessFunction(
         // the failure so a transient encoding/collection error cannot strand the latest value.
         scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
         postponeVersionCollision(timerService, currentProcessingTime, currentTimerCallback)
+        throw e
+    }
+  }
+
+  private def parkBufferedWrite(): Unit = {
+    nextBufferedWriteTimerState.clear()
+    if (hasBufferedWrite) {
+      pendingPublicationState.update(java.lang.Boolean.TRUE)
+    }
+  }
+
+  private def flushBufferedWrite(
+      timerService: TimerService,
+      currentProcessingTime: Long,
+      currentKey: java.util.List[Any],
+      out: Collector[TimestampedTile]
+  ): Unit = {
+    val bufferedVersion = bufferedWriteLatestTsState.value()
+    nextBufferedWriteTimerState.clear()
+    if (bufferedVersion == null) return
+
+    pendingPublicationState.update(java.lang.Boolean.TRUE)
+    try {
+      emitOrCoalesceVersionCollision(timerService,
+                                     processor.packAndFinalize(),
+                                     currentKey,
+                                     bufferedVersion.longValue(),
+                                     System.currentTimeMillis(),
+                                     out)
+      bufferedWriteLatestTsState.clear()
+      if (pendingVersionCollisionState.value() == null) pendingPublicationState.clear()
+      clearPublicationWakeupMarkers()
+    } catch {
+      case e: Exception =>
+        // The fired cadence timer was the only write trigger. Re-arm it before the outer
+        // handler records the failure so a transient encoding/collection error cannot strand
+        // the latest keyed value.
+        scheduleBufferedWriteTimerIfNeeded(timerService, currentProcessingTime)
         throw e
     }
   }
@@ -579,6 +752,7 @@ class GigaTileProcessFunction(
       val timerService = ctx.timerService()
       val currentProcessingTime = timerService.currentProcessingTime()
       repairExpiredProcessingTimerMarkers(timerService, currentProcessingTime, None)
+      repairStaleBufferedWriteTimerIfNeeded(timerService, currentProcessingTime, None)
       if (isFutureEvent(tsMills, currentProcessingTime)) {
         futureEventDropCounter.inc()
         return
@@ -633,6 +807,7 @@ class GigaTileProcessFunction(
       val timerService = ctx.timerService()
       val currentProcessingTime = timerService.currentProcessingTime()
       repairExpiredProcessingTimerMarkers(timerService, currentProcessingTime, None)
+      repairStaleBufferedWriteTimerIfNeeded(timerService, currentProcessingTime, None)
       clearExpiredPublicationRetryMarker(currentProcessingTime, None)
       val eventTimeWatermark = timerService.currentWatermark()
       val mode = currentClockMode(currentProcessingTime, eventTimeWatermark)
@@ -682,6 +857,7 @@ class GigaTileProcessFunction(
     var timerServiceOnFailure: TimerService = null
     var processingTimeOnFailure = Long.MinValue
     var evictionTimerFired = false
+    var bufferedWriteTimerFired = false
     var versionCollisionTimerFired = false
     var publicationRetryTimerFired = false
     var publicationActivationTimerFired = false
@@ -706,7 +882,7 @@ class GigaTileProcessFunction(
         if (isPublicationActivationTimer) pendingPublicationActivationTimerState.clear()
         scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
         if (isPublicationActivationTimer) {
-          if (hasPendingPublication) {
+          if (hasDeferredPublication) {
             val eventTimeWatermark = timerService.currentWatermark()
             currentClockMode(currentProcessingTime, eventTimeWatermark) match {
               case Live =>
@@ -747,18 +923,29 @@ class GigaTileProcessFunction(
         return
       }
 
-      val isEvictionTimer = isCurrentProcessingEvictionTimer(timestamp)
+      // One physical Flink timer can represent several logical triggers. Snapshot every role
+      // before clearing any marker, then mutate state before publication work.
+      val isTrackedEvictionTimer = isCurrentProcessingEvictionTimer(timestamp)
+      val isBufferedWriteTimer = isCurrentBufferedWriteTimer(timestamp)
+      bufferedWriteTimerFired = isBufferedWriteTimer
       val isVersionCollisionTimer = isCurrentVersionCollisionTimer(timestamp)
-      val isPublicationRetryTimer = isCurrentPublicationRetryTimer(timestamp)
-      evictionTimerFired = isEvictionTimer
       versionCollisionTimerFired = isVersionCollisionTimer
+      val isPublicationRetryTimer = isCurrentPublicationRetryTimer(timestamp)
       publicationRetryTimerFired = isPublicationRetryTimer
+      val isLegacyEvictionTimer =
+        !isTrackedEvictionTimer && !isBufferedWriteTimer && !isVersionCollisionTimer && !isPublicationRetryTimer &&
+          isUnmarkedLegacyEvictionTimer(timestamp)
+      val isEvictionTimer = isTrackedEvictionTimer || isLegacyEvictionTimer
+      evictionTimerFired = isEvictionTimer
+
+      repairStaleBufferedWriteTimerIfNeeded(timerService, currentProcessingTime, currentTimerCallback)
       if (!isPublicationRetryTimer) {
         expiredPublicationRetryMarkerCleared =
           clearExpiredPublicationRetryMarker(currentProcessingTime, currentTimerCallback)
       }
+
       if (
-        !isEvictionTimer && !isVersionCollisionTimer && !isPublicationRetryTimer &&
+        !isEvictionTimer && !isBufferedWriteTimer && !isVersionCollisionTimer && !isPublicationRetryTimer &&
         !expiredPublicationRetryMarkerCleared
       ) return
 
@@ -772,32 +959,45 @@ class GigaTileProcessFunction(
                                                                    eventTimeWatermark,
                                                                    processor.minSmallWindowTileSize)
 
-      var result = GigaEmitResult(null)
+      var timerResult: Option[GigaEmitResult] = None
+      var rebuiltPendingPublication = false
       if (isEvictionTimer) {
         nextProcessingEvictionTimerState.clear()
-        mode match {
+        val result = mode match {
           case NoWatermark =>
             // The active batch input holds the connected watermark at MIN while it scans.
             // Keep consuming records, but do not age or roll keyed state from wall clock.
             val snapshot = processor.currentSnapshot
             if (!snapshot.isEmpty) pendingPublicationState.update(java.lang.Boolean.TRUE)
-            result = GigaEmitResult(null, needsEvictionTimer = snapshot.needsEvictionTimer, isEmpty = snapshot.isEmpty)
+            GigaEmitResult(null, needsEvictionTimer = snapshot.needsEvictionTimer, isEmpty = snapshot.isEmpty)
           case _ =>
             val horizons = timerHorizons.get
             val rolloverResult = advanceDayForMode(mode, currentProcessingTime, eventTimeWatermark)
-            val evictionResult = rebuildPendingAtCurrentTime(mode, horizons, currentProcessingTime)
-              .getOrElse(
-                processor.onEviction(EvictionTimes(timerTs = horizons.largeWindowAsOfMillis,
-                                                   smallWindowAsOfTs = horizons.smallWindowAsOfMillis)))
-            result = preferLatestResult(evictionResult, rolloverResult)
+            val pendingRebuild = rebuildPendingAtCurrentTime(mode, horizons, currentProcessingTime)
+            rebuiltPendingPublication = pendingRebuild.nonEmpty
+            val evictionResult = pendingRebuild.getOrElse(
+              processor.onEviction(EvictionTimes(timerTs = horizons.largeWindowAsOfMillis,
+                                                 smallWindowAsOfTs = horizons.smallWindowAsOfMillis)))
+            preferLatestResult(evictionResult, rolloverResult)
         }
+        timerResult = Some(result)
 
         // Keep normal decay live while state or a deferred publication remains. A coincident
         // collision flush rearms itself on failure, so it does not need a speculative timer.
-        if (!result.isEmpty || result.needsEvictionTimer || hasPendingPublication) {
+        if (!result.isEmpty || result.needsEvictionTimer || hasPendingPublication || hasBufferedWrite) {
           scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
         }
+      }
 
+      if (isPublicationRetryTimer && !isEvictionTimer && hasDeferredPublication) {
+        timerHorizons.foreach { horizons =>
+          val pendingRebuild = rebuildPendingAtCurrentTime(mode, horizons, currentProcessingTime)
+          rebuiltPendingPublication = pendingRebuild.nonEmpty
+          timerResult = Some(pendingRebuild.getOrElse(GigaEmitResult(null)))
+        }
+      }
+
+      timerResult.foreach { result =>
         timerHorizons.foreach { horizons =>
           emitOrDefer(mode,
                       horizons,
@@ -811,22 +1011,39 @@ class GigaTileProcessFunction(
         }
       }
 
-      if (isPublicationRetryTimer && !isEvictionTimer && hasPendingPublication) {
-        timerHorizons.foreach { horizons =>
-          val retryResult = rebuildPendingAtCurrentTime(mode, horizons, currentProcessingTime)
-            .getOrElse(GigaEmitResult(null))
-          emitOrDefer(mode,
-                      horizons,
-                      retryResult,
-                      ctx.getCurrentKey,
-                      currentProcessingTime,
-                      System.currentTimeMillis(),
-                      timerService,
-                      out,
-                      scheduleWatermarkRetry = false)
+      if (hasPendingPublication) {
+        scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
+      }
+
+      if (isBufferedWriteTimer) {
+        timerHorizons match {
+          case Some(horizons) if shouldPublish(mode, horizons, currentProcessingTime) =>
+            if (!rebuiltPendingPublication && hasDeferredPublication) {
+              rebuildPendingAtCurrentTime(mode, horizons, currentProcessingTime).foreach { rebuildResult =>
+                emitOrDefer(mode,
+                            horizons,
+                            rebuildResult,
+                            ctx.getCurrentKey,
+                            currentProcessingTime,
+                            System.currentTimeMillis(),
+                            timerService,
+                            out,
+                            scheduleWatermarkRetry = false)
+              }
+            }
+            flushBufferedWrite(timerService, currentProcessingTime, ctx.getCurrentKey, out)
+          case _ =>
+            // Park cadence ownership while fenced. The watermark/future-time wakeup is the
+            // primary resume path; normal eviction remains a state-decay fallback.
+            parkBufferedWrite()
+            if (hasPendingPublication) {
+              scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
+            }
         }
       }
 
+      // Version collision is always last so a shared callback emits only the post-mutation,
+      // post-cadence snapshot with a strictly newer version.
       if (isVersionCollisionTimer) {
         timerHorizons match {
           case Some(horizons) if shouldPublish(mode, horizons, currentProcessingTime) =>
@@ -841,7 +1058,10 @@ class GigaTileProcessFunction(
         }
       }
 
-      if ((isPublicationRetryTimer || expiredPublicationRetryMarkerCleared) && hasPendingPublication) {
+      if (
+        (isPublicationRetryTimer || expiredPublicationRetryMarkerCleared || isBufferedWriteTimer) &&
+        hasDeferredPublication
+      ) {
         scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
         scheduleFencedPublicationWakeupIfNeeded(timerService, currentProcessingTime, eventTimeWatermark, mode)
       }
@@ -856,27 +1076,28 @@ class GigaTileProcessFunction(
             nextProcessingEvictionTimerState.clear()
             scheduleProcessingEvictionTimerIfNeeded(timerServiceOnFailure, processingTimeOnFailure)
           }
+          val trackedBufferedWrite = nextBufferedWriteTimerState.value()
+          if (
+            bufferedWriteTimerFired && hasBufferedWrite &&
+            (trackedBufferedWrite == null || trackedBufferedWrite.longValue() <= timestamp)
+          ) {
+            nextBufferedWriteTimerState.clear()
+            scheduleBufferedWriteTimerIfNeeded(timerServiceOnFailure, processingTimeOnFailure)
+          }
           val pendingCollision = pendingVersionCollisionState.value()
           if (
             versionCollisionTimerFired && pendingCollision != null &&
             pendingCollision.longValue() <= timestamp && processingTimeOnFailure < Long.MaxValue
           ) {
-            // A shared callback must preserve eviction-before-publication ordering. If
-            // eviction failed, park the collision on the re-armed eviction timer instead
-            // of publishing the stale pre-eviction snapshot one millisecond later.
-            val retryVersion =
-              if (evictionTimerFired) {
-                Option(nextProcessingEvictionTimerState.value())
-                  .map(_.longValue())
-                  .filter(_ > timestamp)
-                  .getOrElse(processingTimeOnFailure + 1L)
-              } else {
-                processingTimeOnFailure + 1L
-              }
-            timerServiceOnFailure.registerProcessingTimeTimer(retryVersion)
-            pendingVersionCollisionState.update(retryVersion)
+            scheduleProcessingEvictionTimerIfNeeded(timerServiceOnFailure, processingTimeOnFailure)
+            postponeVersionCollision(timerServiceOnFailure,
+                                     processingTimeOnFailure,
+                                     Some(TimeDomain.PROCESSING_TIME -> timestamp))
           }
-          if ((publicationRetryTimerFired || expiredPublicationRetryMarkerCleared) && hasPendingPublication) {
+          if (
+            (publicationRetryTimerFired || expiredPublicationRetryMarkerCleared || bufferedWriteTimerFired) &&
+            hasDeferredPublication
+          ) {
             val eventTimeWatermark = timerServiceOnFailure.currentWatermark()
             currentClockMode(processingTimeOnFailure, eventTimeWatermark) match {
               case Live => schedulePublicationRetryIfNeeded(timerServiceOnFailure, processingTimeOnFailure)
@@ -887,7 +1108,7 @@ class GigaTileProcessFunction(
                                                         mode)
             }
           }
-          if (publicationActivationTimerFired && hasPendingPublication) {
+          if (publicationActivationTimerFired && hasDeferredPublication) {
             schedulePublicationRetryAfterIfNeeded(timerServiceOnFailure,
                                                   processingTimeOnFailure,
                                                   activationCooldownDelayMillis)
@@ -900,6 +1121,11 @@ class GigaTileProcessFunction(
 
   private def isCurrentProcessingEvictionTimer(timestamp: Long): Boolean =
     Option(nextProcessingEvictionTimerState.value()).exists(_.longValue() == timestamp)
+
+  private def isUnmarkedLegacyEvictionTimer(timestamp: Long): Boolean = {
+    val interval = processor.minEvictionInterval
+    nextProcessingEvictionTimerState.value() == null && interval > 0L && timestamp == TsUtils.round(timestamp, interval)
+  }
 
   private def nextProcessingEvictionTimestamp(currentProcessingTime: Long): Option[Long] = {
     val interval = processor.minEvictionInterval

--- a/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
@@ -3,15 +3,17 @@ package ai.chronon.flink.window
 import ai.chronon.aggregator.windowing.{
   EvictionTimes,
   FinalBatchIr,
+  GigaEmitResult,
   GigaTileStore,
   GigaTileStreamProcessor,
   MegaTileAggregator
 }
 import ai.chronon.api.{Constants, DataType, GroupBy, TsUtils}
 import ai.chronon.api.ScalaJavaConversions.IteratorOps
-import ai.chronon.flink.SparkExpressionEval
+import ai.chronon.flink.{FlinkJob, SparkExpressionEval}
 import ai.chronon.flink.deser.ProjectedEvent
 import ai.chronon.flink.types.{BatchIrRow, TimestampedTile}
+import ai.chronon.flink.window.ChrononClockMode.{Catchup, Horizons, Live, Mode, NoWatermark}
 import ai.chronon.online.{GigaTileCodec, MegaTileCodec}
 import ai.chronon.online.serde.ArrayRow
 import org.apache.flink.api.common.state.{MapState, MapStateDescriptor, ValueState, ValueStateDescriptor}
@@ -48,6 +50,7 @@ class GigaTileProcessFunction(
 
   @transient private var eventProcessingErrorCounter: Counter = _
   @transient private var batchUpdateCounter: Counter = _
+  @transient private var futureEventDropCounter: Counter = _
   @transient private var lastKey: java.util.List[Any] = _
 
   private val valueColumns: Array[String] = inputSchema.map(_._1).toArray
@@ -67,6 +70,13 @@ class GigaTileProcessFunction(
   private var lastLargeRecomputeAsOfTsState: ValueState[java.lang.Long] = _
   private var lastEmittedVersionState: ValueState[java.lang.Long] = _
   private var pendingVersionCollisionState: ValueState[java.lang.Long] = _
+  private var pendingPublicationState: ValueState[java.lang.Boolean] = _
+  private var pendingPublicationRetryTimerState: ValueState[java.lang.Long] = _
+  private var pendingPublicationActivationTimerState: ValueState[java.lang.Long] = _
+
+  private val publicationRetryDelayMillis = math.max(1L, 2L * FlinkJob.AutoWatermarkInterval)
+  private val activationCooldownDelayMillis =
+    math.max(publicationRetryDelayMillis, FlinkJob.CatchupWatermarkLagSlackMillis / 2L)
 
   override def open(parameters: Configuration): Unit = {
     super.open(parameters)
@@ -76,6 +86,7 @@ class GigaTileProcessFunction(
       .addGroup("feature_group", groupBy.getMetaData.getName)
     eventProcessingErrorCounter = metricsGroup.counter("event_processing_error")
     batchUpdateCounter = metricsGroup.counter("batch_update_count")
+    futureEventDropCounter = metricsGroup.counter("future_event_drop_count")
 
     tileState = getRuntimeContext.getMapState(
       new MapStateDescriptor[String, Array[Byte]]("giga-tile-tiles", classOf[String], classOf[Array[Byte]]))
@@ -105,6 +116,13 @@ class GigaTileProcessFunction(
       new ValueStateDescriptor[java.lang.Long]("giga-tile-last-emitted-version", classOf[java.lang.Long]))
     pendingVersionCollisionState = getRuntimeContext.getState(
       new ValueStateDescriptor[java.lang.Long]("giga-tile-pending-version-collision", classOf[java.lang.Long]))
+    pendingPublicationState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Boolean]("giga-tile-pending-publication", classOf[java.lang.Boolean]))
+    pendingPublicationRetryTimerState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Long]("giga-tile-pending-publication-retry-pt-timer", classOf[java.lang.Long]))
+    pendingPublicationActivationTimerState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Long]("giga-tile-pending-publication-activation-et-timer",
+                                               classOf[java.lang.Long]))
 
     initializeTransients()
   }
@@ -141,11 +159,214 @@ class GigaTileProcessFunction(
     }
   }
 
-  // Small-window ranges use an exclusive upper bound. At an exact hop, nudge only that
-  // horizon so the just-opened tile remains visible; large windows keep the real time.
-  private def adjustedSmallWindowAsOfTs(asOfTs: Long): Long =
-    if (asOfTs < Long.MaxValue && asOfTs == TsUtils.round(asOfTs, processor.minSmallWindowTileSize)) asOfTs + 1L
-    else asOfTs
+  private def currentClockMode(currentProcessingTime: Long, eventTimeWatermark: Long): Mode =
+    ChrononClockMode.classify(currentProcessingTime,
+                              eventTimeWatermark,
+                              FlinkJob.AllowedOutOfOrderness.toMillis,
+                              FlinkJob.LiveWatermarkLagToleranceMillis)
+
+  private def isFutureEvent(eventTime: Long, currentProcessingTime: Long): Boolean =
+    eventTime > currentProcessingTime
+
+  private def hasPendingPublication: Boolean =
+    java.lang.Boolean.TRUE.equals(pendingPublicationState.value()) && pendingVersionCollisionState.value() == null
+
+  private def schedulePublicationRetryIfNeeded(
+      timerService: TimerService,
+      currentProcessingTime: Long
+  ): Unit =
+    schedulePublicationRetryAfterIfNeeded(timerService, currentProcessingTime, publicationRetryDelayMillis)
+
+  private def schedulePublicationRetryAfterIfNeeded(
+      timerService: TimerService,
+      currentProcessingTime: Long,
+      delayMillis: Long
+  ): Unit = {
+    if (!hasPublicationWakeupTimer && currentProcessingTime <= Long.MaxValue - delayMillis) {
+      val retryTimestamp = currentProcessingTime + delayMillis
+      timerService.registerProcessingTimeTimer(retryTimestamp)
+      pendingPublicationRetryTimerState.update(retryTimestamp)
+    }
+  }
+
+  private def schedulePublicationRetryAtIfNeeded(
+      timerService: TimerService,
+      currentProcessingTime: Long,
+      retryTimestamp: Long
+  ): Unit = {
+    if (!hasPublicationWakeupTimer && retryTimestamp > currentProcessingTime) {
+      timerService.registerProcessingTimeTimer(retryTimestamp)
+      pendingPublicationRetryTimerState.update(retryTimestamp)
+    }
+  }
+
+  private def hasPublicationWakeupTimer: Boolean =
+    pendingPublicationRetryTimerState.value() != null || pendingPublicationActivationTimerState.value() != null
+
+  private def nextPublicationActivationWatermark(currentProcessingTime: Long): Option[Long] = {
+    val liveWatermarkLagMillis = FlinkJob.LiveWatermarkLagToleranceMillis
+    if (currentProcessingTime < Long.MinValue + liveWatermarkLagMillis) None
+    else Some(currentProcessingTime - liveWatermarkLagMillis)
+  }
+
+  private def firstSafeProcessingTimeAfterFutureWatermark(eventTimeWatermark: Long): Option[Long] = {
+    val outOfOrdernessMillis = FlinkJob.AllowedOutOfOrderness.toMillis
+    if (eventTimeWatermark > Long.MaxValue - outOfOrdernessMillis) None
+    else {
+      val lastUnsafeProcessingTime = eventTimeWatermark + outOfOrdernessMillis
+      if (lastUnsafeProcessingTime == Long.MaxValue) None else Some(lastUnsafeProcessingTime + 1L)
+    }
+  }
+
+  private def schedulePublicationActivationIfNeeded(
+      timerService: TimerService,
+      currentProcessingTime: Long,
+      eventTimeWatermark: Long
+  ): Unit = {
+    if (!hasPublicationWakeupTimer) {
+      nextPublicationActivationWatermark(currentProcessingTime)
+        .filter(_ > eventTimeWatermark)
+        .foreach { activationWatermark =>
+          timerService.registerEventTimeTimer(activationWatermark)
+          pendingPublicationActivationTimerState.update(activationWatermark)
+        }
+    }
+  }
+
+  private def scheduleFencedPublicationWakeupIfNeeded(
+      timerService: TimerService,
+      currentProcessingTime: Long,
+      eventTimeWatermark: Long,
+      mode: Mode
+  ): Unit =
+    mode match {
+      case Catchup =>
+        schedulePublicationActivationIfNeeded(timerService, currentProcessingTime, eventTimeWatermark)
+      case NoWatermark if eventTimeWatermark == Long.MinValue =>
+        schedulePublicationActivationIfNeeded(timerService, currentProcessingTime, eventTimeWatermark)
+      case NoWatermark =>
+        // Watermarks never move backward. A future-poisoned watermark becomes safe at one
+        // exact wall-clock boundary, so avoid polling every pending key while time catches up.
+        firstSafeProcessingTimeAfterFutureWatermark(eventTimeWatermark)
+          .foreach { retryTimestamp =>
+            schedulePublicationRetryAtIfNeeded(timerService, currentProcessingTime, retryTimestamp)
+          }
+      case Live => ()
+    }
+
+  private def clearPublicationRetryMarker(): Unit =
+    pendingPublicationRetryTimerState.clear()
+
+  private def clearExpiredPublicationRetryMarker(
+      currentProcessingTime: Long,
+      currentTimerCallback: Option[(TimeDomain, Long)]
+  ): Boolean = {
+    val retryTimestamp = pendingPublicationRetryTimerState.value()
+    if (
+      retryTimestamp != null && processingTimerMarkerIsExpired(retryTimestamp.longValue(),
+                                                               currentProcessingTime,
+                                                               currentTimerCallback)
+    ) {
+      pendingPublicationRetryTimerState.clear()
+      true
+    } else {
+      false
+    }
+  }
+
+  private def clearPublicationWakeupMarkers(): Unit = {
+    pendingPublicationRetryTimerState.clear()
+    pendingPublicationActivationTimerState.clear()
+  }
+
+  private def isCurrentPublicationRetryTimer(timestamp: Long): Boolean =
+    Option(pendingPublicationRetryTimerState.value()).exists(_.longValue() == timestamp)
+
+  private def isCurrentPublicationActivationTimer(timestamp: Long): Boolean =
+    Option(pendingPublicationActivationTimerState.value()).exists(_.longValue() == timestamp)
+
+  private def shouldPublish(
+      mode: Mode,
+      horizons: Horizons,
+      currentProcessingTime: Long
+  ): Boolean = {
+    val currentDayStart = flinkStore.getCurrentDayStart
+    ChrononClockMode.allowsPublication(mode) &&
+    horizons.largeWindowAsOfMillis == currentProcessingTime &&
+    !(currentDayStart >= 0L && flinkStore.getBatchEndTs > currentDayStart)
+  }
+
+  private def advanceDayForMode(
+      mode: Mode,
+      currentProcessingTime: Long,
+      eventTimeWatermark: Long
+  ): GigaEmitResult =
+    ChrononClockMode
+      .dayAdvanceAsOfMillis(mode, currentProcessingTime, eventTimeWatermark)
+      .map(processor.advanceDayAsOf)
+      .getOrElse(GigaEmitResult(null))
+
+  private def preferLatestResult(primary: GigaEmitResult, fallback: GigaEmitResult): GigaEmitResult =
+    if (primary.finalizedVector != null || fallback.finalizedVector == null) primary else fallback
+
+  private def rebuildPendingAtCurrentTime(
+      mode: Mode,
+      horizons: Horizons,
+      currentProcessingTime: Long
+  ): Option[GigaEmitResult] =
+    if (hasPendingPublication && shouldPublish(mode, horizons, currentProcessingTime)) {
+      Some(
+        processor.onEviction(
+          EvictionTimes(timerTs = horizons.largeWindowAsOfMillis, smallWindowAsOfTs = horizons.smallWindowAsOfMillis)))
+    } else {
+      None
+    }
+
+  private def emitOrDefer(
+      mode: Mode,
+      horizons: Horizons,
+      result: GigaEmitResult,
+      currentKey: java.util.List[Any],
+      currentProcessingTime: Long,
+      startProcessingTime: Long,
+      timerService: TimerService,
+      out: Collector[TimestampedTile],
+      scheduleWatermarkRetry: Boolean
+  ): Unit = {
+    if (!shouldPublish(mode, horizons, currentProcessingTime)) {
+      val publicationPending = result.finalizedVector != null || result.needsEvictionTimer || hasPendingPublication
+      if (publicationPending) {
+        pendingPublicationState.update(java.lang.Boolean.TRUE)
+        if (scheduleWatermarkRetry) schedulePublicationRetryIfNeeded(timerService, currentProcessingTime)
+      }
+      return
+    }
+
+    val finalizedVector =
+      if (result.finalizedVector != null) result.finalizedVector
+      else if (hasPendingPublication) processor.currentSnapshot.finalizedVector
+      else null
+
+    if (finalizedVector != null) {
+      // This covers encoding and Collector handoff only. The downstream async KV result is
+      // outside this keyed operator and cannot acknowledge or retry through this state.
+      pendingPublicationState.update(java.lang.Boolean.TRUE)
+      try {
+        emitOrCoalesceVersionCollision(timerService,
+                                       finalizedVector,
+                                       currentKey,
+                                       currentProcessingTime,
+                                       startProcessingTime,
+                                       out)
+        if (pendingVersionCollisionState.value() == null) pendingPublicationState.clear()
+        clearPublicationWakeupMarkers()
+      } catch {
+        case e: Exception =>
+          logger.error(s"Error emitting giga tile for groupBy=${groupBy.getMetaData.getName}", e)
+          eventProcessingErrorCounter.inc()
+      }
+    }
+  }
 
   /** Processing-time callbacks can share a millisecond. Coalesce later same-millisecond updates
     * behind a timer so emitted versions are strictly increasing before async sink handoff.
@@ -285,9 +506,36 @@ class GigaTileProcessFunction(
     }
   }
 
+  private def postponeVersionCollision(
+      timerService: TimerService,
+      currentProcessingTime: Long,
+      currentTimerCallback: Option[(TimeDomain, Long)]
+  ): Unit = {
+    if (pendingVersionCollisionState.value() != null) {
+      val trackedEviction = nextProcessingEvictionTimerState.value()
+      val retryVersion =
+        if (
+          trackedEviction != null && !processingTimerMarkerIsExpired(trackedEviction.longValue(),
+                                                                     currentProcessingTime,
+                                                                     currentTimerCallback)
+        ) {
+          Some(trackedEviction.longValue())
+        } else {
+          nextProcessingEvictionTimestamp(currentProcessingTime)
+        }
+      retryVersion.foreach { version =>
+        // This normally shares the tracked eviction timer; registering the same keyed
+        // timestamp is idempotent and avoids a separate hot retry loop while fenced.
+        timerService.registerProcessingTimeTimer(version)
+        pendingVersionCollisionState.update(version)
+      }
+    }
+  }
+
   private def flushVersionCollision(
       timerService: TimerService,
       currentProcessingTime: Long,
+      currentTimerCallback: Option[(TimeDomain, Long)],
       currentKey: java.util.List[Any],
       out: Collector[TimestampedTile]
   ): Unit = {
@@ -300,15 +548,14 @@ class GigaTileProcessFunction(
       out.collect(new TimestampedTile(currentKey, encoded, pendingVersion.longValue(), System.currentTimeMillis()))
       lastEmittedVersionState.update(pendingVersion)
       pendingVersionCollisionState.clear()
+      pendingPublicationState.clear()
+      clearPublicationWakeupMarkers()
     } catch {
       case e: Exception =>
         // The fired timer was the only flush trigger. Re-arm before the outer handler records
         // the failure so a transient encoding/collection error cannot strand the latest value.
-        if (currentProcessingTime < Long.MaxValue) {
-          val retryVersion = currentProcessingTime + 1L
-          timerService.registerProcessingTimeTimer(retryVersion)
-          pendingVersionCollisionState.update(retryVersion)
-        }
+        scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
+        postponeVersionCollision(timerService, currentProcessingTime, currentTimerCallback)
         throw e
     }
   }
@@ -332,20 +579,39 @@ class GigaTileProcessFunction(
       val timerService = ctx.timerService()
       val currentProcessingTime = timerService.currentProcessingTime()
       repairExpiredProcessingTimerMarkers(timerService, currentProcessingTime, None)
-      val rolloverResult = processor.advanceWatermark(currentProcessingTime)
+      if (isFutureEvent(tsMills, currentProcessingTime)) {
+        futureEventDropCounter.inc()
+        return
+      }
+      clearExpiredPublicationRetryMarker(currentProcessingTime, None)
+      val eventTimeWatermark = timerService.currentWatermark()
+      val mode = currentClockMode(currentProcessingTime, eventTimeWatermark)
+      val horizons = ChrononClockMode.streamEventHorizons(mode,
+                                                          tsMills,
+                                                          currentProcessingTime,
+                                                          eventTimeWatermark,
+                                                          processor.minSmallWindowTileSize)
+
+      val rolloverResult =
+        if (mode == NoWatermark) processor.advanceDayAsOf(tsMills)
+        else advanceDayForMode(mode, currentProcessingTime, eventTimeWatermark)
+      val pendingRebuild = rebuildPendingAtCurrentTime(mode, horizons, currentProcessingTime)
       val eventResult = processor.onEvent(row,
                                           tsMills,
-                                          largeWindowAsOfTs = currentProcessingTime,
-                                          smallWindowAsOfTs = adjustedSmallWindowAsOfTs(currentProcessingTime))
-      val result = if (eventResult.finalizedVector != null) eventResult else rolloverResult
+                                          largeWindowAsOfTs = horizons.largeWindowAsOfMillis,
+                                          smallWindowAsOfTs = horizons.smallWindowAsOfMillis)
+      val result = preferLatestResult(eventResult, pendingRebuild.getOrElse(rolloverResult))
 
       scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
-      emitOrCoalesceVersionCollision(timerService,
-                                     result.finalizedVector,
-                                     ctx.getCurrentKey,
-                                     currentProcessingTime,
-                                     event.startProcessingTimeMillis,
-                                     out)
+      emitOrDefer(mode,
+                  horizons,
+                  result,
+                  ctx.getCurrentKey,
+                  currentProcessingTime,
+                  event.startProcessingTimeMillis,
+                  timerService,
+                  out,
+                  scheduleWatermarkRetry = true)
 
     } catch {
       case e: Exception =>
@@ -367,26 +633,40 @@ class GigaTileProcessFunction(
       val timerService = ctx.timerService()
       val currentProcessingTime = timerService.currentProcessingTime()
       repairExpiredProcessingTimerMarkers(timerService, currentProcessingTime, None)
-      val rolloverResult = processor.advanceWatermark(currentProcessingTime)
+      clearExpiredPublicationRetryMarker(currentProcessingTime, None)
+      val eventTimeWatermark = timerService.currentWatermark()
+      val mode = currentClockMode(currentProcessingTime, eventTimeWatermark)
+      val horizons = ChrononClockMode.batchUpdateHorizons(mode,
+                                                          batchRow.batchEndTs,
+                                                          flinkStore.getCurrentDayStart,
+                                                          currentProcessingTime,
+                                                          eventTimeWatermark,
+                                                          processor.minSmallWindowTileSize)
 
+      val rolloverResult = advanceDayForMode(mode, currentProcessingTime, eventTimeWatermark)
+      val pendingRebuild = rebuildPendingAtCurrentTime(mode, horizons, currentProcessingTime)
       val batchIr = gigaTileCodec.decodeBatchIr(batchRow.valueBytes)
       val batchResult = processor.onBatchUpdate(batchIr,
                                                 batchRow.batchEndTs,
-                                                largeWindowAsOfTs = currentProcessingTime,
-                                                smallWindowAsOfTs = adjustedSmallWindowAsOfTs(currentProcessingTime))
-      val result = if (batchResult.finalizedVector != null) batchResult else rolloverResult
+                                                largeWindowAsOfTs = horizons.largeWindowAsOfMillis,
+                                                smallWindowAsOfTs = horizons.smallWindowAsOfMillis)
+      val result = preferLatestResult(batchResult, pendingRebuild.getOrElse(rolloverResult))
 
       batchUpdateCounter.inc()
 
-      if (batchResult.needsEvictionTimer) {
+      emitOrDefer(mode,
+                  horizons,
+                  result,
+                  ctx.getCurrentKey,
+                  currentProcessingTime,
+                  System.currentTimeMillis(),
+                  timerService,
+                  out,
+                  scheduleWatermarkRetry = true)
+
+      if (batchResult.needsEvictionTimer || hasPendingPublication) {
         scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
       }
-      emitOrCoalesceVersionCollision(timerService,
-                                     result.finalizedVector,
-                                     ctx.getCurrentKey,
-                                     currentProcessingTime,
-                                     System.currentTimeMillis(),
-                                     out)
     } catch {
       case e: Exception =>
         logger.error(s"Error processing batch IR for groupBy=${groupBy.getMetaData.getName}", e)
@@ -403,21 +683,63 @@ class GigaTileProcessFunction(
     var processingTimeOnFailure = Long.MinValue
     var evictionTimerFired = false
     var versionCollisionTimerFired = false
+    var publicationRetryTimerFired = false
+    var publicationActivationTimerFired = false
+    var expiredPublicationRetryMarkerCleared = false
     try {
       if (processor == null) initializeTransients()
 
       ensureStateBound(ctx.getCurrentKey)
       val timerService = ctx.timerService()
       val currentProcessingTime = timerService.currentProcessingTime()
+      val currentTimerCallback = Some(ctx.timeDomain() -> timestamp)
       timerServiceOnFailure = timerService
       processingTimeOnFailure = currentProcessingTime
-      repairExpiredProcessingTimerMarkers(timerService, currentProcessingTime, Some(ctx.timeDomain() -> timestamp))
+      repairExpiredProcessingTimerMarkers(timerService, currentProcessingTime, currentTimerCallback)
 
-      // Checkpoints written by the event-time implementation may still contain several
-      // event-time eviction timers per key. Let those callbacks migrate the key to one
-      // processing-time timer, but do not publish from both timer domains.
+      // Checkpoints written by the former event-time implementation may still contain
+      // eviction timers. Only the explicitly tracked activation timer may publish from this
+      // domain; untracked legacy timers remain migration-only.
       if (ctx.timeDomain() == TimeDomain.EVENT_TIME) {
+        val isPublicationActivationTimer = isCurrentPublicationActivationTimer(timestamp)
+        publicationActivationTimerFired = isPublicationActivationTimer
+        if (isPublicationActivationTimer) pendingPublicationActivationTimerState.clear()
         scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
+        if (isPublicationActivationTimer) {
+          if (hasPendingPublication) {
+            val eventTimeWatermark = timerService.currentWatermark()
+            currentClockMode(currentProcessingTime, eventTimeWatermark) match {
+              case Live =>
+                val horizons = ChrononClockMode
+                  .processingTimerHorizons(Live,
+                                           currentProcessingTime,
+                                           eventTimeWatermark,
+                                           processor.minSmallWindowTileSize)
+                  .get
+                val rolloverResult = advanceDayForMode(Live, currentProcessingTime, eventTimeWatermark)
+                val retryResult = rebuildPendingAtCurrentTime(Live, horizons, currentProcessingTime)
+                  .getOrElse(GigaEmitResult(null))
+                val result = preferLatestResult(retryResult, rolloverResult)
+                emitOrDefer(Live,
+                            horizons,
+                            result,
+                            ctx.getCurrentKey,
+                            currentProcessingTime,
+                            System.currentTimeMillis(),
+                            timerService,
+                            out,
+                            scheduleWatermarkRetry = false)
+              case Catchup =>
+                // If callback delivery consumed the Live slack, separate retries from source
+                // watermark cadence before installing a new activation boundary.
+                schedulePublicationRetryAfterIfNeeded(timerService,
+                                                      currentProcessingTime,
+                                                      activationCooldownDelayMillis)
+              case mode =>
+                scheduleFencedPublicationWakeupIfNeeded(timerService, currentProcessingTime, eventTimeWatermark, mode)
+            }
+          }
+        }
         return
       }
 
@@ -427,37 +749,101 @@ class GigaTileProcessFunction(
 
       val isEvictionTimer = isCurrentProcessingEvictionTimer(timestamp)
       val isVersionCollisionTimer = isCurrentVersionCollisionTimer(timestamp)
+      val isPublicationRetryTimer = isCurrentPublicationRetryTimer(timestamp)
       evictionTimerFired = isEvictionTimer
       versionCollisionTimerFired = isVersionCollisionTimer
-      if (!isEvictionTimer && !isVersionCollisionTimer) return
+      publicationRetryTimerFired = isPublicationRetryTimer
+      if (!isPublicationRetryTimer) {
+        expiredPublicationRetryMarkerCleared =
+          clearExpiredPublicationRetryMarker(currentProcessingTime, currentTimerCallback)
+      }
+      if (
+        !isEvictionTimer && !isVersionCollisionTimer && !isPublicationRetryTimer &&
+        !expiredPublicationRetryMarkerCleared
+      ) return
 
-      var finalizedVector: Array[Any] = null
+      // The physical retry timer has fired. Clear only its logical role before running all
+      // coincident roles, then arm one watermark-driven wake-up if publication remains fenced.
+      if (isPublicationRetryTimer) clearPublicationRetryMarker()
+      val eventTimeWatermark = timerService.currentWatermark()
+      val mode = currentClockMode(currentProcessingTime, eventTimeWatermark)
+      val timerHorizons = ChrononClockMode.processingTimerHorizons(mode,
+                                                                   currentProcessingTime,
+                                                                   eventTimeWatermark,
+                                                                   processor.minSmallWindowTileSize)
+
+      var result = GigaEmitResult(null)
       if (isEvictionTimer) {
         nextProcessingEvictionTimerState.clear()
-        val rolloverResult = processor.advanceWatermark(currentProcessingTime)
-        val evictionResult = processor.onEviction(
-          EvictionTimes(timerTs = currentProcessingTime,
-                        smallWindowAsOfTs = adjustedSmallWindowAsOfTs(currentProcessingTime)))
-        finalizedVector =
-          if (evictionResult.finalizedVector != null) evictionResult.finalizedVector else rolloverResult.finalizedVector
+        mode match {
+          case NoWatermark =>
+            // The active batch input holds the connected watermark at MIN while it scans.
+            // Keep consuming records, but do not age or roll keyed state from wall clock.
+            val snapshot = processor.currentSnapshot
+            if (!snapshot.isEmpty) pendingPublicationState.update(java.lang.Boolean.TRUE)
+            result = GigaEmitResult(null, needsEvictionTimer = snapshot.needsEvictionTimer, isEmpty = snapshot.isEmpty)
+          case _ =>
+            val horizons = timerHorizons.get
+            val rolloverResult = advanceDayForMode(mode, currentProcessingTime, eventTimeWatermark)
+            val evictionResult = rebuildPendingAtCurrentTime(mode, horizons, currentProcessingTime)
+              .getOrElse(
+                processor.onEviction(EvictionTimes(timerTs = horizons.largeWindowAsOfMillis,
+                                                   smallWindowAsOfTs = horizons.smallWindowAsOfMillis)))
+            result = preferLatestResult(evictionResult, rolloverResult)
+        }
 
-        // Re-register before a coincident collision flush: if encoding the flush fails, both
-        // the retry and normal eviction cadence remain live.
-        if (!evictionResult.isEmpty || evictionResult.needsEvictionTimer) {
+        // Keep normal decay live while state or a deferred publication remains. A coincident
+        // collision flush rearms itself on failure, so it does not need a speculative timer.
+        if (!result.isEmpty || result.needsEvictionTimer || hasPendingPublication) {
           scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
+        }
+
+        timerHorizons.foreach { horizons =>
+          emitOrDefer(mode,
+                      horizons,
+                      result,
+                      ctx.getCurrentKey,
+                      currentProcessingTime,
+                      System.currentTimeMillis(),
+                      timerService,
+                      out,
+                      scheduleWatermarkRetry = false)
+        }
+      }
+
+      if (isPublicationRetryTimer && !isEvictionTimer && hasPendingPublication) {
+        timerHorizons.foreach { horizons =>
+          val retryResult = rebuildPendingAtCurrentTime(mode, horizons, currentProcessingTime)
+            .getOrElse(GigaEmitResult(null))
+          emitOrDefer(mode,
+                      horizons,
+                      retryResult,
+                      ctx.getCurrentKey,
+                      currentProcessingTime,
+                      System.currentTimeMillis(),
+                      timerService,
+                      out,
+                      scheduleWatermarkRetry = false)
         }
       }
 
       if (isVersionCollisionTimer) {
-        // Eviction wins when both timers share a timestamp; publish one post-eviction snapshot.
-        flushVersionCollision(timerService, currentProcessingTime, ctx.getCurrentKey, out)
-      } else {
-        emitOrCoalesceVersionCollision(timerService,
-                                       finalizedVector,
-                                       ctx.getCurrentKey,
-                                       currentProcessingTime,
-                                       System.currentTimeMillis(),
-                                       out)
+        timerHorizons match {
+          case Some(horizons) if shouldPublish(mode, horizons, currentProcessingTime) =>
+            // Eviction runs first when both markers share a timestamp, so this is one
+            // post-eviction snapshot with a strictly newer version.
+            pendingPublicationState.update(java.lang.Boolean.TRUE)
+            flushVersionCollision(timerService, currentProcessingTime, currentTimerCallback, ctx.getCurrentKey, out)
+          case _ =>
+            pendingPublicationState.update(java.lang.Boolean.TRUE)
+            scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
+            postponeVersionCollision(timerService, currentProcessingTime, currentTimerCallback)
+        }
+      }
+
+      if ((isPublicationRetryTimer || expiredPublicationRetryMarkerCleared) && hasPendingPublication) {
+        scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
+        scheduleFencedPublicationWakeupIfNeeded(timerService, currentProcessingTime, eventTimeWatermark, mode)
       }
     } catch {
       case e: Exception =>
@@ -489,6 +875,22 @@ class GigaTileProcessFunction(
               }
             timerServiceOnFailure.registerProcessingTimeTimer(retryVersion)
             pendingVersionCollisionState.update(retryVersion)
+          }
+          if ((publicationRetryTimerFired || expiredPublicationRetryMarkerCleared) && hasPendingPublication) {
+            val eventTimeWatermark = timerServiceOnFailure.currentWatermark()
+            currentClockMode(processingTimeOnFailure, eventTimeWatermark) match {
+              case Live => schedulePublicationRetryIfNeeded(timerServiceOnFailure, processingTimeOnFailure)
+              case mode =>
+                scheduleFencedPublicationWakeupIfNeeded(timerServiceOnFailure,
+                                                        processingTimeOnFailure,
+                                                        eventTimeWatermark,
+                                                        mode)
+            }
+          }
+          if (publicationActivationTimerFired && hasPendingPublication) {
+            schedulePublicationRetryAfterIfNeeded(timerServiceOnFailure,
+                                                  processingTimeOnFailure,
+                                                  activationCooldownDelayMillis)
           }
         }
         logger.error(s"Error in giga tile eviction for groupBy=${groupBy.getMetaData.getName}", e)
@@ -523,7 +925,7 @@ class GigaTileProcessFunction(
 
 /** TileStore backed by Flink state for GigaTile. Extends the mega tile state with batch IR
   * storage and a per-day large-IR map (keyed by day-start) sized to bridge any retained gap
-  * between batchEndDay and the watermark day.
+  * between batchEndDay and the current materialized day.
   */
 class FlinkGigaTileStore(megaTileAgg: MegaTileAggregator, codec: MegaTileCodec, gigaCodec: GigaTileCodec)
     extends GigaTileStore {

--- a/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
@@ -1,6 +1,12 @@
 package ai.chronon.flink.window
 
-import ai.chronon.aggregator.windowing.{FinalBatchIr, GigaTileStore, GigaTileStreamProcessor, MegaTileAggregator}
+import ai.chronon.aggregator.windowing.{
+  EvictionTimes,
+  FinalBatchIr,
+  GigaTileStore,
+  GigaTileStreamProcessor,
+  MegaTileAggregator
+}
 import ai.chronon.api.{Constants, DataType, GroupBy, TsUtils}
 import ai.chronon.api.ScalaJavaConversions.IteratorOps
 import ai.chronon.flink.SparkExpressionEval
@@ -57,6 +63,8 @@ class GigaTileProcessFunction(
   private var batchEndTsState: ValueState[java.lang.Long] = _
   private var runningLargeIrState: ValueState[Array[Byte]] = _
   private var nextProcessingEvictionTimerState: ValueState[java.lang.Long] = _
+  private var cachedSmallWindowAsOfTsState: ValueState[java.lang.Long] = _
+  private var lastLargeRecomputeAsOfTsState: ValueState[java.lang.Long] = _
   private var lastEmittedVersionState: ValueState[java.lang.Long] = _
   private var pendingVersionCollisionState: ValueState[java.lang.Long] = _
 
@@ -89,6 +97,10 @@ class GigaTileProcessFunction(
       getRuntimeContext.getState(new ValueStateDescriptor[Array[Byte]]("giga-tile-running-large", classOf[Array[Byte]]))
     nextProcessingEvictionTimerState = getRuntimeContext.getState(
       new ValueStateDescriptor[java.lang.Long]("giga-tile-next-evict-pt-timer", classOf[java.lang.Long]))
+    cachedSmallWindowAsOfTsState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Long]("giga-tile-cached-small-window-as-of-ts", classOf[java.lang.Long]))
+    lastLargeRecomputeAsOfTsState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Long]("giga-tile-last-large-recompute-as-of-ts", classOf[java.lang.Long]))
     lastEmittedVersionState = getRuntimeContext.getState(
       new ValueStateDescriptor[java.lang.Long]("giga-tile-last-emitted-version", classOf[java.lang.Long]))
     pendingVersionCollisionState = getRuntimeContext.getState(
@@ -122,10 +134,18 @@ class GigaTileProcessFunction(
         earliestTileStartState,
         batchIrState,
         batchEndTsState,
-        runningLargeIrState
+        runningLargeIrState,
+        cachedSmallWindowAsOfTsState,
+        lastLargeRecomputeAsOfTsState
       )
     }
   }
+
+  // Small-window ranges use an exclusive upper bound. At an exact hop, nudge only that
+  // horizon so the just-opened tile remains visible; large windows keep the real time.
+  private def adjustedSmallWindowAsOfTs(asOfTs: Long): Long =
+    if (asOfTs < Long.MaxValue && asOfTs == TsUtils.round(asOfTs, processor.minSmallWindowTileSize)) asOfTs + 1L
+    else asOfTs
 
   /** Processing-time callbacks can share a millisecond. Coalesce later same-millisecond updates
     * behind a timer so emitted versions are strictly increasing before async sink handoff.
@@ -313,7 +333,10 @@ class GigaTileProcessFunction(
       val currentProcessingTime = timerService.currentProcessingTime()
       repairExpiredProcessingTimerMarkers(timerService, currentProcessingTime, None)
       val rolloverResult = processor.advanceWatermark(currentProcessingTime)
-      val eventResult = processor.onEvent(row, tsMills, currentProcessingTime)
+      val eventResult = processor.onEvent(row,
+                                          tsMills,
+                                          largeWindowAsOfTs = currentProcessingTime,
+                                          smallWindowAsOfTs = adjustedSmallWindowAsOfTs(currentProcessingTime))
       val result = if (eventResult.finalizedVector != null) eventResult else rolloverResult
 
       scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
@@ -347,7 +370,10 @@ class GigaTileProcessFunction(
       val rolloverResult = processor.advanceWatermark(currentProcessingTime)
 
       val batchIr = gigaTileCodec.decodeBatchIr(batchRow.valueBytes)
-      val batchResult = processor.onBatchUpdate(batchIr, batchRow.batchEndTs, currentProcessingTime)
+      val batchResult = processor.onBatchUpdate(batchIr,
+                                                batchRow.batchEndTs,
+                                                largeWindowAsOfTs = currentProcessingTime,
+                                                smallWindowAsOfTs = adjustedSmallWindowAsOfTs(currentProcessingTime))
       val result = if (batchResult.finalizedVector != null) batchResult else rolloverResult
 
       batchUpdateCounter.inc()
@@ -409,13 +435,15 @@ class GigaTileProcessFunction(
       if (isEvictionTimer) {
         nextProcessingEvictionTimerState.clear()
         val rolloverResult = processor.advanceWatermark(currentProcessingTime)
-        val evictionResult = processor.onScheduledEviction(currentProcessingTime)
+        val evictionResult = processor.onEviction(
+          EvictionTimes(timerTs = currentProcessingTime,
+                        smallWindowAsOfTs = adjustedSmallWindowAsOfTs(currentProcessingTime)))
         finalizedVector =
           if (evictionResult.finalizedVector != null) evictionResult.finalizedVector else rolloverResult.finalizedVector
 
         // Re-register before a coincident collision flush: if encoding the flush fails, both
         // the retry and normal eviction cadence remain live.
-        if (!evictionResult.isEmpty) {
+        if (!evictionResult.isEmpty || evictionResult.needsEvictionTimer) {
           scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
         }
       }
@@ -509,6 +537,8 @@ class FlinkGigaTileStore(megaTileAgg: MegaTileAggregator, codec: MegaTileCodec, 
   private var batchIrState: ValueState[Array[Byte]] = _
   private var batchEndTsState: ValueState[java.lang.Long] = _
   private var runningLargeIrState: ValueState[Array[Byte]] = _
+  private var cachedSmallWindowAsOfTsState: ValueState[java.lang.Long] = _
+  private var lastLargeRecomputeAsOfTsState: ValueState[java.lang.Long] = _
 
   // Decode cache invalidated on key switch. Keeping per-day decoded values in an off-heap
   // mutable map would defeat the idea of per-key Flink state, so we just memoize the values
@@ -527,7 +557,9 @@ class FlinkGigaTileStore(megaTileAgg: MegaTileAggregator, codec: MegaTileCodec, 
                      earliest: ValueState[java.lang.Long],
                      batchIr: ValueState[Array[Byte]],
                      batchEndTs: ValueState[java.lang.Long],
-                     runningLarge: ValueState[Array[Byte]]): Unit = {
+                     runningLarge: ValueState[Array[Byte]],
+                     cachedSmallWindowAsOfTs: ValueState[java.lang.Long],
+                     lastLargeRecomputeAsOfTs: ValueState[java.lang.Long]): Unit = {
     tileState = tiles
     megaTileIrState = megaTileIr
     dailyLargeIrState = dailyLargeIr
@@ -536,6 +568,8 @@ class FlinkGigaTileStore(megaTileAgg: MegaTileAggregator, codec: MegaTileCodec, 
     batchIrState = batchIr
     batchEndTsState = batchEndTs
     runningLargeIrState = runningLarge
+    cachedSmallWindowAsOfTsState = cachedSmallWindowAsOfTs
+    lastLargeRecomputeAsOfTsState = lastLargeRecomputeAsOfTs
     cachedSmallValid = false
     batchIrValid = false
     runningLargeValid = false
@@ -576,6 +610,14 @@ class FlinkGigaTileStore(megaTileAgg: MegaTileAggregator, codec: MegaTileCodec, 
     megaTileIrState.update(codec.encode(ir))
     cachedSmallDecoded = ir; cachedSmallValid = true
   }
+
+  override def getCachedSmallWindowAsOfTs: Long =
+    Option(cachedSmallWindowAsOfTsState.value()).map(_.longValue()).getOrElse(-1L)
+  override def putCachedSmallWindowAsOfTs(ts: Long): Unit = cachedSmallWindowAsOfTsState.update(ts)
+
+  override def getLastLargeRecomputeAsOfTs: Long =
+    Option(lastLargeRecomputeAsOfTsState.value()).map(_.longValue()).getOrElse(Long.MinValue)
+  override def putLastLargeRecomputeAsOfTs(ts: Long): Unit = lastLargeRecomputeAsOfTsState.update(ts)
 
   // Today/yesterday accessors required by the parent TileStore trait but unused in GigaTile —
   // routing happens through the per-day map below. Stubbed to safe defaults so a misroute is

--- a/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
@@ -11,6 +11,7 @@ import ai.chronon.online.serde.ArrayRow
 import org.apache.flink.api.common.state.{MapState, MapStateDescriptor, ValueState, ValueStateDescriptor}
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.metrics.Counter
+import org.apache.flink.streaming.api.{TimeDomain, TimerService}
 import org.apache.flink.streaming.api.functions.co.KeyedCoProcessFunction
 import org.apache.flink.util.Collector
 import org.slf4j.{Logger, LoggerFactory}
@@ -55,6 +56,9 @@ class GigaTileProcessFunction(
   private var batchIrState: ValueState[Array[Byte]] = _
   private var batchEndTsState: ValueState[java.lang.Long] = _
   private var runningLargeIrState: ValueState[Array[Byte]] = _
+  private var nextProcessingEvictionTimerState: ValueState[java.lang.Long] = _
+  private var lastEmittedVersionState: ValueState[java.lang.Long] = _
+  private var pendingVersionCollisionState: ValueState[java.lang.Long] = _
 
   override def open(parameters: Configuration): Unit = {
     super.open(parameters)
@@ -70,10 +74,9 @@ class GigaTileProcessFunction(
     megaTileIrState =
       getRuntimeContext.getState(new ValueStateDescriptor[Array[Byte]]("giga-tile-ir", classOf[Array[Byte]]))
     dailyLargeIrState = getRuntimeContext.getMapState(
-      new MapStateDescriptor[java.lang.Long, Array[Byte]](
-        "giga-tile-large-daily",
-        classOf[java.lang.Long],
-        classOf[Array[Byte]]))
+      new MapStateDescriptor[java.lang.Long, Array[Byte]]("giga-tile-large-daily",
+                                                          classOf[java.lang.Long],
+                                                          classOf[Array[Byte]]))
     currentDayStartState = getRuntimeContext.getState(
       new ValueStateDescriptor[java.lang.Long]("giga-tile-day-start", classOf[java.lang.Long]))
     earliestTileStartState = getRuntimeContext.getState(
@@ -82,8 +85,14 @@ class GigaTileProcessFunction(
       getRuntimeContext.getState(new ValueStateDescriptor[Array[Byte]]("giga-tile-batch-ir", classOf[Array[Byte]]))
     batchEndTsState = getRuntimeContext.getState(
       new ValueStateDescriptor[java.lang.Long]("giga-tile-batch-end", classOf[java.lang.Long]))
-    runningLargeIrState = getRuntimeContext.getState(
-      new ValueStateDescriptor[Array[Byte]]("giga-tile-running-large", classOf[Array[Byte]]))
+    runningLargeIrState =
+      getRuntimeContext.getState(new ValueStateDescriptor[Array[Byte]]("giga-tile-running-large", classOf[Array[Byte]]))
+    nextProcessingEvictionTimerState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Long]("giga-tile-next-evict-pt-timer", classOf[java.lang.Long]))
+    lastEmittedVersionState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Long]("giga-tile-last-emitted-version", classOf[java.lang.Long]))
+    pendingVersionCollisionState = getRuntimeContext.getState(
+      new ValueStateDescriptor[java.lang.Long]("giga-tile-pending-version-collision", classOf[java.lang.Long]))
 
     initializeTransients()
   }
@@ -106,10 +115,181 @@ class GigaTileProcessFunction(
     if (lastKey == null || !lastKey.equals(currentKey)) {
       lastKey = currentKey
       flinkStore.bindFlinkState(
-        tileState, megaTileIrState, dailyLargeIrState,
-        currentDayStartState, earliestTileStartState,
-        batchIrState, batchEndTsState, runningLargeIrState
+        tileState,
+        megaTileIrState,
+        dailyLargeIrState,
+        currentDayStartState,
+        earliestTileStartState,
+        batchIrState,
+        batchEndTsState,
+        runningLargeIrState
       )
+    }
+  }
+
+  /** Processing-time callbacks can share a millisecond. Coalesce later same-millisecond updates
+    * behind a timer so emitted versions are strictly increasing before async sink handoff.
+    */
+  private def emitOrCoalesceVersionCollision(
+      timerService: TimerService,
+      finalizedVector: Array[Any],
+      currentKey: java.util.List[Any],
+      versionMillis: Long,
+      startProcessingTimeMillis: Long,
+      out: Collector[TimestampedTile]
+  ): Unit = {
+    if (finalizedVector == null) return
+
+    val lastEmittedVersion = lastEmittedVersionState.value()
+    if (
+      pendingVersionCollisionState.value() != null ||
+      (lastEmittedVersion != null && versionMillis <= lastEmittedVersion.longValue())
+    ) {
+      scheduleVersionCollisionFlushIfNeeded(timerService, lastEmittedVersion)
+    } else {
+      try {
+        out.collect(
+          new TimestampedTile(currentKey,
+                              gigaTileCodec.encodeOutput(finalizedVector),
+                              versionMillis,
+                              startProcessingTimeMillis))
+        lastEmittedVersionState.update(versionMillis)
+      } catch {
+        case e: Exception =>
+          // State was already mutated. Retry the current snapshot on a future timer so a
+          // transient first-write failure cannot leave the key unpublished.
+          scheduleVersionCollisionFlushIfNeeded(timerService, lastEmittedVersion)
+          throw e
+      }
+    }
+  }
+
+  private def scheduleVersionCollisionFlushIfNeeded(
+      timerService: TimerService,
+      lastEmittedVersion: java.lang.Long
+  ): Unit = {
+    val currentProcessingTime = timerService.currentProcessingTime()
+    if (
+      pendingVersionCollisionState.value() == null && currentProcessingTime < Long.MaxValue &&
+      (lastEmittedVersion == null || lastEmittedVersion.longValue() < Long.MaxValue)
+    ) {
+      val flushVersion =
+        if (lastEmittedVersion == null) currentProcessingTime + 1L
+        else math.max(lastEmittedVersion.longValue() + 1L, currentProcessingTime + 1L)
+      timerService.registerProcessingTimeTimer(flushVersion)
+      pendingVersionCollisionState.update(flushVersion)
+    }
+  }
+
+  private def isCurrentVersionCollisionTimer(timestamp: Long): Boolean =
+    Option(pendingVersionCollisionState.value()).exists(_.longValue() == timestamp)
+
+  private def processingTimerMarkerIsExpired(
+      markerTimestamp: Long,
+      currentProcessingTime: Long,
+      currentTimerCallback: Option[(TimeDomain, Long)]
+  ): Boolean =
+    currentTimerCallback match {
+      case None => markerTimestamp <= currentProcessingTime
+      // Flink exposes the jump target as currentProcessingTime while draining every due
+      // timer in timestamp order. A later marker is still physically queued; only a marker
+      // before this callback can have been consumed without clearing its ownership state.
+      case Some((TimeDomain.PROCESSING_TIME, callbackTimestamp)) => markerTimestamp < callbackTimestamp
+      case Some((TimeDomain.EVENT_TIME, _))                      => false
+    }
+
+  private def isCurrentProcessingTimerCallback(
+      timestamp: Long,
+      currentTimerCallback: Option[(TimeDomain, Long)]
+  ): Boolean =
+    currentTimerCallback.contains(TimeDomain.PROCESSING_TIME -> timestamp)
+
+  /** An older binary can consume additive processing-time timers without clearing their
+    * keyed ownership markers. Repair expired ownership on the next keyed callback. This
+    * cannot repair a completely idle key because a KeyedCoProcessFunction cannot enumerate
+    * keyed state during open; rolling back below this timer-aware layer still requires a
+    * retained compatible checkpoint or a state migration.
+    */
+  private def repairExpiredProcessingTimerMarkers(
+      timerService: TimerService,
+      currentProcessingTime: Long,
+      currentTimerCallback: Option[(TimeDomain, Long)]
+  ): Unit = {
+    val trackedEviction = nextProcessingEvictionTimerState.value()
+    if (
+      trackedEviction != null && processingTimerMarkerIsExpired(trackedEviction.longValue(),
+                                                                currentProcessingTime,
+                                                                currentTimerCallback)
+    ) {
+      nextProcessingEvictionTimestamp(currentProcessingTime) match {
+        case Some(nextEviction) =>
+          // Register first. If registration fails, leave the stale marker visible so a later
+          // callback can retry instead of recording ownership with no physical timer.
+          timerService.registerProcessingTimeTimer(nextEviction)
+          nextProcessingEvictionTimerState.update(nextEviction)
+        case None => nextProcessingEvictionTimerState.clear()
+      }
+    }
+
+    val trackedCollision = pendingVersionCollisionState.value()
+    if (
+      trackedCollision != null && processingTimerMarkerIsExpired(trackedCollision.longValue(),
+                                                                 currentProcessingTime,
+                                                                 currentTimerCallback)
+    ) {
+      val sharedEviction = Option(nextProcessingEvictionTimerState.value())
+        .map(_.longValue())
+        .filterNot(processingTimerMarkerIsExpired(_, currentProcessingTime, currentTimerCallback))
+      val nextCollision = sharedEviction.orElse {
+        val lastEmittedVersion = lastEmittedVersionState.value()
+        if (
+          currentProcessingTime == Long.MaxValue ||
+          (lastEmittedVersion != null && lastEmittedVersion.longValue() == Long.MaxValue)
+        ) None
+        else {
+          val afterLast = if (lastEmittedVersion == null) Long.MinValue else lastEmittedVersion.longValue() + 1L
+          Some(math.max(currentProcessingTime + 1L, afterLast))
+        }
+      }
+      nextCollision match {
+        case Some(timestamp) =>
+          // If the collision joins the callback currently being drained, role discovery below
+          // will consume it in this invocation. Re-registering that timestamp would enqueue an
+          // unnecessary immediate duplicate after Flink has removed the physical timer.
+          if (!isCurrentProcessingTimerCallback(timestamp, currentTimerCallback)) {
+            timerService.registerProcessingTimeTimer(timestamp)
+          }
+          pendingVersionCollisionState.update(timestamp)
+        case None => pendingVersionCollisionState.clear()
+      }
+    }
+  }
+
+  private def flushVersionCollision(
+      timerService: TimerService,
+      currentProcessingTime: Long,
+      currentKey: java.util.List[Any],
+      out: Collector[TimestampedTile]
+  ): Unit = {
+    try {
+      val pendingVersion = pendingVersionCollisionState.value()
+      if (pendingVersion == null) return
+
+      val snapshot = processor.currentSnapshot
+      val encoded = gigaTileCodec.encodeOutput(snapshot.finalizedVector)
+      out.collect(new TimestampedTile(currentKey, encoded, pendingVersion.longValue(), System.currentTimeMillis()))
+      lastEmittedVersionState.update(pendingVersion)
+      pendingVersionCollisionState.clear()
+    } catch {
+      case e: Exception =>
+        // The fired timer was the only flush trigger. Re-arm before the outer handler records
+        // the failure so a transient encoding/collection error cannot strand the latest value.
+        if (currentProcessingTime < Long.MaxValue) {
+          val retryVersion = currentProcessingTime + 1L
+          timerService.registerProcessingTimeTimer(retryVersion)
+          pendingVersionCollisionState.update(retryVersion)
+        }
+        throw e
     }
   }
 
@@ -129,19 +309,21 @@ class GigaTileProcessFunction(
       val row = new ArrayRow(values, tsMills)
 
       ensureStateBound(ctx.getCurrentKey)
-      processor.advanceWatermark(ctx.timerService().currentWatermark())
-      val result = processor.onEvent(row, tsMills)
+      val timerService = ctx.timerService()
+      val currentProcessingTime = timerService.currentProcessingTime()
+      repairExpiredProcessingTimerMarkers(timerService, currentProcessingTime, None)
+      val rolloverResult = processor.advanceWatermark(currentProcessingTime)
+      val eventResult = processor.onEvent(row, tsMills, currentProcessingTime)
+      val result = if (eventResult.finalizedVector != null) eventResult else rolloverResult
 
-      if (result.finalizedVector != null) {
-        out.collect(
-          new TimestampedTile(ctx.getCurrentKey,
-                              gigaTileCodec.encodeOutput(result.finalizedVector),
-                              tsMills,
-                              event.startProcessingTimeMillis))
-      }
+      scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
+      emitOrCoalesceVersionCollision(timerService,
+                                     result.finalizedVector,
+                                     ctx.getCurrentKey,
+                                     currentProcessingTime,
+                                     event.startProcessingTimeMillis,
+                                     out)
 
-      val nextEviction = TsUtils.round(tsMills, processor.minEvictionInterval) + processor.minEvictionInterval
-      ctx.timerService().registerEventTimeTimer(nextEviction)
     } catch {
       case e: Exception =>
         logger.error(s"Error processing giga tile event for groupBy=${groupBy.getMetaData.getName}", e)
@@ -159,27 +341,26 @@ class GigaTileProcessFunction(
       if (processor == null) initializeTransients()
 
       ensureStateBound(ctx.getCurrentKey)
-      processor.advanceWatermark(ctx.timerService().currentWatermark())
+      val timerService = ctx.timerService()
+      val currentProcessingTime = timerService.currentProcessingTime()
+      repairExpiredProcessingTimerMarkers(timerService, currentProcessingTime, None)
+      val rolloverResult = processor.advanceWatermark(currentProcessingTime)
 
       val batchIr = gigaTileCodec.decodeBatchIr(batchRow.valueBytes)
-      val result = processor.onBatchUpdate(batchIr, batchRow.batchEndTs,
-        ctx.timerService().currentWatermark())
+      val batchResult = processor.onBatchUpdate(batchIr, batchRow.batchEndTs, currentProcessingTime)
+      val result = if (batchResult.finalizedVector != null) batchResult else rolloverResult
 
       batchUpdateCounter.inc()
 
-      if (result.finalizedVector != null) {
-        out.collect(
-          new TimestampedTile(ctx.getCurrentKey,
-                              gigaTileCodec.encodeOutput(result.finalizedVector),
-                              batchRow.batchEndTs,
-                              System.currentTimeMillis()))
+      if (batchResult.needsEvictionTimer) {
+        scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
       }
-
-      if (result.needsEvictionTimer) {
-        val nextEviction = TsUtils.round(ctx.timerService().currentWatermark(),
-          processor.minEvictionInterval) + processor.minEvictionInterval
-        ctx.timerService().registerEventTimeTimer(nextEviction)
-      }
+      emitOrCoalesceVersionCollision(timerService,
+                                     result.finalizedVector,
+                                     ctx.getCurrentKey,
+                                     currentProcessingTime,
+                                     System.currentTimeMillis(),
+                                     out)
     } catch {
       case e: Exception =>
         logger.error(s"Error processing batch IR for groupBy=${groupBy.getMetaData.getName}", e)
@@ -192,39 +373,122 @@ class GigaTileProcessFunction(
       ctx: KeyedCoProcessFunction[java.util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#OnTimerContext,
       out: Collector[TimestampedTile]
   ): Unit = {
+    var timerServiceOnFailure: TimerService = null
+    var processingTimeOnFailure = Long.MinValue
+    var evictionTimerFired = false
+    var versionCollisionTimerFired = false
     try {
       if (processor == null) initializeTransients()
 
       ensureStateBound(ctx.getCurrentKey)
-      processor.advanceWatermark(ctx.timerService().currentWatermark())
-      val result = processor.onScheduledEviction(timestamp)
+      val timerService = ctx.timerService()
+      val currentProcessingTime = timerService.currentProcessingTime()
+      timerServiceOnFailure = timerService
+      processingTimeOnFailure = currentProcessingTime
+      repairExpiredProcessingTimerMarkers(timerService, currentProcessingTime, Some(ctx.timeDomain() -> timestamp))
 
-      if (result.finalizedVector != null) {
-        out.collect(
-          new TimestampedTile(ctx.getCurrentKey,
-                              gigaTileCodec.encodeOutput(result.finalizedVector),
-                              timestamp,
-                              System.currentTimeMillis()))
+      // Checkpoints written by the event-time implementation may still contain several
+      // event-time eviction timers per key. Let those callbacks migrate the key to one
+      // processing-time timer, but do not publish from both timer domains.
+      if (ctx.timeDomain() == TimeDomain.EVENT_TIME) {
+        scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
+        return
       }
 
-      // Re-register the next eviction timer so idle keys keep decaying without waiting for
-      // a new event. The natural termination is `result.isEmpty`: once every column has
-      // decayed to null there's nothing more to correct, and no new timer is needed until a
-      // fresh event arrives. Without re-registration, an entity that goes silent serves the
-      // last emit forever — even after every event has aged out of every window.
-      if (!result.isEmpty) {
-        val interval = processor.minEvictionInterval
-        // Guard against integer overflow at end-of-stream (watermark = Long.MaxValue): if
-        // the next timer would wrap into the negative range, skip — Flink would either
-        // refuse the registration or fire it immediately, looping forever.
-        if (timestamp <= Long.MaxValue - interval) {
-          ctx.timerService().registerEventTimeTimer(timestamp + interval)
+      if (ctx.timeDomain() != TimeDomain.PROCESSING_TIME) {
+        return
+      }
+
+      val isEvictionTimer = isCurrentProcessingEvictionTimer(timestamp)
+      val isVersionCollisionTimer = isCurrentVersionCollisionTimer(timestamp)
+      evictionTimerFired = isEvictionTimer
+      versionCollisionTimerFired = isVersionCollisionTimer
+      if (!isEvictionTimer && !isVersionCollisionTimer) return
+
+      var finalizedVector: Array[Any] = null
+      if (isEvictionTimer) {
+        nextProcessingEvictionTimerState.clear()
+        val rolloverResult = processor.advanceWatermark(currentProcessingTime)
+        val evictionResult = processor.onScheduledEviction(currentProcessingTime)
+        finalizedVector =
+          if (evictionResult.finalizedVector != null) evictionResult.finalizedVector else rolloverResult.finalizedVector
+
+        // Re-register before a coincident collision flush: if encoding the flush fails, both
+        // the retry and normal eviction cadence remain live.
+        if (!evictionResult.isEmpty) {
+          scheduleProcessingEvictionTimerIfNeeded(timerService, currentProcessingTime)
         }
+      }
+
+      if (isVersionCollisionTimer) {
+        // Eviction wins when both timers share a timestamp; publish one post-eviction snapshot.
+        flushVersionCollision(timerService, currentProcessingTime, ctx.getCurrentKey, out)
+      } else {
+        emitOrCoalesceVersionCollision(timerService,
+                                       finalizedVector,
+                                       ctx.getCurrentKey,
+                                       currentProcessingTime,
+                                       System.currentTimeMillis(),
+                                       out)
       }
     } catch {
       case e: Exception =>
+        if (timerServiceOnFailure != null) {
+          val trackedEviction = nextProcessingEvictionTimerState.value()
+          if (
+            evictionTimerFired &&
+            (trackedEviction == null || trackedEviction.longValue() <= timestamp)
+          ) {
+            nextProcessingEvictionTimerState.clear()
+            scheduleProcessingEvictionTimerIfNeeded(timerServiceOnFailure, processingTimeOnFailure)
+          }
+          val pendingCollision = pendingVersionCollisionState.value()
+          if (
+            versionCollisionTimerFired && pendingCollision != null &&
+            pendingCollision.longValue() <= timestamp && processingTimeOnFailure < Long.MaxValue
+          ) {
+            // A shared callback must preserve eviction-before-publication ordering. If
+            // eviction failed, park the collision on the re-armed eviction timer instead
+            // of publishing the stale pre-eviction snapshot one millisecond later.
+            val retryVersion =
+              if (evictionTimerFired) {
+                Option(nextProcessingEvictionTimerState.value())
+                  .map(_.longValue())
+                  .filter(_ > timestamp)
+                  .getOrElse(processingTimeOnFailure + 1L)
+              } else {
+                processingTimeOnFailure + 1L
+              }
+            timerServiceOnFailure.registerProcessingTimeTimer(retryVersion)
+            pendingVersionCollisionState.update(retryVersion)
+          }
+        }
         logger.error(s"Error in giga tile eviction for groupBy=${groupBy.getMetaData.getName}", e)
         eventProcessingErrorCounter.inc()
+    }
+  }
+
+  private def isCurrentProcessingEvictionTimer(timestamp: Long): Boolean =
+    Option(nextProcessingEvictionTimerState.value()).exists(_.longValue() == timestamp)
+
+  private def nextProcessingEvictionTimestamp(currentProcessingTime: Long): Option[Long] = {
+    val interval = processor.minEvictionInterval
+    if (currentProcessingTime <= Long.MaxValue - interval) {
+      Some(TsUtils.round(currentProcessingTime, interval) + interval)
+    } else {
+      None
+    }
+  }
+
+  private def scheduleProcessingEvictionTimerIfNeeded(
+      timerService: TimerService,
+      currentProcessingTime: Long
+  ): Unit = {
+    if (nextProcessingEvictionTimerState.value() == null) {
+      nextProcessingEvictionTimestamp(currentProcessingTime).foreach { nextEviction =>
+        timerService.registerProcessingTimeTimer(nextEviction)
+        nextProcessingEvictionTimerState.update(nextEviction)
+      }
     }
   }
 }

--- a/flink/src/test/scala/ai/chronon/flink/test/AllowedLatenessConfigTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/AllowedLatenessConfigTest.scala
@@ -1,6 +1,7 @@
 package ai.chronon.flink.test
 
 import ai.chronon.flink.FlinkUtils
+import ai.chronon.flink.window.MegaTileEmissionPolicy
 import ai.chronon.online.TopicInfo
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -155,5 +156,10 @@ class AllowedLatenessConfigTest extends AnyFlatSpec with Matchers {
       FlinkUtils.getNonNegativeLongProperty("buffering_output_jitter_millis", props, topicInfo)
     }
     exception.getMessage should include("invalid buffering_output_jitter_millis value")
+  }
+
+  "GigaTile output buffering" should "require the wall-clock cadence policy" in {
+    FlinkUtils.gigaTileBufferingOutputTimeMillis(1000L, MegaTileEmissionPolicy.Default) shouldBe 0L
+    FlinkUtils.gigaTileBufferingOutputTimeMillis(1000L, MegaTileEmissionPolicy.WallClockCadence) shouldBe 1000L
   }
 }

--- a/flink/src/test/scala/ai/chronon/flink/test/AllowedLatenessConfigTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/AllowedLatenessConfigTest.scala
@@ -162,4 +162,14 @@ class AllowedLatenessConfigTest extends AnyFlatSpec with Matchers {
     FlinkUtils.gigaTileBufferingOutputTimeMillis(1000L, MegaTileEmissionPolicy.Default) shouldBe 0L
     FlinkUtils.gigaTileBufferingOutputTimeMillis(1000L, MegaTileEmissionPolicy.WallClockCadence) shouldBe 1000L
   }
+
+  "gigatile first-seen grace config" should "be opt-in for missing zero and negative values" in {
+    val key = "gigatile_first_seen_key_grace_millis"
+    val topicInfo = TopicInfo("test-topic", "kafka", Map.empty)
+
+    FlinkUtils.getNonNegativeLongProperty(key, Map.empty, topicInfo) shouldBe 0L
+    FlinkUtils.getNonNegativeLongProperty(key, Map(key -> "0"), topicInfo) shouldBe 0L
+    FlinkUtils.getNonNegativeLongProperty(key, Map(key -> "-1"), topicInfo) shouldBe 0L
+    FlinkUtils.getNonNegativeLongProperty(key, Map(key -> "3600000"), topicInfo) shouldBe 3600000L
+  }
 }

--- a/flink/src/test/scala/ai/chronon/flink/test/BatchIrRowDecoderTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/BatchIrRowDecoderTest.scala
@@ -2,11 +2,12 @@ package ai.chronon.flink.test
 
 import ai.chronon.api._
 import ai.chronon.api.Extensions.GroupByOps
-import ai.chronon.flink.source.BatchIrRowDecoder
+import ai.chronon.flink.source.{BatchIrRowDecoder, BatchIrSourceBuilder}
 import ai.chronon.flink.types.BatchIrRow
 import ai.chronon.online.GroupByServingInfoParsed
 import ai.chronon.online.serde.AvroConversions
 import org.apache.flink.table.data.{GenericRowData, StringData}
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.util.Collector
 import org.junit.Assert._
 import org.scalatest.flatspec.AnyFlatSpec
@@ -62,13 +63,16 @@ class BatchIrRowDecoderTest extends AnyFlatSpec {
   }
 
   /** Builds a mock RowData with 5 columns: key_bytes, value_bytes, key_json, value_json, ds. */
-  private def makeRowData(keyBytes: Array[Byte], valueBytes: Array[Byte], ds: String): GenericRowData = {
+  private def makeRowData(keyBytes: Array[Byte],
+                          valueBytes: Array[Byte],
+                          ds: String,
+                          keyJson: String = ""): GenericRowData = {
     val row = new GenericRowData(5)
     row.setField(0, keyBytes)
     row.setField(1, valueBytes)
-    row.setField(2, StringData.fromString(""))   // key_json
+    row.setField(2, if (keyJson == null) null else StringData.fromString(keyJson)) // key_json
     row.setField(3, StringData.fromString(""))   // value_json
-    row.setField(4, StringData.fromString(ds))
+    row.setField(4, if (ds == null) null else StringData.fromString(ds))
     row
   }
 
@@ -129,5 +133,118 @@ class BatchIrRowDecoderTest extends AnyFlatSpec {
     assertEquals("should emit one row", 1, collector.collected.size)
     assertEquals("should use servingInfo.batchEndTsMillis",
                   servingInfo.batchEndTsMillis, collector.collected(0).batchEndTs)
+  }
+
+  it should "fail malformed rows closed only when an absent-row fallback requires them" in {
+    val servingInfo = makeServingInfo()
+    val malformed = makeRowData(Array[Byte](1, 2, 3), Array[Byte](4, 5, 6), "2026-03-28")
+
+    val bestEffortCollector = new CollectingCollector()
+    new BatchIrRowDecoder(servingInfo).flatMap(malformed, bestEffortCollector)
+    assertTrue(bestEffortCollector.collected.isEmpty)
+
+    val requiredCollector = new CollectingCollector()
+    intercept[Exception] {
+      new BatchIrRowDecoder(servingInfo, failOnDecodeError = true).flatMap(malformed, requiredCollector)
+    }
+    assertTrue(requiredCollector.collected.isEmpty)
+  }
+
+  it should "skip the upload metadata row even when strict decoding is enabled" in {
+    val decoder = new BatchIrRowDecoder(makeServingInfo(), failOnDecodeError = true)
+    val collector = new CollectingCollector()
+    val metadataRow = makeRowData(Constants.GroupByServingInfoKey.getBytes(Constants.UTF8),
+                                  Array[Byte](1, 2, 3),
+                                  "2026-03-28",
+                                  keyJson = Constants.GroupByServingInfoKey)
+
+    decoder.flatMap(metadataRow, collector)
+
+    assertTrue(collector.collected.isEmpty)
+  }
+
+  it should "reject null key or value bytes when an absent-row fallback requires them" in {
+    val decoder = new BatchIrRowDecoder(makeServingInfo(), failOnDecodeError = true)
+
+    val error = intercept[IllegalArgumentException] {
+      decoder.flatMap(makeRowData(null, Array[Byte](1), "2026-03-28"), new CollectingCollector())
+    }
+    assertTrue(error.getMessage.contains("null key_bytes or value_bytes"))
+  }
+
+  it should "require a ds partition value when the absent-row fallback is enabled" in {
+    val servingInfo = makeServingInfo()
+    val decoder = new BatchIrRowDecoder(servingInfo, failOnDecodeError = true)
+    val keyEncoder = AvroConversions.encodeBytes(servingInfo.keyChrononSchema, null)
+    val keyBytes = keyEncoder(Array[Any]("user_123"))
+    val valueBytes = Array[Byte](1, 2, 3)
+
+    val missingDs = new GenericRowData(2)
+    missingDs.setField(0, keyBytes)
+    missingDs.setField(1, valueBytes)
+    val missingError = intercept[IllegalArgumentException] {
+      decoder.flatMap(missingDs, new CollectingCollector())
+    }
+    assertTrue(missingError.getMessage.contains("missing required ds"))
+
+    val nullError = intercept[IllegalArgumentException] {
+      decoder.flatMap(makeRowData(keyBytes, valueBytes, null), new CollectingCollector())
+    }
+    assertTrue(nullError.getMessage.contains("missing required ds"))
+  }
+
+  it should "reject invalid or partially parsed ds values when the absent-row fallback is enabled" in {
+    val servingInfo = makeServingInfo()
+    val decoder = new BatchIrRowDecoder(servingInfo, failOnDecodeError = true)
+    val keyEncoder = AvroConversions.encodeBytes(servingInfo.keyChrononSchema, null)
+    val keyBytes = keyEncoder(Array[Any]("user_123"))
+    val valueBytes = Array[Byte](1, 2, 3)
+
+    Seq("2026-02-31", "2026-03-28-junk").foreach { ds =>
+      val error = intercept[java.text.ParseException] {
+        decoder.flatMap(makeRowData(keyBytes, valueBytes, ds), new CollectingCollector())
+      }
+      assertTrue(error.getMessage.contains("Invalid ds partition value"))
+    }
+  }
+
+  "BatchIrSourceBuilder" should "preserve the idle fallback when no batch source is required" in {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val stream = BatchIrSourceBuilder.build(env, makeServingInfo(), Map.empty)
+
+    assertEquals("Idle batch IR source for test_batch_ir_decoder", stream.getTransformation.getName)
+  }
+
+  it should "reject a missing warehouse when an absent-row fallback requires the batch source" in {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+
+    val error = intercept[IllegalArgumentException] {
+      BatchIrSourceBuilder.build(env,
+                                 makeServingInfo(),
+                                 Map.empty,
+                                 requireConfiguredBatchSource = true)
+    }
+    assertTrue(error.getMessage.contains("gigatile_first_seen_key_grace_millis"))
+  }
+
+  it should "fail closed on source construction errors only when the batch source is required" in {
+    val props = Map(
+      "iceberg.catalog.warehouse" -> "/tmp/unused-warehouse",
+      "iceberg.monitor.interval.minutes" -> "not-a-number"
+    )
+
+    val fallbackEnv = StreamExecutionEnvironment.getExecutionEnvironment
+    val fallback = BatchIrSourceBuilder.build(fallbackEnv, makeServingInfo(), props)
+    assertEquals("Idle batch IR source for test_batch_ir_decoder", fallback.getTransformation.getName)
+
+    val requiredEnv = StreamExecutionEnvironment.getExecutionEnvironment
+    val error = intercept[IllegalStateException] {
+      BatchIrSourceBuilder.build(requiredEnv,
+                                 makeServingInfo(),
+                                 props,
+                                 requireConfiguredBatchSource = true)
+    }
+    assertTrue(error.getMessage.contains("Failed to create required Iceberg source"))
+    assertTrue(error.getCause.isInstanceOf[NumberFormatException])
   }
 }

--- a/flink/src/test/scala/ai/chronon/flink/test/GigaTilePushFlinkIntegrationTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/GigaTilePushFlinkIntegrationTest.scala
@@ -30,7 +30,7 @@ import java.util
   * - GigaTileProcessFunction (CoProcessFunction) with connected streams
   * - FlinkGigaTileStore with real Flink keyed state (ValueState/MapState)
   * - Key switching across entities
-  * - Timer registration and event-time eviction
+  * - Timer registration and processing-time eviction
   * - GigaTileAvroCodecFn output encoding
   *
   * Does NOT test Iceberg source (requires a real Iceberg catalog).
@@ -143,12 +143,13 @@ class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
 
   it should "process events through GigaTileProcessFunction and emit finalized vectors" in {
     implicit val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment
+    val now = System.currentTimeMillis()
 
     // 3 events across 2 entities. Each entity should produce at least one finalized vector.
     val elements = Seq(
-      E2ETestEvent("test1", 12, 1.5, 1699366993123L),
-      E2ETestEvent("test2", 13, 1.6, 1699366993124L),
-      E2ETestEvent("test1", 14, 2.5, 1699366993125L)
+      E2ETestEvent("test1", 12, 1.5, now - 3000L),
+      E2ETestEvent("test2", 13, 1.6, now - 2000L),
+      E2ETestEvent("test1", 14, 2.5, now - 1000L)
     )
 
     val groupBy = makePushGroupBy(Seq("id"))
@@ -159,15 +160,12 @@ class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
 
     val results = CollectSink.values.toScala
 
-    // Each event should trigger an emit (finalized vector)
-    results.size should be >= elements.size
-
     // All writes should succeed
     results.forall(_.status) shouldBe true
 
-    // Both entities should have output
-    val keyBytes = results.map(_.keyBytes).distinct
-    keyBytes.size should be >= 2
+    // Same-millisecond updates may be coalesced, but every entity must publish final state.
+    val keyHashes = results.map(result => util.Arrays.hashCode(result.keyBytes)).distinct
+    keyHashes.size shouldBe 2
 
     // Value bytes should be non-empty (finalized vector encoded)
     results.foreach { wr =>
@@ -177,11 +175,12 @@ class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
 
   it should "produce decodable finalized vectors" in {
     implicit val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment
+    val now = System.currentTimeMillis()
 
     // Single entity, known values
     val elements = Seq(
-      E2ETestEvent("entity1", 10, 5.0, 1699366993100L),
-      E2ETestEvent("entity1", 20, 3.0, 1699366993200L)
+      E2ETestEvent("entity1", 10, 5.0, now - 2000L),
+      E2ETestEvent("entity1", 20, 3.0, now - 1000L)
     )
 
     val groupBy = makePushGroupBy(Seq("id"))
@@ -194,9 +193,8 @@ class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
     results should not be empty
     results.forall(_.status) shouldBe true
 
-    // The pipeline now decays idle entities via re-registered eviction timers, so the
-    // tsMillis-latest emit at end-of-stream is a tombstone (all-null). Pick the latest
-    // emit whose SUM is non-null to verify the aggregation itself is correct.
+    // Processing-time freshness gates events against the current wall clock, so these test
+    // rows are intentionally recent rather than fixed historical timestamps.
     val sumFieldName = servingInfo.outputCodec.decodeMap(results.head.valueBytes).keys
       .find(_.contains("double_val")).get
     val nonEmpty = results.toSeq.flatMap { wr =>
@@ -210,12 +208,13 @@ class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
 
   it should "handle multiple entities with correct key isolation" in {
     implicit val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment
+    val now = System.currentTimeMillis()
 
     // Two entities with different values — verify state isolation
     val elements = Seq(
-      E2ETestEvent("alice", 1, 10.0, 1699366993100L),
-      E2ETestEvent("bob", 2, 20.0, 1699366993200L),
-      E2ETestEvent("alice", 3, 5.0, 1699366993300L)
+      E2ETestEvent("alice", 1, 10.0, now - 3000L),
+      E2ETestEvent("bob", 2, 20.0, now - 2000L),
+      E2ETestEvent("alice", 3, 5.0, now - 1000L)
     )
 
     val groupBy = makePushGroupBy(Seq("id"))
@@ -228,10 +227,7 @@ class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
     results should not be empty
     results.forall(_.status) shouldBe true
 
-    // Group by key and pick the latest non-empty write per entity. Idle decay timers fire
-    // at end-of-stream and tombstone each key with an all-null vector after 1d window
-    // expiration; the test verifies the SUM aggregation, not the decay, so filter to non-
-    // null sums per key.
+    // Group by key and pick the latest non-empty write per entity.
     val sumFieldName = servingInfo.outputCodec.decodeMap(results.head.valueBytes).keys
       .find(_.contains("double_val")).get
     val latestSumPerKey: Set[Double] = results

--- a/flink/src/test/scala/ai/chronon/flink/test/GigaTilePushFlinkIntegrationTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/GigaTilePushFlinkIntegrationTest.scala
@@ -3,16 +3,18 @@ package ai.chronon.flink.test
 import ai.chronon.api._
 import ai.chronon.api.Extensions.GroupByOps
 import ai.chronon.api.ScalaJavaConversions._
-import ai.chronon.flink.{GigaTileAvroCodecFn, SparkExpressionEval, SparkExpressionEvalFn}
+import ai.chronon.flink.deser.ProjectedEvent
+import ai.chronon.flink.{FlinkJob, GigaTileAvroCodecFn, SparkExpressionEval, SparkExpressionEvalFn}
 import ai.chronon.flink.types.{BatchIrRow, TimestampedTile, WriteResponse}
 import ai.chronon.flink.window.GigaTileProcessFunction
 import ai.chronon.online.{Api, GigaTileCodec, GroupByServingInfoParsed}
-import ai.chronon.online.serde.SparkConversions
-import org.apache.flink.api.common.eventtime.WatermarkStrategy
+import ai.chronon.online.serde.{AvroCodec, SparkConversions}
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration
 import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+import org.apache.flink.streaming.api.functions.sink.SinkFunction
 import org.apache.flink.streaming.api.functions.source.SourceFunction
+import org.apache.flink.streaming.api.watermark.Watermark
 import org.apache.flink.test.util.MiniClusterWithClientResource
 import org.apache.spark.sql.Encoders
 import org.mockito.Mockito.withSettings
@@ -21,8 +23,8 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 import org.scalatestplus.mockito.MockitoSugar.mock
 
-import java.time.Duration
 import java.util
+import java.util.concurrent.{CountDownLatch, TimeUnit}
 
 /** Flink MiniCluster integration test for the PUSH (giga tile) pipeline.
   *
@@ -46,6 +48,7 @@ class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
   before {
     flinkCluster.before()
     CollectSink.values.clear()
+    GigaTilePushIntegrationSourceGate.reset()
   }
 
   after {
@@ -88,8 +91,6 @@ class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
     val query = SparkExpressionEval.queryFromGroupBy(groupBy)
     val sparkExprEvalFn =
       new SparkExpressionEvalFn(Encoders.product[E2ETestEvent], query, groupBy.metaData.name, groupBy.dataModel)
-    val source = new WatermarkedE2EEventSource(elements, sparkExprEvalFn)
-
     val encoder = Encoders.product[E2ETestEvent]
     val outputSchema =
       new SparkExpressionEval(encoder, query, groupBy.getMetaData.getName, groupBy.dataModel).getOutputSchema
@@ -100,10 +101,14 @@ class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
     val groupByServingInfoParsed =
       makePushGroupByServingInfoParsed(groupBy, encoder.schema, outputSchema)
 
-    // Event stream with watermarks
-    val preparedStream = source
-      .getDataStream("test-topic", groupBy.metaData.name)(env, 2)
+    // The production sources are unbounded, but this fixture is bounded and would otherwise
+    // finish before a periodic watermark or processing-time timer can flush fenced state.
+    // Establish a finite watermark before records after the empty batch input is ready.
+    val preparedStream = env
+      .addSource(new LiveWatermarkedE2EEventSource(elements))
       .uid(s"source-${groupBy.metaData.name}")
+      .flatMap(sparkExprEvalFn)
+      .map(e => ProjectedEvent(e, System.currentTimeMillis()))
 
     // Empty batch stream: completes immediately (so env.execute returns),
     // watermark goes to MAX on completion (doesn't stall event stream's watermark).
@@ -154,7 +159,7 @@ class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
 
     val groupBy = makePushGroupBy(Seq("id"))
     val (writeDS, servingInfo) = buildPushPipeline(groupBy, elements)
-    writeDS.addSink(new CollectSink)
+    writeDS.addSink(new GigaTileCollectSink(expectedKeyCount = 2))
 
     env.execute("PushFlinkIntegrationTest")
 
@@ -163,7 +168,8 @@ class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
     // All writes should succeed
     results.forall(_.status) shouldBe true
 
-    // Same-millisecond updates may be coalesced, but every entity must publish final state.
+    // Same-millisecond coalescing and replay fencing may emit fewer writes, but every entity
+    // must publish final state.
     val keyHashes = results.map(result => util.Arrays.hashCode(result.keyBytes)).distinct
     keyHashes.size shouldBe 2
 
@@ -185,7 +191,7 @@ class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
 
     val groupBy = makePushGroupBy(Seq("id"))
     val (writeDS, servingInfo) = buildPushPipeline(groupBy, elements)
-    writeDS.addSink(new CollectSink)
+    writeDS.addSink(new GigaTileCollectSink(servingInfo.outputCodec, Set(8.0)))
 
     env.execute("PushFlinkDecodableTest")
 
@@ -219,7 +225,7 @@ class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
 
     val groupBy = makePushGroupBy(Seq("id"))
     val (writeDS, servingInfo) = buildPushPipeline(groupBy, elements)
-    writeDS.addSink(new CollectSink)
+    writeDS.addSink(new GigaTileCollectSink(servingInfo.outputCodec, Set(15.0, 20.0)))
 
     env.execute("PushFlinkKeyIsolationTest")
 
@@ -252,6 +258,105 @@ class GigaTilePushFlinkIntegrationTest extends AnyFlatSpec with BeforeAndAfter {
   * so the event stream drives watermark progression normally.
   */
 class EmptyBatchIrSource extends SourceFunction[BatchIrRow] {
-  override def run(ctx: SourceFunction.SourceContext[BatchIrRow]): Unit = {}
+  override def run(ctx: SourceFunction.SourceContext[BatchIrRow]): Unit = {
+    ctx.emitWatermark(new Watermark(Long.MaxValue))
+    GigaTilePushIntegrationSourceGate.batchInputReady()
+  }
   override def cancel(): Unit = {}
+}
+
+/** Bounded event source that establishes a near-live watermark before emitting records. */
+class LiveWatermarkedE2EEventSource(elements: Seq[E2ETestEvent]) extends SourceFunction[E2ETestEvent] {
+  @volatile private var running = true
+
+  private def boundedOutOfOrdernessWatermark(maxEventTime: Long): Long = {
+    val delta = FlinkJob.AllowedOutOfOrderness.toMillis + 1L
+    if (maxEventTime < Long.MinValue + delta) Long.MinValue else maxEventTime - delta
+  }
+
+  override def run(ctx: SourceFunction.SourceContext[E2ETestEvent]): Unit = {
+    if (!GigaTilePushIntegrationSourceGate.awaitBatchInput()) {
+      throw new IllegalStateException("Timed out waiting for the empty batch input")
+    }
+
+    val sourceStartTime = System.currentTimeMillis()
+    val latestOriginalEventTime = elements.map(_.created).reduceOption((left, right) => math.max(left, right))
+      .getOrElse(sourceStartTime)
+    val rebasedElements = elements.map { event =>
+      event.copy(created = sourceStartTime - (latestOriginalEventTime - event.created))
+    }
+    val lock = ctx.getCheckpointLock
+    rebasedElements.headOption.foreach { firstEvent =>
+      val initialWatermark = boundedOutOfOrdernessWatermark(firstEvent.created)
+      lock.synchronized(ctx.emitWatermark(new Watermark(initialWatermark)))
+    }
+
+    var maxEventTime = Long.MinValue
+    rebasedElements.iterator.takeWhile(_ => running).foreach { event =>
+      lock.synchronized {
+        maxEventTime = math.max(maxEventTime, event.created)
+        ctx.collectWithTimestamp(event, event.created)
+        ctx.emitWatermark(new Watermark(boundedOutOfOrdernessWatermark(maxEventTime)))
+      }
+    }
+
+    if (running && !GigaTilePushIntegrationSourceGate.awaitOutput()) {
+      throw new IllegalStateException("Timed out waiting for GigaTile output")
+    }
+  }
+
+  override def cancel(): Unit = running = false
+}
+
+private object GigaTilePushIntegrationSourceGate {
+  @volatile private var batchReady = new CountDownLatch(1)
+  @volatile private var outputReady = new CountDownLatch(1)
+
+  def reset(): Unit = {
+    batchReady = new CountDownLatch(1)
+    outputReady = new CountDownLatch(1)
+  }
+
+  def batchInputReady(): Unit = batchReady.countDown()
+
+  def awaitBatchInput(): Boolean = batchReady.await(10, TimeUnit.SECONDS)
+
+  def outputObserved(): Unit = outputReady.countDown()
+
+  def awaitOutput(): Boolean = outputReady.await(30, TimeUnit.SECONDS)
+}
+
+private class GigaTileCollectSink(
+    outputCodec: AvroCodec = null,
+    expectedFinalSums: Set[Double] = Set.empty,
+    expectedKeyCount: Int = 1)
+    extends SinkFunction[WriteResponse] {
+
+  private def completionObserved: Boolean = {
+    val results = CollectSink.values.synchronized(CollectSink.values.toScala.toSeq)
+    if (expectedFinalSums.nonEmpty) {
+      val sumFieldName = outputCodec.decodeMap(results.head.valueBytes).keys
+        .find(_.contains("double_val"))
+        .get
+      val latestSumPerKey = results
+        .groupBy(result => util.Arrays.hashCode(result.keyBytes))
+        .values
+        .flatMap { writes =>
+          val nonEmpty = writes.flatMap { write =>
+            val decoded = outputCodec.decodeMap(write.valueBytes)
+            Option(decoded(sumFieldName)).map(value => (write.tsMillis, value.asInstanceOf[Double]))
+          }
+          if (nonEmpty.isEmpty) None else Some(nonEmpty.maxBy(_._1)._2)
+        }
+        .toSet
+      latestSumPerKey == expectedFinalSums
+    } else {
+      results.map(result => util.Arrays.hashCode(result.keyBytes)).distinct.size >= expectedKeyCount
+    }
+  }
+
+  override def invoke(value: WriteResponse, context: SinkFunction.Context): Unit = {
+    CollectSink.values.add(value)
+    if (completionObserved) GigaTilePushIntegrationSourceGate.outputObserved()
+  }
 }

--- a/flink/src/test/scala/ai/chronon/flink/test/window/ChrononClockModeTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/window/ChrononClockModeTest.scala
@@ -1,0 +1,98 @@
+package ai.chronon.flink.test.window
+
+import ai.chronon.flink.FlinkJob
+import ai.chronon.flink.window.ChrononClockMode
+import ai.chronon.flink.window.ChrononClockMode.{Catchup, Live, NoWatermark}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ChrononClockModeTest extends AnyFlatSpec with Matchers {
+  private val hopMillis = 5 * 60 * 1000L
+  private val exactHop = 10 * hopMillis
+  private val sourceOutOfOrderness = FlinkJob.AllowedOutOfOrderness.toMillis
+  private val liveBoundary = FlinkJob.LiveWatermarkLagToleranceMillis
+  private val aggregationHops = Seq(hopMillis, 60 * 60 * 1000L, 24 * 60 * 60 * 1000L)
+
+  "ChrononClockMode" should "fence an uninitialized connected watermark without timer horizons" in {
+    val mode = ChrononClockMode.classify(exactHop, Long.MinValue, sourceOutOfOrderness, liveBoundary)
+
+    mode shouldBe NoWatermark
+    ChrononClockMode.allowsPublication(mode) shouldBe false
+    ChrononClockMode.dayAdvanceAsOfMillis(mode, exactHop, Long.MinValue) shouldBe None
+    ChrononClockMode.processingTimerHorizons(mode, exactHop, Long.MinValue, hopMillis) shouldBe None
+    ChrononClockMode.streamEventHorizons(mode, exactHop, exactHop, Long.MinValue, hopMillis) shouldBe
+      ChrononClockMode.Horizons(exactHop, exactHop + 1L)
+  }
+
+  it should "keep every key fenced while the global watermark is behind" in {
+    val processingTime = exactHop + liveBoundary + 1L
+    val mode = ChrononClockMode.classify(processingTime, exactHop, sourceOutOfOrderness, liveBoundary)
+
+    mode shouldBe Catchup
+    ChrononClockMode.allowsPublication(mode) shouldBe false
+    ChrononClockMode.dayAdvanceAsOfMillis(mode, processingTime, exactHop) shouldBe Some(exactHop)
+    ChrononClockMode.processingTimerHorizons(mode, processingTime, exactHop, hopMillis) shouldBe
+      Some(ChrononClockMode.Horizons(exactHop, exactHop + 1L))
+  }
+
+  it should "use one source-readiness tolerance for every aggregation hop" in {
+    val processingTime = 20L * aggregationHops.last
+    val justBehind = processingTime - liveBoundary - 1L
+    val atBoundary = processingTime - liveBoundary
+
+    aggregationHops.foreach { aggregationHop =>
+      ChrononClockMode.classify(processingTime, justBehind, sourceOutOfOrderness, liveBoundary) shouldBe Catchup
+      ChrononClockMode.classify(processingTime, atBoundary, sourceOutOfOrderness, liveBoundary) shouldBe Live
+      ChrononClockMode.processingTimerHorizons(Live, processingTime, atBoundary, aggregationHop) shouldBe
+        Some(ChrononClockMode.Horizons(processingTime, processingTime + 1L))
+    }
+  }
+
+  it should "be live at the lag boundary and preserve separate exact-hop horizons" in {
+    val processingTime = exactHop
+    val watermark = processingTime - liveBoundary
+    val mode = ChrononClockMode.classify(processingTime, watermark, sourceOutOfOrderness, liveBoundary)
+
+    mode shouldBe Live
+    ChrononClockMode.allowsPublication(mode) shouldBe true
+    ChrononClockMode.streamEventHorizons(mode, watermark, processingTime, watermark, hopMillis) shouldBe
+      ChrononClockMode.Horizons(processingTime, processingTime + 1L)
+  }
+
+  it should "leave non-hop small horizons unchanged" in {
+    val processingTime = exactHop + sourceOutOfOrderness + 17L
+    val watermark = processingTime - sourceOutOfOrderness - 1L
+    val mode = ChrononClockMode.classify(processingTime, watermark, sourceOutOfOrderness, liveBoundary)
+
+    ChrononClockMode.streamEventHorizons(mode, processingTime, processingTime, watermark, hopMillis) shouldBe
+      ChrononClockMode.Horizons(processingTime, processingTime)
+  }
+
+  it should "fence a watermark that implies a future source timestamp" in {
+    val processingTime = exactHop + sourceOutOfOrderness
+    val healthyWatermark = processingTime - sourceOutOfOrderness - 1L
+    val futureWatermark = healthyWatermark + 1L
+
+    ChrononClockMode.classify(processingTime,
+                              healthyWatermark,
+                              sourceOutOfOrderness,
+                              liveBoundary) shouldBe Live
+    ChrononClockMode.classify(processingTime,
+                              futureWatermark,
+                              sourceOutOfOrderness,
+                              liveBoundary) shouldBe NoWatermark
+    ChrononClockMode.classify(processingTime,
+                              Long.MaxValue,
+                              sourceOutOfOrderness,
+                              liveBoundary) shouldBe NoWatermark
+  }
+
+  it should "avoid overflow near the end of the timestamp range" in {
+    val watermark = Long.MaxValue - sourceOutOfOrderness - 1L
+    val mode = ChrononClockMode.classify(Long.MaxValue, watermark, sourceOutOfOrderness, liveBoundary)
+
+    mode shouldBe Live
+    ChrononClockMode.processingTimerHorizons(mode, Long.MaxValue, watermark, hopMillis) shouldBe
+      Some(ChrononClockMode.Horizons(Long.MaxValue, Long.MaxValue))
+  }
+}

--- a/flink/src/test/scala/ai/chronon/flink/test/window/GigaTileFirstSeenKeyGraceTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/window/GigaTileFirstSeenKeyGraceTest.scala
@@ -1,0 +1,867 @@
+package ai.chronon.flink.test.window
+
+import ai.chronon.aggregator.windowing.{GigaEmitResult, SawtoothOnlineAggregator}
+import ai.chronon.api._
+import ai.chronon.api.Extensions.WindowOps
+import ai.chronon.flink.FlinkJob
+import ai.chronon.flink.deser.ProjectedEvent
+import ai.chronon.flink.types.{BatchIrRow, TimestampedTile}
+import ai.chronon.flink.window.GigaTileProcessFunction
+import ai.chronon.online.GigaTileCodec
+import ai.chronon.online.serde.{ArrayRow, AvroCodec}
+import org.apache.flink.api.common.state.{ValueState, ValueStateDescriptor}
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.functions.KeySelector
+import org.apache.flink.runtime.state.KeyedStateBackend
+import org.apache.flink.streaming.api.functions.co.KeyedCoProcessFunction
+import org.apache.flink.streaming.api.operators.co.KeyedCoProcessOperator
+import org.apache.flink.streaming.api.watermark.Watermark
+import org.apache.flink.streaming.util.KeyedTwoInputStreamOperatorTestHarness
+import org.apache.flink.util.Collector
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.util
+import scala.collection.JavaConverters._
+
+class GigaTileFirstSeenKeyGraceTest extends AnyFlatSpec with Matchers {
+  import GigaTileFirstSeenKeyGraceTest._
+
+  "GigaTileProcessFunction first-seen grace" should "initialize during catch-up but remain fenced until Live" in {
+    val graceMillis = 1000L
+    val function = new GigaTileProcessFunction(batchBackedGroupBy,
+                                               inputSchema,
+                                               firstSeenKeyGraceMillis = graceMillis)
+    val testHarness = harness(function)
+    val startProcessingTime = tenDays + oneHour
+    val catchupWatermark = startProcessingTime - 3L * dayMillis
+    val eventTime = catchupWatermark - 1000L
+    val graceTimer = nextDay(startProcessingTime)
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(startProcessingTime)
+      advanceConnectedWatermark(testHarness, catchupWatermark)
+      testHarness.processElement1(event(DefaultEntity, eventTime, 5L), eventTime)
+
+      testHarness.setProcessingTime(graceTimer)
+      testHarness.extractOutputValues() shouldBe empty
+      setCurrentKey(testHarness, entityKey(DefaultEntity))
+      state[Array[Byte]](function, "batchIrState").value() shouldBe null
+      state[java.lang.Boolean](function, "syntheticEmptyBatchBaselineState").value() shouldEqual
+        java.lang.Boolean.TRUE
+      state[java.lang.Boolean](function, "pendingEmptyBatchBaselineState").value() shouldBe null
+
+      val liveProcessingTime = graceTimer + 1000L
+      testHarness.setProcessingTime(liveProcessingTime)
+      advanceConnectedHealthyLiveWatermark(testHarness, liveProcessingTime)
+      testHarness.processElement1(event(DefaultEntity, liveProcessingTime - 1L, 0L), liveProcessingTime - 1L)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0), batchBackedGroupBy) shouldEqual 5L
+    } finally testHarness.close()
+  }
+
+  it should "not initialize, age, or publish from a NoWatermark processing timer" in {
+    val graceMillis = dayMillis + oneHour
+    val function = new GigaTileProcessFunction(batchBackedGroupBy,
+                                               inputSchema,
+                                               firstSeenKeyGraceMillis = graceMillis)
+    val testHarness = harness(function)
+    val startProcessingTime = tenDays + oneHour
+    val eventTime = startProcessingTime - 1000L
+    val eventDay = TsUtils.round(eventTime, dayMillis)
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(startProcessingTime)
+      testHarness.processElement1(event(DefaultEntity, eventTime, 5L), eventTime)
+
+      // This crosses two daily processing timers, including one after the grace expires.
+      testHarness.setProcessingTime(startProcessingTime + 2L * dayMillis)
+
+      testHarness.extractOutputValues() shouldBe empty
+      setCurrentKey(testHarness, entityKey(DefaultEntity))
+      state[Array[Byte]](function, "batchIrState").value() shouldBe null
+      state[java.lang.Boolean](function, "pendingEmptyBatchBaselineState").value() shouldEqual java.lang.Boolean.TRUE
+      state[java.lang.Long](function, "currentDayStartState").value().longValue() shouldEqual eventDay
+    } finally testHarness.close()
+  }
+
+  it should "not initialize from a NoWatermark event after grace" in {
+    val graceMillis = 1000L
+    val function = new GigaTileProcessFunction(
+      batchBackedGroupBy,
+      inputSchema,
+      firstSeenKeyGraceMillis = graceMillis)
+    val testHarness = harness(function)
+    val startProcessingTime = tenDays + oneHour
+    val firstEventTime = startProcessingTime - 1000L
+    val afterGraceProcessingTime = startProcessingTime + graceMillis + 1L
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(startProcessingTime)
+      testHarness.processElement1(event(DefaultEntity, firstEventTime, 5L), firstEventTime)
+
+      testHarness.setProcessingTime(afterGraceProcessingTime)
+      testHarness.processElement1(event(DefaultEntity, firstEventTime + 1L, 7L), firstEventTime + 1L)
+
+      testHarness.extractOutputValues() shouldBe empty
+      setCurrentKey(testHarness, entityKey(DefaultEntity))
+      state[Array[Byte]](function, "batchIrState").value() shouldBe null
+      state[java.lang.Boolean](function, "pendingEmptyBatchBaselineState").value() shouldEqual java.lang.Boolean.TRUE
+    } finally testHarness.close()
+  }
+
+  it should "let a real batch row win during the grace" in {
+    val graceMillis = 2000L
+    val function = new GigaTileProcessFunction(batchBackedGroupBy,
+                                               inputSchema,
+                                               firstSeenKeyGraceMillis = graceMillis)
+    val testHarness = harness(function)
+    val startProcessingTime = tenDays + oneHour
+    val eventTime = startProcessingTime - 1000L
+    val batchEnd = tenDays
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(startProcessingTime)
+      advanceConnectedHealthyLiveWatermark(testHarness, startProcessingTime)
+      testHarness.processElement1(event(DefaultEntity, eventTime, 5L), eventTime)
+      decodeSum(testHarness.extractOutputValues().get(0), batchBackedGroupBy) shouldBe null
+
+      val batchProcessingTime = startProcessingTime + graceMillis / 2L
+      testHarness.setProcessingTime(batchProcessingTime)
+      advanceConnectedHealthyLiveWatermark(testHarness, batchProcessingTime)
+      testHarness.processElement2(batchRow(DefaultEntity, batchBackedGroupBy, batchEnd, 7L), batchEnd)
+
+      val outputs = testHarness.extractOutputValues()
+      decodeSum(outputs.get(outputs.size() - 1), batchBackedGroupBy) shouldEqual 12L
+      setCurrentKey(testHarness, entityKey(DefaultEntity))
+      state[java.lang.Boolean](function, "pendingEmptyBatchBaselineState").value() shouldBe null
+      state[java.lang.Long](function, "batchEndTsState").value().longValue() shouldEqual batchEnd
+    } finally testHarness.close()
+  }
+
+  it should "let a real batch row replace a synthetic empty baseline" in {
+    val function = new GigaTileProcessFunction(batchBackedGroupBy,
+                                               inputSchema,
+                                               firstSeenKeyGraceMillis = 1L)
+    val testHarness = harness(function)
+    val startProcessingTime = tenDays + oneHour
+    val eventTime = startProcessingTime - 1000L
+    val batchEnd = tenDays
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(startProcessingTime)
+      advanceConnectedHealthyLiveWatermark(testHarness, startProcessingTime)
+      testHarness.processElement1(event(DefaultEntity, eventTime, 5L), eventTime)
+      decodeSum(testHarness.extractOutputValues().get(0), batchBackedGroupBy) shouldBe null
+
+      val baselineProcessingTime = startProcessingTime + 1L
+      testHarness.setProcessingTime(baselineProcessingTime)
+      advanceConnectedHealthyLiveWatermark(testHarness, baselineProcessingTime)
+      testHarness.processElement1(event(DefaultEntity, eventTime + 1L, 0L), eventTime + 1L)
+      val baselineOutputs = testHarness.extractOutputValues()
+      decodeSum(baselineOutputs.get(baselineOutputs.size() - 1), batchBackedGroupBy) shouldEqual 5L
+
+      setCurrentKey(testHarness, entityKey(DefaultEntity))
+      state[Array[Byte]](function, "batchIrState").value() shouldBe null
+      state[java.lang.Boolean](function, "syntheticEmptyBatchBaselineState").value() shouldEqual
+        java.lang.Boolean.TRUE
+      state[java.lang.Long](function, "batchEndTsState").value() shouldBe null
+
+      testHarness.processElement2(batchRow(DefaultEntity, batchBackedGroupBy, batchEnd, 7L), batchEnd)
+      // The event and batch callbacks share one processing-time millisecond, so the
+      // monotonic publisher flushes the authoritative batch result at the next millisecond.
+      testHarness.setProcessingTime(baselineProcessingTime + 1L)
+      val outputs = testHarness.extractOutputValues()
+      decodeSum(outputs.get(outputs.size() - 1), batchBackedGroupBy) shouldEqual 12L
+      state[Array[Byte]](function, "batchIrState").value() should not be null
+      state[java.lang.Boolean](function, "syntheticEmptyBatchBaselineState").value() shouldBe null
+      state[java.lang.Long](function, "batchEndTsState").value().longValue() shouldEqual batchEnd
+    } finally testHarness.close()
+  }
+
+  it should "fail batch value decoding closed when the fallback is enabled" in {
+    val function = new GigaTileProcessFunction(batchBackedGroupBy,
+                                               inputSchema,
+                                               firstSeenKeyGraceMillis = 1L)
+    val testHarness = harness(function)
+    val startProcessingTime = tenDays + oneHour
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(startProcessingTime)
+      advanceConnectedHealthyLiveWatermark(testHarness, startProcessingTime)
+
+      an[Exception] should be thrownBy testHarness.processElement2(
+        new BatchIrRow(entityKey(DefaultEntity), Array[Byte](1, 2, 3), tenDays),
+        tenDays)
+    } finally testHarness.close()
+  }
+
+  it should "ignore a stale pending fallback when batch state already exists" in {
+    val function = new GigaTileProcessFunction(batchBackedGroupBy,
+                                               inputSchema,
+                                               firstSeenKeyGraceMillis = 1L)
+    val testHarness = harness(function)
+    val startProcessingTime = tenDays + oneHour
+    val batchEnd = tenDays
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(startProcessingTime)
+      advanceConnectedHealthyLiveWatermark(testHarness, startProcessingTime)
+      testHarness.processElement2(batchRow(DefaultEntity, batchBackedGroupBy, batchEnd, 7L), batchEnd)
+
+      setCurrentKey(testHarness, entityKey(DefaultEntity))
+      state[java.lang.Boolean](function, "pendingEmptyBatchBaselineState").update(java.lang.Boolean.TRUE)
+
+      val noOpInitialization = initializeEmptyBatchBaseline(function,
+                                                            startProcessingTime + 1L,
+                                                            startProcessingTime)
+      noOpInitialization shouldBe None
+      state[java.lang.Boolean](function, "pendingEmptyBatchBaselineState").value() shouldBe null
+
+      // A no-op initialization must not replace callback metadata. This is the shape used
+      // by batch callbacks that need to retain the normal eviction schedule without emitting.
+      val callbackResult = GigaEmitResult(null, needsEvictionTimer = true)
+      val mergedResult = noOpInitialization.getOrElse(callbackResult)
+      mergedResult.finalizedVector shouldBe null
+      mergedResult.needsEvictionTimer shouldBe true
+
+      // Exercise the same coexistence through the normal event path and retain its value.
+      state[java.lang.Boolean](function, "pendingEmptyBatchBaselineState").update(java.lang.Boolean.TRUE)
+      val eventProcessingTime = startProcessingTime + 1L
+      testHarness.setProcessingTime(eventProcessingTime)
+      advanceConnectedHealthyLiveWatermark(testHarness, eventProcessingTime)
+      testHarness.processElement1(event(DefaultEntity, eventProcessingTime - 1L, 5L), eventProcessingTime - 1L)
+
+      val outputs = testHarness.extractOutputValues()
+      decodeSum(outputs.get(outputs.size() - 1), batchBackedGroupBy) shouldEqual 12L
+      state[java.lang.Boolean](function, "pendingEmptyBatchBaselineState").value() shouldBe null
+    } finally testHarness.close()
+  }
+
+  it should "restore pending grace and cadence state without bypassing a fresh grace" in {
+    val graceMillis = 1000L
+    val cadenceMillis = 100L
+    val startProcessingTime = tenDays + oneHour
+    val eventTime = startProcessingTime - 1000L
+    val firstCadence = nextBufferedWriteTick(batchBackedGroupBy,
+                                             entityKey(DefaultEntity),
+                                             startProcessingTime,
+                                             cadenceMillis)
+    val originalFunction = new GigaTileProcessFunction(batchBackedGroupBy,
+                                                       inputSchema,
+                                                       bufferingOutputTimeMillis = cadenceMillis,
+                                                       firstSeenKeyGraceMillis = graceMillis)
+    val originalHarness = harness(originalFunction)
+
+    originalHarness.open()
+    originalHarness.setProcessingTime(startProcessingTime)
+    advanceConnectedHealthyLiveWatermark(originalHarness, startProcessingTime)
+    originalHarness.processElement1(event(DefaultEntity, eventTime, 5L), eventTime)
+    val snapshot = originalHarness.snapshot(31L, startProcessingTime)
+    originalHarness.close()
+
+    val restoredFunction = new GigaTileProcessFunction(batchBackedGroupBy,
+                                                       inputSchema,
+                                                       bufferingOutputTimeMillis = cadenceMillis,
+                                                       firstSeenKeyGraceMillis = graceMillis)
+    val restoredHarness = harness(restoredFunction)
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(snapshot)
+      restoredHarness.open()
+      restoredHarness.setProcessingTime(startProcessingTime)
+      advanceConnectedHealthyLiveWatermark(restoredHarness, startProcessingTime)
+
+      // The restored cadence can flush the pre-grace null value, but must not install
+      // synthetic history or clear the keyed pending-grace marker.
+      restoredHarness.setProcessingTime(firstCadence)
+      setCurrentKey(restoredHarness, entityKey(DefaultEntity))
+      state[Array[Byte]](restoredFunction, "batchIrState").value() shouldBe null
+      state[java.lang.Boolean](restoredFunction, "pendingEmptyBatchBaselineState").value() shouldEqual
+        java.lang.Boolean.TRUE
+
+      val readyProcessingTime = firstCadence + graceMillis
+      restoredHarness.setProcessingTime(readyProcessingTime)
+      advanceConnectedHealthyLiveWatermark(restoredHarness, readyProcessingTime)
+      restoredHarness.processElement1(event(DefaultEntity, readyProcessingTime - 1L, 0L), readyProcessingTime - 1L)
+      val finalCadence = nextBufferedWriteTick(batchBackedGroupBy,
+                                               entityKey(DefaultEntity),
+                                               readyProcessingTime,
+                                               cadenceMillis)
+      restoredHarness.setProcessingTime(finalCadence)
+
+      val outputs = restoredHarness.extractOutputValues()
+      decodeSum(outputs.get(outputs.size() - 1), batchBackedGroupBy) shouldEqual 5L
+      state[Array[Byte]](restoredFunction, "batchIrState").value() shouldBe null
+      state[java.lang.Boolean](restoredFunction, "syntheticEmptyBatchBaselineState").value() shouldEqual
+        java.lang.Boolean.TRUE
+      state[java.lang.Boolean](restoredFunction, "pendingPublicationState").value() shouldEqual
+        java.lang.Boolean.TRUE
+      state[java.lang.Boolean](restoredFunction, "syntheticRollbackCorrectionState").value() shouldEqual
+        java.lang.Boolean.TRUE
+    } finally restoredHarness.close()
+  }
+
+  it should "remove a restored synthetic baseline when the option is disabled" in {
+    val graceMillis = 1000L
+    val startProcessingTime = tenDays + oneHour
+    val eventTime = startProcessingTime - 1000L
+    val originalFunction = new GigaTileProcessFunction(batchBackedGroupBy,
+                                                       inputSchema,
+                                                       firstSeenKeyGraceMillis = graceMillis)
+    val originalHarness = harness(originalFunction)
+
+    originalHarness.open()
+    originalHarness.setProcessingTime(startProcessingTime)
+    advanceConnectedHealthyLiveWatermark(originalHarness, startProcessingTime)
+    originalHarness.processElement1(event(DefaultEntity, eventTime, 5L), eventTime)
+    val baselineProcessingTime = startProcessingTime + graceMillis + 1L
+    originalHarness.setProcessingTime(baselineProcessingTime)
+    advanceConnectedHealthyLiveWatermark(originalHarness, baselineProcessingTime)
+    originalHarness.processElement1(event(DefaultEntity, eventTime + 1L, 0L), eventTime + 1L)
+    decodeSum(originalHarness.extractOutputValues().asScala.last, batchBackedGroupBy) shouldEqual 5L
+    setCurrentKey(originalHarness, entityKey(DefaultEntity))
+    state[Array[Byte]](originalFunction, "batchIrState").value() shouldBe null
+    state[java.lang.Boolean](originalFunction, "syntheticEmptyBatchBaselineState").value() shouldEqual
+      java.lang.Boolean.TRUE
+    state[java.lang.Boolean](originalFunction, "pendingPublicationState").value() shouldEqual
+      java.lang.Boolean.TRUE
+    state[java.lang.Boolean](originalFunction, "syntheticRollbackCorrectionState").value() shouldEqual
+      java.lang.Boolean.TRUE
+    val firstCorrectionTimer =
+      state[java.lang.Long](originalFunction, "nextProcessingEvictionTimerState").value().longValue()
+    val snapshot = originalHarness.snapshot(32L, baselineProcessingTime)
+    originalHarness.close()
+
+    val restoredFunction = new GigaTileProcessFunction(batchBackedGroupBy, inputSchema)
+    val restoredHarness = harness(restoredFunction)
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(snapshot)
+      restoredHarness.open()
+      // No new event arrives. The first restored timer disables synthetic availability while
+      // the connected watermark is still catching up; the next live timer must publish the
+      // null-fenced correction so a C4 rollback cannot leave the old KV value serving.
+      restoredHarness.setProcessingTime(firstCorrectionTimer)
+      advanceConnectedHealthyLiveWatermark(restoredHarness, firstCorrectionTimer)
+      setCurrentKey(restoredHarness, entityKey(DefaultEntity))
+      state[java.lang.Boolean](restoredFunction, "syntheticEmptyBatchBaselineState").value() shouldBe null
+      state[java.lang.Boolean](restoredFunction, "syntheticRollbackCorrectionState").value() shouldBe null
+      state[java.lang.Boolean](restoredFunction, "pendingPublicationState").value() shouldEqual
+        java.lang.Boolean.TRUE
+      val liveCorrectionTimer =
+        state[java.lang.Long](restoredFunction, "nextProcessingEvictionTimerState").value().longValue()
+      liveCorrectionTimer should be > firstCorrectionTimer
+      restoredHarness.setProcessingTime(liveCorrectionTimer - 1L)
+      advanceConnectedHealthyLiveWatermark(restoredHarness, liveCorrectionTimer)
+      restoredHarness.setProcessingTime(liveCorrectionTimer)
+
+      val corrections = restoredHarness.extractOutputValues().asScala
+      corrections should have size 1
+      decodeSum(corrections.head, batchBackedGroupBy) shouldBe null
+      setCurrentKey(restoredHarness, entityKey(DefaultEntity))
+      state[Array[Byte]](restoredFunction, "batchIrState").value() shouldBe null
+      state[java.lang.Boolean](restoredFunction, "pendingEmptyBatchBaselineState").value() shouldBe null
+      state[java.lang.Boolean](restoredFunction, "syntheticEmptyBatchBaselineState").value() shouldBe null
+      state[java.lang.Boolean](restoredFunction, "pendingPublicationState").value() shouldBe null
+      state[java.lang.Boolean](restoredFunction, "syntheticRollbackCorrectionState").value() shouldBe null
+    } finally restoredHarness.close()
+  }
+
+  it should "not resurrect a synthetic baseline after a marker-blind rollback checkpoint" in {
+    val graceMillis = 1L
+    val startProcessingTime = tenDays + oneHour
+    val eventTime = startProcessingTime - 1000L
+    val originalFunction = new GigaTileProcessFunction(batchBackedGroupBy,
+                                                       inputSchema,
+                                                       firstSeenKeyGraceMillis = graceMillis)
+    val originalHarness = harness(originalFunction)
+    originalHarness.open()
+    originalHarness.setProcessingTime(startProcessingTime)
+    advanceConnectedHealthyLiveWatermark(originalHarness, startProcessingTime)
+    originalHarness.processElement1(event(DefaultEntity, eventTime, 5L), eventTime)
+    val baselineProcessingTime = startProcessingTime + graceMillis + 1L
+    originalHarness.setProcessingTime(baselineProcessingTime)
+    advanceConnectedHealthyLiveWatermark(originalHarness, baselineProcessingTime)
+    originalHarness.processElement1(event(DefaultEntity, eventTime + 1L, 0L), eventTime + 1L)
+    setCurrentKey(originalHarness, entityKey(DefaultEntity))
+    state[Array[Byte]](originalFunction, "batchIrState").value() shouldBe null
+    state[java.lang.Boolean](originalFunction, "syntheticEmptyBatchBaselineState").value() shouldEqual
+      java.lang.Boolean.TRUE
+    state[java.lang.Boolean](originalFunction, "syntheticRollbackCorrectionState").value() shouldEqual
+      java.lang.Boolean.TRUE
+    state[java.lang.Boolean](originalFunction, "pendingPublicationState").value() shouldEqual
+      java.lang.Boolean.TRUE
+    val correctionTimer =
+      state[java.lang.Long](originalFunction, "nextProcessingEvictionTimerState").value().longValue()
+    val originalSnapshot = originalHarness.snapshot(40L, baselineProcessingTime)
+    originalHarness.close()
+
+    val markerBlindFunction = new MarkerBlindCorrectionConsumer(expectedTimer = Some(correctionTimer))
+    val markerBlindHarness = harness(markerBlindFunction)
+    markerBlindHarness.setup()
+    markerBlindHarness.initializeState(originalSnapshot)
+    markerBlindHarness.open()
+    markerBlindHarness.setProcessingTime(correctionTimer)
+    markerBlindFunction.correctionConsumed shouldBe true
+    val markerBlindSnapshot = markerBlindHarness.snapshot(41L, correctionTimer)
+    markerBlindHarness.close()
+
+    val restoredFunction = new GigaTileProcessFunction(batchBackedGroupBy,
+                                                       inputSchema,
+                                                       firstSeenKeyGraceMillis = graceMillis)
+    val restoredHarness = harness(restoredFunction)
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(markerBlindSnapshot)
+      restoredHarness.open()
+      restoredHarness.setProcessingTime(correctionTimer)
+      restoredHarness.processElement1(event(DefaultEntity, eventTime + 2L, 0L), eventTime + 2L)
+
+      setCurrentKey(restoredHarness, entityKey(DefaultEntity))
+      state[Array[Byte]](restoredFunction, "batchIrState").value() shouldBe null
+      state[java.lang.Boolean](restoredFunction, "syntheticEmptyBatchBaselineState").value() shouldBe null
+      state[java.lang.Boolean](restoredFunction, "syntheticRollbackCorrectionState").value() shouldBe null
+      state[java.lang.Boolean](restoredFunction, "pendingEmptyBatchBaselineState").value() shouldEqual
+        java.lang.Boolean.TRUE
+    } finally restoredHarness.close()
+  }
+
+  it should "restart grace after marker-blind rollback consumes a newer fenced synthetic update" in {
+    val graceMillis = oneHour
+    val startProcessingTime = tenDays + oneHour
+    val eventTime = startProcessingTime - 1000L
+    val originalFunction = new GigaTileProcessFunction(batchBackedGroupBy,
+                                                       inputSchema,
+                                                       firstSeenKeyGraceMillis = graceMillis)
+    val originalHarness = harness(originalFunction)
+    originalHarness.open()
+    originalHarness.setProcessingTime(startProcessingTime)
+    advanceConnectedHealthyLiveWatermark(originalHarness, startProcessingTime)
+    originalHarness.processElement1(event(DefaultEntity, eventTime, 5L), eventTime)
+
+    val baselineProcessingTime = startProcessingTime + graceMillis + 1L
+    originalHarness.setProcessingTime(baselineProcessingTime)
+    advanceConnectedHealthyLiveWatermark(originalHarness, baselineProcessingTime)
+    originalHarness.processElement1(event(DefaultEntity, eventTime + 1L, 0L), eventTime + 1L)
+    setCurrentKey(originalHarness, entityKey(DefaultEntity))
+    state[java.lang.Boolean](originalFunction, "syntheticEmptyBatchBaselineState").value() shouldEqual
+      java.lang.Boolean.TRUE
+    state[java.lang.Boolean](originalFunction, "syntheticRollbackCorrectionState").value() shouldEqual
+      java.lang.Boolean.TRUE
+
+    // Let the connected watermark become stale, then mutate the synthetic view while fenced.
+    // This is the checkpoint shape that clears the correction marker but still owns a pending
+    // publication through the legacy descriptor.
+    val catchupProcessingTime = baselineProcessingTime + 10L * oneHour
+    originalHarness.setProcessingTime(catchupProcessingTime)
+    originalHarness.processElement1(event(DefaultEntity, eventTime + 2L, 7L), eventTime + 2L)
+    setCurrentKey(originalHarness, entityKey(DefaultEntity))
+    state[java.lang.Boolean](originalFunction, "syntheticEmptyBatchBaselineState").value() shouldEqual
+      java.lang.Boolean.TRUE
+    state[java.lang.Boolean](originalFunction, "pendingPublicationState").value() shouldEqual
+      java.lang.Boolean.TRUE
+    state[java.lang.Boolean](originalFunction, "syntheticRollbackCorrectionState").value() shouldBe null
+    val correctionTimer =
+      state[java.lang.Long](originalFunction, "nextProcessingEvictionTimerState").value().longValue()
+    val originalSnapshot = originalHarness.snapshot(42L, catchupProcessingTime)
+    originalHarness.close()
+
+    val markerBlindFunction = new MarkerBlindCorrectionConsumer(expectedTimer = Some(correctionTimer))
+    val markerBlindHarness = harness(markerBlindFunction)
+    markerBlindHarness.setup()
+    markerBlindHarness.initializeState(originalSnapshot)
+    markerBlindHarness.open()
+    markerBlindHarness.setProcessingTime(catchupProcessingTime)
+    markerBlindHarness.setProcessingTime(correctionTimer)
+    markerBlindFunction.correctionConsumed shouldBe true
+    val markerBlindSnapshot = markerBlindHarness.snapshot(43L, correctionTimer)
+    markerBlindHarness.close()
+
+    val restoredFunction = new GigaTileProcessFunction(batchBackedGroupBy,
+                                                       inputSchema,
+                                                       firstSeenKeyGraceMillis = graceMillis)
+    val restoredHarness = harness(restoredFunction)
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(markerBlindSnapshot)
+      restoredHarness.open()
+      restoredHarness.setProcessingTime(correctionTimer)
+      advanceConnectedHealthyLiveWatermark(restoredHarness, correctionTimer)
+      restoredHarness.processElement1(event(DefaultEntity, correctionTimer - 1L, 0L), correctionTimer - 1L)
+
+      restoredHarness.extractOutputValues().asScala.foreach { output =>
+        decodeSum(output, batchBackedGroupBy) shouldBe null
+      }
+      setCurrentKey(restoredHarness, entityKey(DefaultEntity))
+      state[java.lang.Boolean](restoredFunction, "syntheticEmptyBatchBaselineState").value() shouldBe null
+      state[java.lang.Boolean](restoredFunction, "syntheticRollbackCorrectionState").value() shouldBe null
+      state[java.lang.Boolean](restoredFunction, "pendingEmptyBatchBaselineState").value() shouldEqual
+        java.lang.Boolean.TRUE
+      transientLong(restoredFunction, "emptyBatchBaselineSafeAfterMillis") shouldEqual
+        correctionTimer + graceMillis
+    } finally restoredHarness.close()
+  }
+
+  it should "share the operator warm clock while isolating per-key baseline decisions" in {
+    val graceMillis = 1000L
+    val firstKey = "entity-a"
+    val secondKey = "entity-b"
+    val function = new GigaTileProcessFunction(batchBackedGroupBy,
+                                               inputSchema,
+                                               firstSeenKeyGraceMillis = graceMillis)
+    val testHarness = harness(function)
+    val startProcessingTime = tenDays + oneHour
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(startProcessingTime)
+      advanceConnectedHealthyLiveWatermark(testHarness, startProcessingTime)
+      testHarness.processElement1(event(firstKey, startProcessingTime - 1000L, 5L), startProcessingTime - 1000L)
+
+      val warmProcessingTime = startProcessingTime + graceMillis + 1L
+      testHarness.setProcessingTime(warmProcessingTime)
+      advanceConnectedHealthyLiveWatermark(testHarness, warmProcessingTime)
+      testHarness.processElement1(event(secondKey, warmProcessingTime - 1L, 7L), warmProcessingTime - 1L)
+
+      val secondKeyOutput = testHarness.extractOutputValues().asScala
+        .filter(_.keys.get(0).toString == secondKey)
+        .last
+      decodeSum(secondKeyOutput, batchBackedGroupBy) shouldEqual 7L
+
+      testHarness.processElement2(batchRow(firstKey, batchBackedGroupBy, tenDays, 11L), tenDays)
+
+      setCurrentKey(testHarness, entityKey(firstKey))
+      state[java.lang.Long](function, "batchEndTsState").value().longValue() shouldEqual tenDays
+      state[java.lang.Boolean](function, "pendingEmptyBatchBaselineState").value() shouldBe null
+      setCurrentKey(testHarness, entityKey(secondKey))
+      state[Array[Byte]](function, "batchIrState").value() shouldBe null
+      state[java.lang.Boolean](function, "syntheticEmptyBatchBaselineState").value() shouldEqual
+        java.lang.Boolean.TRUE
+      state[java.lang.Long](function, "batchEndTsState").value() shouldBe null
+    } finally testHarness.close()
+  }
+
+  it should "initialize before flushing a coincident eviction and cadence timer" in {
+    val cadenceMillis = 1L
+    val collisionTime = 11L * dayMillis
+    val eventProcessingTime = collisionTime - 1L
+    val function = new GigaTileProcessFunction(batchBackedGroupBy,
+                                               inputSchema,
+                                               bufferingOutputTimeMillis = cadenceMillis,
+                                               firstSeenKeyGraceMillis = 1L)
+    val testHarness = harness(function)
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(eventProcessingTime)
+      advanceConnectedHealthyLiveWatermark(testHarness, eventProcessingTime)
+      testHarness.processElement1(event(DefaultEntity, eventProcessingTime - 1000L, 5L), eventProcessingTime - 1000L)
+      testHarness.extractOutputValues() shouldBe empty
+
+      testHarness.setProcessingTime(collisionTime)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0), batchBackedGroupBy) shouldEqual 5L
+      outputs.get(0).latestTsMillis shouldEqual collisionTime
+    } finally testHarness.close()
+  }
+
+  it should "not initialize from collision-only or retry-only timers" in {
+    val collisionFunction = new GigaTileProcessFunction(batchBackedGroupBy,
+                                                        inputSchema,
+                                                        firstSeenKeyGraceMillis = 1L)
+    val collisionHarness = harness(collisionFunction)
+    val startProcessingTime = tenDays + oneHour
+    val eventTime = startProcessingTime - 1000L
+
+    try {
+      collisionHarness.open()
+      collisionHarness.setProcessingTime(startProcessingTime)
+      advanceConnectedHealthyLiveWatermark(collisionHarness, startProcessingTime)
+      collisionHarness.processElement1(event(DefaultEntity, eventTime, 5L), eventTime)
+      collisionHarness.processElement1(event(DefaultEntity, eventTime + 1L, 0L), eventTime + 1L)
+      collisionHarness.setProcessingTime(startProcessingTime + 1L)
+
+      setCurrentKey(collisionHarness, entityKey(DefaultEntity))
+      state[Array[Byte]](collisionFunction, "batchIrState").value() shouldBe null
+    } finally collisionHarness.close()
+
+    val retryDelay = math.max(1L, 2L * FlinkJob.AutoWatermarkInterval)
+    val retryFunction = new GigaTileProcessFunction(batchBackedGroupBy,
+                                                    inputSchema,
+                                                    firstSeenKeyGraceMillis = retryDelay)
+    val retryHarness = harness(retryFunction)
+    val catchupWatermark = startProcessingTime - 3L * dayMillis
+    try {
+      retryHarness.open()
+      retryHarness.setProcessingTime(startProcessingTime)
+      advanceConnectedWatermark(retryHarness, catchupWatermark)
+      retryHarness.processElement1(event(DefaultEntity, catchupWatermark - 1L, 5L), catchupWatermark - 1L)
+      retryHarness.setProcessingTime(startProcessingTime + retryDelay)
+
+      retryHarness.extractOutputValues() shouldBe empty
+      setCurrentKey(retryHarness, entityKey(DefaultEntity))
+      state[Array[Byte]](retryFunction, "batchIrState").value() shouldBe null
+    } finally retryHarness.close()
+  }
+
+  it should "leave a no-batch-only GroupBy outside the fallback path" in {
+    val function = new GigaTileProcessFunction(noBatchGroupBy,
+                                               inputSchema,
+                                               firstSeenKeyGraceMillis = 1L)
+    val testHarness = harness(function)
+    val startProcessingTime = tenDays + oneHour
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(startProcessingTime)
+      advanceConnectedHealthyLiveWatermark(testHarness, startProcessingTime)
+      testHarness.processElement1(event(DefaultEntity, startProcessingTime - 1000L, 5L), startProcessingTime - 1000L)
+
+      decodeSum(testHarness.extractOutputValues().get(0), noBatchGroupBy) shouldEqual 5L
+      setCurrentKey(testHarness, entityKey(DefaultEntity))
+      state[Array[Byte]](function, "batchIrState").value() shouldBe null
+      state[java.lang.Boolean](function, "pendingEmptyBatchBaselineState").value() shouldBe null
+    } finally testHarness.close()
+  }
+
+  it should "leave the fallback disabled by default" in {
+    GigaTileProcessFunction.DefaultFirstSeenKeyGraceMillis shouldEqual 0L
+    val function = new GigaTileProcessFunction(batchBackedGroupBy, inputSchema)
+    val testHarness = harness(function)
+    val startProcessingTime = tenDays + oneHour
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(startProcessingTime)
+      advanceConnectedHealthyLiveWatermark(testHarness, startProcessingTime)
+      testHarness.processElement1(event(DefaultEntity, startProcessingTime - 1000L, 5L), startProcessingTime - 1000L)
+
+      decodeSum(testHarness.extractOutputValues().get(0), batchBackedGroupBy) shouldBe null
+      setCurrentKey(testHarness, entityKey(DefaultEntity))
+      state[Array[Byte]](function, "batchIrState").value() shouldBe null
+      state[java.lang.Boolean](function, "pendingEmptyBatchBaselineState").value() shouldBe null
+    } finally testHarness.close()
+  }
+
+  it should "reject a negative grace at the operator boundary" in {
+    an[IllegalArgumentException] should be thrownBy new GigaTileProcessFunction(
+      batchBackedGroupBy,
+      inputSchema,
+      firstSeenKeyGraceMillis = -1L)
+  }
+
+  it should "saturate the operator grace deadline instead of overflowing" in {
+    val function = new GigaTileProcessFunction(batchBackedGroupBy,
+                                               inputSchema,
+                                               firstSeenKeyGraceMillis = 10L)
+    val testHarness = harness(function)
+    val eventTime = tenDays + oneHour
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(Long.MaxValue - 5L)
+      testHarness.processElement1(event(DefaultEntity, eventTime, 5L), eventTime)
+
+      transientLong(function, "emptyBatchBaselineSafeAfterMillis") shouldEqual Long.MaxValue
+      setCurrentKey(testHarness, entityKey(DefaultEntity))
+      state[Array[Byte]](function, "batchIrState").value() shouldBe null
+    } finally testHarness.close()
+  }
+}
+
+object GigaTileFirstSeenKeyGraceTest {
+  private val DefaultEntity = "entity-1"
+  private val dayMillis = new Window(1, TimeUnit.DAYS).millis
+  private val oneHour = new Window(1, TimeUnit.HOURS).millis
+  private val tenDays = 10L * dayMillis
+  private val inputSchema: Seq[(String, DataType)] =
+    Seq(Constants.TimeColumn -> LongType, "num" -> LongType)
+  private val batchBackedGroupBy = groupBy("gigatile-first-seen-batch-backed", new Window(7, TimeUnit.DAYS))
+  private val noBatchGroupBy = groupBy("gigatile-first-seen-no-batch", new Window(1, TimeUnit.HOURS))
+
+  private def groupBy(name: String, window: Window): GroupBy =
+    Builders.GroupBy(
+      metaData = Builders.MetaData(name = name),
+      aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(window))))
+
+  private def harness(
+      function: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]
+  ): KeyedTwoInputStreamOperatorTestHarness[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile] =
+    new KeyedTwoInputStreamOperatorTestHarness[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile](
+      new KeyedCoProcessOperator(function),
+      new KeySelector[ProjectedEvent, util.List[Any]] {
+        override def getKey(value: ProjectedEvent): util.List[Any] =
+          entityKey(value.fields.getOrElse("entity", DefaultEntity).toString)
+      },
+      new KeySelector[BatchIrRow, util.List[Any]] {
+        override def getKey(value: BatchIrRow): util.List[Any] = value.entityKeys
+      },
+      TypeInformation
+        .of(classOf[util.List[_]])
+        .asInstanceOf[TypeInformation[util.List[Any]]])
+
+  /** Models a rollback binary that binds only the legacy correction descriptors and
+    * checkpoints without knowing the additive synthetic markers.
+    */
+  private class MarkerBlindCorrectionConsumer(expectedTimer: Option[Long] = None)
+      extends KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile] {
+    @transient private var batchIrState: ValueState[Array[Byte]] = _
+    @transient private var pendingPublicationState: ValueState[java.lang.Boolean] = _
+    @transient private var nextEvictionTimerState: ValueState[java.lang.Long] = _
+    var correctionConsumed: Boolean = false
+
+    override def open(parameters: org.apache.flink.configuration.Configuration): Unit = {
+      batchIrState = getRuntimeContext.getState(
+        new ValueStateDescriptor[Array[Byte]]("giga-tile-batch-ir", classOf[Array[Byte]]))
+      pendingPublicationState = getRuntimeContext.getState(
+        new ValueStateDescriptor[java.lang.Boolean]("giga-tile-pending-publication", classOf[java.lang.Boolean]))
+      nextEvictionTimerState = getRuntimeContext.getState(
+        new ValueStateDescriptor[java.lang.Long]("giga-tile-next-evict-pt-timer", classOf[java.lang.Long]))
+    }
+
+    override def processElement1(
+        event: ProjectedEvent,
+        ctx: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#Context,
+        out: Collector[TimestampedTile]
+    ): Unit = ()
+
+    override def processElement2(
+        batchRow: BatchIrRow,
+        ctx: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#Context,
+        out: Collector[TimestampedTile]
+    ): Unit = ()
+
+    override def onTimer(
+        timestamp: Long,
+        ctx: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#OnTimerContext,
+        out: Collector[TimestampedTile]
+    ): Unit = {
+      if (expectedTimer.forall(_ == timestamp)) {
+        require(batchIrState.value() == null)
+        require(java.lang.Boolean.TRUE.equals(pendingPublicationState.value()))
+        pendingPublicationState.clear()
+        nextEvictionTimerState.clear()
+        correctionConsumed = true
+      }
+    }
+  }
+
+  private def event(entity: String, timestamp: Long, value: Long): ProjectedEvent =
+    ProjectedEvent(Map("entity" -> entity, Constants.TimeColumn -> timestamp, "num" -> value), timestamp)
+
+  private def entityKey(entity: String): util.List[Any] = {
+    val result = new util.ArrayList[Any](1)
+    result.add(entity)
+    result
+  }
+
+  private def batchRow(entity: String, targetGroupBy: GroupBy, batchEnd: Long, value: Long): BatchIrRow = {
+    val batchEventTime = batchEnd - 1000L
+    val aggregator = new SawtoothOnlineAggregator(
+      batchEnd,
+      targetGroupBy.getAggregations.asScala.toSeq,
+      inputSchema)
+    val batchIr = aggregator.update(
+      aggregator.init,
+      new ArrayRow(Array[Any](batchEventTime, value), batchEventTime))
+    val finalBatchIr = aggregator.denormalizeBatchIr(aggregator.normalizeBatchIr(batchIr))
+    val codec = new GigaTileCodec(targetGroupBy, inputSchema)
+    new BatchIrRow(entityKey(entity), codec.encodeBatchIr(finalBatchIr), batchEnd)
+  }
+
+  private def advanceConnectedWatermark(
+      testHarness: KeyedTwoInputStreamOperatorTestHarness[
+        util.List[Any],
+        ProjectedEvent,
+        BatchIrRow,
+        TimestampedTile],
+      watermark: Long
+  ): Unit = {
+    testHarness.processWatermark1(new Watermark(watermark))
+    testHarness.processWatermark2(new Watermark(watermark))
+  }
+
+  private def advanceConnectedHealthyLiveWatermark(
+      testHarness: KeyedTwoInputStreamOperatorTestHarness[
+        util.List[Any],
+        ProjectedEvent,
+        BatchIrRow,
+        TimestampedTile],
+      processingTime: Long
+  ): Unit =
+    advanceConnectedWatermark(testHarness,
+                              processingTime - FlinkJob.AllowedOutOfOrderness.toMillis - 1L)
+
+  private def nextDay(timestamp: Long): Long = TsUtils.round(timestamp, dayMillis) + dayMillis
+
+  private def nextBufferedWriteTick(
+      targetGroupBy: GroupBy,
+      key: util.List[Any],
+      currentProcessingTime: Long,
+      cadenceMillis: Long
+  ): Long = {
+    val phase =
+      Math.floorMod((targetGroupBy.getMetaData.getName :: key.iterator().asScala.toList).hashCode().toLong,
+                    cadenceMillis)
+    val elapsedSincePhase = Math.floorMod(Math.floorMod(currentProcessingTime, cadenceMillis) - phase, cadenceMillis)
+    val delay = if (elapsedSincePhase == 0L) cadenceMillis else cadenceMillis - elapsedSincePhase
+    currentProcessingTime + delay
+  }
+
+  private def setCurrentKey(
+      testHarness: KeyedTwoInputStreamOperatorTestHarness[
+        util.List[Any],
+        ProjectedEvent,
+        BatchIrRow,
+        TimestampedTile],
+      key: util.List[Any]
+  ): Unit =
+    testHarness.getOperator.getKeyedStateBackend
+      .asInstanceOf[KeyedStateBackend[util.List[Any]]]
+      .setCurrentKey(key)
+
+  private def state[T](function: GigaTileProcessFunction, fieldName: String): ValueState[T] = {
+    val field = classOf[GigaTileProcessFunction].getDeclaredField(fieldName)
+    field.setAccessible(true)
+    field.get(function).asInstanceOf[ValueState[T]]
+  }
+
+  private def transientLong(function: GigaTileProcessFunction, fieldName: String): Long = {
+    val field = classOf[GigaTileProcessFunction].getDeclaredField(fieldName)
+    field.setAccessible(true)
+    field.get(function).asInstanceOf[java.lang.Long].longValue()
+  }
+
+  private def initializeEmptyBatchBaseline(
+      function: GigaTileProcessFunction,
+      currentProcessingTime: Long,
+      largeWindowAsOfMillis: Long
+  ): Option[GigaEmitResult] = {
+    val method = classOf[GigaTileProcessFunction]
+      .getDeclaredMethod("initializeEmptyBatchBaselineIfReady", java.lang.Long.TYPE, java.lang.Long.TYPE)
+    method.setAccessible(true)
+    method
+      .invoke(function, Long.box(currentProcessingTime), Long.box(largeWindowAsOfMillis))
+      .asInstanceOf[Option[GigaEmitResult]]
+  }
+
+  private def decodeSum(tile: TimestampedTile, targetGroupBy: GroupBy): AnyRef = {
+    val outputCodec = new GigaTileCodec(targetGroupBy, inputSchema)
+    val fieldName = outputCodec.outputSchema.fields.head.name
+    AvroCodec
+      .of(ai.chronon.online.serde.AvroConversions.fromChrononSchema(outputCodec.outputSchema).toString)
+      .decodeMap(tile.tileBytes)(fieldName)
+  }
+}

--- a/flink/src/test/scala/ai/chronon/flink/test/window/GigaTileProcessFunctionTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/window/GigaTileProcessFunctionTest.scala
@@ -1,8 +1,11 @@
 package ai.chronon.flink.test.window
 
 import ai.chronon.aggregator.windowing.{
+  EvictionTimes,
   GigaEmitResult,
   GigaTileStreamProcessor,
+  InMemoryGigaTileStore,
+  MegaTileAggregator,
   SawtoothOnlineAggregator
 }
 import ai.chronon.api._
@@ -10,11 +13,12 @@ import ai.chronon.api.Extensions.WindowOps
 import ai.chronon.flink.deser.ProjectedEvent
 import ai.chronon.flink.types.{BatchIrRow, TimestampedTile}
 import ai.chronon.flink.window.GigaTileProcessFunction
-import ai.chronon.online.GigaTileCodec
+import ai.chronon.online.{GigaTileCodec, MegaTileCodec}
 import ai.chronon.online.serde.{ArrayRow, AvroCodec}
-import org.apache.flink.api.common.state.ValueState
+import org.apache.flink.api.common.state.{MapState, MapStateDescriptor, ValueState, ValueStateDescriptor}
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.functions.KeySelector
+import org.apache.flink.configuration.Configuration
 import org.apache.flink.runtime.state.KeyedStateBackend
 import org.apache.flink.streaming.api.functions.co.KeyedCoProcessFunction
 import org.apache.flink.streaming.api.operators.co.KeyedCoProcessOperator
@@ -144,6 +148,51 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
 
       testHarness.extractOutputValues().asScala shouldBe empty
       testHarness.numProcessingTimeTimers() shouldEqual 1
+    } finally testHarness.close()
+  }
+
+  it should "keep an empty key scheduled until a deferred future batch activates" in {
+    val dayMillis = new Window(1, TimeUnit.DAYS).millis
+    val hourMillis = new Window(1, TimeUnit.HOURS).millis
+    val batchGroupBy = Builders.GroupBy(
+      metaData = Builders.MetaData(name = "gigatile-process-function-future-batch-test"),
+      aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(7, TimeUnit.DAYS)))))
+    val testHarness = harness(new GigaTileProcessFunction(batchGroupBy, inputSchema))
+    val batchCodec = new GigaTileCodec(batchGroupBy, inputSchema)
+    val currentBatchEnd = 10 * dayMillis
+    val currentProcessingTs = currentBatchEnd + hourMillis
+    val futureBatchEnd = currentBatchEnd + dayMillis
+    val futureEventTs = futureBatchEnd - hourMillis
+    val batchAggregator =
+      new SawtoothOnlineAggregator(futureBatchEnd, batchGroupBy.getAggregations.asScala.toSeq, inputSchema)
+    val futureBatchIr = batchAggregator.update(
+      batchAggregator.init,
+      new ArrayRow(Array[Any](futureEventTs, 50L), futureEventTs))
+    val futureBatchRow = new BatchIrRow(
+      entityKey(),
+      batchCodec.encodeBatchIr(batchAggregator.denormalizeBatchIr(batchAggregator.normalizeBatchIr(futureBatchIr))),
+      futureBatchEnd)
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(currentProcessingTs)
+      testHarness.processElement2(emptyBatchRow(batchGroupBy, currentBatchEnd), currentBatchEnd)
+      testHarness.processElement2(futureBatchRow, futureBatchEnd)
+
+      testHarness.extractOutputValues().asScala shouldBe empty
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+
+      testHarness.setProcessingTime(currentProcessingTs + hourMillis)
+
+      testHarness.extractOutputValues().asScala shouldBe empty
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+
+      testHarness.setProcessingTime(futureBatchEnd + hourMillis)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs.size() shouldEqual 1
+      decodeSum(outputs.get(0), batchGroupBy) shouldEqual 50L
+      outputs.get(0).latestTsMillis shouldEqual futureBatchEnd + hourMillis
     } finally testHarness.close()
   }
 
@@ -446,7 +495,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
       testHarness.setProcessingTime(collisionProcessingTs)
       testHarness.processElement1(event(expiringEventTs, 5L), expiringEventTs)
       testHarness.processElement1(event(expiringEventTs, 7L), expiringEventTs)
-      failNextScheduledEviction(function)
+      failNextEviction(function)
 
       testHarness.setProcessingTime(evictionTs)
 
@@ -487,6 +536,89 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
         .toMap
       flushedByKey shouldEqual Map("campaign-1" -> 12L, "campaign-2" -> 24L)
     } finally testHarness.close()
+  }
+
+  it should "include an event that arrives exactly on a small-window hop" in {
+    val testHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    val hopMillis = new Window(5, TimeUnit.MINUTES).millis
+    val exactHopTs = 30 * hopMillis
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(exactHopTs)
+      testHarness.processElement1(event(exactHopTs, 5L), exactHopTs)
+
+      val output = testHarness.extractOutputValues().get(0)
+      decodeSum(output) shouldEqual 5L
+      output.latestTsMillis shouldEqual exactHopTs
+    } finally testHarness.close()
+  }
+
+  it should "restore state from before the horizon markers existed" in {
+    val eventTimestamp = 4 * new Window(1, TimeUnit.DAYS).millis + new Window(1, TimeUnit.HOURS).millis
+    val legacyHarness = harness(new LegacyHorizonStateFunction(groupBy, inputSchema))
+    legacyHarness.open()
+    legacyHarness.processElement1(event(eventTimestamp, 5L), eventTimestamp)
+    val snapshot = legacyHarness.snapshot(9L, eventTimestamp)
+    legacyHarness.close()
+
+    val restoredHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    val batchCallbackTs = eventTimestamp + new Window(2, TimeUnit.HOURS).millis
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(snapshot)
+      restoredHarness.open()
+      restoredHarness.setProcessingTime(batchCallbackTs)
+      restoredHarness.processElement2(emptyBatchRow(groupBy, batchEndTs = 0L), 0L)
+
+      val outputs = restoredHarness.extractOutputValues()
+      outputs.size() shouldEqual 1
+      decodeSum(outputs.get(0)) shouldBe null
+      outputs.get(0).latestTsMillis shouldEqual batchCallbackTs
+    } finally restoredHarness.close()
+  }
+
+  it should "rebuild large state when a restored checkpoint has no recompute marker" in {
+    val dayMillis = new Window(1, TimeUnit.DAYS).millis
+    val hourMillis = new Window(1, TimeUnit.HOURS).millis
+    val batchEndTs = 10 * dayMillis
+    val batchEventTs = batchEndTs - 48 * hourMillis
+    val beforeExpiry = batchEndTs + 59 * 60 * 1000L
+    val delayedCallbackTs = batchEndTs + 3 * hourMillis + 60 * 1000L
+    val batchGroupBy = Builders.GroupBy(
+      metaData = Builders.MetaData(name = "gigatile-process-function-legacy-large-marker-test"),
+      aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(49, TimeUnit.HOURS)))))
+    val batchAggregator =
+      new SawtoothOnlineAggregator(batchEndTs, batchGroupBy.getAggregations.asScala.toSeq, inputSchema)
+    val batchIr = batchAggregator.update(
+      batchAggregator.init,
+      new ArrayRow(Array[Any](batchEventTs, 5L), batchEventTs))
+    val finalBatchIr = batchAggregator.denormalizeBatchIr(batchAggregator.normalizeBatchIr(batchIr))
+    val batchRow = new BatchIrRow(
+      entityKey(),
+      new GigaTileCodec(batchGroupBy, inputSchema).encodeBatchIr(finalBatchIr),
+      batchEndTs)
+
+    val legacyHarness = harness(new LegacyHorizonStateFunction(batchGroupBy, inputSchema))
+    legacyHarness.open()
+    legacyHarness.setProcessingTime(beforeExpiry)
+    legacyHarness.processElement2(batchRow, batchEndTs)
+    val snapshot = legacyHarness.snapshot(10L, beforeExpiry)
+    legacyHarness.close()
+
+    val restoredHarness = harness(new GigaTileProcessFunction(batchGroupBy, inputSchema))
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(snapshot)
+      restoredHarness.open()
+      restoredHarness.setProcessingTime(delayedCallbackTs)
+      restoredHarness.processElement1(event(delayedCallbackTs - 1L, 7L), delayedCallbackTs - 1L)
+
+      val outputs = restoredHarness.extractOutputValues()
+      outputs.size() shouldEqual 1
+      decodeSum(outputs.get(0), batchGroupBy) shouldEqual 7L
+      outputs.get(0).latestTsMillis shouldEqual delayedCallbackTs
+    } finally restoredHarness.close()
   }
 }
 
@@ -601,7 +733,7 @@ object GigaTileProcessFunctionTest {
       })
   }
 
-  private def failNextScheduledEviction(function: GigaTileProcessFunction): Unit = {
+  private def failNextEviction(function: GigaTileProcessFunction): Unit = {
     val processorField = classOf[GigaTileProcessFunction].getDeclaredField("processor")
     processorField.setAccessible(true)
     val delegate = processorField.get(function).asInstanceOf[GigaTileStreamProcessor]
@@ -615,15 +747,22 @@ object GigaTileProcessFunctionTest {
       ) {
         private var shouldFail = true
 
-        override def onScheduledEviction(timerTs: Long): GigaEmitResult = {
+        override private[chronon] def onEviction(evictionTimes: EvictionTimes): GigaEmitResult = {
           if (shouldFail) {
             shouldFail = false
-            throw new RuntimeException("expected scheduled eviction failure")
+            throw new RuntimeException("expected eviction failure")
           }
-          delegate.onScheduledEviction(timerTs)
+          delegate.onEviction(evictionTimes)
         }
       }
     )
+  }
+
+  private def emptyBatchRow(batchGroupBy: GroupBy, batchEndTs: Long): BatchIrRow = {
+    val batchAggregator =
+      new SawtoothOnlineAggregator(batchEndTs, batchGroupBy.getAggregations.asScala.toSeq, inputSchema)
+    val emptyBatchIr = batchAggregator.denormalizeBatchIr(batchAggregator.normalizeBatchIr(batchAggregator.init))
+    new BatchIrRow(entityKey(), new GigaTileCodec(batchGroupBy, inputSchema).encodeBatchIr(emptyBatchIr), batchEndTs)
   }
 
   private class LegacyEventTimeTimerFunction(timerTimestamps: Seq[Long])
@@ -679,5 +818,82 @@ object GigaTileProcessFunctionTest {
         ctx: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#Context,
         out: Collector[TimestampedTile]
     ): Unit = ()
+  }
+
+  /** Seeds only descriptors that existed before the cached-as-of markers were introduced. */
+  private class LegacyHorizonStateFunction(groupBy: GroupBy, inputSchema: Seq[(String, DataType)])
+      extends KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile] {
+    private var tileState: MapState[String, Array[Byte]] = _
+    private var megaTileIrState: ValueState[Array[Byte]] = _
+    private var currentDayStartState: ValueState[java.lang.Long] = _
+    private var earliestTileStartState: ValueState[java.lang.Long] = _
+    private var batchIrState: ValueState[Array[Byte]] = _
+    private var batchEndTsState: ValueState[java.lang.Long] = _
+    private var runningLargeIrState: ValueState[Array[Byte]] = _
+    private var megaTileAgg: MegaTileAggregator = _
+    private var codec: MegaTileCodec = _
+    private var gigaCodec: GigaTileCodec = _
+
+    override def open(parameters: Configuration): Unit = {
+      super.open(parameters)
+      val aggregations = groupBy.getAggregations.asScala.toSeq
+      megaTileAgg = new MegaTileAggregator(aggregations, inputSchema)
+      codec = new MegaTileCodec(groupBy, inputSchema)
+      gigaCodec = new GigaTileCodec(groupBy, inputSchema)
+      tileState = getRuntimeContext.getMapState(
+        new MapStateDescriptor[String, Array[Byte]]("giga-tile-tiles", classOf[String], classOf[Array[Byte]]))
+      megaTileIrState = getRuntimeContext.getState(
+        new ValueStateDescriptor[Array[Byte]]("giga-tile-ir", classOf[Array[Byte]]))
+      currentDayStartState = getRuntimeContext.getState(
+        new ValueStateDescriptor[java.lang.Long]("giga-tile-day-start", classOf[java.lang.Long]))
+      earliestTileStartState = getRuntimeContext.getState(
+        new ValueStateDescriptor[java.lang.Long]("giga-tile-earliest-tile", classOf[java.lang.Long]))
+      batchIrState = getRuntimeContext.getState(
+        new ValueStateDescriptor[Array[Byte]]("giga-tile-batch-ir", classOf[Array[Byte]]))
+      batchEndTsState = getRuntimeContext.getState(
+        new ValueStateDescriptor[java.lang.Long]("giga-tile-batch-end", classOf[java.lang.Long]))
+      runningLargeIrState = getRuntimeContext.getState(
+        new ValueStateDescriptor[Array[Byte]]("giga-tile-running-large", classOf[Array[Byte]]))
+    }
+
+    override def processElement1(
+        event: ProjectedEvent,
+        ctx: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#Context,
+        out: Collector[TimestampedTile]
+    ): Unit = {
+      val timestamp = event.fields(Constants.TimeColumn).asInstanceOf[Long]
+      val row = new ArrayRow(inputSchema.map { case (name, _) => event.fields(name) }.toArray, timestamp)
+      val baseIr = megaTileAgg.baseAggregator.init
+      megaTileAgg.baseAggregator.update(baseIr, row)
+      val tileStarts = megaTileAgg.tileStartsForEvent(timestamp)
+      tileStarts.foreach { case (hopSize, tileStart) =>
+        tileState.put(s"$hopSize:$tileStart", codec.encodeBaseIr(baseIr))
+      }
+
+      val cachedIr = megaTileAgg.windowedAggregator.init
+      megaTileAgg.windowedAggregator.columnAggregators(0).update(cachedIr, row)
+      megaTileIrState.update(codec.encode(cachedIr))
+      currentDayStartState.update(TsUtils.round(timestamp, new Window(1, TimeUnit.DAYS).millis))
+      earliestTileStartState.update(tileStarts.map(_._2).min)
+    }
+
+    override def processElement2(
+        batchRow: BatchIrRow,
+        ctx: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#Context,
+        out: Collector[TimestampedTile]
+    ): Unit = {
+      val batchIr = gigaCodec.decodeBatchIr(batchRow.valueBytes)
+      val seedStore = new InMemoryGigaTileStore(megaTileAgg.windowedAggregator)
+      val seedProcessor = new GigaTileStreamProcessor(megaTileAgg, seedStore)
+      seedProcessor.onBatchUpdate(
+        batchIr,
+        batchRow.batchEndTs,
+        ctx.timerService().currentProcessingTime())
+
+      batchIrState.update(gigaCodec.encodeBatchIr(seedStore.getBatchIr))
+      batchEndTsState.update(batchRow.batchEndTs)
+      runningLargeIrState.update(codec.encode(seedStore.getRunningLargeIr))
+      currentDayStartState.update(TsUtils.round(batchRow.batchEndTs, new Window(1, TimeUnit.DAYS).millis))
+    }
   }
 }

--- a/flink/src/test/scala/ai/chronon/flink/test/window/GigaTileProcessFunctionTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/window/GigaTileProcessFunctionTest.scala
@@ -166,7 +166,8 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     val batchGroupBy = Builders.GroupBy(
       metaData = Builders.MetaData(name = "gigatile-process-function-future-batch-test"),
       aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(7, TimeUnit.DAYS)))))
-    val testHarness = harness(new GigaTileProcessFunction(batchGroupBy, inputSchema))
+    val function = new GigaTileProcessFunction(batchGroupBy, inputSchema)
+    val testHarness = harness(function)
     val batchCodec = new GigaTileCodec(batchGroupBy, inputSchema)
     val currentBatchEnd = 10 * dayMillis
     val currentProcessingTs = currentBatchEnd + hourMillis
@@ -191,11 +192,12 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
       testHarness.extractOutputValues().asScala shouldBe empty
       // A short watermark retry and the normal eviction timer are both live initially.
       testHarness.numProcessingTimeTimers() shouldEqual 2
+      valueState[java.lang.Long](function, "nextProcessingEvictionTimerState").value() should not be null
 
       testHarness.setProcessingTime(currentProcessingTs + hourMillis)
 
       testHarness.extractOutputValues().asScala shouldBe empty
-      testHarness.numProcessingTimeTimers() shouldEqual 1
+      valueState[java.lang.Long](function, "nextProcessingEvictionTimerState").value() should not be null
 
       advanceToHealthyLiveWatermark(testHarness, futureBatchEnd + hourMillis)
       testHarness.setProcessingTime(futureBatchEnd + hourMillis)

--- a/flink/src/test/scala/ai/chronon/flink/test/window/GigaTileProcessFunctionTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/window/GigaTileProcessFunctionTest.scala
@@ -10,6 +10,7 @@ import ai.chronon.aggregator.windowing.{
 }
 import ai.chronon.api._
 import ai.chronon.api.Extensions.WindowOps
+import ai.chronon.flink.FlinkJob
 import ai.chronon.flink.deser.ProjectedEvent
 import ai.chronon.flink.types.{BatchIrRow, TimestampedTile}
 import ai.chronon.flink.window.GigaTileProcessFunction
@@ -23,6 +24,7 @@ import org.apache.flink.runtime.state.KeyedStateBackend
 import org.apache.flink.streaming.api.functions.co.KeyedCoProcessFunction
 import org.apache.flink.streaming.api.operators.co.KeyedCoProcessOperator
 import org.apache.flink.streaming.api.watermark.Watermark
+import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus
 import org.apache.flink.streaming.util.KeyedTwoInputStreamOperatorTestHarness
 import org.apache.flink.util.Collector
 import org.scalatest.flatspec.AnyFlatSpec
@@ -42,6 +44,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     try {
       testHarness.open()
       testHarness.setProcessingTime(processingTs)
+      advanceToHealthyLiveWatermark(testHarness, processingTs)
       testHarness.processElement1(
         ProjectedEvent(Map(Constants.TimeColumn -> retainedLateEventTs, "num" -> 5L), carriedProcessingTs),
         retainedLateEventTs)
@@ -64,7 +67,9 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     try {
       testHarness.open()
       testHarness.setProcessingTime(justBeforeExpiry)
+      advanceToHealthyLiveWatermark(testHarness, justBeforeExpiry)
       testHarness.processElement1(event(eventTs, 5L), eventTs)
+      advanceToHealthyLiveWatermark(testHarness, afterExpiry)
       testHarness.setProcessingTime(afterExpiry)
 
       val outputs = testHarness.extractOutputValues()
@@ -86,7 +91,9 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     try {
       testHarness.open()
       testHarness.setProcessingTime(beforeMidnightProcessingTs)
+      advanceToHealthyLiveWatermark(testHarness, beforeMidnightProcessingTs)
       testHarness.processElement1(event(initialEventTs, 5L), initialEventTs)
+      advanceToHealthyLiveWatermark(testHarness, afterMidnightProcessingTs)
       testHarness.setProcessingTime(afterMidnightProcessingTs)
       // Zipline suppresses redundant timer writes. Crossing midnight must still leave the
       // retained pre-midnight value available to the next event.
@@ -118,6 +125,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     try {
       testHarness.open()
       testHarness.setProcessingTime(processingTs)
+      advanceToHealthyLiveWatermark(testHarness, processingTs)
       testHarness.processElement2(
         new BatchIrRow(entityKey(), batchCodec.encodeBatchIr(finalBatchIr), batchEndTs),
         batchEndTs)
@@ -142,6 +150,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     try {
       testHarness.open()
       testHarness.setProcessingTime(processingTs)
+      advanceToHealthyLiveWatermark(testHarness, processingTs)
       testHarness.processElement2(
         new BatchIrRow(entityKey(), batchCodec.encodeBatchIr(emptyBatchIr), batchEndTs),
         batchEndTs)
@@ -180,19 +189,105 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
       testHarness.processElement2(futureBatchRow, futureBatchEnd)
 
       testHarness.extractOutputValues().asScala shouldBe empty
-      testHarness.numProcessingTimeTimers() shouldEqual 1
+      // A short watermark retry and the normal eviction timer are both live initially.
+      testHarness.numProcessingTimeTimers() shouldEqual 2
 
       testHarness.setProcessingTime(currentProcessingTs + hourMillis)
 
       testHarness.extractOutputValues().asScala shouldBe empty
       testHarness.numProcessingTimeTimers() shouldEqual 1
 
+      advanceToHealthyLiveWatermark(testHarness, futureBatchEnd + hourMillis)
       testHarness.setProcessingTime(futureBatchEnd + hourMillis)
 
       val outputs = testHarness.extractOutputValues()
       outputs.size() shouldEqual 1
       decodeSum(outputs.get(0), batchGroupBy) shouldEqual 50L
       outputs.get(0).latestTsMillis shouldEqual futureBatchEnd + hourMillis
+    } finally testHarness.close()
+  }
+
+  it should "drop a future event before it can poison batch-backed large-window state" in {
+    val dayMillis = new Window(1, TimeUnit.DAYS).millis
+    val batchGroupBy = Builders.GroupBy(
+      metaData = Builders.MetaData(name = "gigatile-process-function-future-event-test"),
+      aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(7, TimeUnit.DAYS)))))
+    val testHarness = harness(new GigaTileProcessFunction(batchGroupBy, inputSchema))
+    val currentProcessingTime = 10 * dayMillis + new Window(1, TimeUnit.HOURS).millis
+    val batchCallbackTime = currentProcessingTime - 2L
+    val batchEnd = 9 * dayMillis
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(batchCallbackTime)
+      advanceToHealthyLiveWatermark(testHarness, batchCallbackTime)
+      testHarness.processElement2(batchRow(batchGroupBy, batchEnd, batchEnd - 1000L, 3L), batchEnd)
+      decodeSum(testHarness.extractOutputValues().get(0), batchGroupBy) shouldEqual 3L
+
+      testHarness.setProcessingTime(currentProcessingTime)
+      advanceToHealthyLiveWatermark(testHarness, currentProcessingTime)
+      testHarness.processElement1(event(currentProcessingTime + 1L, 11L), currentProcessingTime + 1L)
+      testHarness.processElement1(event(currentProcessingTime - 1000L, 5L), currentProcessingTime - 1000L)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs.size() shouldEqual 2
+      decodeSum(outputs.get(1), batchGroupBy) shouldEqual 8L
+      outputs.get(1).latestTsMillis shouldEqual currentProcessingTime
+    } finally testHarness.close()
+  }
+
+  it should "stay fenced while a source watermark implies a future event" in {
+    val testHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    val futureEventTime = processingTs + 1L
+    val historicalEventTime = processingTs - 1000L
+    val poisonedWatermark = processingTs - FlinkJob.AllowedOutOfOrderness.toMillis
+    val retryTime = processingTs + 2L * FlinkJob.AutoWatermarkInterval
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      testHarness.processWatermarkStatus2(WatermarkStatus.IDLE)
+      testHarness.processElement1(event(futureEventTime, 11L), futureEventTime)
+      testHarness.processWatermark1(new Watermark(poisonedWatermark))
+      testHarness.processElement1(event(historicalEventTime, 5L), historicalEventTime)
+
+      testHarness.extractOutputValues() shouldBe empty
+      testHarness.setProcessingTime(retryTime)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldEqual 5L
+      outputs.get(0).latestTsMillis shouldEqual retryTime
+    } finally testHarness.close()
+  }
+
+  it should "wait once at the exact safe boundary for a finite future watermark" in {
+    val function = new GigaTileProcessFunction(groupBy, inputSchema)
+    val testHarness = harness(function)
+    val futureWatermark = processingTs + 1000L
+    val shortRetryTime = processingTs + 2L * FlinkJob.AutoWatermarkInterval
+    val safeProcessingTime = futureWatermark + FlinkJob.AllowedOutOfOrderness.toMillis + 1L
+    val eventTime = processingTs - 1000L
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      advanceToLiveWatermark(testHarness, futureWatermark)
+      testHarness.processElement1(event(eventTime, 5L), eventTime)
+
+      testHarness.extractOutputValues() shouldBe empty
+      testHarness.setProcessingTime(shortRetryTime)
+      publicationRetryTimestamp(function) shouldEqual safeProcessingTime
+
+      testHarness.setProcessingTime(shortRetryTime + FlinkJob.IdlenessTimeout.toMillis)
+      testHarness.extractOutputValues() shouldBe empty
+      publicationRetryTimestamp(function) shouldEqual safeProcessingTime
+
+      testHarness.setProcessingTime(safeProcessingTime)
+      val outputs = testHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldEqual 5L
+      outputs.get(0).latestTsMillis shouldEqual safeProcessingTime
     } finally testHarness.close()
   }
 
@@ -221,11 +316,567 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     } finally restoredHarness.close()
   }
 
-  it should "restore and flush same-millisecond updates with a strictly newer version" in {
+  it should "advance only by event time while the batch input holds the watermark at MIN" in {
+    val dayMillis = new Window(1, TimeUnit.DAYS).millis
+    val currentProcessingTime = 10 * dayMillis + new Window(1, TimeUnit.HOURS).millis
+    val firstEventTime = dayMillis + new Window(1, TimeUnit.HOURS).millis
+    val laterEventTime = 4 * dayMillis + new Window(1, TimeUnit.HOURS).millis
+    val firstFutureEventTime = currentProcessingTime + 1L
+    val farFutureEventTime = currentProcessingTime + 2 * dayMillis
+    val function = new GigaTileProcessFunction(groupBy, inputSchema)
+    val testHarness = harness(function)
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(currentProcessingTime)
+      // Input 2 remains active, so this input-1 watermark does not initialize the connected one.
+      testHarness.processWatermark1(new Watermark(currentProcessingTime))
+      testHarness.processElement1(event(firstEventTime, 5L), firstEventTime)
+      testHarness.processElement1(event(laterEventTime, 7L), laterEventTime)
+
+      testHarness.extractOutputValues() shouldBe empty
+      currentFinalizedSum(function) shouldEqual 7L
+      currentDayStart(function) shouldEqual 4 * dayMillis
+
+      // Any future event is rejected before it can mutate either small- or large-window state.
+      testHarness.processElement1(event(firstFutureEventTime, 11L), firstFutureEventTime)
+      testHarness.processElement1(event(farFutureEventTime, 11L), farFutureEventTime)
+      currentFinalizedSum(function) shouldEqual 7L
+      testHarness.setProcessingTime(nextEvictionHop(currentProcessingTime))
+      testHarness.extractOutputValues() shouldBe empty
+      currentDayStart(function) shouldEqual 4 * dayMillis
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+    } finally testHarness.close()
+  }
+
+  it should "remain fail-closed when both inputs idle before any finite watermark" in {
+    val batchGroupBy = Builders.GroupBy(
+      metaData = Builders.MetaData(name = "gigatile-process-function-idle-bootstrap-test"),
+      aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(7, TimeUnit.DAYS)))))
+    val function = new GigaTileProcessFunction(batchGroupBy, inputSchema)
+    val testHarness = harness(function)
+    val batchEnd = TsUtils.round(eventTs, new Window(1, TimeUnit.DAYS).millis)
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      testHarness.processElement2(batchRow(batchGroupBy, batchEnd, eventTs - 1000L, 3L), batchEnd)
+      testHarness.processWatermarkStatus1(WatermarkStatus.IDLE)
+      testHarness.processWatermarkStatus2(WatermarkStatus.IDLE)
+      testHarness.setProcessingTime(nextEvictionHop(processingTs))
+
+      // Marking both inputs idle does not synthesize a finite watermark. Without a previously
+      // observed finite event watermark, retain state rather than publish a partial row.
+      testHarness.extractOutputValues() shouldBe empty
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+    } finally testHarness.close()
+  }
+
+  it should "bound finite batch-backed state during a long replay with an uninitialized watermark" in {
+    val dayMillis = new Window(1, TimeUnit.DAYS).millis
+    val replayGroupBy = Builders.GroupBy(
+      metaData = Builders.MetaData(name = "gigatile-process-function-long-replay-test"),
+      aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(7, TimeUnit.DAYS)))))
+    val function = new GigaTileProcessFunction(replayGroupBy, inputSchema)
+    val testHarness = harness(function)
+    // Keep the serving horizon day-aligned so the daily large-IR boundary is exact.
+    val currentProcessingTime = 41 * dayMillis
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(currentProcessingTime)
+      testHarness.processElement2(emptyBatchRow(replayGroupBy, dayMillis), dayMillis)
+      (1 to 40).foreach { day =>
+        val eventTime = day * dayMillis + new Window(1, TimeUnit.HOURS).millis
+        testHarness.processElement1(event(eventTime, 1L), eventTime)
+      }
+
+      testHarness.extractOutputValues() shouldBe empty
+      currentDayStart(function) shouldEqual 40 * dayMillis
+      dailyLargeSlotCount(function) should be <= 8
+
+      val liveTimer = nextEvictionHop(currentProcessingTime)
+      advanceToHealthyLiveWatermark(testHarness, liveTimer)
+      testHarness.setProcessingTime(liveTimer)
+      val outputs = testHarness.extractOutputValues()
+      outputs should not be empty
+      decodeSum(outputs.get(outputs.size() - 1), replayGroupBy) shouldEqual 7L
+    } finally testHarness.close()
+  }
+
+  it should "use source watermark readiness across five-minute, hourly, and daily aggregation hops" in {
+    val hourMillis = new Window(1, TimeUnit.HOURS).millis
+    val dayMillis = new Window(1, TimeUnit.DAYS).millis
+    val staleWatermark = processingTs - 30 * 60 * 1000L
+    val liveWatermark = processingTs - FlinkJob.LiveWatermarkLagToleranceMillis
+    val cases = Seq(
+      ("five-minute", new Window(1, TimeUnit.HOURS), 5 * 60 * 1000L, false),
+      ("hourly", new Window(7, TimeUnit.DAYS), hourMillis, true),
+      ("daily", new Window(30, TimeUnit.DAYS), dayMillis, true)
+    )
+
+    cases.foreach { case (name, window, expectedHopMillis, needsBatch) =>
+      val testGroupBy = Builders.GroupBy(metaData = Builders.MetaData(name = s"gigatile-source-readiness-$name-test"),
+                                         aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(window))))
+      val function = new GigaTileProcessFunction(testGroupBy, inputSchema)
+      val testHarness = harness(function)
+
+      try {
+        testHarness.open()
+        testHarness.setProcessingTime(processingTs)
+        currentProcessor(function).minSmallWindowTileSize shouldEqual expectedHopMillis
+        if (needsBatch) {
+          testHarness.processElement2(batchRow(testGroupBy, 0L, -1000L, 3L), 0L)
+        }
+        advanceToLiveWatermark(testHarness, staleWatermark)
+        testHarness.processElement1(event(staleWatermark - 1000L, 5L), staleWatermark - 1000L)
+
+        withClue(s"$name aggregation hop: ") {
+          testHarness.extractOutputValues() shouldBe empty
+        }
+
+        testHarness.processWatermark1(new Watermark(liveWatermark))
+        testHarness.processElement1(event(liveWatermark, 7L), liveWatermark)
+
+        val outputs = testHarness.extractOutputValues()
+        withClue(s"$name aggregation hop: ") {
+          outputs should have size 1
+          decodeSum(outputs.get(0), testGroupBy) shouldEqual (if (needsBatch) 15L else 12L)
+        }
+      } finally testHarness.close()
+    }
+  }
+
+  it should "keep a sparse key fenced until the global watermark is live" in {
+    val testHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    val staleWatermark = processingTs - 10 * 60 * 1000L
+    val secondTimer = nextEvictionHop(nextEvictionHop(processingTs))
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      advanceToLiveWatermark(testHarness, staleWatermark)
+      testHarness.processElement1(event(staleWatermark - 1000L, 5L), staleWatermark - 1000L)
+      testHarness.setProcessingTime(secondTimer)
+      testHarness.extractOutputValues() shouldBe empty
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+
+      testHarness.processElement1(event(staleWatermark + 1000L, 7L), staleWatermark + 1000L)
+      testHarness.extractOutputValues() shouldBe empty
+
+      val liveTimer = nextEvictionHop(secondTimer)
+      testHarness.processWatermark1(new Watermark(healthyLiveWatermark(liveTimer)))
+      testHarness.setProcessingTime(liveTimer)
+      val outputs = testHarness.extractOutputValues()
+      outputs.size() shouldEqual 1
+      decodeSum(outputs.get(0)) shouldEqual 12L
+      outputs.get(0).latestTsMillis shouldEqual liveTimer
+    } finally testHarness.close()
+  }
+
+  it should "publish a lone event after its periodic watermark catches up" in {
+    val testHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    val eventTime = processingTs - 1000L
+    val retryTime = processingTs + 2L * FlinkJob.AutoWatermarkInterval
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      testHarness.processWatermarkStatus2(WatermarkStatus.IDLE)
+      testHarness.processElement1(event(eventTime, 5L), eventTime)
+
+      testHarness.extractOutputValues() shouldBe empty
+      testHarness.numProcessingTimeTimers() shouldEqual 2
+
+      testHarness.setProcessingTime(retryTime)
+      testHarness.extractOutputValues() shouldBe empty
+      testHarness.numEventTimeTimers() shouldEqual 1
+
+      val periodicWatermark = healthyLiveWatermark(processingTs)
+      testHarness.processWatermark1(new Watermark(periodicWatermark))
+
+      val outputs = testHarness.extractOutputValues()
+      outputs.size() shouldEqual 1
+      decodeSum(outputs.get(0)) shouldEqual 5L
+      outputs.get(0).latestTsMillis shouldEqual retryTime
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+    } finally testHarness.close()
+  }
+
+  it should "park a catch-up publication on one event-time activation without hot retries" in {
+    val testHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    val staleWatermark = processingTs - new Window(1, TimeUnit.HOURS).millis
+    val retryTime = processingTs + 2L * FlinkJob.AutoWatermarkInterval
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      advanceToLiveWatermark(testHarness, staleWatermark)
+      testHarness.processElement1(event(staleWatermark - 1000L, 5L), staleWatermark - 1000L)
+
+      testHarness.numProcessingTimeTimers() shouldEqual 2
+      testHarness.setProcessingTime(retryTime)
+
+      testHarness.extractOutputValues() shouldBe empty
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+      testHarness.numEventTimeTimers() shouldEqual 1
+      testHarness.processElement1(event(staleWatermark + 1000L, 7L), staleWatermark + 1000L)
+      testHarness.setProcessingTime(retryTime + 5L * FlinkJob.AutoWatermarkInterval)
+      testHarness.extractOutputValues() shouldBe empty
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+      testHarness.numEventTimeTimers() shouldEqual 1
+    } finally testHarness.close()
+  }
+
+  it should "publish a daily sparse key after watermark-only activation" in {
+    val dayMillis = new Window(1, TimeUnit.DAYS).millis
+    val dailyGroupBy = Builders.GroupBy(
+      metaData = Builders.MetaData(name = "gigatile-daily-sparse-activation-test"),
+      aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(30, TimeUnit.DAYS)))))
+    val function = new GigaTileProcessFunction(dailyGroupBy, inputSchema)
+    val testHarness = harness(function)
+    val staleWatermark = processingTs - new Window(1, TimeUnit.HOURS).millis
+    val retryDelay = 2L * FlinkJob.AutoWatermarkInterval
+    val retryTime = processingTs + retryDelay
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      testHarness.processElement2(batchRow(dailyGroupBy, 0L, -1000L, 3L), 0L)
+      advanceToLiveWatermark(testHarness, staleWatermark)
+      testHarness.processElement1(event(staleWatermark - 1000L, 5L), staleWatermark - 1000L)
+      currentProcessor(function).minEvictionInterval shouldEqual dayMillis
+
+      testHarness.setProcessingTime(retryTime)
+      testHarness.extractOutputValues() shouldBe empty
+      testHarness.numEventTimeTimers() shouldEqual 1
+
+      testHarness.processWatermark1(new Watermark(healthyLiveWatermark(retryTime)))
+
+      val outputs = testHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0), dailyGroupBy) shouldEqual 8L
+      outputs.get(0).latestTsMillis shouldEqual retryTime
+      retryTime should be < nextDay(processingTs)
+    } finally testHarness.close()
+  }
+
+  it should "advance a catch-up day before publishing a batch-ahead sparse key" in {
+    val dayMillis = new Window(1, TimeUnit.DAYS).millis
+    val dailyGroupBy = Builders.GroupBy(
+      metaData = Builders.MetaData(name = "gigatile-batch-ahead-activation-test"),
+      aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(30, TimeUnit.DAYS)))))
+    val function = new GigaTileProcessFunction(dailyGroupBy, inputSchema)
+    val testHarness = harness(function)
+    val currentProcessingTime = 10L * dayMillis + new Window(1, TimeUnit.HOURS).millis
+    val staleWatermark = 8L * dayMillis + new Window(1, TimeUnit.HOURS).millis
+    val batchEnd = 9L * dayMillis
+    val retryTime = currentProcessingTime + 2L * FlinkJob.AutoWatermarkInterval
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(currentProcessingTime)
+      advanceToLiveWatermark(testHarness, staleWatermark)
+      testHarness.processElement1(event(staleWatermark - 1000L, 5L), staleWatermark - 1000L)
+      testHarness.processElement2(batchRow(dailyGroupBy, batchEnd, batchEnd - 1000L, 3L), batchEnd)
+
+      currentDayStart(function) should be < batchEnd
+      testHarness.extractOutputValues() shouldBe empty
+      testHarness.setProcessingTime(retryTime)
+      testHarness.numEventTimeTimers() shouldEqual 1
+
+      testHarness.processWatermark1(new Watermark(liveActivationWatermark(retryTime)))
+
+      val outputs = testHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0), dailyGroupBy) shouldEqual 3L
+      currentDayStart(function) should be >= batchEnd
+    } finally testHarness.close()
+  }
+
+  it should "publish at the exact lower Live watermark boundary" in {
+    val testHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    val staleWatermark = processingTs - new Window(1, TimeUnit.HOURS).millis
+    val retryTime = processingTs + 2L * FlinkJob.AutoWatermarkInterval
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      advanceToLiveWatermark(testHarness, staleWatermark)
+      testHarness.processElement1(event(staleWatermark - 1000L, 5L), staleWatermark - 1000L)
+      testHarness.setProcessingTime(retryTime)
+
+      testHarness.processWatermark1(new Watermark(liveActivationWatermark(retryTime)))
+
+      val outputs = testHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldEqual 5L
+      outputs.get(0).latestTsMillis shouldEqual retryTime
+    } finally testHarness.close()
+  }
+
+  it should "move activation forward when processing time consumes the live slack" in {
+    val testHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    val staleWatermark = processingTs - new Window(1, TimeUnit.HOURS).millis
+    val retryDelay = 2L * FlinkJob.AutoWatermarkInterval
+    val retryTime = processingTs + retryDelay
+    val firstActivationWatermark = liveActivationWatermark(retryTime)
+    val delayedProcessingTime = retryTime + FlinkJob.CatchupWatermarkLagSlackMillis + 1L
+    val cooldownDelay = math.max(retryDelay, FlinkJob.CatchupWatermarkLagSlackMillis / 2L)
+    val cooldownTime = delayedProcessingTime + cooldownDelay
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      advanceToLiveWatermark(testHarness, staleWatermark)
+      testHarness.processElement1(event(staleWatermark - 1000L, 5L), staleWatermark - 1000L)
+      testHarness.setProcessingTime(retryTime)
+
+      testHarness.setProcessingTime(delayedProcessingTime)
+      testHarness.processWatermark1(new Watermark(firstActivationWatermark))
+      testHarness.extractOutputValues() shouldBe empty
+      testHarness.numEventTimeTimers() shouldEqual 0
+
+      testHarness.setProcessingTime(cooldownTime)
+      testHarness.extractOutputValues() shouldBe empty
+      testHarness.numEventTimeTimers() shouldEqual 1
+
+      testHarness.processWatermark1(new Watermark(healthyLiveWatermark(cooldownTime)))
+
+      val outputs = testHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldEqual 5L
+    } finally testHarness.close()
+  }
+
+  it should "preserve an eviction timer that shares a cleared publication-retry timestamp" in {
+    val testHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    val retryDelay = 2L * FlinkJob.AutoWatermarkInterval
+    val evictionTime = nextEvictionHop(processingTs)
+    val firstProcessingTime = evictionTime - retryDelay
+    val firstEventTime = firstProcessingTime - 1000L
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(firstProcessingTime)
+      testHarness.processWatermarkStatus2(WatermarkStatus.IDLE)
+      testHarness.processElement1(event(firstEventTime, 5L), firstEventTime)
+      // The retry and normal eviction markers share one physical Flink timer.
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+
+      testHarness.setProcessingTime(evictionTime)
+      testHarness.extractOutputValues() shouldBe empty
+      // Both roles fired: normal eviction remains scheduled and publication waits on watermark.
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+      testHarness.numEventTimeTimers() shouldEqual 1
+    } finally testHarness.close()
+  }
+
+  it should "preserve a pending publication retry while draining an earlier callback" in {
+    val eventTime = processingTs - 1000L
+    val injectedTimer = processingTs + 1L
+    val retryTime = processingTs + 2L * FlinkJob.AutoWatermarkInterval
+    injectedTimer should be < retryTime
+    val originalHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+
+    originalHarness.open()
+    originalHarness.setProcessingTime(processingTs)
+    originalHarness.processWatermarkStatus2(WatermarkStatus.IDLE)
+    originalHarness.processElement1(event(eventTime, 5L), eventTime)
+    val snapshot = originalHarness.snapshot(10L, processingTs)
+    originalHarness.close()
+
+    val injectorHarness = harness(new ProcessingTimerInjector(injectedTimer))
+    injectorHarness.setup()
+    injectorHarness.initializeState(snapshot)
+    injectorHarness.open()
+    injectorHarness.setProcessingTime(processingTs)
+    injectorHarness.processElement1(event(eventTime, 0L), eventTime)
+    val injectedSnapshot = injectorHarness.snapshot(11L, processingTs)
+    injectorHarness.close()
+
+    val restoredHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(injectedSnapshot)
+      restoredHarness.open()
+      restoredHarness.setProcessingTime(processingTs)
+      // The injected callback runs first while Flink already reports retryTime. It must not
+      // clear the still-queued publication retry marker.
+      restoredHarness.numProcessingTimeTimers() shouldEqual 3
+      advanceToHealthyLiveWatermark(restoredHarness, retryTime)
+      restoredHarness.setProcessingTime(retryTime)
+
+      val outputs = restoredHarness.extractOutputValues()
+      outputs.size() shouldEqual 1
+      decodeSum(outputs.get(0)) shouldEqual 5L
+      outputs.get(0).latestTsMillis shouldEqual retryTime
+      restoredHarness.numProcessingTimeTimers() shouldEqual 1
+    } finally restoredHarness.close()
+  }
+
+  it should "restore a watermark activation without another element" in {
+    val staleWatermark = processingTs - new Window(10, TimeUnit.MINUTES).millis
+    val retryTime = processingTs + 2L * FlinkJob.AutoWatermarkInterval
+    val originalHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+
+    originalHarness.open()
+    originalHarness.setProcessingTime(processingTs)
+    advanceToLiveWatermark(originalHarness, staleWatermark)
+    originalHarness.processElement1(event(staleWatermark - 1000L, 5L), staleWatermark - 1000L)
+    originalHarness.setProcessingTime(retryTime)
+    originalHarness.extractOutputValues() shouldBe empty
+    originalHarness.numProcessingTimeTimers() shouldEqual 1
+    originalHarness.numEventTimeTimers() shouldEqual 1
+    val snapshot = originalHarness.snapshot(11L, retryTime)
+    originalHarness.close()
+
+    val restoredHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(snapshot)
+      restoredHarness.open()
+      restoredHarness.setProcessingTime(retryTime)
+      advanceToHealthyLiveWatermark(restoredHarness, retryTime)
+      val outputs = restoredHarness.extractOutputValues()
+      outputs.size() shouldEqual 1
+      decodeSum(outputs.get(0)) shouldEqual 5L
+      outputs.get(0).latestTsMillis shouldEqual retryTime
+    } finally restoredHarness.close()
+  }
+
+  it should "restore a delayed activation cooldown without another element" in {
+    val staleWatermark = processingTs - new Window(10, TimeUnit.MINUTES).millis
+    val retryDelay = 2L * FlinkJob.AutoWatermarkInterval
+    val retryTime = processingTs + retryDelay
+    val firstActivationWatermark = liveActivationWatermark(retryTime)
+    val delayedProcessingTime = retryTime + FlinkJob.CatchupWatermarkLagSlackMillis + 1L
+    val cooldownDelay = math.max(retryDelay, FlinkJob.CatchupWatermarkLagSlackMillis / 2L)
+    val cooldownTime = delayedProcessingTime + cooldownDelay
+    val originalHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+
+    originalHarness.open()
+    originalHarness.setProcessingTime(processingTs)
+    advanceToLiveWatermark(originalHarness, staleWatermark)
+    originalHarness.processElement1(event(staleWatermark - 1000L, 5L), staleWatermark - 1000L)
+    originalHarness.setProcessingTime(retryTime)
+    originalHarness.setProcessingTime(delayedProcessingTime)
+    originalHarness.processWatermark1(new Watermark(firstActivationWatermark))
+    originalHarness.extractOutputValues() shouldBe empty
+    originalHarness.numEventTimeTimers() shouldEqual 0
+    val snapshot = originalHarness.snapshot(12L, delayedProcessingTime)
+    originalHarness.close()
+
+    val restoredHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(snapshot)
+      restoredHarness.open()
+      restoredHarness.setProcessingTime(delayedProcessingTime)
+      advanceToLiveWatermark(restoredHarness, firstActivationWatermark)
+      restoredHarness.setProcessingTime(cooldownTime)
+
+      restoredHarness.extractOutputValues() shouldBe empty
+      restoredHarness.numEventTimeTimers() shouldEqual 1
+      restoredHarness.processWatermark1(new Watermark(healthyLiveWatermark(cooldownTime)))
+
+      val outputs = restoredHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldEqual 5L
+      outputs.get(0).latestTsMillis shouldEqual cooldownTime
+    } finally restoredHarness.close()
+  }
+
+  it should "recover an expired retry marker on the next keyed callback" in {
+    val staleWatermark = processingTs - new Window(10, TimeUnit.MINUTES).millis
+    val retryDelay = 2L * FlinkJob.AutoWatermarkInterval
+    val retryTime = processingTs + retryDelay
+    val originalFunction = new GigaTileProcessFunction(groupBy, inputSchema)
+    val originalHarness = harness(originalFunction)
+
+    originalHarness.open()
+    originalHarness.setProcessingTime(processingTs)
+    advanceToLiveWatermark(originalHarness, staleWatermark)
+    originalHarness.processElement1(event(staleWatermark - 1000L, 5L), staleWatermark - 1000L)
+    originalHarness.setProcessingTime(retryTime)
+    originalHarness.extractOutputValues() shouldBe empty
+    setPublicationRetryTimestamp(originalFunction, retryTime)
+    clearPublicationActivationTimestamp(originalFunction)
+    val snapshot = originalHarness.snapshot(12L, retryTime)
+    originalHarness.close()
+
+    val restoredFunction = new GigaTileProcessFunction(groupBy, inputSchema)
+    val restoredHarness = harness(restoredFunction)
+    val restoredProcessingTime = retryTime + 1L
+    val restoredRetryTime = restoredProcessingTime + retryDelay
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(snapshot)
+      restoredHarness.open()
+      restoredHarness.setProcessingTime(restoredProcessingTime)
+      restoredHarness.processElement1(event(staleWatermark + 1000L, 7L), staleWatermark + 1000L)
+
+      publicationRetryTimestamp(restoredFunction) shouldEqual restoredRetryTime
+      advanceToHealthyLiveWatermark(restoredHarness, restoredRetryTime)
+      restoredHarness.setProcessingTime(restoredRetryTime)
+
+      val outputs = restoredHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldEqual 12L
+      outputs.get(0).latestTsMillis shouldEqual restoredRetryTime
+    } finally restoredHarness.close()
+  }
+
+  it should "coalesce event and batch publications from the same processing millisecond" in {
+    val dayMillis = new Window(1, TimeUnit.DAYS).millis
+    val batchGroupBy = Builders.GroupBy(
+      metaData = Builders.MetaData(name = "gigatile-process-function-collision-batch-test"),
+      aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(7, TimeUnit.DAYS)))))
+    val function = new GigaTileProcessFunction(batchGroupBy, inputSchema)
+    val testHarness = harness(function)
+    val callbackProcessingTime = 3 * dayMillis + new Window(1, TimeUnit.HOURS).millis
+    val initialBatchEnd = dayMillis
+    val replacementBatchEnd = 2 * dayMillis
+    val streamEventTime = replacementBatchEnd + new Window(1, TimeUnit.HOURS).millis
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(callbackProcessingTime - 1L)
+      advanceToHealthyLiveWatermark(testHarness, callbackProcessingTime - 1L)
+      testHarness.processElement2(
+        batchRow(batchGroupBy, initialBatchEnd, initialBatchEnd - 1000L, 1L),
+        initialBatchEnd)
+      decodeSum(testHarness.extractOutputValues().get(0), batchGroupBy) shouldEqual 1L
+
+      testHarness.setProcessingTime(callbackProcessingTime)
+      testHarness.processElement1(event(streamEventTime, 5L), streamEventTime)
+      testHarness.processElement2(
+        batchRow(batchGroupBy, replacementBatchEnd, replacementBatchEnd - 1000L, 7L),
+        replacementBatchEnd)
+
+      val initialOutputs = testHarness.extractOutputValues()
+      initialOutputs.size() shouldEqual 2
+      decodeSum(initialOutputs.get(1), batchGroupBy) shouldEqual 6L
+      setCurrentKey(testHarness, entityKey())
+      valueState[java.lang.Boolean](function, "pendingPublicationState").value() shouldEqual
+        java.lang.Boolean.TRUE
+
+      testHarness.setProcessingTime(callbackProcessingTime + 1L)
+      val outputs = testHarness.extractOutputValues()
+      outputs.size() shouldEqual 3
+      decodeSum(outputs.get(2), batchGroupBy) shouldEqual 12L
+      outputs.get(2).latestTsMillis shouldEqual callbackProcessingTime + 1L
+      setCurrentKey(testHarness, entityKey())
+      valueState[java.lang.Boolean](function, "pendingPublicationState").value() shouldBe null
+    } finally testHarness.close()
+  }
+
+  it should "keep a restored version collision fenced without a timer storm" in {
     val originalHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
     val firstEventTs = processingTs - 1000L
     originalHarness.open()
     originalHarness.setProcessingTime(processingTs)
+    advanceToHealthyLiveWatermark(originalHarness, processingTs)
     originalHarness.processElement1(event(firstEventTs, 5L), firstEventTs)
     originalHarness.processElement1(event(firstEventTs + 1L, 7L), firstEventTs + 1L)
     originalHarness.processElement1(event(firstEventTs + 2L, 3L), firstEventTs + 2L)
@@ -244,14 +895,19 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
       restoredHarness.setup()
       restoredHarness.initializeState(snapshot)
       restoredHarness.open()
-      // A delayed callback still uses the reserved strictly-newer version without moving
-      // aggregation time merely to flush the current snapshot.
       restoredHarness.setProcessingTime(processingTs + 100L)
+      restoredHarness.extractOutputValues() shouldBe empty
+      // The collision marker shares the next normal eviction timer while the connected
+      // watermark is uninitialized; it does not retry every millisecond.
+      restoredHarness.numProcessingTimeTimers() shouldEqual 1
 
+      val retryTimer = nextEvictionHop(processingTs + 100L)
+      advanceToHealthyLiveWatermark(restoredHarness, retryTimer)
+      restoredHarness.setProcessingTime(retryTimer)
       val outputs = restoredHarness.extractOutputValues()
       outputs.size() shouldEqual 1
       decodeSum(outputs.get(0)) shouldEqual 15L
-      outputs.get(0).latestTsMillis shouldEqual processingTs + 1L
+      outputs.get(0).latestTsMillis shouldEqual retryTimer
     } finally restoredHarness.close()
   }
 
@@ -262,6 +918,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     val originalHarness = harness(originalFunction)
     originalHarness.open()
     originalHarness.setProcessingTime(processingTs)
+    advanceToHealthyLiveWatermark(originalHarness, processingTs)
     originalHarness.processElement1(event(firstEventTs, 5L), firstEventTs)
     originalHarness.processElement1(event(firstEventTs + 1L, 7L), firstEventTs + 1L)
     val originalSnapshot = originalHarness.snapshot(31L, processingTs)
@@ -287,6 +944,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
       // With no keyed callback, there is no way for open() to enumerate and repair this key.
       restoredHarness.numProcessingTimeTimers() shouldEqual 0
 
+      advanceToHealthyLiveWatermark(restoredHarness, evictionTs)
       restoredHarness.processElement1(event(firstEventTs + 2L, 3L), firstEventTs + 2L)
       setCurrentKey(restoredHarness, entityKey())
       val repairedEviction = valueState[java.lang.Long](restoredFunction,
@@ -297,6 +955,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
       repairedCollision shouldEqual repairedEviction
       restoredHarness.numProcessingTimeTimers() shouldEqual 1
 
+      advanceToHealthyLiveWatermark(restoredHarness, repairedCollision)
       restoredHarness.setProcessingTime(repairedCollision)
 
       val outputs = restoredHarness.extractOutputValues()
@@ -318,6 +977,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     val originalHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
     originalHarness.open()
     originalHarness.setProcessingTime(justBeforeExpiry)
+    advanceToHealthyLiveWatermark(originalHarness, justBeforeExpiry)
     originalHarness.processElement1(event(eventTs, 5L), eventTs)
     val originalSnapshot = originalHarness.snapshot(33L, justBeforeExpiry)
     originalHarness.close()
@@ -338,6 +998,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
       restoredHarness.open()
       // Flink reports this jump target while it first drains injectedTimer. That earlier
       // callback must not steal ownership from the still-queued evictionTimer.
+      advanceToHealthyLiveWatermark(restoredHarness, evictionTimer)
       restoredHarness.setProcessingTime(evictionTimer)
 
       val outputs = restoredHarness.extractOutputValues()
@@ -358,6 +1019,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     val originalHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
     originalHarness.open()
     originalHarness.setProcessingTime(processingTs)
+    advanceToHealthyLiveWatermark(originalHarness, processingTs)
     originalHarness.processElement1(event(firstEventTs, 5L), firstEventTs)
     originalHarness.processElement1(event(firstEventTs + 1L, 7L), firstEventTs + 1L)
     val originalSnapshot = originalHarness.snapshot(35L, processingTs)
@@ -391,6 +1053,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
       restoredHarness.setProcessingTime(consumedCollisionTimer)
       // The injected callback runs first while Flink already reports evictionTimer as the
       // current processing time. The stale collision must join that still-queued eviction.
+      advanceToHealthyLiveWatermark(restoredHarness, evictionTimer)
       restoredHarness.setProcessingTime(evictionTimer)
 
       val outputs = restoredHarness.extractOutputValues()
@@ -411,6 +1074,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     try {
       testHarness.open()
       testHarness.setProcessingTime(processingTs)
+      advanceToHealthyLiveWatermark(testHarness, processingTs)
       failNextEncode(function)
       testHarness.processElement1(event(firstEventTs, 5L), firstEventTs)
 
@@ -428,32 +1092,31 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     } finally testHarness.close()
   }
 
-  it should "re-arm a version collision when snapshot construction fails" in {
+  it should "keep a failed collision on a queued eviction while draining delayed callbacks" in {
     val function = new GigaTileProcessFunction(groupBy, inputSchema)
     val testHarness = harness(function)
     val firstEventTs = processingTs - 1000L
+    val retryTimer = nextEvictionHop(processingTs)
 
     try {
       testHarness.open()
       testHarness.setProcessingTime(processingTs)
+      advanceToHealthyLiveWatermark(testHarness, processingTs)
       testHarness.processElement1(event(firstEventTs, 5L), firstEventTs)
       testHarness.processElement1(event(firstEventTs + 1L, 7L), firstEventTs + 1L)
 
       testHarness.extractOutputValues().size() shouldEqual 1
       failNextSnapshot(function)
 
-      testHarness.setProcessingTime(processingTs + 1L)
-
-      testHarness.extractOutputValues().size() shouldEqual 1
-      // The normal eviction timer and the re-armed collision timer must both remain live.
-      testHarness.numProcessingTimeTimers() shouldEqual 2
-
-      testHarness.setProcessingTime(processingTs + 2L)
+      // Flink drains the earlier collision callback while already reporting retryTimer as the
+      // wall clock. A transient failure must keep the collision on the queued eviction timer.
+      advanceToHealthyLiveWatermark(testHarness, retryTimer)
+      testHarness.setProcessingTime(retryTimer)
 
       val outputs = testHarness.extractOutputValues()
       outputs.size() shouldEqual 2
       decodeSum(outputs.get(1)) shouldEqual 12L
-      outputs.get(1).latestTsMillis shouldEqual processingTs + 2L
+      outputs.get(1).latestTsMillis shouldEqual retryTimer
       testHarness.numProcessingTimeTimers() shouldEqual 1
     } finally testHarness.close()
   }
@@ -468,6 +1131,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     try {
       testHarness.open()
       testHarness.setProcessingTime(collisionProcessingTs)
+      advanceToHealthyLiveWatermark(testHarness, collisionProcessingTs)
       testHarness.processElement1(event(expiringEventTs, 5L), expiringEventTs)
       testHarness.processElement1(event(expiringEventTs, 7L), expiringEventTs)
 
@@ -493,6 +1157,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     try {
       testHarness.open()
       testHarness.setProcessingTime(collisionProcessingTs)
+      advanceToHealthyLiveWatermark(testHarness, collisionProcessingTs)
       testHarness.processElement1(event(expiringEventTs, 5L), expiringEventTs)
       testHarness.processElement1(event(expiringEventTs, 7L), expiringEventTs)
       failNextEviction(function)
@@ -505,6 +1170,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
       testHarness.setProcessingTime(evictionTs + 1L)
       testHarness.extractOutputValues().size() shouldEqual 1
 
+      advanceToHealthyLiveWatermark(testHarness, retryTs)
       testHarness.setProcessingTime(retryTs)
 
       val outputs = testHarness.extractOutputValues()
@@ -522,6 +1188,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     try {
       testHarness.open()
       testHarness.setProcessingTime(processingTs)
+      advanceToHealthyLiveWatermark(testHarness, processingTs)
       testHarness.processElement1(keyedEvent("campaign-1", firstEventTs, 5L), firstEventTs)
       testHarness.processElement1(keyedEvent("campaign-1", firstEventTs + 1L, 7L), firstEventTs + 1L)
       testHarness.processElement1(keyedEvent("campaign-2", firstEventTs, 11L), firstEventTs)
@@ -546,6 +1213,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     try {
       testHarness.open()
       testHarness.setProcessingTime(exactHopTs)
+      advanceToHealthyLiveWatermark(testHarness, exactHopTs)
       testHarness.processElement1(event(exactHopTs, 5L), exactHopTs)
 
       val output = testHarness.extractOutputValues().get(0)
@@ -569,6 +1237,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
       restoredHarness.initializeState(snapshot)
       restoredHarness.open()
       restoredHarness.setProcessingTime(batchCallbackTs)
+      advanceToHealthyLiveWatermark(restoredHarness, batchCallbackTs)
       restoredHarness.processElement2(emptyBatchRow(groupBy, batchEndTs = 0L), 0L)
 
       val outputs = restoredHarness.extractOutputValues()
@@ -612,6 +1281,7 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
       restoredHarness.initializeState(snapshot)
       restoredHarness.open()
       restoredHarness.setProcessingTime(delayedCallbackTs)
+      advanceToHealthyLiveWatermark(restoredHarness, delayedCallbackTs)
       restoredHarness.processElement1(event(delayedCallbackTs - 1L, 7L), delayedCallbackTs - 1L)
 
       val outputs = restoredHarness.extractOutputValues()
@@ -649,6 +1319,72 @@ object GigaTileProcessFunctionTest {
 
   private def event(timestamp: Long, value: Long): ProjectedEvent =
     ProjectedEvent(Map(Constants.TimeColumn -> timestamp, "num" -> value), timestamp)
+
+  private def advanceToLiveWatermark(
+      testHarness: KeyedTwoInputStreamOperatorTestHarness[
+        util.List[Any],
+        ProjectedEvent,
+        BatchIrRow,
+        TimestampedTile],
+      watermark: Long
+  ): Unit = {
+    testHarness.processWatermarkStatus2(WatermarkStatus.IDLE)
+    testHarness.processWatermark1(new Watermark(watermark))
+  }
+
+  private def healthyLiveWatermark(processingTime: Long): Long =
+    processingTime - FlinkJob.AllowedOutOfOrderness.toMillis - 1L
+
+  private def liveActivationWatermark(processingTime: Long): Long =
+    processingTime - FlinkJob.LiveWatermarkLagToleranceMillis
+
+  private def advanceToHealthyLiveWatermark(
+      testHarness: KeyedTwoInputStreamOperatorTestHarness[
+        util.List[Any],
+        ProjectedEvent,
+        BatchIrRow,
+        TimestampedTile],
+      processingTime: Long
+  ): Unit =
+    advanceToLiveWatermark(testHarness, healthyLiveWatermark(processingTime))
+
+  private def nextDay(timestamp: Long): Long = {
+    val dayMillis = new Window(1, TimeUnit.DAYS).millis
+    TsUtils.round(timestamp, dayMillis) + dayMillis
+  }
+
+  private def currentProcessor(function: GigaTileProcessFunction): GigaTileStreamProcessor = {
+    val processorField = classOf[GigaTileProcessFunction].getDeclaredField("processor")
+    processorField.setAccessible(true)
+    processorField.get(function).asInstanceOf[GigaTileStreamProcessor]
+  }
+
+  private def publicationTimerState(
+      function: GigaTileProcessFunction,
+      fieldName: String
+  ): ValueState[java.lang.Long] = {
+    val stateField = classOf[GigaTileProcessFunction].getDeclaredField(fieldName)
+    stateField.setAccessible(true)
+    stateField.get(function).asInstanceOf[ValueState[java.lang.Long]]
+  }
+
+  private def publicationRetryTimestamp(function: GigaTileProcessFunction): Long =
+    publicationTimerState(function, "pendingPublicationRetryTimerState").value().longValue()
+
+  private def setPublicationRetryTimestamp(function: GigaTileProcessFunction, timestamp: Long): Unit =
+    publicationTimerState(function, "pendingPublicationRetryTimerState").update(timestamp)
+
+  private def clearPublicationActivationTimestamp(function: GigaTileProcessFunction): Unit =
+    publicationTimerState(function, "pendingPublicationActivationTimerState").clear()
+
+  private def currentFinalizedSum(function: GigaTileProcessFunction): AnyRef =
+    currentProcessor(function).currentSnapshot.finalizedVector(0).asInstanceOf[AnyRef]
+
+  private def currentDayStart(function: GigaTileProcessFunction): Long =
+    currentProcessor(function).store.getCurrentDayStart
+
+  private def dailyLargeSlotCount(function: GigaTileProcessFunction): Int =
+    currentProcessor(function).store.dailyLargeIrIterator.size
 
   private def keyedEvent(entity: String, timestamp: Long, value: Long): ProjectedEvent =
     ProjectedEvent(Map("entity" -> entity, Constants.TimeColumn -> timestamp, "num" -> value), timestamp)
@@ -763,6 +1499,21 @@ object GigaTileProcessFunctionTest {
       new SawtoothOnlineAggregator(batchEndTs, batchGroupBy.getAggregations.asScala.toSeq, inputSchema)
     val emptyBatchIr = batchAggregator.denormalizeBatchIr(batchAggregator.normalizeBatchIr(batchAggregator.init))
     new BatchIrRow(entityKey(), new GigaTileCodec(batchGroupBy, inputSchema).encodeBatchIr(emptyBatchIr), batchEndTs)
+  }
+
+  private def batchRow(
+      batchGroupBy: GroupBy,
+      batchEndTs: Long,
+      batchEventTs: Long,
+      value: Long
+  ): BatchIrRow = {
+    val batchAggregator =
+      new SawtoothOnlineAggregator(batchEndTs, batchGroupBy.getAggregations.asScala.toSeq, inputSchema)
+    val batchIr = batchAggregator.update(
+      batchAggregator.init,
+      new ArrayRow(Array[Any](batchEventTs, value), batchEventTs))
+    val finalBatchIr = batchAggregator.denormalizeBatchIr(batchAggregator.normalizeBatchIr(batchIr))
+    new BatchIrRow(entityKey(), new GigaTileCodec(batchGroupBy, inputSchema).encodeBatchIr(finalBatchIr), batchEndTs)
   }
 
   private class LegacyEventTimeTimerFunction(timerTimestamps: Seq[Long])

--- a/flink/src/test/scala/ai/chronon/flink/test/window/GigaTileProcessFunctionTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/window/GigaTileProcessFunctionTest.scala
@@ -1,0 +1,683 @@
+package ai.chronon.flink.test.window
+
+import ai.chronon.aggregator.windowing.{
+  GigaEmitResult,
+  GigaTileStreamProcessor,
+  SawtoothOnlineAggregator
+}
+import ai.chronon.api._
+import ai.chronon.api.Extensions.WindowOps
+import ai.chronon.flink.deser.ProjectedEvent
+import ai.chronon.flink.types.{BatchIrRow, TimestampedTile}
+import ai.chronon.flink.window.GigaTileProcessFunction
+import ai.chronon.online.GigaTileCodec
+import ai.chronon.online.serde.{ArrayRow, AvroCodec}
+import org.apache.flink.api.common.state.ValueState
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.functions.KeySelector
+import org.apache.flink.runtime.state.KeyedStateBackend
+import org.apache.flink.streaming.api.functions.co.KeyedCoProcessFunction
+import org.apache.flink.streaming.api.operators.co.KeyedCoProcessOperator
+import org.apache.flink.streaming.api.watermark.Watermark
+import org.apache.flink.streaming.util.KeyedTwoInputStreamOperatorTestHarness
+import org.apache.flink.util.Collector
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.util
+import scala.collection.JavaConverters._
+
+class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
+  import GigaTileProcessFunctionTest._
+
+  "GigaTileProcessFunction" should "use processing time for current-value versions and eviction timers" in {
+    val testHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    val retainedLateEventTs = processingTs - 30 * 60 * 1000L
+    val carriedProcessingTs = processingTs - 10 * 60 * 1000L
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      testHarness.processElement1(
+        ProjectedEvent(Map(Constants.TimeColumn -> retainedLateEventTs, "num" -> 5L), carriedProcessingTs),
+        retainedLateEventTs)
+
+      val output = testHarness.extractOutputValues().get(0)
+      decodeSum(output) shouldEqual 5L
+      output.latestTsMillis shouldEqual processingTs
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+      testHarness.numEventTimeTimers() shouldEqual 0
+    } finally testHarness.close()
+  }
+
+  it should "evict small-window state on processing time" in {
+    val testHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    val windowMillis = new Window(1, TimeUnit.HOURS).millis
+    val justBeforeExpiry = eventTs + windowMillis - 1L
+    val afterExpiry = TsUtils.round(justBeforeExpiry, new Window(5, TimeUnit.MINUTES).millis) +
+      new Window(5, TimeUnit.MINUTES).millis
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(justBeforeExpiry)
+      testHarness.processElement1(event(eventTs, 5L), eventTs)
+      testHarness.setProcessingTime(afterExpiry)
+
+      val outputs = testHarness.extractOutputValues()
+      val evictionOutput = outputs.get(outputs.size() - 1)
+      decodeSum(evictionOutput) shouldBe null
+      evictionOutput.latestTsMillis shouldEqual afterExpiry
+      testHarness.numProcessingTimeTimers() shouldEqual 0
+    } finally testHarness.close()
+  }
+
+  it should "roll the current day on processing time while retaining an eligible late event" in {
+    val testHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    val dayMillis = new Window(1, TimeUnit.DAYS).millis
+    val beforeMidnightProcessingTs = dayMillis - 60 * 1000L
+    val afterMidnightProcessingTs = dayMillis + 60 * 1000L
+    val initialEventTs = dayMillis - 30 * 60 * 1000L
+    val delayedEventTs = dayMillis - 10 * 60 * 1000L
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(beforeMidnightProcessingTs)
+      testHarness.processElement1(event(initialEventTs, 5L), initialEventTs)
+      testHarness.setProcessingTime(afterMidnightProcessingTs)
+      // Zipline suppresses redundant timer writes. Crossing midnight must still leave the
+      // retained pre-midnight value available to the next event.
+      testHarness.extractOutputValues().size() shouldEqual 1
+
+      testHarness.processElement1(event(delayedEventTs, 7L), delayedEventTs)
+      val outputs = testHarness.extractOutputValues()
+      val delayedEventOutput = outputs.get(outputs.size() - 1)
+      decodeSum(delayedEventOutput) shouldEqual 12L
+      delayedEventOutput.latestTsMillis shouldEqual afterMidnightProcessingTs
+    } finally testHarness.close()
+  }
+
+  it should "use processing time for batch refresh versions" in {
+    val batchGroupBy = Builders.GroupBy(
+      metaData = Builders.MetaData(name = "gigatile-process-function-batch-test"),
+      aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(7, TimeUnit.DAYS)))))
+    val testHarness = harness(new GigaTileProcessFunction(batchGroupBy, inputSchema))
+    val batchCodec = new GigaTileCodec(batchGroupBy, inputSchema)
+    val batchEndTs = TsUtils.round(eventTs, new Window(1, TimeUnit.DAYS).millis)
+    val batchEventTs = batchEndTs - 60 * 1000L
+    val batchAggregator =
+      new SawtoothOnlineAggregator(batchEndTs, batchGroupBy.getAggregations.asScala.toSeq, inputSchema)
+    val batchIr = batchAggregator.update(
+      batchAggregator.init,
+      new ArrayRow(Array[Any](batchEventTs, 7L), batchEventTs))
+    val finalBatchIr = batchAggregator.denormalizeBatchIr(batchAggregator.normalizeBatchIr(batchIr))
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      testHarness.processElement2(
+        new BatchIrRow(entityKey(), batchCodec.encodeBatchIr(finalBatchIr), batchEndTs),
+        batchEndTs)
+
+      val output = testHarness.extractOutputValues().get(0)
+      decodeSum(output, batchGroupBy) shouldEqual 7L
+      output.latestTsMillis shouldEqual processingTs
+    } finally testHarness.close()
+  }
+
+  it should "schedule decay when a batch refresh leaves the current value unchanged" in {
+    val batchGroupBy = Builders.GroupBy(
+      metaData = Builders.MetaData(name = "gigatile-process-function-empty-batch-test"),
+      aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(7, TimeUnit.DAYS)))))
+    val testHarness = harness(new GigaTileProcessFunction(batchGroupBy, inputSchema))
+    val batchCodec = new GigaTileCodec(batchGroupBy, inputSchema)
+    val batchEndTs = TsUtils.round(eventTs, new Window(1, TimeUnit.DAYS).millis)
+    val batchAggregator =
+      new SawtoothOnlineAggregator(batchEndTs, batchGroupBy.getAggregations.asScala.toSeq, inputSchema)
+    val emptyBatchIr = batchAggregator.denormalizeBatchIr(batchAggregator.normalizeBatchIr(batchAggregator.init))
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      testHarness.processElement2(
+        new BatchIrRow(entityKey(), batchCodec.encodeBatchIr(emptyBatchIr), batchEndTs),
+        batchEndTs)
+
+      testHarness.extractOutputValues().asScala shouldBe empty
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+    } finally testHarness.close()
+  }
+
+  it should "migrate restored legacy event-time timers without publishing twice" in {
+    val firstLegacyTimer = eventTs + 1000L
+    val secondLegacyTimer = firstLegacyTimer + 1000L
+    val originalHarness = harness(new LegacyEventTimeTimerFunction(Seq(firstLegacyTimer, secondLegacyTimer)))
+    originalHarness.open()
+    originalHarness.processElement1(event(eventTs, 1L), eventTs)
+    originalHarness.numEventTimeTimers() shouldEqual 2
+    val snapshot = originalHarness.snapshot(7L, processingTs)
+    originalHarness.close()
+
+    val restoredHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(snapshot)
+      restoredHarness.open()
+      restoredHarness.setProcessingTime(processingTs)
+      restoredHarness.processWatermark1(new Watermark(secondLegacyTimer))
+      restoredHarness.processWatermark2(new Watermark(secondLegacyTimer))
+
+      restoredHarness.extractOutputValues().asScala shouldBe empty
+      restoredHarness.numEventTimeTimers() shouldEqual 0
+      restoredHarness.numProcessingTimeTimers() shouldEqual 1
+    } finally restoredHarness.close()
+  }
+
+  it should "restore and flush same-millisecond updates with a strictly newer version" in {
+    val originalHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    val firstEventTs = processingTs - 1000L
+    originalHarness.open()
+    originalHarness.setProcessingTime(processingTs)
+    originalHarness.processElement1(event(firstEventTs, 5L), firstEventTs)
+    originalHarness.processElement1(event(firstEventTs + 1L, 7L), firstEventTs + 1L)
+    originalHarness.processElement1(event(firstEventTs + 2L, 3L), firstEventTs + 2L)
+
+    val initialOutputs = originalHarness.extractOutputValues()
+    initialOutputs.size() shouldEqual 1
+    decodeSum(initialOutputs.get(0)) shouldEqual 5L
+    initialOutputs.get(0).latestTsMillis shouldEqual processingTs
+    // One timer keeps normal eviction cadence; the other flushes the version collision.
+    originalHarness.numProcessingTimeTimers() shouldEqual 2
+    val snapshot = originalHarness.snapshot(8L, processingTs)
+    originalHarness.close()
+
+    val restoredHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(snapshot)
+      restoredHarness.open()
+      // A delayed callback still uses the reserved strictly-newer version without moving
+      // aggregation time merely to flush the current snapshot.
+      restoredHarness.setProcessingTime(processingTs + 100L)
+
+      val outputs = restoredHarness.extractOutputValues()
+      outputs.size() shouldEqual 1
+      decodeSum(outputs.get(0)) shouldEqual 15L
+      outputs.get(0).latestTsMillis shouldEqual processingTs + 1L
+    } finally restoredHarness.close()
+  }
+
+  it should "repair collision and eviction markers after a state-blind timer consumer" in {
+    val firstEventTs = processingTs - 1000L
+    val evictionTs = nextEvictionHop(processingTs)
+    val originalFunction = new GigaTileProcessFunction(groupBy, inputSchema)
+    val originalHarness = harness(originalFunction)
+    originalHarness.open()
+    originalHarness.setProcessingTime(processingTs)
+    originalHarness.processElement1(event(firstEventTs, 5L), firstEventTs)
+    originalHarness.processElement1(event(firstEventTs + 1L, 7L), firstEventTs + 1L)
+    val originalSnapshot = originalHarness.snapshot(31L, processingTs)
+    originalHarness.close()
+
+    val legacyHarness = harness(new StateBlindProcessingTimerConsumer)
+    legacyHarness.setup()
+    legacyHarness.initializeState(originalSnapshot)
+    legacyHarness.open()
+    legacyHarness.setProcessingTime(processingTs)
+    legacyHarness.setProcessingTime(evictionTs)
+    legacyHarness.numProcessingTimeTimers() shouldEqual 0
+    val legacySnapshot = legacyHarness.snapshot(32L, evictionTs)
+    legacyHarness.close()
+
+    val restoredFunction = new GigaTileProcessFunction(groupBy, inputSchema)
+    val restoredHarness = harness(restoredFunction)
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(legacySnapshot)
+      restoredHarness.open()
+      restoredHarness.setProcessingTime(evictionTs)
+      // With no keyed callback, there is no way for open() to enumerate and repair this key.
+      restoredHarness.numProcessingTimeTimers() shouldEqual 0
+
+      restoredHarness.processElement1(event(firstEventTs + 2L, 3L), firstEventTs + 2L)
+      setCurrentKey(restoredHarness, entityKey())
+      val repairedEviction = valueState[java.lang.Long](restoredFunction,
+                                                        "nextProcessingEvictionTimerState").value().longValue()
+      val repairedCollision = valueState[java.lang.Long](restoredFunction,
+                                                         "pendingVersionCollisionState").value().longValue()
+      repairedEviction should be > evictionTs
+      repairedCollision shouldEqual repairedEviction
+      restoredHarness.numProcessingTimeTimers() shouldEqual 1
+
+      restoredHarness.setProcessingTime(repairedCollision)
+
+      val outputs = restoredHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldEqual 15L
+      outputs.get(0).latestTsMillis shouldEqual repairedCollision
+      valueState[java.lang.Long](restoredFunction, "pendingVersionCollisionState").value() shouldBe null
+      restoredHarness.numProcessingTimeTimers() shouldEqual 1
+    } finally restoredHarness.close()
+  }
+
+  it should "keep a later owned timer while draining an earlier due callback" in {
+    val windowMillis = new Window(1, TimeUnit.HOURS).millis
+    val justBeforeExpiry = eventTs + windowMillis - 1L
+    val injectedTimer = justBeforeExpiry + 1L
+    val evictionTimer = nextEvictionHop(justBeforeExpiry)
+    injectedTimer should be < evictionTimer
+
+    val originalHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    originalHarness.open()
+    originalHarness.setProcessingTime(justBeforeExpiry)
+    originalHarness.processElement1(event(eventTs, 5L), eventTs)
+    val originalSnapshot = originalHarness.snapshot(33L, justBeforeExpiry)
+    originalHarness.close()
+
+    val injectorHarness = harness(new ProcessingTimerInjector(injectedTimer))
+    injectorHarness.setup()
+    injectorHarness.initializeState(originalSnapshot)
+    injectorHarness.open()
+    injectorHarness.setProcessingTime(justBeforeExpiry)
+    injectorHarness.processElement1(event(eventTs, 0L), eventTs)
+    val injectedSnapshot = injectorHarness.snapshot(34L, justBeforeExpiry)
+    injectorHarness.close()
+
+    val restoredHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(injectedSnapshot)
+      restoredHarness.open()
+      // Flink reports this jump target while it first drains injectedTimer. That earlier
+      // callback must not steal ownership from the still-queued evictionTimer.
+      restoredHarness.setProcessingTime(evictionTimer)
+
+      val outputs = restoredHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldBe null
+      outputs.get(0).latestTsMillis shouldEqual evictionTimer
+      restoredHarness.numProcessingTimeTimers() shouldEqual 0
+    } finally restoredHarness.close()
+  }
+
+  it should "share a queued eviction while draining an earlier collision repair callback" in {
+    val firstEventTs = processingTs - 1000L
+    val consumedCollisionTimer = processingTs + 1L
+    val injectedTimer = processingTs + 2L
+    val evictionTimer = nextEvictionHop(processingTs)
+    injectedTimer should be < evictionTimer
+
+    val originalHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    originalHarness.open()
+    originalHarness.setProcessingTime(processingTs)
+    originalHarness.processElement1(event(firstEventTs, 5L), firstEventTs)
+    originalHarness.processElement1(event(firstEventTs + 1L, 7L), firstEventTs + 1L)
+    val originalSnapshot = originalHarness.snapshot(35L, processingTs)
+    originalHarness.close()
+
+    val legacyHarness = harness(new StateBlindProcessingTimerConsumer)
+    legacyHarness.setup()
+    legacyHarness.initializeState(originalSnapshot)
+    legacyHarness.open()
+    legacyHarness.setProcessingTime(processingTs)
+    legacyHarness.setProcessingTime(consumedCollisionTimer)
+    legacyHarness.numProcessingTimeTimers() shouldEqual 1
+    val legacySnapshot = legacyHarness.snapshot(36L, consumedCollisionTimer)
+    legacyHarness.close()
+
+    val injectorHarness = harness(new ProcessingTimerInjector(injectedTimer))
+    injectorHarness.setup()
+    injectorHarness.initializeState(legacySnapshot)
+    injectorHarness.open()
+    injectorHarness.setProcessingTime(consumedCollisionTimer)
+    injectorHarness.processElement1(event(firstEventTs, 0L), firstEventTs)
+    val injectedSnapshot = injectorHarness.snapshot(37L, consumedCollisionTimer)
+    injectorHarness.close()
+
+    val restoredFunction = new GigaTileProcessFunction(groupBy, inputSchema)
+    val restoredHarness = harness(restoredFunction)
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(injectedSnapshot)
+      restoredHarness.open()
+      restoredHarness.setProcessingTime(consumedCollisionTimer)
+      // The injected callback runs first while Flink already reports evictionTimer as the
+      // current processing time. The stale collision must join that still-queued eviction.
+      restoredHarness.setProcessingTime(evictionTimer)
+
+      val outputs = restoredHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldEqual 12L
+      outputs.get(0).latestTsMillis shouldEqual evictionTimer
+      setCurrentKey(restoredHarness, entityKey())
+      valueState[java.lang.Long](restoredFunction, "pendingVersionCollisionState").value() shouldBe null
+      restoredHarness.numProcessingTimeTimers() shouldEqual 1
+    } finally restoredHarness.close()
+  }
+
+  it should "retry the current snapshot when the first publication fails" in {
+    val function = new GigaTileProcessFunction(groupBy, inputSchema)
+    val testHarness = harness(function)
+    val firstEventTs = processingTs - 1000L
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      failNextEncode(function)
+      testHarness.processElement1(event(firstEventTs, 5L), firstEventTs)
+
+      testHarness.extractOutputValues() shouldBe empty
+      // Normal eviction and the failed-snapshot retry both remain live.
+      testHarness.numProcessingTimeTimers() shouldEqual 2
+
+      testHarness.setProcessingTime(processingTs + 1L)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs.size() shouldEqual 1
+      decodeSum(outputs.get(0)) shouldEqual 5L
+      outputs.get(0).latestTsMillis shouldEqual processingTs + 1L
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+    } finally testHarness.close()
+  }
+
+  it should "re-arm a version collision when snapshot construction fails" in {
+    val function = new GigaTileProcessFunction(groupBy, inputSchema)
+    val testHarness = harness(function)
+    val firstEventTs = processingTs - 1000L
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      testHarness.processElement1(event(firstEventTs, 5L), firstEventTs)
+      testHarness.processElement1(event(firstEventTs + 1L, 7L), firstEventTs + 1L)
+
+      testHarness.extractOutputValues().size() shouldEqual 1
+      failNextSnapshot(function)
+
+      testHarness.setProcessingTime(processingTs + 1L)
+
+      testHarness.extractOutputValues().size() shouldEqual 1
+      // The normal eviction timer and the re-armed collision timer must both remain live.
+      testHarness.numProcessingTimeTimers() shouldEqual 2
+
+      testHarness.setProcessingTime(processingTs + 2L)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs.size() shouldEqual 2
+      decodeSum(outputs.get(1)) shouldEqual 12L
+      outputs.get(1).latestTsMillis shouldEqual processingTs + 2L
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+    } finally testHarness.close()
+  }
+
+  it should "evict before flushing when version and eviction timers coincide" in {
+    val testHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    val hopMillis = new Window(5, TimeUnit.MINUTES).millis
+    val evictionTs = TsUtils.round(processingTs, hopMillis) + hopMillis
+    val collisionProcessingTs = evictionTs - 1L
+    val expiringEventTs = evictionTs - new Window(1, TimeUnit.HOURS).millis - 1L
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(collisionProcessingTs)
+      testHarness.processElement1(event(expiringEventTs, 5L), expiringEventTs)
+      testHarness.processElement1(event(expiringEventTs, 7L), expiringEventTs)
+
+      testHarness.setProcessingTime(evictionTs)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs.size() shouldEqual 2
+      decodeSum(outputs.get(1)) shouldBe null
+      outputs.get(1).latestTsMillis shouldEqual evictionTs
+      testHarness.numProcessingTimeTimers() shouldEqual 0
+    } finally testHarness.close()
+  }
+
+  it should "delay a shared collision until a failed eviction is retried" in {
+    val function = new GigaTileProcessFunction(groupBy, inputSchema)
+    val testHarness = harness(function)
+    val hopMillis = new Window(5, TimeUnit.MINUTES).millis
+    val evictionTs = TsUtils.round(processingTs, hopMillis) + hopMillis
+    val retryTs = evictionTs + hopMillis
+    val collisionProcessingTs = evictionTs - 1L
+    val expiringEventTs = retryTs - new Window(1, TimeUnit.HOURS).millis - 1L
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(collisionProcessingTs)
+      testHarness.processElement1(event(expiringEventTs, 5L), expiringEventTs)
+      testHarness.processElement1(event(expiringEventTs, 7L), expiringEventTs)
+      failNextScheduledEviction(function)
+
+      testHarness.setProcessingTime(evictionTs)
+
+      testHarness.extractOutputValues().size() shouldEqual 1
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+
+      testHarness.setProcessingTime(evictionTs + 1L)
+      testHarness.extractOutputValues().size() shouldEqual 1
+
+      testHarness.setProcessingTime(retryTs)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs.size() shouldEqual 2
+      decodeSum(outputs.get(1)) shouldBe null
+      outputs.get(1).latestTsMillis shouldEqual retryTs
+      testHarness.numProcessingTimeTimers() shouldEqual 0
+    } finally testHarness.close()
+  }
+
+  it should "isolate same-millisecond publication collisions by key" in {
+    val testHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
+    val firstEventTs = processingTs - 1000L
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      testHarness.processElement1(keyedEvent("campaign-1", firstEventTs, 5L), firstEventTs)
+      testHarness.processElement1(keyedEvent("campaign-1", firstEventTs + 1L, 7L), firstEventTs + 1L)
+      testHarness.processElement1(keyedEvent("campaign-2", firstEventTs, 11L), firstEventTs)
+      testHarness.processElement1(keyedEvent("campaign-2", firstEventTs + 1L, 13L), firstEventTs + 1L)
+
+      testHarness.extractOutputValues().size() shouldEqual 2
+      testHarness.setProcessingTime(processingTs + 1L)
+
+      val flushedByKey = testHarness.extractOutputValues().asScala
+        .filter(_.latestTsMillis == processingTs + 1L)
+        .map(tile => tile.keys.get(0).toString -> decodeSum(tile))
+        .toMap
+      flushedByKey shouldEqual Map("campaign-1" -> 12L, "campaign-2" -> 24L)
+    } finally testHarness.close()
+  }
+}
+
+object GigaTileProcessFunctionTest {
+  private val eventTs = 1000000L
+  private val processingTs = eventTs + new Window(2, TimeUnit.HOURS).millis
+  private val inputSchema: Seq[(String, DataType)] =
+    Seq(Constants.TimeColumn -> LongType, "num" -> LongType)
+  private val groupBy = Builders.GroupBy(
+    metaData = Builders.MetaData(name = "gigatile-process-function-test"),
+    aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(1, TimeUnit.HOURS)))))
+
+  private def harness(
+      function: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]
+  ): KeyedTwoInputStreamOperatorTestHarness[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile] =
+    new KeyedTwoInputStreamOperatorTestHarness[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile](
+      new KeyedCoProcessOperator(function),
+      new KeySelector[ProjectedEvent, util.List[Any]] {
+        override def getKey(value: ProjectedEvent): util.List[Any] =
+          entityKey(value.fields.getOrElse("entity", "campaign-1").toString)
+      },
+      new KeySelector[BatchIrRow, util.List[Any]] {
+        override def getKey(value: BatchIrRow): util.List[Any] = value.entityKeys
+      },
+      TypeInformation
+        .of(classOf[util.List[_]])
+        .asInstanceOf[TypeInformation[util.List[Any]]])
+
+  private def event(timestamp: Long, value: Long): ProjectedEvent =
+    ProjectedEvent(Map(Constants.TimeColumn -> timestamp, "num" -> value), timestamp)
+
+  private def keyedEvent(entity: String, timestamp: Long, value: Long): ProjectedEvent =
+    ProjectedEvent(Map("entity" -> entity, Constants.TimeColumn -> timestamp, "num" -> value), timestamp)
+
+  private def entityKey(entity: String = "campaign-1"): util.List[Any] = {
+    val result = new util.ArrayList[Any](1)
+    result.add(entity)
+    result
+  }
+
+  private def nextEvictionHop(timestamp: Long): Long = {
+    val hopMillis = new Window(5, TimeUnit.MINUTES).millis
+    TsUtils.round(timestamp, hopMillis) + hopMillis
+  }
+
+  private def setCurrentKey(
+      testHarness: KeyedTwoInputStreamOperatorTestHarness[
+        util.List[Any],
+        ProjectedEvent,
+        BatchIrRow,
+        TimestampedTile],
+      key: util.List[Any]
+  ): Unit =
+    testHarness.getOperator.getKeyedStateBackend
+      .asInstanceOf[KeyedStateBackend[util.List[Any]]]
+      .setCurrentKey(key)
+
+  private def valueState[T](function: GigaTileProcessFunction, fieldName: String): ValueState[T] = {
+    val field = classOf[GigaTileProcessFunction].getDeclaredField(fieldName)
+    field.setAccessible(true)
+    field.get(function).asInstanceOf[ValueState[T]]
+  }
+
+  private def decodeSum(tile: TimestampedTile, decodeGroupBy: GroupBy = groupBy): AnyRef = {
+    val outputCodec = new GigaTileCodec(decodeGroupBy, inputSchema)
+    val fieldName = outputCodec.outputSchema.fields.head.name
+    AvroCodec
+      .of(ai.chronon.online.serde.AvroConversions.fromChrononSchema(outputCodec.outputSchema).toString)
+      .decodeMap(tile.tileBytes)(fieldName)
+  }
+
+  private def failNextSnapshot(function: GigaTileProcessFunction): Unit = {
+    val processorField = classOf[GigaTileProcessFunction].getDeclaredField("processor")
+    processorField.setAccessible(true)
+    val delegate = processorField.get(function).asInstanceOf[GigaTileStreamProcessor]
+    processorField.set(
+      function,
+      new GigaTileStreamProcessor(
+        delegate.megaTileAgg,
+        delegate.store,
+        delegate.irEqual,
+        delegate.maxBatchStalenessDays
+      ) {
+        private var shouldFail = true
+
+        override private[chronon] def currentSnapshot: GigaEmitResult = {
+          if (shouldFail) {
+            shouldFail = false
+            throw new RuntimeException("expected snapshot failure")
+          }
+          delegate.currentSnapshot
+        }
+      }
+    )
+  }
+
+  private def failNextEncode(function: GigaTileProcessFunction): Unit = {
+    val codecField = classOf[GigaTileProcessFunction].getDeclaredField("gigaTileCodec")
+    codecField.setAccessible(true)
+    codecField.set(
+      function,
+      new GigaTileCodec(groupBy, inputSchema) {
+        private var shouldFail = true
+
+        override def encodeOutput(finalizedVector: Array[Any]): Array[Byte] = {
+          if (shouldFail) {
+            shouldFail = false
+            throw new RuntimeException("expected publication encoding failure")
+          }
+          super.encodeOutput(finalizedVector)
+        }
+      })
+  }
+
+  private def failNextScheduledEviction(function: GigaTileProcessFunction): Unit = {
+    val processorField = classOf[GigaTileProcessFunction].getDeclaredField("processor")
+    processorField.setAccessible(true)
+    val delegate = processorField.get(function).asInstanceOf[GigaTileStreamProcessor]
+    processorField.set(
+      function,
+      new GigaTileStreamProcessor(
+        delegate.megaTileAgg,
+        delegate.store,
+        delegate.irEqual,
+        delegate.maxBatchStalenessDays
+      ) {
+        private var shouldFail = true
+
+        override def onScheduledEviction(timerTs: Long): GigaEmitResult = {
+          if (shouldFail) {
+            shouldFail = false
+            throw new RuntimeException("expected scheduled eviction failure")
+          }
+          delegate.onScheduledEviction(timerTs)
+        }
+      }
+    )
+  }
+
+  private class LegacyEventTimeTimerFunction(timerTimestamps: Seq[Long])
+      extends KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile] {
+    override def processElement1(
+        event: ProjectedEvent,
+        ctx: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#Context,
+        out: Collector[TimestampedTile]
+    ): Unit =
+      timerTimestamps.foreach(ctx.timerService().registerEventTimeTimer)
+
+    override def processElement2(
+        batchRow: BatchIrRow,
+        ctx: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#Context,
+        out: Collector[TimestampedTile]
+    ): Unit = ()
+  }
+
+  /** Models a rollback binary that consumes physical timers without binding the additive
+    * collision and eviction ownership descriptors.
+    */
+  private class StateBlindProcessingTimerConsumer
+      extends KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile] {
+    override def processElement1(
+        event: ProjectedEvent,
+        ctx: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#Context,
+        out: Collector[TimestampedTile]
+    ): Unit = ()
+
+    override def processElement2(
+        batchRow: BatchIrRow,
+        ctx: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#Context,
+        out: Collector[TimestampedTile]
+    ): Unit = ()
+
+    override def onTimer(
+        timestamp: Long,
+        ctx: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#OnTimerContext,
+        out: Collector[TimestampedTile]
+    ): Unit = ()
+  }
+
+  private class ProcessingTimerInjector(timerTimestamp: Long)
+      extends KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile] {
+    override def processElement1(
+        event: ProjectedEvent,
+        ctx: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#Context,
+        out: Collector[TimestampedTile]
+    ): Unit = ctx.timerService().registerProcessingTimeTimer(timerTimestamp)
+
+    override def processElement2(
+        batchRow: BatchIrRow,
+        ctx: KeyedCoProcessFunction[util.List[Any], ProjectedEvent, BatchIrRow, TimestampedTile]#Context,
+        out: Collector[TimestampedTile]
+    ): Unit = ()
+  }
+}

--- a/flink/src/test/scala/ai/chronon/flink/test/window/GigaTileProcessFunctionTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/window/GigaTileProcessFunctionTest.scala
@@ -1121,6 +1121,44 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     } finally testHarness.close()
   }
 
+  it should "re-arm shared eviction and collision roles when eviction fails" in {
+    val function = new GigaTileProcessFunction(groupBy, inputSchema)
+    val testHarness = harness(function)
+    val evictionTs = nextEvictionHop(processingTs)
+    val initialProcessingTs = evictionTs - 1L
+    val expiringEventTs = evictionTs - new Window(1, TimeUnit.HOURS).millis - 1L
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(initialProcessingTs)
+      advanceToHealthyLiveWatermark(testHarness, initialProcessingTs)
+      testHarness.processElement1(event(expiringEventTs, 5L), expiringEventTs)
+      testHarness.processElement1(event(expiringEventTs, 7L), expiringEventTs)
+
+      testHarness.extractOutputValues().size() shouldEqual 1
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+      failNextEviction(function)
+
+      testHarness.setProcessingTime(evictionTs)
+
+      testHarness.extractOutputValues().size() shouldEqual 1
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+      val retryTs = nextEvictionHop(evictionTs)
+      setCurrentKey(testHarness, entityKey())
+      valueState[java.lang.Long](function, "nextProcessingEvictionTimerState").value() shouldEqual retryTs
+      valueState[java.lang.Long](function, "pendingVersionCollisionState").value() shouldEqual retryTs
+
+      advanceToHealthyLiveWatermark(testHarness, retryTs)
+      testHarness.setProcessingTime(retryTs)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs.size() shouldEqual 2
+      decodeSum(outputs.get(1)) shouldBe null
+      outputs.get(1).latestTsMillis shouldEqual retryTs
+      testHarness.numProcessingTimeTimers() shouldEqual 0
+    } finally testHarness.close()
+  }
+
   it should "evict before flushing when version and eviction timers coincide" in {
     val testHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema))
     val hopMillis = new Window(5, TimeUnit.MINUTES).millis
@@ -1202,6 +1240,435 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
         .map(tile => tile.keys.get(0).toString -> decodeSum(tile))
         .toMap
       flushedByKey shouldEqual Map("campaign-1" -> 12L, "campaign-2" -> 24L)
+    } finally testHarness.close()
+  }
+
+  it should "coalesce live updates onto one wall-clock cadence" in {
+    val cadenceMillis = 1000L
+    val function = new GigaTileProcessFunction(groupBy, inputSchema, bufferingOutputTimeMillis = cadenceMillis)
+    val testHarness = harness(function)
+    val cadenceTs = nextBufferedWriteTick(groupBy, entityKey(), processingTs, cadenceMillis)
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      advanceToHealthyLiveWatermark(testHarness, processingTs)
+      testHarness.processElement1(event(processingTs - 2000L, 5L), processingTs - 2000L)
+      testHarness.processElement1(event(processingTs - 1999L, 7L), processingTs - 1999L)
+
+      testHarness.extractOutputValues() shouldBe empty
+      setCurrentKey(testHarness, entityKey())
+      valueState[java.lang.Boolean](function, "pendingPublicationState").value() shouldEqual java.lang.Boolean.TRUE
+      testHarness.setProcessingTime(cadenceTs)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldEqual 12L
+      outputs.get(0).latestTsMillis shouldEqual processingTs
+      setCurrentKey(testHarness, entityKey())
+      valueState[java.lang.Boolean](function, "pendingPublicationState").value() shouldBe null
+    } finally testHarness.close()
+  }
+
+  it should "hold a live batch refresh until the wall-clock cadence" in {
+    val cadenceMillis = 1000L
+    val batchGroupBy = Builders.GroupBy(
+      metaData = Builders.MetaData(name = "gigatile-buffered-batch-test"),
+      aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(7, TimeUnit.DAYS)))))
+    val testHarness = harness(
+      new GigaTileProcessFunction(batchGroupBy, inputSchema, bufferingOutputTimeMillis = cadenceMillis))
+    val cadenceTs = nextBufferedWriteTick(batchGroupBy, entityKey(), processingTs, cadenceMillis)
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      advanceToHealthyLiveWatermark(testHarness, processingTs)
+      testHarness.processElement2(batchRow(batchGroupBy, 0L, -1000L, 7L), 0L)
+
+      testHarness.extractOutputValues() shouldBe empty
+      testHarness.setProcessingTime(cadenceTs)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0), batchGroupBy) shouldEqual 7L
+      outputs.get(0).latestTsMillis shouldEqual processingTs
+    } finally testHarness.close()
+  }
+
+  it should "park a buffered write across Catchup cadence intervals and rebuild once Live" in {
+    val cadenceMillis = 1000L
+    val function = new GigaTileProcessFunction(groupBy, inputSchema, bufferingOutputTimeMillis = cadenceMillis)
+    val testHarness = harness(function)
+    val firstCadenceTs = nextBufferedWriteTick(groupBy, entityKey(), processingTs, cadenceMillis)
+    val catchupThreshold = new Window(5, TimeUnit.MINUTES).millis + FlinkJob.CatchupWatermarkLagSlackMillis
+    val watermark = processingTs - catchupThreshold + (firstCadenceTs - processingTs) / 2L
+    val evictionTs = nextEvictionHop(processingTs)
+    val afterSeveralCadences = firstCadenceTs + 10L * cadenceMillis
+    val liveCadenceTs = nextBufferedWriteTick(groupBy, entityKey(), afterSeveralCadences, cadenceMillis)
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      advanceToLiveWatermark(testHarness, watermark)
+      testHarness.processElement1(event(watermark - 1L, 5L), watermark - 1L)
+      setCurrentKey(testHarness, entityKey())
+      valueState[java.lang.Long](function, "pendingPublicationRetryTimerState").value() shouldBe null
+      valueState[java.lang.Long](function, "pendingPublicationActivationTimerState").value() shouldBe null
+
+      testHarness.setProcessingTime(firstCadenceTs)
+      testHarness.extractOutputValues() shouldBe empty
+      setCurrentKey(testHarness, entityKey())
+      valueState[java.lang.Long](function, "nextBufferedWriteTimerState").value() shouldBe null
+      valueState[java.lang.Long](function, "bufferedWriteLatestTsState").value() shouldEqual processingTs
+      valueState[java.lang.Boolean](function, "pendingPublicationState").value() shouldEqual java.lang.Boolean.TRUE
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+      testHarness.numEventTimeTimers() shouldEqual 1
+      valueState[java.lang.Long](function, "pendingPublicationRetryTimerState").value() shouldBe null
+      valueState[java.lang.Long](function, "pendingPublicationActivationTimerState").value() should not be null
+
+      afterSeveralCadences should be < evictionTs
+      testHarness.setProcessingTime(afterSeveralCadences)
+      testHarness.extractOutputValues() shouldBe empty
+      testHarness.numProcessingTimeTimers() shouldEqual 1
+      testHarness.numEventTimeTimers() shouldEqual 1
+
+      advanceToHealthyLiveWatermark(testHarness, afterSeveralCadences)
+      testHarness.extractOutputValues() shouldBe empty
+      setCurrentKey(testHarness, entityKey())
+      valueState[java.lang.Long](function, "pendingPublicationActivationTimerState").value() shouldBe null
+      valueState[java.lang.Long](function, "nextBufferedWriteTimerState").value() shouldEqual liveCadenceTs
+      testHarness.setProcessingTime(liveCadenceTs)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldEqual 5L
+      outputs.get(0).latestTsMillis shouldEqual afterSeveralCadences
+    } finally testHarness.close()
+  }
+
+  it should "run eviction before a cadence timer at the same timestamp" in {
+    val cadenceMillis = 1L
+    val collisionTs = nextEvictionHop(processingTs)
+    val eventProcessingTs = collisionTs - 1L
+    val expiringEventTs = collisionTs - new Window(1, TimeUnit.HOURS).millis - 1L
+    val testHarness = harness(
+      new GigaTileProcessFunction(groupBy, inputSchema, bufferingOutputTimeMillis = cadenceMillis))
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(eventProcessingTs)
+      advanceToHealthyLiveWatermark(testHarness, eventProcessingTs)
+      testHarness.processElement1(event(expiringEventTs, 5L), expiringEventTs)
+
+      testHarness.extractOutputValues() shouldBe empty
+      testHarness.setProcessingTime(collisionTs)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldBe null
+      outputs.get(0).latestTsMillis shouldEqual collisionTs
+    } finally testHarness.close()
+  }
+
+  it should "emit once after eviction when all four timer roles share a callback" in {
+    val collisionTs = nextEvictionHop(processingTs)
+    val eventProcessingTs = collisionTs - 1L
+    val expiringEventTs = collisionTs - new Window(1, TimeUnit.HOURS).millis - 1L
+    val function = new GigaTileProcessFunction(groupBy, inputSchema, bufferingOutputTimeMillis = 1L)
+    val testHarness = harness(function)
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(eventProcessingTs)
+      advanceToHealthyLiveWatermark(testHarness, eventProcessingTs)
+      testHarness.processElement1(event(expiringEventTs, 5L), expiringEventTs)
+      setCurrentKey(testHarness, entityKey())
+      valueState[java.lang.Long](function, "pendingVersionCollisionState").update(collisionTs)
+      valueState[java.lang.Long](function, "pendingPublicationRetryTimerState").update(collisionTs)
+      valueState[java.lang.Boolean](function, "pendingPublicationState").update(java.lang.Boolean.TRUE)
+
+      testHarness.setProcessingTime(collisionTs)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldBe null
+      outputs.get(0).latestTsMillis shouldEqual collisionTs
+      valueState[java.lang.Long](function, "pendingVersionCollisionState").value() shouldBe null
+    } finally testHarness.close()
+  }
+
+  it should "clear a later cadence after a shared eviction and collision publishes" in {
+    val cadenceMillis = new Window(1, TimeUnit.HOURS).millis
+    val seedCadenceTs = nextBufferedWriteTick(groupBy, entityKey(), processingTs, cadenceMillis)
+    val eventProcessingTs = seedCadenceTs + 1L
+    val evictionTs = nextEvictionHop(eventProcessingTs)
+    val cadenceTs = nextBufferedWriteTick(groupBy, entityKey(), eventProcessingTs, cadenceMillis)
+    val expiringEventTs = evictionTs - new Window(1, TimeUnit.HOURS).millis - 1L
+    val function =
+      new GigaTileProcessFunction(groupBy, inputSchema, bufferingOutputTimeMillis = cadenceMillis)
+    val testHarness = harness(function)
+
+    cadenceTs should be > evictionTs
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(eventProcessingTs)
+      advanceToHealthyLiveWatermark(testHarness, eventProcessingTs)
+      testHarness.processElement1(event(expiringEventTs, 5L), expiringEventTs)
+      setCurrentKey(testHarness, entityKey())
+      valueState[java.lang.Long](function, "pendingVersionCollisionState").update(evictionTs)
+
+      advanceToHealthyLiveWatermark(testHarness, evictionTs)
+      testHarness.setProcessingTime(evictionTs)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldBe null
+      valueState[java.lang.Long](function, "bufferedWriteLatestTsState").value() shouldBe null
+      valueState[java.lang.Long](function, "nextBufferedWriteTimerState").value() shouldBe null
+
+      testHarness.setProcessingTime(cadenceTs + 1L)
+      testHarness.extractOutputValues() should have size 1
+      testHarness.numProcessingTimeTimers() shouldEqual 0
+    } finally testHarness.close()
+  }
+
+  it should "retry a failed cadence encoding on the next cadence tick" in {
+    val cadenceMillis = 1000L
+    val function = new GigaTileProcessFunction(groupBy, inputSchema, bufferingOutputTimeMillis = cadenceMillis)
+    val testHarness = harness(function)
+    val firstCadenceTs = nextBufferedWriteTick(groupBy, entityKey(), processingTs, cadenceMillis)
+    val secondCadenceTs = nextBufferedWriteTick(groupBy, entityKey(), firstCadenceTs, cadenceMillis)
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      advanceToHealthyLiveWatermark(testHarness, processingTs)
+      testHarness.processElement1(event(processingTs - 1000L, 5L), processingTs - 1000L)
+      failNextEncode(function)
+
+      testHarness.setProcessingTime(firstCadenceTs)
+      testHarness.extractOutputValues() shouldBe empty
+      testHarness.setProcessingTime(secondCadenceTs)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldEqual 5L
+    } finally testHarness.close()
+  }
+
+  it should "isolate buffered cadence state by key" in {
+    val cadenceMillis = 1000L
+    val testHarness = harness(
+      new GigaTileProcessFunction(groupBy, inputSchema, bufferingOutputTimeMillis = cadenceMillis))
+    val keys = Seq("campaign-1", "campaign-2")
+    val lastCadenceTs = keys.map(key => nextBufferedWriteTick(groupBy, entityKey(key), processingTs, cadenceMillis)).max
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      advanceToHealthyLiveWatermark(testHarness, processingTs)
+      testHarness.processElement1(keyedEvent(keys.head, processingTs - 1000L, 5L), processingTs - 1000L)
+      testHarness.processElement1(keyedEvent(keys.last, processingTs - 1000L, 11L), processingTs - 1000L)
+
+      testHarness.extractOutputValues() shouldBe empty
+      testHarness.setProcessingTime(lastCadenceTs)
+
+      val byKey = testHarness.extractOutputValues().asScala.map { tile =>
+        tile.keys.get(0).toString -> decodeSum(tile)
+      }.toMap
+      byKey shouldEqual Map("campaign-1" -> 5L, "campaign-2" -> 11L)
+    } finally testHarness.close()
+  }
+
+  it should "preserve a pending cadence while draining an earlier callback" in {
+    val cadenceMillis = 1000L
+    val firstCadenceTs = nextBufferedWriteTick(groupBy, entityKey(), processingTs, cadenceMillis)
+    val eventProcessingTime = if (firstCadenceTs - processingTs > 1L) processingTs else processingTs + 1L
+    val cadenceTs = nextBufferedWriteTick(groupBy, entityKey(), eventProcessingTime, cadenceMillis)
+    val injectedTimer = eventProcessingTime + 1L
+    injectedTimer should be < cadenceTs
+    val originalHarness = harness(
+      new GigaTileProcessFunction(groupBy, inputSchema, bufferingOutputTimeMillis = cadenceMillis))
+    originalHarness.open()
+    originalHarness.setProcessingTime(eventProcessingTime)
+    advanceToHealthyLiveWatermark(originalHarness, eventProcessingTime)
+    originalHarness.processElement1(event(eventProcessingTime - 1000L, 5L), eventProcessingTime - 1000L)
+    val snapshot = originalHarness.snapshot(20L, eventProcessingTime)
+    originalHarness.close()
+
+    val injectorHarness = harness(new ProcessingTimerInjector(injectedTimer))
+    injectorHarness.setup()
+    injectorHarness.initializeState(snapshot)
+    injectorHarness.open()
+    injectorHarness.setProcessingTime(eventProcessingTime)
+    injectorHarness.processElement1(event(eventProcessingTime - 1000L, 0L), eventProcessingTime - 1000L)
+    val injectedSnapshot = injectorHarness.snapshot(21L, eventProcessingTime)
+    injectorHarness.close()
+
+    val restoredHarness = harness(
+      new GigaTileProcessFunction(groupBy, inputSchema, bufferingOutputTimeMillis = cadenceMillis))
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(injectedSnapshot)
+      restoredHarness.open()
+      restoredHarness.setProcessingTime(eventProcessingTime)
+      // The injected callback runs first while Flink already reports cadenceTs. It must not
+      // move the still-queued cadence marker to the following interval.
+      restoredHarness.numProcessingTimeTimers() shouldEqual 3
+      advanceToHealthyLiveWatermark(restoredHarness, cadenceTs)
+      restoredHarness.setProcessingTime(cadenceTs)
+
+      val outputs = restoredHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldEqual 5L
+      outputs.get(0).latestTsMillis shouldEqual eventProcessingTime
+    } finally restoredHarness.close()
+  }
+
+  it should "flush a restored cadence after buffering is disabled" in {
+    val cadenceMillis = 1000L
+    val cadenceTs = nextBufferedWriteTick(groupBy, entityKey(), processingTs, cadenceMillis)
+    val originalHarness = harness(
+      new GigaTileProcessFunction(groupBy, inputSchema, bufferingOutputTimeMillis = cadenceMillis))
+    originalHarness.open()
+    originalHarness.setProcessingTime(processingTs)
+    advanceToHealthyLiveWatermark(originalHarness, processingTs)
+    originalHarness.processElement1(event(processingTs - 1000L, 5L), processingTs - 1000L)
+    val snapshot = originalHarness.snapshot(21L, processingTs)
+    originalHarness.close()
+
+    val restoredHarness = harness(new GigaTileProcessFunction(groupBy, inputSchema, bufferingOutputTimeMillis = 0L))
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(snapshot)
+      restoredHarness.open()
+      restoredHarness.setProcessingTime(processingTs)
+      advanceToHealthyLiveWatermark(restoredHarness, processingTs)
+      restoredHarness.setProcessingTime(cadenceTs)
+
+      val outputs = restoredHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldEqual 5L
+      outputs.get(0).latestTsMillis shouldEqual processingTs
+    } finally restoredHarness.close()
+  }
+
+  it should "repair a cadence marker after a state-blind timer consumer" in {
+    val cadenceMillis = 1000L
+    val cadenceTs = nextBufferedWriteTick(groupBy, entityKey(), processingTs, cadenceMillis)
+    val evictionTs = nextEvictionHop(processingTs)
+    val originalFunction =
+      new GigaTileProcessFunction(groupBy, inputSchema, bufferingOutputTimeMillis = cadenceMillis)
+    val originalHarness = harness(originalFunction)
+    cadenceTs should be < evictionTs
+    originalHarness.open()
+    originalHarness.setProcessingTime(processingTs)
+    advanceToHealthyLiveWatermark(originalHarness, processingTs)
+    originalHarness.processElement1(event(processingTs - 1000L, 5L), processingTs - 1000L)
+    setCurrentKey(originalHarness, entityKey())
+    valueState[java.lang.Boolean](originalFunction, "pendingPublicationState").value() shouldEqual java.lang.Boolean.TRUE
+    valueState[java.lang.Long](originalFunction, "nextProcessingEvictionTimerState").value() should not be null
+    val snapshot = originalHarness.snapshot(23L, processingTs)
+    originalHarness.close()
+
+    // The older binary neither binds the cadence state nor recognizes its physical timer.
+    val legacyHarness = harness(new StateBlindProcessingTimerConsumer)
+    legacyHarness.setup()
+    legacyHarness.initializeState(snapshot)
+    legacyHarness.open()
+    legacyHarness.setProcessingTime(processingTs)
+    legacyHarness.setProcessingTime(cadenceTs)
+    legacyHarness.extractOutputValues() shouldBe empty
+    val legacySnapshot = legacyHarness.snapshot(24L, cadenceTs)
+    legacyHarness.close()
+
+    val restoredFunction =
+      new GigaTileProcessFunction(groupBy, inputSchema, bufferingOutputTimeMillis = cadenceMillis)
+    val restoredHarness = harness(restoredFunction)
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(legacySnapshot)
+      restoredHarness.open()
+      restoredHarness.setProcessingTime(cadenceTs)
+      advanceToHealthyLiveWatermark(restoredHarness, cadenceTs)
+      restoredHarness.processElement1(event(processingTs - 999L, 7L), processingTs - 999L)
+      setCurrentKey(restoredHarness, entityKey())
+      val repairedCadenceTs =
+        valueState[java.lang.Long](restoredFunction, "nextBufferedWriteTimerState").value().longValue()
+      repairedCadenceTs should be > cadenceTs
+      valueState[java.lang.Boolean](restoredFunction, "pendingPublicationState").value() shouldEqual
+        java.lang.Boolean.TRUE
+
+      restoredHarness.setProcessingTime(repairedCadenceTs)
+
+      val outputs = restoredHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldEqual 12L
+    } finally restoredHarness.close()
+  }
+
+  it should "flush a restored parked write through activation after buffering is disabled" in {
+    val cadenceMillis = 1000L
+    val function = new GigaTileProcessFunction(groupBy, inputSchema, bufferingOutputTimeMillis = cadenceMillis)
+    val cadenceTs = nextBufferedWriteTick(groupBy, entityKey(), processingTs, cadenceMillis)
+    val catchupThreshold = new Window(5, TimeUnit.MINUTES).millis + FlinkJob.CatchupWatermarkLagSlackMillis
+    val watermark = processingTs - catchupThreshold + (cadenceTs - processingTs) / 2L
+    val originalHarness = harness(function)
+    originalHarness.open()
+    originalHarness.setProcessingTime(processingTs)
+    advanceToLiveWatermark(originalHarness, watermark)
+    originalHarness.processElement1(event(watermark - 1L, 5L), watermark - 1L)
+    originalHarness.setProcessingTime(cadenceTs)
+    setCurrentKey(originalHarness, entityKey())
+    valueState[java.lang.Long](function, "nextBufferedWriteTimerState").value() shouldBe null
+    val snapshot = originalHarness.snapshot(22L, cadenceTs)
+    originalHarness.close()
+
+    val restoredFunction = new GigaTileProcessFunction(groupBy, inputSchema, bufferingOutputTimeMillis = 0L)
+    val restoredHarness = harness(restoredFunction)
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(snapshot)
+      restoredHarness.open()
+      restoredHarness.setProcessingTime(cadenceTs)
+      advanceToHealthyLiveWatermark(restoredHarness, cadenceTs)
+
+      val outputs = restoredHarness.extractOutputValues()
+      outputs should have size 1
+      decodeSum(outputs.get(0)) shouldEqual 5L
+      outputs.get(0).latestTsMillis shouldEqual cadenceTs
+      setCurrentKey(restoredHarness, entityKey())
+      valueState[java.lang.Long](restoredFunction, "bufferedWriteLatestTsState").value() shouldBe null
+      valueState[java.lang.Long](restoredFunction, "nextBufferedWriteTimerState").value() shouldBe null
+    } finally restoredHarness.close()
+  }
+
+  it should "schedule a stale buffered version collision strictly after the cadence callback" in {
+    val cadenceMillis = 1000L
+    val function = new GigaTileProcessFunction(groupBy, inputSchema, bufferingOutputTimeMillis = cadenceMillis)
+    val testHarness = harness(function)
+    val cadenceTs = nextBufferedWriteTick(groupBy, entityKey(), processingTs, cadenceMillis)
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(processingTs)
+      advanceToHealthyLiveWatermark(testHarness, processingTs)
+      testHarness.processElement1(event(processingTs - 1000L, 5L), processingTs - 1000L)
+      setCurrentKey(testHarness, entityKey())
+      valueState[java.lang.Long](function, "lastEmittedVersionState").update(processingTs)
+
+      testHarness.setProcessingTime(cadenceTs)
+
+      testHarness.extractOutputValues() shouldBe empty
+      setCurrentKey(testHarness, entityKey())
+      val collisionTs = valueState[java.lang.Long](function, "pendingVersionCollisionState").value().longValue()
+      collisionTs should be > cadenceTs
+      valueState[java.lang.Boolean](function, "pendingPublicationState").value() shouldEqual
+        java.lang.Boolean.TRUE
+      testHarness.setProcessingTime(collisionTs)
+      decodeSum(testHarness.extractOutputValues().get(0)) shouldEqual 5L
+      setCurrentKey(testHarness, entityKey())
+      valueState[java.lang.Boolean](function, "pendingPublicationState").value() shouldBe null
     } finally testHarness.close()
   }
 
@@ -1351,6 +1818,19 @@ object GigaTileProcessFunctionTest {
   private def nextDay(timestamp: Long): Long = {
     val dayMillis = new Window(1, TimeUnit.DAYS).millis
     TsUtils.round(timestamp, dayMillis) + dayMillis
+  }
+
+  private def nextBufferedWriteTick(
+      phaseGroupBy: GroupBy,
+      key: util.List[Any],
+      currentProcessingTime: Long,
+      cadenceMillis: Long
+  ): Long = {
+    val phase =
+      Math.floorMod((phaseGroupBy.getMetaData.getName :: key.iterator().asScala.toList).hashCode().toLong, cadenceMillis)
+    val elapsedSincePhase = Math.floorMod(Math.floorMod(currentProcessingTime, cadenceMillis) - phase, cadenceMillis)
+    val delay = if (elapsedSincePhase == 0L) cadenceMillis else cadenceMillis - elapsedSincePhase
+    currentProcessingTime + delay
   }
 
   private def currentProcessor(function: GigaTileProcessFunction): GigaTileStreamProcessor = {

--- a/online/src/test/scala/ai/chronon/online/test/GigaTileCodecRoundTripTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/GigaTileCodecRoundTripTest.scala
@@ -94,6 +94,8 @@ class GigaTileCodecRoundTripTest extends AnyFlatSpec {
     private var batchIrBytes: Array[Byte] = _
     private var batchEnd: Long = -1L
     private var runningLargeBytes: Array[Byte] = codec.encode(windowedAgg.init)
+    private var cachedSmallWindowAsOfTs: Long = -1L
+    private var lastLargeRecomputeAsOfTs: Long = Long.MinValue
 
     override def getTile(h: Long, t: Long): Array[Any] = tileBytes.get((h, t)).map(codec.decodeBaseIr).orNull
     override def putTile(h: Long, t: Long, ir: Array[Any]): Unit = tileBytes((h, t)) = codec.encodeBaseIr(ir)
@@ -122,6 +124,10 @@ class GigaTileCodecRoundTripTest extends AnyFlatSpec {
     override def putBatchEndTs(ts: Long): Unit = batchEnd = ts
     override def getRunningLargeIr: Array[Any] = codec.decode(runningLargeBytes)
     override def putRunningLargeIr(ir: Array[Any]): Unit = runningLargeBytes = codec.encode(ir)
+    override def getCachedSmallWindowAsOfTs: Long = cachedSmallWindowAsOfTs
+    override def putCachedSmallWindowAsOfTs(ts: Long): Unit = cachedSmallWindowAsOfTs = ts
+    override def getLastLargeRecomputeAsOfTs: Long = lastLargeRecomputeAsOfTs
+    override def putLastLargeRecomputeAsOfTs(ts: Long): Unit = lastLargeRecomputeAsOfTs = ts
 
     // Daily slot IRs are base-aggregator-shaped (one column per (op, input)) — fanned out
     // to per-window columns at recompute time via baseIrIndices.


### PR DESCRIPTION
## Summary

Layer 5 of 5, stacked on #2025 and based on [openai/chronon-private#154](https://github.com/openai/chronon-private/pull/154).

This adds an opt-in fallback for live keys that have not received a batch row while keeping real batch data authoritative and failing closed on source or decode errors.

GitHub shows the cumulative stack because the parent head is fork-only. [Incremental diff](https://github.com/simengyang/chronon/compare/582ee41df87442e640dbb2314d7be356540d404c...ade116c4b7c97d60335d309dc627ea17f2d173c1).

## Changes

- Enable the fallback only when `gigatile_first_seen_key_grace_millis` is positive; the default is disabled.
- Publish retained live state after grace when no batch row has arrived.
- Keep later real batch rows authoritative and preserve correction state across restore or disable.
- Require the Iceberg batch source when enabled.
- Fail closed on entity-row decode or update errors while ignoring only the serving-info metadata row.
- Document the enablement and rollback boundary.

## Operational notes

- Grace is a lower bound, not proof that the initial Iceberg scan completed. Validate real batch input, checkpoints, and serving output before routing traffic.
- To disable or roll back, fence output first and verify null corrections plus a later checkpoint before changing binaries or unfencing.
- Async sink acknowledgement and newer-version ordering remain external KV guarantees.

## Validation

- Exact final stack head `ade116c4b7c97d60335d309dc627ea17f2d173c1`: 164 focused GigaTile tests pass on Scala 2.12.18 and 164 pass on Scala 2.13.17 (328 total).
- `git diff --check` passes, as do formatting checks for all files changed by this stack.
- Not run: real Iceberg scan, external KV completion, production savepoint/rescale, load test, or OSS deployment.

## Checklist

- [x] Added Unit Tests
- [ ] Covered by existing CI
- [x] Integration tested
- [x] Documentation update
