### PR TITLE
Use GroupBy key types for direct Join request keys

### DIFF
--- a/online/src/main/scala/ai/chronon/online/fetcher/JoinRequestKeys.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/JoinRequestKeys.scala
@@ -21,8 +21,9 @@ import scala.util.Try
   *   - `buildKeyMapping` is run while building the JoinCodec so SQL parsing, input-schema construction, and Catalyst
   *     setup are attempted once and cached with the Join metadata instead of repeated per request. A Catalyst setup
   *     failure is surfaced only if a request actually needs key derivation.
-  *   - `requestKeyFields` reports the raw request keys needed to derive selected Join keys, plus the derived key aliases
-  *     themselves so existing direct-key callers can still be logged against the Join key schema.
+  *   - `requestKeyFields` uses the GroupBy key schema for direct Join keys. For selected Join keys it reports the raw
+  *     request keys needed for derivation, plus the derived key aliases themselves so existing direct-key callers can
+  *     still be logged against the Join key schema.
   *   - `valueInfoLeftKeys` reports only the raw request keys for selected Join keys, so fetchJoinSchema does not imply
   *     that callers must provide derived keys.
   *   - `missingRequestKeys` validates against those raw inputs, while still accepting a derived key if the caller
@@ -146,10 +147,13 @@ private[online] object JoinRequestKeys {
               s"but $rightKey is not present in GroupBy key schema ${keySchema.fields.map(_.name).mkString(", ")}")
         )
         .fieldType
+      val derivesLeftKey = selectExpression(join, leftKey).isDefined
       val requestKeys = rawInputsByLeftKey.getOrElse(leftKey, Seq(leftKey))
       requestKeys.foreach { requestKey =>
         if (!fieldsByRequestKey.contains(requestKey)) {
-          fieldsByRequestKey.put(requestKey, StructField(requestKey, rawInputType(servingInfo, requestKey, fieldType)))
+          val requestFieldType =
+            if (derivesLeftKey) rawInputType(servingInfo, requestKey, fieldType) else fieldType
+          fieldsByRequestKey.put(requestKey, StructField(requestKey, requestFieldType))
         }
       }
       if (!fieldsByRequestKey.contains(leftKey)) {

--- a/online/src/test/scala/ai/chronon/online/fetcher/JoinRequestKeysTest.scala
+++ b/online/src/test/scala/ai/chronon/online/fetcher/JoinRequestKeysTest.scala
@@ -32,14 +32,22 @@ class JoinRequestKeysTest extends AnyFlatSpec {
         ))
     )
 
-  private def servingInfo(inputSchema: StructType): GroupByServingInfoParsed = {
+  private def servingInfo(groupByConf: GroupBy,
+                          inputSchema: StructType,
+                          keySchema: StructType): GroupByServingInfoParsed = {
     val groupByServingInfo = new GroupByServingInfo()
-    groupByServingInfo.setGroupBy(groupBy)
-    groupByServingInfo.setKeyAvroSchema(
-      AvroConversions.fromChrononSchema(StructType("Key", Array(StructField("query_normalized", StringType)))).toString)
+    groupByServingInfo.setGroupBy(groupByConf)
+    groupByServingInfo.setKeyAvroSchema(AvroConversions.fromChrononSchema(keySchema).toString)
     groupByServingInfo.setInputAvroSchema(AvroConversions.fromChrononSchema(inputSchema).toString)
     new GroupByServingInfoParsed(groupByServingInfo)
   }
+
+  private def servingInfo(inputSchema: StructType): GroupByServingInfoParsed =
+    servingInfo(
+      groupBy,
+      inputSchema,
+      StructType("Key", Array(StructField("query_normalized", StringType)))
+    )
 
   it should "include join left selects in cached key mapping keys" in {
     val firstJoin = join("lower(query)")
@@ -94,6 +102,40 @@ class JoinRequestKeysTest extends AnyFlatSpec {
       JoinRequestKeys.partKey(firstJoin, firstJoin.joinPartOps.head),
       JoinRequestKeys.partKey(secondJoin, secondJoin.joinPartOps.head)
     )
+  }
+
+  it should "use GroupBy key types for direct Join request keys" in {
+    Seq("user_id", "seller_id").foreach { keyName =>
+      val directGroupBy = Builders.GroupBy(
+        metaData = Builders.MetaData(name = s"unit_test.${keyName}_group_by"),
+        keyColumns = Seq(keyName)
+      )
+      val directJoin = Builders.Join(
+        metaData = Builders.MetaData(name = s"unit_test.${keyName}_join"),
+        left = Builders.Source.events(
+          query = Builders.Query(selects = Map(keyName -> keyName)),
+          table = "unit_test.requests"
+        ),
+        joinParts = Seq(
+          Builders.JoinPart(
+            groupBy = directGroupBy,
+            keyMapping = Map(keyName -> keyName)
+          ))
+      )
+      val directServingInfo = servingInfo(
+        directGroupBy,
+        StructType("Input", Array(StructField(keyName, IntType))),
+        StructType("Key", Array(StructField(keyName, LongType)))
+      )
+
+      assertEquals(
+        Seq(StructField(keyName, LongType)),
+        JoinRequestKeys
+          .buildKeyMapping(directJoin, directJoin.joinPartOps.head, directServingInfo)
+          .requestKeyFields
+          .toSeq
+      )
+    }
   }
 
   it should "validate missing request keys against raw selected inputs" in {


### PR DESCRIPTION
## Summary

In cases where a `GroupBy` is casting a key field, the fetcher still reads the raw types instead of using the GroupBy key schema for the direct key types - and then only using the raw input types for derived keys. 

## Checklist
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected request-key field types for direct Join keys by using the configured GroupBy key schema.
  * Preserved raw input types for derived Join keys while including their derived-key aliases.
  * Added test coverage for accurate key-type handling when input and serving schemas differ.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->