### PR TITLE
Infer nested left-key types in JoinRequestKeys for chaining

### DIFF
--- a/online/src/main/scala/ai/chronon/online/fetcher/JoinRequestKeys.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/JoinRequestKeys.scala
@@ -8,7 +8,6 @@ import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 
 import scala.collection.mutable
-import scala.util.Try
 
 /** Translates a Join request's keys into the keys needed by each underlying GroupBy fetch.
   *
@@ -111,17 +110,49 @@ private[online] object JoinRequestKeys {
     leftSelects(join).get(leftKey).filter(_ != leftKey)
 
   private[fetcher] def rawInputs(expression: String): Seq[String] =
+    rawAttributePaths(expression).map(_.head).distinct
+
+  /** Full attribute paths referenced by a select expression, e.g. data.productId -> Seq("data", "productId"). */
+  private[fetcher] def rawAttributePaths(expression: String): Seq[Seq[String]] =
     CatalystSqlParser
       .parseExpression(expression)
       .collect { case attr: UnresolvedAttribute =>
-        attr.nameParts.head
+        attr.nameParts.toSeq
       }
+      .filter(_.nonEmpty)
       .distinct
 
-  private def rawInputType(servingInfo: GroupByServingInfoParsed,
-                           requestKey: String,
-                           fallbackType: DataType): DataType =
-    Try(servingInfo.inputChrononSchema.typeOf(requestKey)).toOption.flatten.getOrElse(fallbackType)
+  /** Build the Catalyst input type for a top-level request field from a nested attribute path.
+    *
+    * Left-key selects often extract flat Join keys from nested Kafka envelopes
+    * (CAST(data.productId AS BIGINT)). Join metadata does not carry the left topic schema at codec
+    * build time, and the right GroupBy input schema is a different entity — so we infer a minimal
+    * struct shaped like the path, with the mapped GroupBy key type as the leaf.
+    */
+  private[fetcher] def requestFieldType(path: Seq[String], leafType: DataType): (String, DataType) = {
+    require(path.nonEmpty, "attribute path must be non-empty")
+    val nestedType = path.tail.foldRight(leafType) { (name, innerType) =>
+      StructType(s"${name}_struct", Array(StructField(name, innerType)))
+    }
+    path.head -> nestedType
+  }
+
+  private[fetcher] def mergeTypes(left: DataType, right: DataType): DataType =
+    (left, right) match {
+      case (leftStruct: StructType, rightStruct: StructType) =>
+        val merged = mutable.LinkedHashMap.empty[String, DataType]
+        (leftStruct.fields ++ rightStruct.fields).foreach { field =>
+          merged.get(field.name) match {
+            case None             => merged.put(field.name, field.fieldType)
+            case Some(existing)   => merged.put(field.name, mergeTypes(existing, field.fieldType))
+          }
+        }
+        StructType(leftStruct.name, merged.map { case (name, dataType) => StructField(name, dataType) }.toArray)
+      case (leftStruct: StructType, _) => leftStruct
+      case (_, rightStruct: StructType) => rightStruct
+      case _ if left == right           => left
+      case _                            => left
+    }
 
   def valueInfoLeftKeys(join: Join, joinPart: JoinPartOps): Iterable[String] =
     joinPart.leftToRight.keys.toSeq.flatMap { leftKey =>
@@ -130,14 +161,19 @@ private[online] object JoinRequestKeys {
 
   private def requestKeyFields(join: Join,
                                joinPart: JoinPartOps,
-                               servingInfo: GroupByServingInfoParsed,
-                               rawInputsByLeftKey: Map[String, Seq[String]]): Iterable[StructField] = {
+                               servingInfo: GroupByServingInfoParsed): Iterable[StructField] = {
     val keySchema = servingInfo.keyCodec.chrononSchema.asInstanceOf[StructType]
     val fieldsByRightKey = keySchema.fields.map(field => field.name -> field).toMap
-    val fieldsByRequestKey = mutable.LinkedHashMap.empty[String, StructField]
+    val fieldsByRequestKey = mutable.LinkedHashMap.empty[String, DataType]
+
+    def putOrMerge(name: String, dataType: DataType): Unit =
+      fieldsByRequestKey.get(name) match {
+        case None           => fieldsByRequestKey.put(name, dataType)
+        case Some(existing) => fieldsByRequestKey.put(name, mergeTypes(existing, dataType))
+      }
 
     joinPart.leftToRight.foreach { case (leftKey, rightKey) =>
-      val fieldType = fieldsByRightKey
+      val leafType = fieldsByRightKey
         .getOrElse(
           rightKey,
           throw new IllegalArgumentException(
@@ -145,18 +181,23 @@ private[online] object JoinRequestKeys {
               s"but $rightKey is not present in GroupBy key schema ${keySchema.fields.map(_.name).mkString(", ")}")
         )
         .fieldType
-      val requestKeys = rawInputsByLeftKey.getOrElse(leftKey, Seq(leftKey))
-      requestKeys.foreach { requestKey =>
-        if (!fieldsByRequestKey.contains(requestKey)) {
-          fieldsByRequestKey.put(requestKey, StructField(requestKey, rawInputType(servingInfo, requestKey, fieldType)))
-        }
+
+      selectExpression(join, leftKey) match {
+        case Some(expression) =>
+          rawAttributePaths(expression).foreach { path =>
+            val (root, dataType) = requestFieldType(path, leafType)
+            putOrMerge(root, dataType)
+          }
+        case None =>
+          putOrMerge(leftKey, leafType)
       }
+
       if (!fieldsByRequestKey.contains(leftKey)) {
-        fieldsByRequestKey.put(leftKey, StructField(leftKey, fieldType))
+        putOrMerge(leftKey, leafType)
       }
     }
 
-    fieldsByRequestKey.values
+    fieldsByRequestKey.map { case (name, dataType) => StructField(name, dataType) }
   }
 
   def buildKeyMapping(join: Join, joinPart: JoinPartOps, servingInfo: GroupByServingInfoParsed): KeyMapping = {
@@ -171,7 +212,7 @@ private[online] object JoinRequestKeys {
         }
         .getOrElse(Seq(leftKey))
     }.toMap
-    val keyFields = requestKeyFields(join, joinPart, servingInfo, rawInputsByLeftKey)
+    val keyFields = requestKeyFields(join, joinPart, servingInfo)
     val catalystUtil =
       if (selectedLeftKeys.isEmpty) None
       else

--- a/online/src/test/scala/ai/chronon/online/fetcher/JoinRequestKeysTest.scala
+++ b/online/src/test/scala/ai/chronon/online/fetcher/JoinRequestKeysTest.scala
@@ -5,7 +5,7 @@ import ai.chronon.api._
 import ai.chronon.online.GroupByServingInfoParsed
 import ai.chronon.online.fetcher.Fetcher.Request
 import ai.chronon.online.serde.AvroConversions
-import org.junit.Assert.{assertEquals, assertNotEquals}
+import org.junit.Assert.{assertEquals, assertNotEquals, assertTrue}
 import org.scalatest.flatspec.AnyFlatSpec
 
 class JoinRequestKeysTest extends AnyFlatSpec {
@@ -13,6 +13,11 @@ class JoinRequestKeysTest extends AnyFlatSpec {
   private val groupBy = Builders.GroupBy(
     metaData = Builders.MetaData(name = "unit_test.query_group_by"),
     keyColumns = Seq("query_normalized")
+  )
+
+  private val productGroupBy = Builders.GroupBy(
+    metaData = Builders.MetaData(name = "unit_test.product_hydrate"),
+    keyColumns = Seq("product_id")
   )
 
   private def join(selectExpr: String, setups: Seq[String] = Seq.empty): Join =
@@ -32,14 +37,37 @@ class JoinRequestKeysTest extends AnyFlatSpec {
         ))
     )
 
-  private def servingInfo(inputSchema: StructType): GroupByServingInfoParsed = {
+  private def productViewJoin(selects: Map[String, String]): Join =
+    Builders.Join(
+      metaData = Builders.MetaData(name = "unit_test.product_views_hydrated"),
+      left = Builders.Source.events(
+        query = Builders.Query(selects = selects),
+        table = "unit_test.product_views"
+      ),
+      joinParts = Seq(
+        Builders.JoinPart(
+          groupBy = productGroupBy,
+          keyMapping = Map("product_id" -> "product_id")
+        ))
+    )
+
+  private def servingInfo(inputSchema: StructType,
+                          gb: GroupBy = groupBy,
+                          keyFields: Array[StructField] = Array(StructField("query_normalized", StringType)))
+      : GroupByServingInfoParsed = {
     val groupByServingInfo = new GroupByServingInfo()
-    groupByServingInfo.setGroupBy(groupBy)
-    groupByServingInfo.setKeyAvroSchema(
-      AvroConversions.fromChrononSchema(StructType("Key", Array(StructField("query_normalized", StringType)))).toString)
+    groupByServingInfo.setGroupBy(gb)
+    groupByServingInfo.setKeyAvroSchema(AvroConversions.fromChrononSchema(StructType("Key", keyFields)).toString)
     groupByServingInfo.setInputAvroSchema(AvroConversions.fromChrononSchema(inputSchema).toString)
     new GroupByServingInfoParsed(groupByServingInfo)
   }
+
+  private def productServingInfo(inputSchema: StructType): GroupByServingInfoParsed =
+    servingInfo(
+      inputSchema,
+      gb = productGroupBy,
+      keyFields = Array(StructField("product_id", LongType))
+    )
 
   it should "include join left selects in cached key mapping keys" in {
     val firstJoin = join("lower(query)")
@@ -128,5 +156,74 @@ class JoinRequestKeysTest extends AnyFlatSpec {
       Map("query_normalized" -> "shoes"),
       JoinRequestKeys.deriveLeftKeys(request, queryJoin, joinPart, keyServingInfo)
     )
+  }
+
+  it should "infer nested struct types from left-key select paths" in {
+    assertEquals(
+      "data" -> StructType("productId_struct", Array(StructField("productId", LongType))),
+      JoinRequestKeys.requestFieldType(Seq("data", "productId"), LongType)
+    )
+    assertEquals(
+      "data" -> StructType(
+        "baseEvent_struct",
+        Array(
+          StructField(
+            "baseEvent",
+            StructType("userId_struct", Array(StructField("userId", LongType)))
+          ))),
+      JoinRequestKeys.requestFieldType(Seq("data", "baseEvent", "userId"), LongType)
+    )
+  }
+
+  it should "merge nested struct types that share a root" in {
+    val productIdType = JoinRequestKeys.requestFieldType(Seq("data", "productId"), LongType)._2
+    val userIdType = JoinRequestKeys.requestFieldType(Seq("data", "baseEvent", "userId"), LongType)._2
+    val merged = JoinRequestKeys.mergeTypes(productIdType, userIdType).asInstanceOf[StructType]
+
+    assertEquals(Set("productId", "baseEvent"), merged.fields.map(_.name).toSet)
+    assertEquals(LongType, merged.typeOf("productId").get)
+    val baseEvent = merged.typeOf("baseEvent").get.asInstanceOf[StructType]
+    assertEquals(LongType, baseEvent.typeOf("userId").get)
+  }
+
+  it should "build join codec key mapping for nested Avro left selects without using right GroupBy input schema" in {
+    // Right GroupBy input schema has no usable nested `data` struct (or a wrong scalar), which is
+    // what previously caused rawInputType to fall back to the product_id LongType.
+    val wrongHydrateInput = StructType(
+      "HydrateInput",
+      Array(
+        StructField("product_id", LongType),
+        StructField("data", StringType)
+      )
+    )
+    val keyServingInfo = productServingInfo(wrongHydrateInput)
+    val viewsJoin = productViewJoin(
+      Map(
+        "product_id" -> "CAST(data.productId AS BIGINT)",
+        "user_id" -> "CAST(data.baseEvent.userId AS BIGINT)"
+      ))
+    val joinPart = viewsJoin.joinPartOps.head
+
+    val keyMapping = JoinRequestKeys.buildKeyMapping(viewsJoin, joinPart, keyServingInfo)
+    val dataField = keyMapping.requestKeyFields.find(_.name == "data").get
+    assertTrue(dataField.fieldType.isInstanceOf[StructType])
+    val dataStruct = dataField.fieldType.asInstanceOf[StructType]
+    assertEquals(LongType, dataStruct.typeOf("productId").get)
+
+    // Catalyst planning must succeed (this is where Flink join-codec build previously failed).
+    assertTrue(keyMapping.catalystUtil.isDefined)
+  }
+
+  it should "type deeper nested left selects for join codec Catalyst planning" in {
+    val keyServingInfo = productServingInfo(StructType("HydrateInput", Array(StructField("seller_id", LongType))))
+    val viewsJoin = productViewJoin(
+      Map(
+        "product_id" -> "CAST(data.baseEvent.userId AS BIGINT)"
+      ))
+    val keyMapping = JoinRequestKeys.buildKeyMapping(viewsJoin, viewsJoin.joinPartOps.head, keyServingInfo)
+    val dataStruct = keyMapping.requestKeyFields.find(_.name == "data").get.fieldType.asInstanceOf[StructType]
+    val baseEvent = dataStruct.typeOf("baseEvent").get.asInstanceOf[StructType]
+    assertEquals(LongType, baseEvent.typeOf("userId").get)
+    assertTrue(keyMapping.catalystUtil.isDefined)
   }
 }


### PR DESCRIPTION
## Summary

Fixes Flink ChainedGroupBy / join-codec startup failures when a Join left source extracts flat keys from nested Kafka Avro paths, e.g.:

```scala
product_id = CAST(data.productId AS BIGINT)
user_id   = CAST(data.baseEvent.userId AS BIGINT)
```

**Bug:** `JoinRequestKeys.rawInputType` typed raw inputs of those left selects from the **right GroupBy** `inputChrononSchema`. When that schema has no matching nested `data` (hydrate ≠ product-view envelope), it fell back to the GroupBy key type (`BIGINT`). Catalyst then failed with:

```
INVALID_EXTRACT_BASE_FIELD_TYPE: Can't extract a value from "data" ... got "BIGINT"
Failure to build join codec for join ... due to bad groupBy serving info for ...hydrate...
```

This hits both Flink `buildJoinCodec` at chained job startup and the online fetcher when deriving nested keys.

**Fix:** Stop looking up types on the right GroupBy input schema. Infer a minimal nested `StructType` from the select expression's attribute path (`UnresolvedAttribute.nameParts`), using the mapped GroupBy key type as the leaf. Flat transforms like `lower(query)` are unchanged.

Reproduced at Depop on `ranking.user.views.enriched` + `ranking.product.hydrate.latest_value` (and earlier on `ranking.product.views.hydrated` chaining).

## Test plan

- [x] `./mill online.test.testOnly "ai.chronon.online.fetcher.JoinRequestKeysTest"` (10/10 pass)
- [ ] CI online tests
- [ ] After release: redeploy Depop `ranking.user.views.enriched` / JoinSource GroupBys that use nested Avro left selects and confirm Flink chained jobs start


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved join-request key inference for nested Avro struct fields.
  * Correctly merges overlapping nested key paths into a consistent structure.
  * Supports deeper nested fields during join key mapping and Catalyst planning.
  * Prevents failures when hydrate inputs have mismatched or unusable nested shapes.

* **Tests**
  * Added coverage for nested, overlapping, and deeply nested join-key paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->