### PR TITLE
fix(JoinRequestKeys): fix online join key derivation for expressions that use fields from a struct

### DIFF
--- a/online/src/main/scala/ai/chronon/online/fetcher/JoinRequestKeys.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/JoinRequestKeys.scala
@@ -65,9 +65,32 @@ private[online] object JoinRequestKeys {
         if (keysToDerive.isEmpty) {
           Map.empty[String, Any]
         } else {
-          val derivedValues = catalystUtil
-            .map(_.performSql(request.keys).headOption.getOrElse(Map.empty))
-            .getOrElse(Map.empty)
+          // Input types are inferred, so mismatched caller values fail deep in Catalyst encoding -
+          // surface expected-vs-actual here instead.
+          val derivedValues =
+            try {
+              catalystUtil
+                .map(_.performSql(request.keys).headOption.getOrElse(Map.empty))
+                .getOrElse(Map.empty)
+            } catch {
+              case e: Exception =>
+                val expectedVsActual = requestKeyFields
+                  .map { field =>
+                    val actual = request.keys.get(field.name) match {
+                      case Some(null) => "null"
+                      case Some(value) => value.getClass.getName
+                      case None => "<missing>"
+                    }
+                    s"${field.name}: expected ${field.fieldType}, got $actual"
+                  }
+                  .mkString("; ")
+                throw new IllegalArgumentException(
+                  s"Failed to derive left keys [${keysToDerive.map { case (k, expr) => s"$k=$expr" }.mkString(", ")}] " +
+                    s"for join ${request.name}. Request key types may not match the inferred input schema " +
+                    s"($expectedVsActual)",
+                  e
+                )
+            }
           keysToDerive.map { case (leftKey, _) =>
             leftKey -> derivedValues.getOrElse(leftKey, null)
           }.toMap
@@ -110,18 +133,42 @@ private[online] object JoinRequestKeys {
   private def selectExpression(join: Join, leftKey: String): Option[String] =
     leftSelects(join).get(leftKey).filter(_ != leftKey)
 
-  private[fetcher] def rawInputs(expression: String): Seq[String] =
+  private[fetcher] def rawInputPaths(expression: String): Seq[Seq[String]] =
     CatalystSqlParser
       .parseExpression(expression)
       .collect { case attr: UnresolvedAttribute =>
-        attr.nameParts.head
+        attr.nameParts
       }
       .distinct
 
+  private[fetcher] def rawInputs(expression: String): Seq[String] =
+    rawInputPaths(expression).map(_.head).distinct
+
   private def rawInputType(servingInfo: GroupByServingInfoParsed,
                            requestKey: String,
-                           fallbackType: DataType): DataType =
-    Try(servingInfo.inputChrononSchema.typeOf(requestKey)).toOption.flatten.getOrElse(fallbackType)
+                           pathTypes: Seq[(Seq[String], DataType)]): DataType =
+    Try(servingInfo.inputChrononSchema.typeOf(requestKey)).toOption.flatten.getOrElse {
+      val nested = pathTypes.filter { case (path, _) => path.nonEmpty }
+      if (nested.isEmpty) pathTypes.head._2
+      else syntheticStructType(requestKey, nested)
+    }
+
+  // Left-source struct columns are invisible to the GroupBy input schema; leaf types fall back to
+  // the mapped right key's type.
+  private def syntheticStructType(name: String, pathTypes: Seq[(Seq[String], DataType)]): StructType = {
+    val pathTypesByField = mutable.LinkedHashMap.empty[String, mutable.ArrayBuffer[(Seq[String], DataType)]]
+    pathTypes.foreach { case (path, leafType) =>
+      pathTypesByField.getOrElseUpdate(path.head, mutable.ArrayBuffer.empty) += (path.tail -> leafType)
+    }
+    val fields = pathTypesByField.map { case (fieldName, fieldPathTypes) =>
+      val nested = fieldPathTypes.filter { case (path, _) => path.nonEmpty }
+      val fieldType =
+        if (nested.isEmpty) fieldPathTypes.head._2
+        else syntheticStructType(s"${name}_$fieldName", nested.toSeq)
+      StructField(fieldName, fieldType)
+    }.toArray
+    StructType(name, fields)
+  }
 
   def valueInfoLeftKeys(join: Join, joinPart: JoinPartOps): Iterable[String] =
     joinPart.leftToRight.keys.toSeq.flatMap { leftKey =>
@@ -131,13 +178,12 @@ private[online] object JoinRequestKeys {
   private def requestKeyFields(join: Join,
                                joinPart: JoinPartOps,
                                servingInfo: GroupByServingInfoParsed,
-                               rawInputsByLeftKey: Map[String, Seq[String]]): Iterable[StructField] = {
+                               rawInputPathsByLeftKey: Map[String, Seq[Seq[String]]]): Iterable[StructField] = {
     val keySchema = servingInfo.keyCodec.chrononSchema.asInstanceOf[StructType]
     val fieldsByRightKey = keySchema.fields.map(field => field.name -> field).toMap
-    val fieldsByRequestKey = mutable.LinkedHashMap.empty[String, StructField]
 
-    joinPart.leftToRight.foreach { case (leftKey, rightKey) =>
-      val fieldType = fieldsByRightKey
+    def rightKeyType(leftKey: String, rightKey: String): DataType =
+      fieldsByRightKey
         .getOrElse(
           rightKey,
           throw new IllegalArgumentException(
@@ -145,10 +191,24 @@ private[online] object JoinRequestKeys {
               s"but $rightKey is not present in GroupBy key schema ${keySchema.fields.map(_.name).mkString(", ")}")
         )
         .fieldType
-      val requestKeys = rawInputsByLeftKey.getOrElse(leftKey, Seq(leftKey))
-      requestKeys.foreach { requestKey =>
+
+    val pathTypesByRequestKey = mutable.LinkedHashMap.empty[String, mutable.ArrayBuffer[(Seq[String], DataType)]]
+    joinPart.leftToRight.foreach { case (leftKey, rightKey) =>
+      val fieldType = rightKeyType(leftKey, rightKey)
+      rawInputPathsByLeftKey.getOrElse(leftKey, Seq(Seq(leftKey))).foreach { path =>
+        pathTypesByRequestKey.getOrElseUpdate(path.head, mutable.ArrayBuffer.empty) += (path.tail -> fieldType)
+      }
+    }
+
+    val fieldsByRequestKey = mutable.LinkedHashMap.empty[String, StructField]
+    joinPart.leftToRight.foreach { case (leftKey, rightKey) =>
+      val fieldType = rightKeyType(leftKey, rightKey)
+      rawInputPathsByLeftKey.getOrElse(leftKey, Seq(Seq(leftKey))).foreach { path =>
+        val requestKey = path.head
         if (!fieldsByRequestKey.contains(requestKey)) {
-          fieldsByRequestKey.put(requestKey, StructField(requestKey, rawInputType(servingInfo, requestKey, fieldType)))
+          fieldsByRequestKey.put(
+            requestKey,
+            StructField(requestKey, rawInputType(servingInfo, requestKey, pathTypesByRequestKey(requestKey).toSeq)))
         }
       }
       if (!fieldsByRequestKey.contains(leftKey)) {
@@ -171,7 +231,15 @@ private[online] object JoinRequestKeys {
         }
         .getOrElse(Seq(leftKey))
     }.toMap
-    val keyFields = requestKeyFields(join, joinPart, servingInfo, rawInputsByLeftKey)
+    val rawInputPathsByLeftKey = joinPart.leftToRight.keys.map { leftKey =>
+      leftKey -> selectedLeftKeys
+        .find(_._1 == leftKey)
+        .map { case (_, expression) =>
+          rawInputPaths(expression)
+        }
+        .getOrElse(Seq(Seq(leftKey)))
+    }.toMap
+    val keyFields = requestKeyFields(join, joinPart, servingInfo, rawInputPathsByLeftKey)
     val catalystUtil =
       if (selectedLeftKeys.isEmpty) None
       else

--- a/online/src/main/scala/ai/chronon/online/fetcher/JoinRequestKeys.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/JoinRequestKeys.scala
@@ -77,9 +77,9 @@ private[online] object JoinRequestKeys {
                 val expectedVsActual = requestKeyFields
                   .map { field =>
                     val actual = request.keys.get(field.name) match {
-                      case Some(null) => "null"
+                      case Some(null)  => "null"
                       case Some(value) => value.getClass.getName
-                      case None => "<missing>"
+                      case None        => "<missing>"
                     }
                     s"${field.name}: expected ${field.fieldType}, got $actual"
                   }

--- a/online/src/test/scala/ai/chronon/online/fetcher/JoinRequestKeysTest.scala
+++ b/online/src/test/scala/ai/chronon/online/fetcher/JoinRequestKeysTest.scala
@@ -32,11 +32,15 @@ class JoinRequestKeysTest extends AnyFlatSpec {
         ))
     )
 
-  private def servingInfo(inputSchema: StructType): GroupByServingInfoParsed = {
+  private def servingInfo(inputSchema: StructType): GroupByServingInfoParsed =
+    servingInfo(groupBy, StructType("Key", Array(StructField("query_normalized", StringType))), inputSchema)
+
+  private def servingInfo(groupBy: GroupBy,
+                          keySchema: StructType,
+                          inputSchema: StructType): GroupByServingInfoParsed = {
     val groupByServingInfo = new GroupByServingInfo()
     groupByServingInfo.setGroupBy(groupBy)
-    groupByServingInfo.setKeyAvroSchema(
-      AvroConversions.fromChrononSchema(StructType("Key", Array(StructField("query_normalized", StringType)))).toString)
+    groupByServingInfo.setKeyAvroSchema(AvroConversions.fromChrononSchema(keySchema).toString)
     groupByServingInfo.setInputAvroSchema(AvroConversions.fromChrononSchema(inputSchema).toString)
     new GroupByServingInfoParsed(groupByServingInfo)
   }
@@ -115,6 +119,47 @@ class JoinRequestKeysTest extends AnyFlatSpec {
         queryJoin,
         joinPart)
     )
+  }
+
+  it should "derive GroupBy keys from struct-extracting select expressions" in {
+    val testGroupBy = Builders.GroupBy(
+      metaData = Builders.MetaData(name = "unit_test.test_group_by"),
+      keyColumns = Seq("test_id")
+    )
+    val testJoin = Builders.Join(
+      metaData = Builders.MetaData(name = "unit_test.test_join"),
+      left = Builders.Source.events(
+        query = Builders.Query(selects = Map("test_id" -> "CAST(data.testId AS BIGINT)")),
+        table = "unit_test.test_events"
+      ),
+      joinParts = Seq(
+        Builders.JoinPart(
+          groupBy = testGroupBy,
+          keyMapping = Map("testId" -> "test_id")
+        ))
+    )
+    val joinPart = testJoin.joinPartOps.head
+
+    val keyServingInfo = servingInfo(
+      testGroupBy,
+      StructType("Key", Array(StructField("test_id", LongType))),
+      StructType("Input", Array(StructField("test_id", LongType)))
+    )
+    val request = Request(testJoin.metaData.name, Map("data" -> Map("testId" -> 123L)))
+
+    assertEquals(
+      Map("test_id" -> 123L),
+      JoinRequestKeys.deriveLeftKeys(request, testJoin, joinPart, keyServingInfo)
+    )
+
+    // Wrong-shaped value: scalar where the inferred schema expects a struct.
+    val badRequest = Request(testJoin.metaData.name, Map("data" -> "not-a-struct"))
+    val thrown = intercept[IllegalArgumentException] {
+      JoinRequestKeys.deriveLeftKeys(badRequest, testJoin, joinPart, keyServingInfo)
+    }
+    assert(thrown.getMessage.contains("test_id=CAST(data.testId AS BIGINT)"))
+    assert(thrown.getMessage.contains("data: expected"))
+    assert(thrown.getMessage.contains("got java.lang.String"))
   }
 
   it should "derive GroupBy keys from raw request keys" in {

--- a/online/src/test/scala/ai/chronon/online/fetcher/JoinRequestKeysTest.scala
+++ b/online/src/test/scala/ai/chronon/online/fetcher/JoinRequestKeysTest.scala
@@ -132,11 +132,7 @@ class JoinRequestKeysTest extends AnyFlatSpec {
         query = Builders.Query(selects = Map("test_id" -> "CAST(data.testId AS BIGINT)")),
         table = "unit_test.test_events"
       ),
-      joinParts = Seq(
-        Builders.JoinPart(
-          groupBy = testGroupBy,
-          keyMapping = Map("testId" -> "test_id")
-        ))
+      joinParts = Seq(Builders.JoinPart(groupBy = testGroupBy))
     )
     val joinPart = testJoin.joinPartOps.head
 


### PR DESCRIPTION
## Summary
Fixes online join key derivation for chaining when a left-side select expression
un-nests a value from a struct (e.g. `test_id = CAST(data.testId AS BIGINT)`).

Previously the fetcher collapsed the expression's inputs to the base column 
and typed it with the mapped GroupBy key's type and the struct was treated as the
key's type (i.e. `BIGINT` instead of `STRUCT`) and field extraction would fail. 

```Can't extract a value from "data". Need a complex type [STRUCT, ARRAY, MAP] but got "BIGINT"```

This should now track full extraction paths and synthesize a minimal
struct type from the fields the expressions actually access.

Worth noting, leaf types within this synthesized struct are still inferred from the mapped
GroupBy key's type. To compensate, type-mismatch failures
now raise a more descriptive error naming the join, the expression, and the
expected v actual type per request key.


## Checklist
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for deriving join request keys from nested input fields and struct-based select expressions.
  * Improved construction of complex request-key schemas from nested attribute paths.

* **Bug Fixes**
  * Enhanced validation with clearer, join-specific error messages when request key values have incompatible shapes or types.
  * Error details now include the relevant expressions and expected vs. actual JVM types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->