### PR TITLE
[chronon] Fence GigaTile writes until the batch baseline is ready

### DIFF
--- a/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/GigaTileProcessFunction.scala
@@ -60,7 +60,7 @@ class GigaTileProcessFunction(
 
   @transient private var eventProcessingErrorCounter: Counter = _
   @transient private var batchUpdateCounter: Counter = _
-  @transient private var futureEventDropCounter: Counter = _
+  @transient private var futureEventClampCounter: Counter = _
   @transient private var lastKey: java.util.List[Any] = _
   // Deliberately operator-local and not checkpointed. Recovery starts a fresh delay on its first
   // keyed callback before an unseen batch row can be treated as empty history.
@@ -104,7 +104,7 @@ class GigaTileProcessFunction(
       .addGroup("feature_group", groupBy.getMetaData.getName)
     eventProcessingErrorCounter = metricsGroup.counter("event_processing_error")
     batchUpdateCounter = metricsGroup.counter("batch_update_count")
-    futureEventDropCounter = metricsGroup.counter("future_event_drop_count")
+    futureEventClampCounter = metricsGroup.counter("future_event_clamp_count")
 
     tileState = getRuntimeContext.getMapState(
       new MapStateDescriptor[String, Array[Byte]]("giga-tile-tiles", classOf[String], classOf[Array[Byte]]))
@@ -200,13 +200,19 @@ class GigaTileProcessFunction(
   private def startEmptyBatchGrace(currentProcessingTime: Long): Unit = {
     if (!firstSeenKeyGraceEnabled) {
       // Synthetic availability lives outside the legacy batch-IR descriptor so both a config
-      // rollback and an older binary return to the normal null fence. Keep the legacy pending
-      // publication marker armed so the next callback retracts any synthetic value already
-      // handed to KV.
+      // rollback and an older binary return to the normal null fence. If the synthetic value
+      // reached KV, preserve its keyed correction marker until the null-fenced replacement is
+      // handed off.
+      val needsRollbackCorrection =
+        hasRawPendingPublication && (flinkStore.hasSyntheticBatchIr || hasSyntheticRollbackCorrection)
       emptyBatchBaselineSafeAfterMillis = null
       pendingEmptyBatchBaselineState.clear()
       flinkStore.clearSyntheticBatchIr()
-      syntheticRollbackCorrectionState.clear()
+      if (needsRollbackCorrection) {
+        syntheticRollbackCorrectionState.update(java.lang.Boolean.TRUE)
+      } else {
+        syntheticRollbackCorrectionState.clear()
+      }
     } else {
       // A pre-fallback binary understands pendingPublicationState but not the two synthetic
       // markers. If it cleared pending state, it already handed off the null-fenced correction;
@@ -340,20 +346,24 @@ class GigaTileProcessFunction(
     scheduleBufferedWriteTimerIfNeeded(timerService, versionMillis)
   }
 
-  private def isFutureEvent(eventTime: Long, currentProcessingTime: Long): Boolean =
-    eventTime > currentProcessingTime
-
   private def hasRawPendingPublication: Boolean =
     java.lang.Boolean.TRUE.equals(pendingPublicationState.value())
 
   private def hasSyntheticRollbackCorrection: Boolean =
     java.lang.Boolean.TRUE.equals(syntheticRollbackCorrectionState.value())
 
+  private def requiresNullBaselineCorrection: Boolean =
+    hasRawPendingPublication && hasSyntheticRollbackCorrection && !flinkStore.hasSyntheticBatchIr
+
   private def hasPendingPublication: Boolean =
-    hasRawPendingPublication && !hasSyntheticRollbackCorrection && pendingVersionCollisionState.value() == null
+    hasRawPendingPublication &&
+      (!hasSyntheticRollbackCorrection || requiresNullBaselineCorrection) &&
+      pendingVersionCollisionState.value() == null
 
   private def markPublicationPending(): Unit = {
-    syntheticRollbackCorrectionState.clear()
+    if (!requiresNullBaselineCorrection) {
+      syntheticRollbackCorrectionState.clear()
+    }
     pendingPublicationState.update(java.lang.Boolean.TRUE)
   }
 
@@ -494,6 +504,9 @@ class GigaTileProcessFunction(
       currentProcessingTime: Long
   ): Boolean = {
     val currentDayStart = flinkStore.getCurrentDayStart
+    val hasPublicationBaseline =
+      !processor.hasBatchBackedColumns || flinkStore.getBatchIr != null || requiresNullBaselineCorrection
+    hasPublicationBaseline &&
     ChrononClockMode.allowsPublication(mode) &&
     horizons.largeWindowAsOfMillis == currentProcessingTime &&
     !(currentDayStart >= 0L && flinkStore.getBatchEndTs > currentDayStart)
@@ -858,10 +871,8 @@ class GigaTileProcessFunction(
       if (processor == null) initializeTransients()
 
       val element = event.fields
-      val tsMills = Try(element(timeColumnAlias).asInstanceOf[Long])
+      val eventTimeMillis = Try(element(timeColumnAlias).asInstanceOf[Long])
         .getOrElse(element(timeColumnAlias).asInstanceOf[Double].toLong)
-      val values: Array[Any] = valueColumns.map(element(_))
-      val row = new ArrayRow(values, tsMills)
 
       ensureStateBound(ctx.getCurrentKey)
       val timerService = ctx.timerService()
@@ -869,26 +880,32 @@ class GigaTileProcessFunction(
       startEmptyBatchGrace(currentProcessingTime)
       repairExpiredProcessingTimerMarkers(timerService, currentProcessingTime, None)
       repairStaleBufferedWriteTimerIfNeeded(timerService, currentProcessingTime, None)
-      if (isFutureEvent(tsMills, currentProcessingTime)) {
-        futureEventDropCounter.inc()
-        return
-      }
+      val effectiveEventTimeMillis =
+        if (eventTimeMillis > currentProcessingTime) {
+          futureEventClampCounter.inc()
+          currentProcessingTime
+        } else {
+          eventTimeMillis
+        }
+      val values: Array[Any] =
+        valueColumns.map(column => if (column == timeColumnAlias) effectiveEventTimeMillis else element(column))
+      val row = new ArrayRow(values, effectiveEventTimeMillis)
       clearExpiredPublicationRetryMarker(currentProcessingTime, None)
       markEmptyBatchBaselinePendingIfNeeded()
       val eventTimeWatermark = timerService.currentWatermark()
       val mode = currentClockMode(currentProcessingTime, eventTimeWatermark)
       val horizons = ChrononClockMode.streamEventHorizons(mode,
-                                                          tsMills,
+                                                          effectiveEventTimeMillis,
                                                           currentProcessingTime,
                                                           eventTimeWatermark,
                                                           processor.minSmallWindowTileSize)
 
       val rolloverResult =
-        if (mode == NoWatermark) processor.advanceDayAsOf(tsMills)
+        if (mode == NoWatermark) processor.advanceDayAsOf(effectiveEventTimeMillis)
         else advanceDayForMode(mode, currentProcessingTime, eventTimeWatermark)
       val pendingRebuild = rebuildPendingAtCurrentTime(mode, horizons, currentProcessingTime)
       val eventResult = processor.onEvent(row,
-                                          tsMills,
+                                          effectiveEventTimeMillis,
                                           largeWindowAsOfTs = horizons.largeWindowAsOfMillis,
                                           smallWindowAsOfTs = horizons.smallWindowAsOfMillis)
       val callbackResult = preferLatestResult(eventResult, pendingRebuild.getOrElse(rolloverResult))

--- a/flink/src/test/scala/ai/chronon/flink/test/window/GigaTileFirstSeenKeyGraceTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/window/GigaTileFirstSeenKeyGraceTest.scala
@@ -130,7 +130,7 @@ class GigaTileFirstSeenKeyGraceTest extends AnyFlatSpec with Matchers {
       testHarness.setProcessingTime(startProcessingTime)
       advanceConnectedHealthyLiveWatermark(testHarness, startProcessingTime)
       testHarness.processElement1(event(DefaultEntity, eventTime, 5L), eventTime)
-      decodeSum(testHarness.extractOutputValues().get(0), batchBackedGroupBy) shouldBe null
+      testHarness.extractOutputValues() shouldBe empty
 
       val batchProcessingTime = startProcessingTime + graceMillis / 2L
       testHarness.setProcessingTime(batchProcessingTime)
@@ -159,7 +159,7 @@ class GigaTileFirstSeenKeyGraceTest extends AnyFlatSpec with Matchers {
       testHarness.setProcessingTime(startProcessingTime)
       advanceConnectedHealthyLiveWatermark(testHarness, startProcessingTime)
       testHarness.processElement1(event(DefaultEntity, eventTime, 5L), eventTime)
-      decodeSum(testHarness.extractOutputValues().get(0), batchBackedGroupBy) shouldBe null
+      testHarness.extractOutputValues() shouldBe empty
 
       val baselineProcessingTime = startProcessingTime + 1L
       testHarness.setProcessingTime(baselineProcessingTime)
@@ -252,10 +252,6 @@ class GigaTileFirstSeenKeyGraceTest extends AnyFlatSpec with Matchers {
     val cadenceMillis = 100L
     val startProcessingTime = tenDays + oneHour
     val eventTime = startProcessingTime - 1000L
-    val firstCadence = nextBufferedWriteTick(batchBackedGroupBy,
-                                             entityKey(DefaultEntity),
-                                             startProcessingTime,
-                                             cadenceMillis)
     val originalFunction = new GigaTileProcessFunction(batchBackedGroupBy,
                                                        inputSchema,
                                                        bufferingOutputTimeMillis = cadenceMillis,
@@ -280,16 +276,17 @@ class GigaTileFirstSeenKeyGraceTest extends AnyFlatSpec with Matchers {
       restoredHarness.open()
       restoredHarness.setProcessingTime(startProcessingTime)
       advanceConnectedHealthyLiveWatermark(restoredHarness, startProcessingTime)
+      restoredHarness.processElement1(event(DefaultEntity, eventTime + 1L, 0L), eventTime + 1L)
 
-      // The restored cadence can flush the pre-grace null value, but must not install
-      // synthetic history or clear the keyed pending-grace marker.
-      restoredHarness.setProcessingTime(firstCadence)
+      // Restoring the pending key starts a fresh operator-local grace. It must not publish
+      // before a baseline is available, install synthetic history, or clear the keyed marker.
+      restoredHarness.extractOutputValues() shouldBe empty
       setCurrentKey(restoredHarness, entityKey(DefaultEntity))
       state[Array[Byte]](restoredFunction, "batchIrState").value() shouldBe null
       state[java.lang.Boolean](restoredFunction, "pendingEmptyBatchBaselineState").value() shouldEqual
         java.lang.Boolean.TRUE
 
-      val readyProcessingTime = firstCadence + graceMillis
+      val readyProcessingTime = startProcessingTime + graceMillis
       restoredHarness.setProcessingTime(readyProcessingTime)
       advanceConnectedHealthyLiveWatermark(restoredHarness, readyProcessingTime)
       restoredHarness.processElement1(event(DefaultEntity, readyProcessingTime - 1L, 0L), readyProcessingTime - 1L)
@@ -311,10 +308,13 @@ class GigaTileFirstSeenKeyGraceTest extends AnyFlatSpec with Matchers {
     } finally restoredHarness.close()
   }
 
-  it should "remove a restored synthetic baseline when the option is disabled" in {
+  it should "remove every restored synthetic baseline when the option is disabled" in {
     val graceMillis = 1000L
     val startProcessingTime = tenDays + oneHour
     val eventTime = startProcessingTime - 1000L
+    val firstKey = "entity-a"
+    val secondKey = "entity-b"
+    val keys = Seq(firstKey, secondKey)
     val originalFunction = new GigaTileProcessFunction(batchBackedGroupBy,
                                                        inputSchema,
                                                        firstSeenKeyGraceMillis = graceMillis)
@@ -323,20 +323,27 @@ class GigaTileFirstSeenKeyGraceTest extends AnyFlatSpec with Matchers {
     originalHarness.open()
     originalHarness.setProcessingTime(startProcessingTime)
     advanceConnectedHealthyLiveWatermark(originalHarness, startProcessingTime)
-    originalHarness.processElement1(event(DefaultEntity, eventTime, 5L), eventTime)
+    originalHarness.processElement1(event(firstKey, eventTime, 5L), eventTime)
+    originalHarness.processElement1(event(secondKey, eventTime, 7L), eventTime)
     val baselineProcessingTime = startProcessingTime + graceMillis + 1L
     originalHarness.setProcessingTime(baselineProcessingTime)
     advanceConnectedHealthyLiveWatermark(originalHarness, baselineProcessingTime)
-    originalHarness.processElement1(event(DefaultEntity, eventTime + 1L, 0L), eventTime + 1L)
-    decodeSum(originalHarness.extractOutputValues().asScala.last, batchBackedGroupBy) shouldEqual 5L
-    setCurrentKey(originalHarness, entityKey(DefaultEntity))
-    state[Array[Byte]](originalFunction, "batchIrState").value() shouldBe null
-    state[java.lang.Boolean](originalFunction, "syntheticEmptyBatchBaselineState").value() shouldEqual
-      java.lang.Boolean.TRUE
-    state[java.lang.Boolean](originalFunction, "pendingPublicationState").value() shouldEqual
-      java.lang.Boolean.TRUE
-    state[java.lang.Boolean](originalFunction, "syntheticRollbackCorrectionState").value() shouldEqual
-      java.lang.Boolean.TRUE
+    originalHarness.processElement1(event(firstKey, eventTime + 1L, 0L), eventTime + 1L)
+    originalHarness.processElement1(event(secondKey, eventTime + 1L, 0L), eventTime + 1L)
+    originalHarness.extractOutputValues().asScala
+      .map(output => output.keys.get(0).toString -> decodeSum(output, batchBackedGroupBy))
+      .toMap shouldEqual Map(firstKey -> 5L, secondKey -> 7L)
+    keys.foreach { key =>
+      setCurrentKey(originalHarness, entityKey(key))
+      state[Array[Byte]](originalFunction, "batchIrState").value() shouldBe null
+      state[java.lang.Boolean](originalFunction, "syntheticEmptyBatchBaselineState").value() shouldEqual
+        java.lang.Boolean.TRUE
+      state[java.lang.Boolean](originalFunction, "pendingPublicationState").value() shouldEqual
+        java.lang.Boolean.TRUE
+      state[java.lang.Boolean](originalFunction, "syntheticRollbackCorrectionState").value() shouldEqual
+        java.lang.Boolean.TRUE
+    }
+    setCurrentKey(originalHarness, entityKey(firstKey))
     val firstCorrectionTimer =
       state[java.lang.Long](originalFunction, "nextProcessingEvictionTimerState").value().longValue()
     val snapshot = originalHarness.snapshot(32L, baselineProcessingTime)
@@ -353,27 +360,102 @@ class GigaTileFirstSeenKeyGraceTest extends AnyFlatSpec with Matchers {
       // null-fenced correction so a C4 rollback cannot leave the old KV value serving.
       restoredHarness.setProcessingTime(firstCorrectionTimer)
       advanceConnectedHealthyLiveWatermark(restoredHarness, firstCorrectionTimer)
-      setCurrentKey(restoredHarness, entityKey(DefaultEntity))
-      state[java.lang.Boolean](restoredFunction, "syntheticEmptyBatchBaselineState").value() shouldBe null
-      state[java.lang.Boolean](restoredFunction, "syntheticRollbackCorrectionState").value() shouldBe null
-      state[java.lang.Boolean](restoredFunction, "pendingPublicationState").value() shouldEqual
-        java.lang.Boolean.TRUE
-      val liveCorrectionTimer =
+      val liveCorrectionTimers = keys.map { key =>
+        setCurrentKey(restoredHarness, entityKey(key))
+        state[java.lang.Boolean](restoredFunction, "syntheticEmptyBatchBaselineState").value() shouldBe null
+        state[java.lang.Boolean](restoredFunction, "syntheticRollbackCorrectionState").value() shouldEqual
+          java.lang.Boolean.TRUE
+        state[java.lang.Boolean](restoredFunction, "pendingPublicationState").value() shouldEqual
+          java.lang.Boolean.TRUE
         state[java.lang.Long](restoredFunction, "nextProcessingEvictionTimerState").value().longValue()
-      liveCorrectionTimer should be > firstCorrectionTimer
-      restoredHarness.setProcessingTime(liveCorrectionTimer - 1L)
-      advanceConnectedHealthyLiveWatermark(restoredHarness, liveCorrectionTimer)
-      restoredHarness.setProcessingTime(liveCorrectionTimer)
+      }
+      liveCorrectionTimers.foreach(_ should be > firstCorrectionTimer)
+      liveCorrectionTimers.distinct.sorted.foreach { liveCorrectionTimer =>
+        restoredHarness.setProcessingTime(liveCorrectionTimer - 1L)
+        advanceConnectedHealthyLiveWatermark(restoredHarness, liveCorrectionTimer)
+        restoredHarness.setProcessingTime(liveCorrectionTimer)
+      }
 
       val corrections = restoredHarness.extractOutputValues().asScala
-      corrections should have size 1
-      decodeSum(corrections.head, batchBackedGroupBy) shouldBe null
-      setCurrentKey(restoredHarness, entityKey(DefaultEntity))
-      state[Array[Byte]](restoredFunction, "batchIrState").value() shouldBe null
-      state[java.lang.Boolean](restoredFunction, "pendingEmptyBatchBaselineState").value() shouldBe null
-      state[java.lang.Boolean](restoredFunction, "syntheticEmptyBatchBaselineState").value() shouldBe null
-      state[java.lang.Boolean](restoredFunction, "pendingPublicationState").value() shouldBe null
-      state[java.lang.Boolean](restoredFunction, "syntheticRollbackCorrectionState").value() shouldBe null
+      corrections should have size 2
+      corrections.map(_.keys.get(0).toString).toSet shouldEqual keys.toSet
+      corrections.foreach { correction =>
+        decodeSum(correction, batchBackedGroupBy) shouldBe null
+      }
+      keys.foreach { key =>
+        setCurrentKey(restoredHarness, entityKey(key))
+        state[Array[Byte]](restoredFunction, "batchIrState").value() shouldBe null
+        state[java.lang.Boolean](restoredFunction, "pendingEmptyBatchBaselineState").value() shouldBe null
+        state[java.lang.Boolean](restoredFunction, "syntheticEmptyBatchBaselineState").value() shouldBe null
+        state[java.lang.Boolean](restoredFunction, "pendingPublicationState").value() shouldBe null
+        state[java.lang.Boolean](restoredFunction, "syntheticRollbackCorrectionState").value() shouldBe null
+      }
+    } finally restoredHarness.close()
+  }
+
+  it should "publish only baseline-safe corrections for live keys when the option is disabled" in {
+    val graceMillis = 1L
+    val startProcessingTime = tenDays + oneHour
+    val eventTime = startProcessingTime - 1000L
+    val firstKey = "entity-a"
+    val secondKey = "entity-b"
+    val initialValues = Map(firstKey -> 5L, secondKey -> 7L)
+    val mixedGroupBy = Builders.GroupBy(
+      metaData = Builders.MetaData(name = "gigatile-first-seen-mixed-window"),
+      aggregations = Seq(
+        Builders.Aggregation(Operation.MAX, "num", Seq(new Window(1, TimeUnit.HOURS))),
+        Builders.Aggregation(Operation.SUM, "num", Seq(new Window(7, TimeUnit.DAYS)))
+      ))
+    val originalFunction = new GigaTileProcessFunction(mixedGroupBy,
+                                                       inputSchema,
+                                                       firstSeenKeyGraceMillis = graceMillis)
+    val originalHarness = harness(originalFunction)
+
+    originalHarness.open()
+    originalHarness.setProcessingTime(startProcessingTime)
+    advanceConnectedHealthyLiveWatermark(originalHarness, startProcessingTime)
+    initialValues.foreach { case (key, value) =>
+      originalHarness.processElement1(event(key, eventTime, value), eventTime)
+    }
+    val baselineProcessingTime = startProcessingTime + graceMillis + 1L
+    originalHarness.setProcessingTime(baselineProcessingTime)
+    advanceConnectedHealthyLiveWatermark(originalHarness, baselineProcessingTime)
+    initialValues.keys.foreach { key =>
+      originalHarness.processElement1(event(key, eventTime + 1L, 0L), eventTime + 1L)
+    }
+    originalHarness.setProcessingTime(baselineProcessingTime + 1L)
+    val snapshot = originalHarness.snapshot(33L, baselineProcessingTime + 1L)
+    originalHarness.close()
+
+    val restoredFunction = new GigaTileProcessFunction(mixedGroupBy, inputSchema)
+    val restoredHarness = harness(restoredFunction)
+    try {
+      restoredHarness.setup()
+      restoredHarness.initializeState(snapshot)
+      restoredHarness.open()
+      val restoredProcessingTime = baselineProcessingTime + 2L
+      restoredHarness.setProcessingTime(restoredProcessingTime)
+      advanceConnectedHealthyLiveWatermark(restoredHarness, restoredProcessingTime)
+      initialValues.keys.foreach { key =>
+        restoredHarness.processElement1(event(key, restoredProcessingTime - 1L, 11L),
+                                        restoredProcessingTime - 1L)
+      }
+
+      val corrections = restoredHarness.extractOutputValues().asScala
+      corrections should have size 2
+      val correctionsByKey = corrections.map(correction => correction.keys.get(0).toString -> correction).toMap
+      correctionsByKey.keySet shouldEqual initialValues.keySet
+      initialValues.keys.foreach { key =>
+        decodeOutputField(correctionsByKey(key), mixedGroupBy, 0) shouldEqual 11L
+        decodeOutputField(correctionsByKey(key), mixedGroupBy, 1) shouldBe null
+      }
+
+      restoredHarness.setProcessingTime(restoredProcessingTime + 1L)
+      advanceConnectedHealthyLiveWatermark(restoredHarness, restoredProcessingTime + 1L)
+      initialValues.keys.foreach { key =>
+        restoredHarness.processElement1(event(key, restoredProcessingTime, 13L), restoredProcessingTime)
+      }
+      restoredHarness.extractOutputValues() should have size 2
     } finally restoredHarness.close()
   }
 
@@ -525,11 +607,16 @@ class GigaTileFirstSeenKeyGraceTest extends AnyFlatSpec with Matchers {
     originalHarness.setProcessingTime(startProcessingTime)
     advanceConnectedHealthyLiveWatermark(originalHarness, startProcessingTime)
     originalHarness.processElement1(event(DefaultEntity, eventTime, 5L), eventTime)
+    originalHarness.extractOutputValues() shouldBe empty
 
     val baselineProcessingTime = startProcessingTime + graceMillis + 1L
     originalHarness.setProcessingTime(baselineProcessingTime)
     advanceConnectedHealthyLiveWatermark(originalHarness, baselineProcessingTime)
     originalHarness.processElement1(event(DefaultEntity, eventTime + 1L, 0L), eventTime + 1L)
+    // Watermark activation and the event share one processing-time version. Flush their
+    // coalesced snapshot before asserting that the synthetic handoff is complete.
+    originalHarness.setProcessingTime(baselineProcessingTime + 1L)
+    decodeSum(originalHarness.extractOutputValues().asScala.last, batchBackedGroupBy) shouldEqual 5L
     setCurrentKey(originalHarness, entityKey(DefaultEntity))
     state[java.lang.Boolean](originalFunction, "syntheticEmptyBatchBaselineState").value() shouldEqual
       java.lang.Boolean.TRUE
@@ -646,6 +733,8 @@ class GigaTileFirstSeenKeyGraceTest extends AnyFlatSpec with Matchers {
       testHarness.extractOutputValues() shouldBe empty
 
       testHarness.setProcessingTime(collisionTime)
+      testHarness.extractOutputValues() shouldBe empty
+      testHarness.setProcessingTime(collisionTime + cadenceMillis)
 
       val outputs = testHarness.extractOutputValues()
       outputs should have size 1
@@ -725,7 +814,7 @@ class GigaTileFirstSeenKeyGraceTest extends AnyFlatSpec with Matchers {
       advanceConnectedHealthyLiveWatermark(testHarness, startProcessingTime)
       testHarness.processElement1(event(DefaultEntity, startProcessingTime - 1000L, 5L), startProcessingTime - 1000L)
 
-      decodeSum(testHarness.extractOutputValues().get(0), batchBackedGroupBy) shouldBe null
+      testHarness.extractOutputValues() shouldBe empty
       setCurrentKey(testHarness, entityKey(DefaultEntity))
       state[Array[Byte]](function, "batchIrState").value() shouldBe null
       state[java.lang.Boolean](function, "pendingEmptyBatchBaselineState").value() shouldBe null
@@ -935,8 +1024,12 @@ object GigaTileFirstSeenKeyGraceTest {
   }
 
   private def decodeSum(tile: TimestampedTile, targetGroupBy: GroupBy): AnyRef = {
+    decodeOutputField(tile, targetGroupBy, 0)
+  }
+
+  private def decodeOutputField(tile: TimestampedTile, targetGroupBy: GroupBy, fieldIndex: Int): AnyRef = {
     val outputCodec = new GigaTileCodec(targetGroupBy, inputSchema)
-    val fieldName = outputCodec.outputSchema.fields.head.name
+    val fieldName = outputCodec.outputSchema.fields(fieldIndex).name
     AvroCodec
       .of(ai.chronon.online.serde.AvroConversions.fromChrononSchema(outputCodec.outputSchema).toString)
       .decodeMap(tile.tileBytes)(fieldName)

--- a/flink/src/test/scala/ai/chronon/flink/test/window/GigaTileProcessFunctionTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/window/GigaTileProcessFunctionTest.scala
@@ -209,11 +209,14 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     } finally testHarness.close()
   }
 
-  it should "drop a future event before it can poison batch-backed large-window state" in {
+  it should "clamp a future event to processing time without dropping it" in {
     val dayMillis = new Window(1, TimeUnit.DAYS).millis
     val batchGroupBy = Builders.GroupBy(
       metaData = Builders.MetaData(name = "gigatile-process-function-future-event-test"),
-      aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(7, TimeUnit.DAYS)))))
+      aggregations = Seq(
+        Builders.Aggregation(Operation.SUM, "num", Seq(new Window(7, TimeUnit.DAYS))),
+        Builders.Aggregation(Operation.MAX, Constants.TimeColumn, Seq(new Window(7, TimeUnit.DAYS)))
+      ))
     val testHarness = harness(new GigaTileProcessFunction(batchGroupBy, inputSchema))
     val currentProcessingTime = 10 * dayMillis + new Window(1, TimeUnit.HOURS).millis
     val batchCallbackTime = currentProcessingTime - 2L
@@ -229,12 +232,20 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
       testHarness.setProcessingTime(currentProcessingTime)
       advanceToHealthyLiveWatermark(testHarness, currentProcessingTime)
       testHarness.processElement1(event(currentProcessingTime + 1L, 11L), currentProcessingTime + 1L)
+
+      val outputsAfterFutureEvent = testHarness.extractOutputValues()
+      outputsAfterFutureEvent.size() shouldEqual 2
+      decodeSum(outputsAfterFutureEvent.get(1), batchGroupBy) shouldEqual 14L
+      decodeOutputField(outputsAfterFutureEvent.get(1), batchGroupBy, 1) shouldEqual currentProcessingTime
+      outputsAfterFutureEvent.get(1).latestTsMillis shouldEqual currentProcessingTime
+
       testHarness.processElement1(event(currentProcessingTime - 1000L, 5L), currentProcessingTime - 1000L)
+      testHarness.setProcessingTime(currentProcessingTime + 1L)
 
       val outputs = testHarness.extractOutputValues()
-      outputs.size() shouldEqual 2
-      decodeSum(outputs.get(1), batchGroupBy) shouldEqual 8L
-      outputs.get(1).latestTsMillis shouldEqual currentProcessingTime
+      outputs.size() shouldEqual 3
+      decodeSum(outputs.get(2), batchGroupBy) shouldEqual 19L
+      outputs.get(2).latestTsMillis shouldEqual currentProcessingTime + 1L
     } finally testHarness.close()
   }
 
@@ -244,22 +255,27 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
     val historicalEventTime = processingTs - 1000L
     val poisonedWatermark = processingTs - FlinkJob.AllowedOutOfOrderness.toMillis
     val retryTime = processingTs + 2L * FlinkJob.AutoWatermarkInterval
+    val firstKey = "entity-a"
+    val secondKey = "entity-b"
 
     try {
       testHarness.open()
       testHarness.setProcessingTime(processingTs)
       testHarness.processWatermarkStatus2(WatermarkStatus.IDLE)
-      testHarness.processElement1(event(futureEventTime, 11L), futureEventTime)
+      testHarness.processElement1(keyedEvent(firstKey, futureEventTime, 11L), futureEventTime)
+      testHarness.processElement1(keyedEvent(secondKey, futureEventTime, 13L), futureEventTime)
       testHarness.processWatermark1(new Watermark(poisonedWatermark))
-      testHarness.processElement1(event(historicalEventTime, 5L), historicalEventTime)
+      testHarness.processElement1(keyedEvent(firstKey, historicalEventTime, 5L), historicalEventTime)
+      testHarness.processElement1(keyedEvent(secondKey, historicalEventTime, 7L), historicalEventTime)
 
       testHarness.extractOutputValues() shouldBe empty
       testHarness.setProcessingTime(retryTime)
 
-      val outputs = testHarness.extractOutputValues()
-      outputs should have size 1
-      decodeSum(outputs.get(0)) shouldEqual 5L
-      outputs.get(0).latestTsMillis shouldEqual retryTime
+      val outputs = testHarness.extractOutputValues().asScala
+      outputs should have size 2
+      outputs.map(output => output.keys.get(0).toString -> decodeSum(output)).toMap shouldEqual
+        Map(firstKey -> 16L, secondKey -> 20L)
+      outputs.foreach(_.latestTsMillis shouldEqual retryTime)
     } finally testHarness.close()
   }
 
@@ -340,13 +356,13 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
       currentFinalizedSum(function) shouldEqual 7L
       currentDayStart(function) shouldEqual 4 * dayMillis
 
-      // Any future event is rejected before it can mutate either small- or large-window state.
+      // Clamp producer clock skew to processing time so the rows remain bounded without being lost.
       testHarness.processElement1(event(firstFutureEventTime, 11L), firstFutureEventTime)
       testHarness.processElement1(event(farFutureEventTime, 11L), farFutureEventTime)
-      currentFinalizedSum(function) shouldEqual 7L
+      currentFinalizedSum(function) shouldEqual 22L
       testHarness.setProcessingTime(nextEvictionHop(currentProcessingTime))
       testHarness.extractOutputValues() shouldBe empty
-      currentDayStart(function) shouldEqual 4 * dayMillis
+      currentDayStart(function) shouldEqual 10 * dayMillis
       testHarness.numProcessingTimeTimers() shouldEqual 1
     } finally testHarness.close()
   }
@@ -371,6 +387,55 @@ class GigaTileProcessFunctionTest extends AnyFlatSpec with Matchers {
       // observed finite event watermark, retain state rather than publish a partial row.
       testHarness.extractOutputValues() shouldBe empty
       testHarness.numProcessingTimeTimers() shouldEqual 1
+    } finally testHarness.close()
+  }
+
+  it should "keep every batch-backed key fenced when the batch input idles before its baseline arrives" in {
+    val dayMillis = new Window(1, TimeUnit.DAYS).millis
+    val batchGroupBy = Builders.GroupBy(
+      metaData = Builders.MetaData(name = "gigatile-process-function-partial-idle-bootstrap-test"),
+      aggregations = Seq(Builders.Aggregation(Operation.SUM, "num", Seq(new Window(7, TimeUnit.DAYS)))))
+    val function = new GigaTileProcessFunction(batchGroupBy, inputSchema)
+    val testHarness = harness(function)
+    val currentProcessingTime = 10 * dayMillis + new Window(1, TimeUnit.HOURS).millis
+    val batchEnd = 9 * dayMillis
+    val liveEventTime = currentProcessingTime - 1000L
+    val firstKey = "entity-a"
+    val secondKey = "entity-b"
+
+    try {
+      testHarness.open()
+      testHarness.setProcessingTime(currentProcessingTime)
+      advanceToHealthyLiveWatermark(testHarness, currentProcessingTime)
+      testHarness.processElement1(keyedEvent(firstKey, liveEventTime, 5L), liveEventTime)
+      testHarness.processElement1(keyedEvent(secondKey, liveEventTime, 7L), liveEventTime)
+
+      // Input 2 is idle and input 1 is live, but neither key has a batch baseline yet.
+      testHarness.extractOutputValues() shouldBe empty
+
+      testHarness.processElement2(
+        batchRow(batchGroupBy, batchEnd, batchEnd - 1000L, 3L, entity = firstKey),
+        batchEnd)
+
+      val outputs = testHarness.extractOutputValues()
+      outputs should have size 1
+      outputs.get(0).keys.get(0) shouldEqual firstKey
+      decodeSum(outputs.get(0), batchGroupBy) shouldEqual 8L
+
+      testHarness.setProcessingTime(nextEvictionHop(currentProcessingTime))
+      testHarness.extractOutputValues() should have size 1
+
+      val secondBatchProcessingTime = nextEvictionHop(currentProcessingTime) + 1L
+      testHarness.setProcessingTime(secondBatchProcessingTime)
+      advanceToHealthyLiveWatermark(testHarness, secondBatchProcessingTime)
+      testHarness.processElement2(
+        batchRow(batchGroupBy, batchEnd, batchEnd - 1000L, 4L, entity = secondKey),
+        batchEnd)
+
+      val finalOutputs = testHarness.extractOutputValues().asScala
+      finalOutputs should have size 2
+      finalOutputs.last.keys.get(0) shouldEqual secondKey
+      decodeSum(finalOutputs.last, batchGroupBy) shouldEqual 11L
     } finally testHarness.close()
   }
 
@@ -1901,8 +1966,12 @@ object GigaTileProcessFunctionTest {
   }
 
   private def decodeSum(tile: TimestampedTile, decodeGroupBy: GroupBy = groupBy): AnyRef = {
+    decodeOutputField(tile, decodeGroupBy, 0)
+  }
+
+  private def decodeOutputField(tile: TimestampedTile, decodeGroupBy: GroupBy, fieldIndex: Int): AnyRef = {
     val outputCodec = new GigaTileCodec(decodeGroupBy, inputSchema)
-    val fieldName = outputCodec.outputSchema.fields.head.name
+    val fieldName = outputCodec.outputSchema.fields(fieldIndex).name
     AvroCodec
       .of(ai.chronon.online.serde.AvroConversions.fromChrononSchema(outputCodec.outputSchema).toString)
       .decodeMap(tile.tileBytes)(fieldName)
@@ -1987,7 +2056,8 @@ object GigaTileProcessFunctionTest {
       batchGroupBy: GroupBy,
       batchEndTs: Long,
       batchEventTs: Long,
-      value: Long
+      value: Long,
+      entity: String = "campaign-1"
   ): BatchIrRow = {
     val batchAggregator =
       new SawtoothOnlineAggregator(batchEndTs, batchGroupBy.getAggregations.asScala.toSeq, inputSchema)
@@ -1995,7 +2065,9 @@ object GigaTileProcessFunctionTest {
       batchAggregator.init,
       new ArrayRow(Array[Any](batchEventTs, value), batchEventTs))
     val finalBatchIr = batchAggregator.denormalizeBatchIr(batchAggregator.normalizeBatchIr(batchIr))
-    new BatchIrRow(entityKey(), new GigaTileCodec(batchGroupBy, inputSchema).encodeBatchIr(finalBatchIr), batchEndTs)
+    new BatchIrRow(entityKey(entity),
+                   new GigaTileCodec(batchGroupBy, inputSchema).encodeBatchIr(finalBatchIr),
+                   batchEndTs)
   }
 
   private class LegacyEventTimeTimerFunction(timerTimestamps: Seq[Long])


### PR DESCRIPTION
## Summary

Follow-up to #2024 after Nikhil's review.

Ordinary GigaTile writes for a batch-backed key now stay fenced until that key has either its real batch IR or the configured synthetic empty baseline. A temporarily IDLE Iceberg input alone no longer counts as scan completion.

Future producer timestamps are clamped to processing time instead of dropping the event.

## Example

Key `B` has `100` in KV, but its Iceberg row is still being scanned. Kafka receives `+7` while Iceberg is temporarily IDLE.

Before: GigaTile could publish `7`, overwriting the complete value with a live-only undercount.

After: with the default zero grace, `B` publishes nothing until its batch row arrives, then emits the historical baseline plus `7`.

On grace rollback, the narrow correction path keeps valid no-batch fields, clears batch-backed fields to null, then fences later writes until a baseline exists.

## Scope

- GigaTile only; MegaTile is unchanged.
- #2026's one-key reconciliation bug is already fixed by `b8439569e`; this change only preserves that rollback guarantee under the new baseline fence.
- `AllowedOutOfOrderness` is unchanged; `099e1f136` already documents that only the slack controls the Live gate.
- A configured positive grace can still install a synthetic empty baseline after the grace expires. The default remains zero and fail-closed.
- Future events are retained and their aggregation timestamps are bounded, but the raw source timestamp can still delay the upstream Flink watermark.
- `future_event_drop_count` is replaced by `future_event_clamp_count`.

## Validation

- The focused GigaTile suites pass on Scala 2.12.18: 74/74 tests.
- The same suites pass on Scala 2.13.17: 74/74 tests.
- `git diff --check` passes.
- All touched files are formatted. The module-wide format check still reports two pre-existing untouched files: `GigaTileAvroCodecFn.scala` and `FlinkTypes.scala`.
