### PR TITLE
Redis implementation read optimizations

### DIFF
--- a/online/src/main/scala/ai/chronon/online/fetcher/FetcherCache.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/FetcherCache.scala
@@ -120,38 +120,33 @@ trait FetcherCache {
   def getCachedRequests(
       groupByRequestToKvRequest: Seq[(Fetcher.Request, Try[LambdaKvRequest])]): Map[GetRequest, CachedBatchResponse] = {
 
-    def empty = Map.empty[GetRequest, CachedBatchResponse]
+    val empty = Map.empty[GetRequest, CachedBatchResponse]
 
     if (!isCacheSizeConfigured) return empty
 
-    groupByRequestToKvRequest
-      .map {
+    val cachedRequests = Map.newBuilder[GetRequest, CachedBatchResponse]
+    groupByRequestToKvRequest.foreach {
+      case (request, Success(LambdaKvRequest(servingInfo, _, batchRequest, _, _, _)))
+          if isCachingEnabled(servingInfo.groupBy) =>
+        val batchRequestCacheKey =
+          BatchIrCache.Key(batchRequest.dataset, request.keys, servingInfo.batchEndTsMillis)
 
-        case (request, Success(LambdaKvRequest(servingInfo, _, batchRequest, _, _, _)))
-            if isCachingEnabled(servingInfo.groupBy) =>
-          val batchRequestCacheKey =
-            BatchIrCache.Key(batchRequest.dataset, request.keys, servingInfo.batchEndTsMillis)
+        // Metrics so we can get per-group-by cache metrics
+        val metricsContext =
+          request.context.getOrElse(Metrics.Context(Metrics.Environment.JoinFetching, servingInfo.groupBy))
 
-          // Metrics so we can get per-group-by cache metrics
-          val metricsContext =
-            request.context.getOrElse(Metrics.Context(Metrics.Environment.JoinFetching, servingInfo.groupBy))
-
-          maybeBatchIrCache.get.cache.getIfPresent(batchRequestCacheKey) match {
-
-            case null =>
-              metricsContext.increment(s"${batchIrCacheName}_gb_misses")
-              empty
-
-            case cachedIr: CachedBatchResponse =>
-              metricsContext.increment(s"${batchIrCacheName}_gb_hits")
-              Map(batchRequest -> cachedIr)
-
-          }
-
-        case _ => empty
-
-      }
-      .foldLeft(empty)(_ ++ _)
+        maybeBatchIrCache.get.cache.getIfPresent(batchRequestCacheKey) match {
+          case null =>
+            metricsContext.increment(s"${batchIrCacheName}_gb_misses")
+          case cachedIr: CachedBatchResponse =>
+            metricsContext.increment(s"${batchIrCacheName}_gb_hits")
+            cachedRequests += batchRequest -> cachedIr
+          case _ =>
+            metricsContext.increment(s"${batchIrCacheName}_gb_misses")
+        }
+      case _ => ()
+    }
+    cachedRequests.result()
   }
 }
 

--- a/online/src/main/scala/ai/chronon/online/fetcher/GroupByFetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/GroupByFetcher.scala
@@ -58,6 +58,9 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
 
       var batchKeyBytes: Array[Byte] = null
       var streamingKeyBytes: Array[Byte] = null
+      val needsStreamingRead =
+        groupByServingInfo.groupByOps.inferredAccuracy == Accuracy.TEMPORAL &&
+          groupByServingInfo.groupByOps.streamingSource.isDefined
 
       try {
         // The formats of key bytes for batch requests and key bytes for streaming requests may differ based
@@ -65,9 +68,11 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
         batchKeyBytes = fetchContext.kvStore.createKeyBytes(request.keys,
                                                             groupByServingInfo,
                                                             groupByServingInfo.groupByOps.batchDataset)
-        streamingKeyBytes = fetchContext.kvStore.createKeyBytes(request.keys,
-                                                                groupByServingInfo,
-                                                                groupByServingInfo.groupByOps.streamingDataset)
+        if (needsStreamingRead) {
+          streamingKeyBytes = fetchContext.kvStore.createKeyBytes(request.keys,
+                                                                  groupByServingInfo,
+                                                                  groupByServingInfo.groupByOps.streamingDataset)
+        }
 
       } catch {
 
@@ -81,9 +86,11 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
                                                                 groupByServingInfo,
                                                                 groupByServingInfo.groupByOps.batchDataset)
 
-            streamingKeyBytes = fetchContext.kvStore.createKeyBytes(castedKeys,
-                                                                    groupByServingInfo,
-                                                                    groupByServingInfo.groupByOps.streamingDataset)
+            if (needsStreamingRead) {
+              streamingKeyBytes = fetchContext.kvStore.createKeyBytes(castedKeys,
+                                                                      groupByServingInfo,
+                                                                      groupByServingInfo.groupByOps.streamingDataset)
+            }
           } catch {
             case exInner: Exception =>
               exInner.addSuppressed(ex)
@@ -94,9 +101,8 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
 
       val batchRequest = GetRequest(batchKeyBytes, groupByServingInfo.groupByOps.batchDataset)
 
-      val streamingRequestOpt = groupByServingInfo.groupByOps.inferredAccuracy match {
-        // fetch batch(ir) and streaming(input) and aggregate
-        case Accuracy.TEMPORAL =>
+      val streamingRequestOpt =
+        if (needsStreamingRead) {
           // Build a tile key for the streaming request
           // When we build support for layering, we can expand this out into a utility that builds n tile keys for n layers
           val keyBytes = if (fetchContext.isTilingEnabled) {
@@ -117,11 +123,7 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
             GetRequest(keyBytes,
                        groupByServingInfo.groupByOps.streamingDataset,
                        Some(groupByServingInfo.batchEndTsMillis)))
-
-        // no further aggregation is required - the value in KvStore is good as is
-        case Accuracy.SNAPSHOT => None
-
-      }
+        } else None
 
       val castedRequest = request.copy(keys = groupByServingInfo.keyChrononSchema.cast(request.keys))
       LambdaKvRequest(groupByServingInfo, castedRequest, batchRequest, streamingRequestOpt, request.atMillis, context)

--- a/online/src/main/scala/ai/chronon/online/fetcher/GroupByFetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/GroupByFetcher.scala
@@ -211,15 +211,20 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
             .flatMap(_.get.map(v => Option(v.bytes).map(_.length).getOrElse(0)))
             .sum
 
-        val responses: Seq[Response] = groupByRequestToKvRequest.iterator.map { case (request, requestMetaTry) =>
-          val responseMapTry: Try[Map[String, AnyRef]] = requestMetaTry.map { requestMeta =>
-            val LambdaKvRequest(groupByServingInfo, castedRequest, batchRequest, streamingRequestOpt, _, context) =
-              requestMeta
-
+        groupByRequestToKvRequest.iterator
+          .flatMap(_._2.toOption.map(_.context))
+          .toSet
+          .foreach { context: metrics.Metrics.Context =>
             context.count("multi_get.batch.size", allRequestsToFetch.length)
             context.distribution("multi_get.bytes", totalResponseValueBytes)
             context.distribution("multi_get.response.length", kvResponses.length)
             context.distribution("multi_get.latency.millis", multiGetMillis)
+          }
+
+        val responses: Seq[Response] = groupByRequestToKvRequest.iterator.map { case (request, requestMetaTry) =>
+          val responseMapTry: Try[Map[String, AnyRef]] = requestMetaTry.map { requestMeta =>
+            val LambdaKvRequest(groupByServingInfo, castedRequest, batchRequest, streamingRequestOpt, _, context) =
+              requestMeta
 
             // pick the batch version with highest timestamp
             val batchResponses: BatchResponses =

--- a/online/src/main/scala/ai/chronon/online/fetcher/GroupByFetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/GroupByFetcher.scala
@@ -242,8 +242,15 @@ class GroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
                 case Some(cachedResponse: CachedBatchResponse) => cachedResponse
               }
 
-            val streamingResponsesOpt =
-              streamingRequestOpt.map(responsesMap.getOrElse(_, Success(Seq.empty)).getOrElse(Seq.empty))
+            // Preserve the response-handler contract without issuing a streaming read: temporal batch values still
+            // need finalization when no streaming source exists, while None continues to identify snapshot values.
+            val streamingResponsesOpt: Option[Seq[TimedValue]] = streamingRequestOpt match {
+              case Some(streamingRequest) =>
+                Some(responsesMap.getOrElse(streamingRequest, Success(Seq.empty)).getOrElse(Seq.empty))
+              case None if groupByServingInfo.groupByOps.inferredAccuracy == Accuracy.TEMPORAL =>
+                Some(Seq.empty)
+              case None => None
+            }
 
             val queryTs = request.atMillis.getOrElse(System.currentTimeMillis())
             val requestContext = RequestContext(groupByServingInfo, queryTs, startTimeMs, context, request.keys)

--- a/online/src/main/scala/ai/chronon/online/fetcher/GroupByResponseHandler.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/GroupByResponseHandler.scala
@@ -3,7 +3,7 @@ import ai.chronon.aggregator.windowing
 import ai.chronon.aggregator.windowing.{FinalBatchIr, SawtoothOnlineAggregator, TiledIr}
 import ai.chronon.api.Extensions.WindowOps
 import ai.chronon.api.ScalaJavaConversions.{IteratorOps, JMapOps}
-import ai.chronon.api.{DataModel, Row, Window}
+import ai.chronon.api.{Accuracy, DataModel, Row, Window}
 import ai.chronon.online.serde.AvroConversions
 import ai.chronon.online.GroupByServingInfoParsed
 import ai.chronon.online.KVStore.TimedValue
@@ -49,8 +49,12 @@ class GroupByResponseHandler(fetchContext: FetchContext, metadataStore: Metadata
     // The bulk upload may not have removed an older batch values. We manually discard all but the latest one.
     val batchBytes: Array[Byte] = batchResponses.getBatchBytes(newServingInfo.batchEndTsMillis)
 
+    val requiresTemporalMerge =
+      newServingInfo.groupBy.aggregations != null &&
+        newServingInfo.groupByOps.inferredAccuracy == Accuracy.TEMPORAL
+
     val responseMap: Map[String, AnyRef] =
-      if (newServingInfo.groupBy.aggregations == null || streamingResponsesOpt.isEmpty) { // no-agg
+      if (!requiresTemporalMerge) { // no-agg or snapshot
 
         val batchResponseDecodeStartTime = System.currentTimeMillis()
         val response = getMapResponseFromBatchResponse(batchResponses,
@@ -64,7 +68,8 @@ class GroupByResponseHandler(fetchContext: FetchContext, metadataStore: Metadata
 
       } else { // temporal accurate
 
-        val streamingResponses = streamingResponsesOpt.get
+        // A temporal GroupBy without a streaming source still stores batch aggregation IRs that must be finalized.
+        val streamingResponses = streamingResponsesOpt.getOrElse(Seq.empty)
         val output: Array[Any] = mergeWithStreaming(batchResponses,
                                                     streamingResponses,
                                                     batchBytes,

--- a/online/src/main/scala/ai/chronon/online/fetcher/GroupByResponseHandler.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/GroupByResponseHandler.scala
@@ -3,7 +3,7 @@ import ai.chronon.aggregator.windowing
 import ai.chronon.aggregator.windowing.{FinalBatchIr, SawtoothOnlineAggregator, TiledIr}
 import ai.chronon.api.Extensions.WindowOps
 import ai.chronon.api.ScalaJavaConversions.{IteratorOps, JMapOps}
-import ai.chronon.api.{Accuracy, DataModel, Row, Window}
+import ai.chronon.api.{DataModel, Row, Window}
 import ai.chronon.online.serde.AvroConversions
 import ai.chronon.online.GroupByServingInfoParsed
 import ai.chronon.online.KVStore.TimedValue
@@ -49,12 +49,8 @@ class GroupByResponseHandler(fetchContext: FetchContext, metadataStore: Metadata
     // The bulk upload may not have removed an older batch values. We manually discard all but the latest one.
     val batchBytes: Array[Byte] = batchResponses.getBatchBytes(newServingInfo.batchEndTsMillis)
 
-    val requiresTemporalMerge =
-      newServingInfo.groupBy.aggregations != null &&
-        newServingInfo.groupByOps.inferredAccuracy == Accuracy.TEMPORAL
-
     val responseMap: Map[String, AnyRef] =
-      if (!requiresTemporalMerge) { // no-agg or snapshot
+      if (newServingInfo.groupBy.aggregations == null || streamingResponsesOpt.isEmpty) { // no-agg
 
         val batchResponseDecodeStartTime = System.currentTimeMillis()
         val response = getMapResponseFromBatchResponse(batchResponses,
@@ -68,8 +64,7 @@ class GroupByResponseHandler(fetchContext: FetchContext, metadataStore: Metadata
 
       } else { // temporal accurate
 
-        // A temporal GroupBy without a streaming source still stores batch aggregation IRs that must be finalized.
-        val streamingResponses = streamingResponsesOpt.getOrElse(Seq.empty)
+        val streamingResponses = streamingResponsesOpt.get
         val output: Array[Any] = mergeWithStreaming(batchResponses,
                                                     streamingResponses,
                                                     batchBytes,

--- a/online/src/main/scala/ai/chronon/online/fetcher/JoinPartFetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/JoinPartFetcher.scala
@@ -23,6 +23,7 @@ import ai.chronon.online.fetcher.Fetcher.{ColumnSpec, PrefixedRequest, Request, 
 import ai.chronon.online.fetcher.FetcherCache.BatchResponses
 import org.slf4j.{Logger, LoggerFactory}
 
+import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
@@ -144,12 +145,9 @@ class JoinPartFetcher(fetchContext: FetchContext, metadataStore: MetadataStore) 
     }
 
     // One representative request per unique (name, keys, atMillis) — first occurrence wins.
-    val groupByRequests: Seq[Request] = allGroupByRequests
-      .foldLeft((Set.empty[GroupByKey], List.empty[Request])) { case ((seen, acc), r) =>
-        val key = groupByKey(r)
-        if (seen.contains(key)) (seen, acc) else (seen + key, acc :+ r)
-      }
-      ._2
+    val uniqueGroupByRequests = mutable.LinkedHashMap.empty[GroupByKey, Request]
+    allGroupByRequests.foreach(request => uniqueGroupByRequests.getOrElseUpdate(groupByKey(request), request))
+    val groupByRequests: Seq[Request] = uniqueGroupByRequests.values.toSeq
 
     val groupByResponsesFuture = fetchGroupBys(groupByRequests)
 

--- a/online/src/test/scala/ai/chronon/online/test/JoinPartFetcherPlanningPerfTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/JoinPartFetcherPlanningPerfTest.scala
@@ -69,7 +69,7 @@ class JoinPartFetcherPlanningPerfTest extends AnyFlatSpec with Matchers {
 
   behavior of "JoinPartFetcher planning and fanout"
 
-  it should "model 50 candidates, 25 shared GroupBys, and 25 candidate GroupBys" in {
+  ignore should "model 50 candidates, 25 shared GroupBys, and 25 candidate GroupBys" in {
     val executor = newExecutor(2)
     try {
       val fetcher = newFetcher(executor)

--- a/online/src/test/scala/ai/chronon/online/test/JoinPartFetcherPlanningPerfTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/JoinPartFetcherPlanningPerfTest.scala
@@ -1,0 +1,267 @@
+package ai.chronon.online.test
+
+import ai.chronon.api.{Accuracy, Builders, Join}
+import ai.chronon.online.KVStore
+import ai.chronon.online.KVStore.{GetRequest, GetResponse, PutRequest}
+import ai.chronon.online.fetcher.Fetcher.{Request, Response}
+import ai.chronon.online.fetcher.{FetchContext, JoinPartFetcher, MetadataStore}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
+import java.util.concurrent.{Callable, CountDownLatch, Executors, TimeUnit}
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutorService, Future}
+import scala.util.Success
+
+/** Opt-in microbenchmark for JoinPartFetcher request planning, deduplication, and response fanout.
+  *
+  * GroupByFetcher, Redis, the batch cache, value decoding, and aggregation merging are deliberately excluded:
+  * fetchGroupBys immediately echoes one lightweight feature value for every deduplicated request.
+  */
+class JoinPartFetcherPlanningPerfTest extends AnyFlatSpec with Matchers {
+
+  private val CandidateCount = 50
+  private val ContextGroupByCount = 25
+  private val CandidateGroupByCount = 25
+  private val GroupByCount = ContextGroupByCount + CandidateGroupByCount
+  private val UniqueGroupByRequestCount =
+    ContextGroupByCount + (CandidateCount * CandidateGroupByCount)
+  private val BenchmarkAtMillis = Some(1721606400000L)
+  private val SharedContextId: AnyRef = "context-0"
+  private val FeatureValue: AnyRef = java.lang.Long.valueOf(1L)
+
+  private val contextGroupBys = (0 until ContextGroupByCount).map { index =>
+    Builders.GroupBy(
+      metaData = Builders.MetaData(name = f"benchmark.context_$index%02d"),
+      keyColumns = Seq("context_id"),
+      accuracy = Accuracy.SNAPSHOT
+    )
+  }
+
+  private val candidateGroupBys = (0 until CandidateGroupByCount).map { index =>
+    Builders.GroupBy(
+      metaData = Builders.MetaData(name = f"benchmark.candidate_$index%02d"),
+      keyColumns = Seq("candidate_id"),
+      accuracy = Accuracy.SNAPSHOT
+    )
+  }
+
+  private val benchmarkJoin: Join = Builders.Join(
+    metaData = Builders.MetaData(name = "benchmark.join_part_planning"),
+    joinParts = contextGroupBys.map { groupBy =>
+      Builders.JoinPart(groupBy = groupBy, keyMapping = Map("context_id" -> "context_id"))
+    } ++ candidateGroupBys.map { groupBy =>
+      Builders.JoinPart(groupBy = groupBy, keyMapping = Map("candidate_id" -> "candidate_id"))
+    }
+  )
+
+  private val joinRequests: Seq[Request] = (0 until CandidateCount).map { candidateIndex =>
+    Request(
+      benchmarkJoin.metaData.name,
+      Map(
+        "context_id" -> SharedContextId,
+        "candidate_id" -> s"candidate-$candidateIndex"
+      ),
+      BenchmarkAtMillis
+    )
+  }
+
+  behavior of "JoinPartFetcher planning and fanout"
+
+  it should "model 50 candidates, 25 shared GroupBys, and 25 candidate GroupBys" in {
+    val executor = newExecutor(2)
+    try {
+      val fetcher = newFetcher(executor)
+      val responses = Await.result(fetcher.fetchJoins(joinRequests, Some(benchmarkJoin)), 30.seconds)
+
+      validateShape(fetcher.capturedRequests.get(), responses)
+    } finally {
+      closeExecutor(executor)
+    }
+  }
+
+  it should "run the opt-in planning and fanout concurrency sweep" in {
+    if (!envBoolean("CHRONON_RUN_JOIN_PART_PLANNING_BENCHMARK", default = false)) {
+      cancel(
+        "Set CHRONON_RUN_JOIN_PART_PLANNING_BENCHMARK=true to run the JoinPartFetcher planning/fanout benchmark")
+    }
+
+    val warmupBatches = envPositiveInt("CHRONON_JOIN_PART_PLANNING_WARMUP_BATCHES", 50)
+    val measuredBatches = envPositiveInt("CHRONON_JOIN_PART_PLANNING_MEASURED_BATCHES", 500)
+    val batchConcurrencies = envPositiveInts("CHRONON_JOIN_PART_PLANNING_BATCH_CONCURRENCIES", Seq(1, 4, 16, 32))
+    val executorThreadCounts =
+      envPositiveInts("CHRONON_JOIN_PART_PLANNING_EXECUTOR_THREADS", Seq(1, 4, 16, 32))
+
+    println(
+      "JOIN_PART_PLANNING_FANOUT_SCOPE " +
+        "included=JoinPartFetcher.fetchJoins_planning_dedup_response_fanout " +
+        "fetchGroupBys=immediate_in_memory_echo " +
+        "excluded=GroupByFetcher,Redis,batch_cache,value_decode,aggregation_merge")
+
+    executorThreadCounts.foreach { executorThreads =>
+      batchConcurrencies.foreach { batchConcurrency =>
+        runScenario(executorThreads, batchConcurrency, warmupBatches, measuredBatches)
+      }
+    }
+  }
+
+  private final class ImmediateGroupByJoinPartFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
+      extends JoinPartFetcher(fetchContext, metadataStore) {
+    val capturedRequests = new AtomicReference[Seq[Request]]()
+
+    override def fetchGroupBys(requests: Seq[Request]): Future[Seq[Response]] = {
+      require(
+        requests.size == UniqueGroupByRequestCount,
+        s"Expected $UniqueGroupByRequestCount deduplicated GroupBy requests, got ${requests.size}"
+      )
+      capturedRequests.compareAndSet(null, requests)
+      Future.successful(requests.map(request => Response(request, Success(Map("value" -> FeatureValue)))))
+    }
+  }
+
+  private case class Measurement(latenciesNanos: Array[Long], wallNanos: Long)
+
+  private final class UnusedKVStore extends KVStore {
+    override implicit val executionContext: ExecutionContext = ExecutionContext.global
+    override def create(dataset: String): Unit = ()
+    override def multiGet(requests: Seq[GetRequest]): Future[Seq[GetResponse]] =
+      Future.failed(new UnsupportedOperationException("JoinPartFetcher planning benchmark excludes KV reads"))
+    override def multiPut(keyValueDatasets: Seq[PutRequest]): Future[Seq[Boolean]] =
+      Future.failed(new UnsupportedOperationException("JoinPartFetcher planning benchmark excludes KV writes"))
+    override def bulkPut(sourceOfflineTable: String, destinationOnlineDataSet: String, partition: String): Unit = ()
+  }
+
+  private def newFetcher(executor: ExecutionContextExecutorService): ImmediateGroupByJoinPartFetcher = {
+    val fetchContext = FetchContext(new UnusedKVStore, executionContextOverride = executor)
+    new ImmediateGroupByJoinPartFetcher(fetchContext, new MetadataStore(fetchContext))
+  }
+
+  private def runScenario(executorThreads: Int,
+                          batchConcurrency: Int,
+                          warmupBatches: Int,
+                          measuredBatches: Int): Unit = {
+    val fanoutExecutor = newExecutor(executorThreads)
+    val driverExecutor = Executors.newFixedThreadPool(batchConcurrency)
+    try {
+      val fetcher = newFetcher(fanoutExecutor)
+      val validationResponses = Await.result(fetcher.fetchJoins(joinRequests, Some(benchmarkJoin)), 30.seconds)
+      validateShape(fetcher.capturedRequests.get(), validationResponses)
+
+      runPhase(fetcher, driverExecutor, batchConcurrency, warmupBatches)
+      val measurement = runPhase(fetcher, driverExecutor, batchConcurrency, measuredBatches)
+      printResult(executorThreads, batchConcurrency, warmupBatches, measurement)
+    } finally {
+      driverExecutor.shutdownNow()
+      driverExecutor.awaitTermination(30, TimeUnit.SECONDS)
+      closeExecutor(fanoutExecutor)
+    }
+  }
+
+  private def runPhase(fetcher: ImmediateGroupByJoinPartFetcher,
+                       driverExecutor: java.util.concurrent.ExecutorService,
+                       batchConcurrency: Int,
+                       batches: Int): Measurement = {
+    val latenciesNanos = new Array[Long](batches)
+    val nextBatch = new AtomicInteger(0)
+    val startGate = new CountDownLatch(1)
+    val workerCount = math.min(batchConcurrency, batches)
+    val workers = (0 until workerCount).map { _ =>
+      driverExecutor.submit(new Callable[Unit] {
+        override def call(): Unit = {
+          startGate.await()
+          var batchIndex = nextBatch.getAndIncrement()
+          while (batchIndex < batches) {
+            val startNanos = System.nanoTime()
+            Await.result(fetcher.fetchJoins(joinRequests, Some(benchmarkJoin)), 30.seconds)
+            latenciesNanos(batchIndex) = System.nanoTime() - startNanos
+            batchIndex = nextBatch.getAndIncrement()
+          }
+        }
+      })
+    }
+
+    val wallStartNanos = System.nanoTime()
+    startGate.countDown()
+    workers.foreach(_.get(10, TimeUnit.MINUTES))
+    Measurement(latenciesNanos, System.nanoTime() - wallStartNanos)
+  }
+
+  private def validateShape(groupByRequests: Seq[Request], responses: Seq[Response]): Unit = {
+    groupByRequests should have size UniqueGroupByRequestCount
+    groupByRequests.map(request => (request.name, request.keys, request.atMillis)).distinct should have size
+      UniqueGroupByRequestCount
+
+    val contextNames = contextGroupBys.map(_.metaData.name).toSet
+    val candidateNames = candidateGroupBys.map(_.metaData.name).toSet
+    val contextRequests = groupByRequests.filter(request => contextNames.contains(request.name))
+    val candidateRequests = groupByRequests.filter(request => candidateNames.contains(request.name))
+
+    contextRequests should have size ContextGroupByCount
+    contextRequests.foreach(_.keys shouldBe Map("context_id" -> SharedContextId))
+    candidateRequests should have size (CandidateCount * CandidateGroupByCount)
+    candidateNames.foreach { name =>
+      candidateRequests.count(_.name == name) shouldBe CandidateCount
+    }
+
+    responses should have size CandidateCount
+    responses.foreach { response =>
+      response.values.isSuccess shouldBe true
+      response.values.get should have size GroupByCount
+    }
+  }
+
+  private def printResult(executorThreads: Int,
+                          batchConcurrency: Int,
+                          warmupBatches: Int,
+                          measurement: Measurement): Unit = {
+    val sorted = measurement.latenciesNanos.sorted
+    val wallSeconds = measurement.wallNanos.toDouble / TimeUnit.SECONDS.toNanos(1)
+    val batchesPerSecond = sorted.length / wallSeconds
+    val averageMillis = sorted.iterator.map(_.toDouble).sum / sorted.length / TimeUnit.MILLISECONDS.toNanos(1)
+
+    println(
+      f"JOIN_PART_PLANNING_FANOUT_RESULT planning_threads=$batchConcurrency%d " +
+        f"fanout_executor_threads=$executorThreads%d batch_concurrency=$batchConcurrency%d " +
+        f"warmup_batches=$warmupBatches%d measured_batches=${sorted.length}%d " +
+        f"join_part_planning_fanout_batches_per_sec=$batchesPerSecond%.2f " +
+        f"avg_ms=$averageMillis%.3f p95_ms=${percentileMillis(sorted, 0.95)}%.3f " +
+        f"p99_ms=${percentileMillis(sorted, 0.99)}%.3f " +
+        f"unique_groupby_requests_per_batch=$UniqueGroupByRequestCount%d " +
+        f"join_responses_per_batch=$CandidateCount%d features_per_response=$GroupByCount%d")
+  }
+
+  private def percentileMillis(sortedNanos: Array[Long], percentile: Double): Double = {
+    val index = math.max(0, math.min(sortedNanos.length - 1, math.ceil(sortedNanos.length * percentile).toInt - 1))
+    sortedNanos(index).toDouble / TimeUnit.MILLISECONDS.toNanos(1)
+  }
+
+  private def newExecutor(threads: Int): ExecutionContextExecutorService =
+    scala.concurrent.ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(threads))
+
+  private def closeExecutor(executor: ExecutionContextExecutorService): Unit = {
+    executor.shutdown()
+    if (!executor.awaitTermination(30, TimeUnit.SECONDS)) {
+      executor.shutdownNow()
+    }
+  }
+
+  private def envBoolean(name: String, default: Boolean): Boolean =
+    sys.env.get(name).map(_.trim.toBoolean).getOrElse(default)
+
+  private def envPositiveInt(name: String, default: Int): Int = {
+    val value = sys.env.get(name).map(_.trim.toInt).getOrElse(default)
+    require(value > 0, s"$name must be positive, got $value")
+    value
+  }
+
+  private def envPositiveInts(name: String, defaults: Seq[Int]): Seq[Int] = {
+    val values = sys.env
+      .get(name)
+      .map(_.split(",").iterator.map(_.trim).filter(_.nonEmpty).map(_.toInt).toSeq)
+      .getOrElse(defaults)
+      .distinct
+    require(values.nonEmpty && values.forall(_ > 0), s"$name must contain positive integers")
+    values
+  }
+}

--- a/online/src/test/scala/ai/chronon/online/test/OnlineFetcherHotPathPerfTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/OnlineFetcherHotPathPerfTest.scala
@@ -173,7 +173,7 @@ class OnlineFetcherHotPathPerfTest extends AnyFlatSpec with Matchers {
     preparedRequests.map(_.request.context.get).distinct should have size DistinctMetricsContextCount
 
     val validation = validateGroupByPlanningShape()
-    Set(UniqueGroupByRequestCount * 2L, KvRequestCount.toLong) should contain(validation.keyEncodes)
+    validation.keyEncodes shouldBe KvRequestCount.toLong
     validation.kvRequests shouldBe KvRequestCount
     val metricsValidation = validateGroupByResponseMetricsShape()
     Set(LegacyMultiGetMetricWrites, DeduplicatedMultiGetMetricWrites) should contain(metricsValidation.metricWrites)
@@ -189,6 +189,36 @@ class OnlineFetcherHotPathPerfTest extends AnyFlatSpec with Matchers {
         s"kv_requests=$KvRequestCount key_encodes_observed=${validation.keyEncodes} " +
         s"multi_get_metric_writes_observed=${metricsValidation.metricWrites} " +
         s"legacy_metric_writes=$LegacyMultiGetMetricWrites deduplicated_metric_writes=$DeduplicatedMultiGetMetricWrites")
+  }
+
+  it should "skip streaming reads for temporal GroupBys without a topic" in {
+    val name = "benchmark.batch_only_temporal"
+    val groupBy = Builders.GroupBy(
+      sources = Seq(Builders.Source.events(query = Builders.Query(), table = s"$name.events")),
+      metaData = Builders.MetaData(name = name),
+      keyColumns = Seq(KeyColumn),
+      accuracy = Accuracy.TEMPORAL
+    )
+    val servingInfo = new GroupByServingInfoParsed(
+      new GroupByServingInfo()
+        .setGroupBy(groupBy)
+        .setKeyAvroSchema(KeySchema)
+        .setBatchEndTs(BenchmarkAtMillis))
+    val fixture = newGroupByFixture(
+      executorThreads = 1,
+      failAfterPlanning = true,
+      countKeyEncodes = true,
+      servingInfos = Map(name -> servingInfo)
+    )
+    try {
+      awaitPlanningComplete(
+        fixture.fetcher.fetchGroupBys(
+          Seq(Request(name, Map(KeyColumn -> "batch-only".asInstanceOf[AnyRef]), Some(BenchmarkAtMillis)))))
+      fixture.store.keyEncodeCount.get() shouldBe 1L
+      fixture.store.lastMultiGetSize.get() shouldBe 1
+    } finally {
+      closeExecutor(fixture.executor)
+    }
   }
 
   it should "run the opt-in cache lookup benchmark" in {
@@ -411,12 +441,13 @@ class OnlineFetcherHotPathPerfTest extends AnyFlatSpec with Matchers {
 
   private def newGroupByFixture(executorThreads: Int,
                                 failAfterPlanning: Boolean,
-                                countKeyEncodes: Boolean): GroupByFixture = {
+                                countKeyEncodes: Boolean,
+                                servingInfos: Map[String, GroupByServingInfoParsed] = servingInfoByName): GroupByFixture = {
     val executor = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(executorThreads))
     val store = new BenchmarkKVStore(failAfterPlanning, countKeyEncodes)
     val fetchContext = FetchContext(store, executionContextOverride = executor, kvTimeoutMillis = 0L)
-    val metadataStore = new StaticMetadataStore(fetchContext, servingInfoByName)
-    servingInfoByName.keys.foreach(metadataStore.getGroupByServingInfo(_))
+    val metadataStore = new StaticMetadataStore(fetchContext, servingInfos)
+    servingInfos.keys.foreach(metadataStore.getGroupByServingInfo(_))
     val fetcher = this.synchronized {
       val previousCacheSize = Option(System.getProperty(BatchIrCacheSizeProperty))
       System.setProperty(BatchIrCacheSizeProperty, "0")

--- a/online/src/test/scala/ai/chronon/online/test/OnlineFetcherHotPathPerfTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/OnlineFetcherHotPathPerfTest.scala
@@ -1,0 +1,602 @@
+package ai.chronon.online.test
+
+import ai.chronon.api.{Accuracy, Builders, GroupBy, GroupByServingInfo, StringType, StructField, StructType}
+import ai.chronon.online.KVStore.{GetRequest, GetResponse, PutRequest, TimedValue}
+import ai.chronon.online.fetcher.Fetcher.Request
+import ai.chronon.online.fetcher.FetcherCache.{BatchIrCache, BatchResponses, CachedBatchResponse}
+import ai.chronon.online.fetcher.{FetchContext, FetcherCache, GroupByFetcher, LambdaKvRequest, MetadataStore}
+import ai.chronon.online.metrics.{Metrics, TTLCache}
+import ai.chronon.online.serde.AvroConversions
+import ai.chronon.online.{GroupByServingInfoParsed, KVStore}
+import org.mockito.Mockito.{mock, mockingDetails}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.atomic.{AtomicInteger, AtomicLong}
+import java.util.concurrent.{Callable, CountDownLatch, Executors, TimeUnit}
+import scala.collection.JavaConverters._
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutorService, Future}
+import scala.util.{Failure, Success, Try}
+
+/** Opt-in microbenchmarks for the CPU-side fetcher work surrounding a KV multi-get.
+  *
+  * Each scenario isolates one production change so sequential commits can be attributed without Redis noise:
+  *   - cache_lookup calls FetcherCache.getCachedRequests directly;
+  *   - groupby_planning stops immediately after GroupByFetcher constructs the KV requests;
+  *   - groupby_response_metrics echoes empty KV responses and replaces value decoding with a no-op.
+  *
+  * The workload is the same deduplicated 50-candidate shape used by the Redis benchmark: 25 shared context
+  * GroupBys, 25 candidate GroupBys, and 10 temporal GroupBys split 5/5 across context and candidate ownership.
+  */
+class OnlineFetcherHotPathPerfTest extends AnyFlatSpec with Matchers {
+
+  private val CandidateCount = 50
+  private val ContextGroupByCount = 25
+  private val CandidateGroupByCount = 25
+  private val ContextLastGroupByCount = 3
+  private val ContextTiledGroupByCount = 2
+  private val CandidateLastGroupByCount = 2
+  private val CandidateTiledGroupByCount = 3
+  private val GroupByCount = ContextGroupByCount + CandidateGroupByCount
+  private val ContextTemporalGroupByCount = ContextLastGroupByCount + ContextTiledGroupByCount
+  private val CandidateTemporalGroupByCount = CandidateLastGroupByCount + CandidateTiledGroupByCount
+  private val UniqueGroupByRequestCount = ContextGroupByCount + CandidateCount * CandidateGroupByCount
+  private val UniqueStreamingRequestCount =
+    ContextTemporalGroupByCount + CandidateCount * CandidateTemporalGroupByCount
+  private val KvRequestCount = UniqueGroupByRequestCount + UniqueStreamingRequestCount
+  private val DistinctMetricsContextCount = GroupByCount
+  private val LegacyMultiGetMetricWrites = UniqueGroupByRequestCount * 4
+  private val DeduplicatedMultiGetMetricWrites = DistinctMetricsContextCount * 4
+  private val MultiGetMetricNames = Set(
+    "multi_get.batch.size",
+    "multi_get.bytes",
+    "multi_get.response.length",
+    "multi_get.latency.millis"
+  )
+  private val BenchmarkAtMillis = 1721606400000L
+  private val SharedContextId = "context-0"
+  private val KeyColumn = "entity_id"
+  private val BatchIrCacheSizeProperty = "ai.chronon.fetcher.batch_ir_cache_size_elements"
+  private val KeySchema = AvroConversions
+    .fromChrononSchema(StructType("BenchmarkKey", Array(StructField(KeyColumn, StringType))))
+    .toString
+
+  private sealed trait Ownership
+  private case object ContextOwnership extends Ownership
+  private case object CandidateOwnership extends Ownership
+
+  private final case class GroupByDefinition(name: String, ownership: Ownership, temporal: Boolean)
+  private final case class PreparedGroupBy(definition: GroupByDefinition,
+                                           groupBy: GroupBy,
+                                           servingInfo: GroupByServingInfoParsed,
+                                           metricsContext: Metrics.Context)
+  private final case class PreparedRequest(groupBy: PreparedGroupBy,
+                                           request: Request,
+                                           candidateIndex: Option[Int])
+
+  private val groupByDefinitions: Vector[GroupByDefinition] = {
+    def definitions(prefix: String, ownership: Ownership, temporal: Boolean, count: Int): Vector[GroupByDefinition] =
+      (0 until count).map(index => GroupByDefinition(f"benchmark.$prefix.$index%02d", ownership, temporal)).toVector
+
+    definitions("context_last", ContextOwnership, temporal = true, ContextLastGroupByCount) ++
+      definitions("context_tiled", ContextOwnership, temporal = true, ContextTiledGroupByCount) ++
+      definitions("context_snapshot",
+                  ContextOwnership,
+                  temporal = false,
+                  ContextGroupByCount - ContextTemporalGroupByCount) ++
+      definitions("candidate_last", CandidateOwnership, temporal = true, CandidateLastGroupByCount) ++
+      definitions("candidate_tiled", CandidateOwnership, temporal = true, CandidateTiledGroupByCount) ++
+      definitions("candidate_snapshot",
+                  CandidateOwnership,
+                  temporal = false,
+                  CandidateGroupByCount - CandidateTemporalGroupByCount)
+  }
+
+  private val preparedGroupBys: Vector[PreparedGroupBy] = groupByDefinitions.map { definition =>
+    val groupBy = Builders.GroupBy(
+      sources = if (definition.temporal) {
+        Seq(
+          Builders.Source.events(
+            query = Builders.Query(),
+            table = s"${definition.name}.events",
+            topic = s"${definition.name}.topic"
+          ))
+      } else Seq.empty,
+      metaData = Builders.MetaData(name = definition.name),
+      keyColumns = Seq(KeyColumn),
+      accuracy = if (definition.temporal) Accuracy.TEMPORAL else Accuracy.SNAPSHOT
+    )
+    val rawServingInfo = new GroupByServingInfo()
+      .setGroupBy(groupBy)
+      .setKeyAvroSchema(KeySchema)
+      .setBatchEndTs(BenchmarkAtMillis)
+    PreparedGroupBy(
+      definition,
+      groupBy,
+      new GroupByServingInfoParsed(rawServingInfo),
+      Metrics.Context(
+        environment = Metrics.Environment.GroupByFetching,
+        groupBy = definition.name,
+        accuracy = if (definition.temporal) Accuracy.TEMPORAL else Accuracy.SNAPSHOT
+      )
+    )
+  }
+
+  private val preparedRequests: Vector[PreparedRequest] = {
+    val contextRequests = preparedGroupBys
+      .filter(_.definition.ownership == ContextOwnership)
+      .map { preparedGroupBy =>
+        PreparedRequest(
+          preparedGroupBy,
+          Request(
+            preparedGroupBy.definition.name,
+            Map(KeyColumn -> SharedContextId.asInstanceOf[AnyRef]),
+            Some(BenchmarkAtMillis),
+            Some(preparedGroupBy.metricsContext)
+          ),
+          None
+        )
+      }
+
+    val candidateGroupBys = preparedGroupBys.filter(_.definition.ownership == CandidateOwnership)
+    val candidateRequests = (0 until CandidateCount).flatMap { candidateIndex =>
+      candidateGroupBys.map { preparedGroupBy =>
+        PreparedRequest(
+          preparedGroupBy,
+          Request(
+            preparedGroupBy.definition.name,
+            Map(KeyColumn -> f"candidate-$candidateIndex%02d".asInstanceOf[AnyRef]),
+            Some(BenchmarkAtMillis),
+            Some(preparedGroupBy.metricsContext)
+          ),
+          Some(candidateIndex)
+        )
+      }
+    }
+    contextRequests ++ candidateRequests
+  }
+
+  private val groupByRequests: Vector[Request] = preparedRequests.map(_.request)
+  private val servingInfoByName: Map[String, GroupByServingInfoParsed] =
+    preparedGroupBys.iterator.map(prepared => prepared.definition.name -> prepared.servingInfo).toMap
+
+  behavior of "online fetcher hot-path workload"
+
+  it should "model the exact deduplicated GroupBy and KV request shape" in {
+    preparedGroupBys should have size GroupByCount
+    preparedRequests should have size UniqueGroupByRequestCount
+    preparedRequests.count(_.candidateIndex.isEmpty) shouldBe ContextGroupByCount
+    preparedRequests.count(_.candidateIndex.isDefined) shouldBe CandidateCount * CandidateGroupByCount
+    preparedRequests.count(_.groupBy.definition.temporal) shouldBe UniqueStreamingRequestCount
+    preparedRequests.map(_.request.context.get).distinct should have size DistinctMetricsContextCount
+
+    val validation = validateGroupByPlanningShape()
+    Set(UniqueGroupByRequestCount * 2L, KvRequestCount.toLong) should contain(validation.keyEncodes)
+    validation.kvRequests shouldBe KvRequestCount
+    val metricsValidation = validateGroupByResponseMetricsShape()
+    Set(LegacyMultiGetMetricWrites, DeduplicatedMultiGetMetricWrites) should contain(metricsValidation.metricWrites)
+
+    Seq(0, 50, 80, 100).foreach { hitPercent =>
+      val fixture = newCacheFixture(hitPercent)
+      fixture.fetcherCache.getCachedRequests(fixture.requests).size shouldBe expectedCacheHits(hitPercent)
+    }
+
+    println(
+      s"ONLINE_FETCHER_HOT_PATH_SHAPE candidates=$CandidateCount groupbys=$GroupByCount " +
+        s"unique_groupby_requests=$UniqueGroupByRequestCount unique_streaming_requests=$UniqueStreamingRequestCount " +
+        s"kv_requests=$KvRequestCount key_encodes_observed=${validation.keyEncodes} " +
+        s"multi_get_metric_writes_observed=${metricsValidation.metricWrites} " +
+        s"legacy_metric_writes=$LegacyMultiGetMetricWrites deduplicated_metric_writes=$DeduplicatedMultiGetMetricWrites")
+  }
+
+  it should "run the opt-in cache lookup benchmark" in {
+    requireBenchmarkScenario("cache_lookup")
+    val warmupBatches = envPositiveInt("CHRONON_ONLINE_FETCHER_WARMUP_BATCHES", 100)
+    val measuredBatches = envPositiveInt("CHRONON_ONLINE_FETCHER_MEASURED_BATCHES", 1000)
+    val batchConcurrencies = envPositiveInts("CHRONON_ONLINE_FETCHER_BATCH_CONCURRENCIES", Seq(1, 4))
+    val hitPercents = envNonNegativeInts("CHRONON_ONLINE_FETCHER_CACHE_HIT_PERCENTS", Seq(0, 50, 80, 100))
+    require(hitPercents.forall(_ <= 100), "CHRONON_ONLINE_FETCHER_CACHE_HIT_PERCENTS values must be <= 100")
+
+    println(
+      "ONLINE_FETCHER_HOT_PATH_SCOPE scenario=cache_lookup " +
+        "included=FetcherCache.getCachedRequests,Caffeine_lookup,cache_hit_miss_metrics " +
+        "excluded=GroupByFetcher,Redis,key_encode,value_decode,aggregation_merge")
+
+    hitPercents.foreach { hitPercent =>
+      val fixture = newCacheFixture(hitPercent)
+      val expectedHits = expectedCacheHits(hitPercent)
+      fixture.fetcherCache.getCachedRequests(fixture.requests).size shouldBe expectedHits
+      batchConcurrencies.foreach { batchConcurrency =>
+        runScenario(
+          scenario = "cache_lookup",
+          batchConcurrency = batchConcurrency,
+          warmupBatches = warmupBatches,
+          measuredBatches = measuredBatches,
+          fields = s"cache_hit_percent=$hitPercent expected_cache_hits=$expectedHits",
+          operation = () => fixture.fetcherCache.getCachedRequests(fixture.requests).size.toLong
+        )
+      }
+    }
+  }
+
+  it should "run the opt-in GroupBy request planning benchmark" in {
+    requireBenchmarkScenario("groupby_planning")
+    val warmupBatches = envPositiveInt("CHRONON_ONLINE_FETCHER_WARMUP_BATCHES", 100)
+    val measuredBatches = envPositiveInt("CHRONON_ONLINE_FETCHER_MEASURED_BATCHES", 1000)
+    val batchConcurrencies = envPositiveInts("CHRONON_ONLINE_FETCHER_BATCH_CONCURRENCIES", Seq(1, 4))
+    val executorThreadCounts = envPositiveInts("CHRONON_ONLINE_FETCHER_EXECUTOR_THREADS", Seq(1, 4))
+    val validation = validateGroupByPlanningShape()
+
+    println(
+      "ONLINE_FETCHER_HOT_PATH_SCOPE scenario=groupby_planning " +
+        "included=GroupByFetcher.metadata_cache,key_cast,key_encode,GetRequest_planning " +
+        "multiGet=immediate_failed_future " +
+        "excluded=Redis,Caffeine,response_metrics,value_decode,aggregation_merge")
+
+    executorThreadCounts.foreach { executorThreads =>
+      val fixture = newGroupByFixture(executorThreads, failAfterPlanning = true, countKeyEncodes = false)
+      try {
+        batchConcurrencies.foreach { batchConcurrency =>
+          runScenario(
+            scenario = "groupby_planning",
+            batchConcurrency = batchConcurrency,
+            warmupBatches = warmupBatches,
+            measuredBatches = measuredBatches,
+            fields =
+              s"fetcher_executor_threads=$executorThreads key_encodes_per_batch=${validation.keyEncodes} " +
+                s"kv_requests_per_batch=$KvRequestCount",
+            operation = () => {
+              awaitPlanningComplete(fixture.fetcher.fetchGroupBys(groupByRequests))
+              UniqueGroupByRequestCount.toLong
+            }
+          )
+        }
+      } finally {
+        closeExecutor(fixture.executor)
+      }
+    }
+  }
+
+  it should "run the opt-in multi-get response metrics benchmark" in {
+    requireBenchmarkScenario("groupby_response_metrics")
+    val warmupBatches = envPositiveInt("CHRONON_ONLINE_FETCHER_WARMUP_BATCHES", 100)
+    val measuredBatches = envPositiveInt("CHRONON_ONLINE_FETCHER_MEASURED_BATCHES", 1000)
+    val batchConcurrencies = envPositiveInts("CHRONON_ONLINE_FETCHER_BATCH_CONCURRENCIES", Seq(1, 4))
+    val executorThreadCounts = envPositiveInts("CHRONON_ONLINE_FETCHER_EXECUTOR_THREADS", Seq(1, 4))
+    val metricsValidation = validateGroupByResponseMetricsShape()
+    Set(LegacyMultiGetMetricWrites, DeduplicatedMultiGetMetricWrites) should contain(metricsValidation.metricWrites)
+
+    println(
+      "ONLINE_FETCHER_HOT_PATH_SCOPE scenario=groupby_response_metrics " +
+        "included=GroupByFetcher.request_planning,response_index,multi_get_metrics,response_fanout " +
+        "multiGet=immediate_empty_echo decodeAndMerge=no_op " +
+        "excluded=Redis,Caffeine,value_decode,aggregation_merge")
+
+    executorThreadCounts.foreach { executorThreads =>
+      val fixture = newGroupByFixture(executorThreads, failAfterPlanning = false, countKeyEncodes = false)
+      try {
+        val validationResponses = Await.result(fixture.fetcher.fetchGroupBys(groupByRequests), 30.seconds)
+        validationResponses should have size UniqueGroupByRequestCount
+        validationResponses.forall(_.values.isSuccess) shouldBe true
+
+        batchConcurrencies.foreach { batchConcurrency =>
+          runScenario(
+            scenario = "groupby_response_metrics",
+            batchConcurrency = batchConcurrency,
+            warmupBatches = warmupBatches,
+            measuredBatches = measuredBatches,
+            fields =
+              s"fetcher_executor_threads=$executorThreads legacy_metric_writes_per_batch=$LegacyMultiGetMetricWrites " +
+                s"deduplicated_metric_writes_per_batch=$DeduplicatedMultiGetMetricWrites " +
+                s"multi_get_metric_writes_observed=${metricsValidation.metricWrites}",
+            operation = () =>
+              Await.result(fixture.fetcher.fetchGroupBys(groupByRequests), 30.seconds).size.toLong
+          )
+        }
+      } finally {
+        closeExecutor(fixture.executor)
+      }
+    }
+  }
+
+  private final case class CacheFixture(fetcherCache: BenchmarkFetcherCache,
+                                        requests: Seq[(Request, Try[LambdaKvRequest])])
+
+  private final class BenchmarkFetcherCache(cache: BatchIrCache) extends FetcherCache {
+    override val maybeBatchIrCache: Option[BatchIrCache] = Some(cache)
+    override def isCachingEnabled(groupBy: GroupBy): Boolean = true
+  }
+
+  private def newCacheFixture(hitPercent: Int): CacheFixture = {
+    val cache = new BatchIrCache(s"fetcher-hot-path-$hitPercent", UniqueGroupByRequestCount * 2)
+    val fetcherCache = new BenchmarkFetcherCache(cache)
+    val cachedValue: CachedBatchResponse = BatchResponses(Map("value" -> java.lang.Long.valueOf(1L)))
+    val requests = preparedRequests.map { prepared =>
+      val batchRequest = GetRequest(
+        s"${prepared.request.name}:${prepared.request.keys(KeyColumn)}".getBytes(StandardCharsets.UTF_8),
+        prepared.groupBy.servingInfo.groupByOps.batchDataset
+      )
+      val lambdaRequest = LambdaKvRequest(
+        prepared.groupBy.servingInfo,
+        prepared.request,
+        batchRequest,
+        None,
+        prepared.request.atMillis,
+        prepared.groupBy.metricsContext
+      )
+      if (isCacheHit(prepared, hitPercent)) {
+        val cacheKey = BatchIrCache.Key(batchRequest.dataset,
+                                        prepared.request.keys,
+                                        prepared.groupBy.servingInfo.batchEndTsMillis)
+        cache.cache.put(cacheKey, cachedValue)
+      }
+      prepared.request -> Success(lambdaRequest)
+    }
+    CacheFixture(fetcherCache, requests)
+  }
+
+  private def isCacheHit(request: PreparedRequest, hitPercent: Int): Boolean = {
+    if (hitPercent == 0) false
+    else {
+      request.candidateIndex match {
+        case None => true
+        case Some(candidateIndex) =>
+          val candidateMisses = math.ceil(CandidateCount * (100 - hitPercent) / 100.0).toInt
+          candidateIndex >= candidateMisses
+      }
+    }
+  }
+
+  private def expectedCacheHits(hitPercent: Int): Int = {
+    if (hitPercent == 0) 0
+    else {
+      val candidateMisses = math.ceil(CandidateCount * (100 - hitPercent) / 100.0).toInt
+      ContextGroupByCount + (CandidateCount - candidateMisses) * CandidateGroupByCount
+    }
+  }
+
+  private object PlanningComplete extends RuntimeException("planning complete", null, false, false)
+
+  private final class BenchmarkKVStore(val failAfterPlanning: Boolean, val countKeyEncodes: Boolean) extends KVStore {
+    override implicit val executionContext: ExecutionContext = ExecutionContext.global
+    val keyEncodeCount = new AtomicLong(0L)
+    val lastMultiGetSize = new AtomicInteger(0)
+
+    override def create(dataset: String): Unit = ()
+
+    override def createKeyBytes(keys: Map[String, AnyRef],
+                                groupByServingInfo: GroupByServingInfoParsed,
+                                dataset: String): Array[Byte] = {
+      if (countKeyEncodes) keyEncodeCount.incrementAndGet()
+      super.createKeyBytes(keys, groupByServingInfo, dataset)
+    }
+
+    override def multiGet(requests: Seq[GetRequest]): Future[Seq[GetResponse]] = {
+      lastMultiGetSize.set(requests.size)
+      if (failAfterPlanning) Future.failed(PlanningComplete)
+      else Future.successful(requests.map(request => GetResponse(request, Success(Seq.empty))))
+    }
+
+    override def multiPut(keyValueDatasets: Seq[PutRequest]): Future[Seq[Boolean]] =
+      Future.successful(keyValueDatasets.map(_ => true))
+
+    override def bulkPut(sourceOfflineTable: String,
+                         destinationOnlineDataSet: String,
+                         partition: String): Unit = ()
+  }
+
+  private final class StaticMetadataStore(fetchContext: FetchContext,
+                                          servingInfos: Map[String, GroupByServingInfoParsed])
+      extends MetadataStore(fetchContext) {
+    override lazy val getGroupByServingInfo: TTLCache[String, Try[GroupByServingInfoParsed]] =
+      new TTLCache[String, Try[GroupByServingInfoParsed]](
+        name => Success(servingInfos(name)),
+        name => Metrics.Context(Metrics.Environment.MetaDataFetching, groupBy = name),
+        ttlMillis = 24.hours.toMillis
+      )
+  }
+
+  private final class BenchmarkGroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
+      extends GroupByFetcher(fetchContext, metadataStore) {
+    override def decodeAndMerge(batchResponses: BatchResponses,
+                                streamingResponsesOpt: Option[Seq[TimedValue]],
+                                requestContext: RequestContext): Map[String, AnyRef] = Map.empty
+  }
+
+  private final case class GroupByFixture(fetcher: BenchmarkGroupByFetcher,
+                                          store: BenchmarkKVStore,
+                                          executor: ExecutionContextExecutorService)
+
+  private def newGroupByFixture(executorThreads: Int,
+                                failAfterPlanning: Boolean,
+                                countKeyEncodes: Boolean): GroupByFixture = {
+    val executor = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(executorThreads))
+    val store = new BenchmarkKVStore(failAfterPlanning, countKeyEncodes)
+    val fetchContext = FetchContext(store, executionContextOverride = executor, kvTimeoutMillis = 0L)
+    val metadataStore = new StaticMetadataStore(fetchContext, servingInfoByName)
+    servingInfoByName.keys.foreach(metadataStore.getGroupByServingInfo(_))
+    val fetcher = this.synchronized {
+      val previousCacheSize = Option(System.getProperty(BatchIrCacheSizeProperty))
+      System.setProperty(BatchIrCacheSizeProperty, "0")
+      try new BenchmarkGroupByFetcher(fetchContext, metadataStore)
+      finally {
+        previousCacheSize match {
+          case Some(value) => System.setProperty(BatchIrCacheSizeProperty, value)
+          case None        => System.clearProperty(BatchIrCacheSizeProperty)
+        }
+      }
+    }
+    GroupByFixture(fetcher, store, executor)
+  }
+
+  private final case class PlanningValidation(keyEncodes: Long, kvRequests: Int)
+  private final case class MetricsValidation(metricWrites: Int)
+
+  private def validateGroupByPlanningShape(): PlanningValidation = {
+    val fixture = newGroupByFixture(executorThreads = 1, failAfterPlanning = true, countKeyEncodes = true)
+    try {
+      awaitPlanningComplete(fixture.fetcher.fetchGroupBys(groupByRequests))
+      PlanningValidation(fixture.store.keyEncodeCount.get(), fixture.store.lastMultiGetSize.get())
+    } finally {
+      closeExecutor(fixture.executor)
+    }
+  }
+
+  private def validateGroupByResponseMetricsShape(): MetricsValidation = {
+    val contextsByName = preparedGroupBys.iterator.map { prepared =>
+      prepared.definition.name -> mock(classOf[Metrics.Context])
+    }.toMap
+    val requests = groupByRequests.map(request => request.copy(context = Some(contextsByName(request.name))))
+    val fixture = newGroupByFixture(executorThreads = 1, failAfterPlanning = false, countKeyEncodes = false)
+    try {
+      val responses = Await.result(fixture.fetcher.fetchGroupBys(requests), 30.seconds)
+      responses should have size UniqueGroupByRequestCount
+      responses.forall(_.values.isSuccess) shouldBe true
+      val metricWrites = contextsByName.valuesIterator.map { context =>
+        mockingDetails(context).getInvocations.asScala.count { invocation =>
+          invocation.getArguments.headOption.exists {
+            case metric: String => MultiGetMetricNames.contains(metric)
+            case _              => false
+          }
+        }
+      }.sum
+      MetricsValidation(metricWrites)
+    } finally {
+      closeExecutor(fixture.executor)
+    }
+  }
+
+  private def awaitPlanningComplete(future: Future[_]): Unit = {
+    Await.ready(future, 30.seconds).value match {
+      case Some(Failure(error)) if error eq PlanningComplete => ()
+      case Some(Failure(error)) =>
+        throw new IllegalStateException("GroupBy planning failed before reaching multiGet", error)
+      case Some(Success(_)) =>
+        throw new IllegalStateException("GroupBy planning unexpectedly completed multiGet")
+      case None =>
+        throw new IllegalStateException("GroupBy planning future was not completed")
+    }
+  }
+
+  private final case class Measurement(latenciesNanos: Array[Long], wallNanos: Long, checksum: Long)
+
+  private def runScenario(scenario: String,
+                          batchConcurrency: Int,
+                          warmupBatches: Int,
+                          measuredBatches: Int,
+                          fields: String,
+                          operation: () => Long): Unit = {
+    val driverExecutor = Executors.newFixedThreadPool(batchConcurrency)
+    try {
+      runPhase(operation, driverExecutor, batchConcurrency, warmupBatches)
+      val measurement = runPhase(operation, driverExecutor, batchConcurrency, measuredBatches)
+      printResult(scenario, batchConcurrency, warmupBatches, fields, measurement)
+    } finally {
+      driverExecutor.shutdownNow()
+      driverExecutor.awaitTermination(30, TimeUnit.SECONDS)
+    }
+  }
+
+  private def runPhase(operation: () => Long,
+                       driverExecutor: java.util.concurrent.ExecutorService,
+                       batchConcurrency: Int,
+                       batches: Int): Measurement = {
+    val latenciesNanos = new Array[Long](batches)
+    val nextBatch = new AtomicInteger(0)
+    val checksum = new AtomicLong(0L)
+    val startGate = new CountDownLatch(1)
+    val workerCount = math.min(batchConcurrency, batches)
+    val workers = (0 until workerCount).map { _ =>
+      driverExecutor.submit(new Callable[Unit] {
+        override def call(): Unit = {
+          startGate.await()
+          var localChecksum = 0L
+          var batchIndex = nextBatch.getAndIncrement()
+          while (batchIndex < batches) {
+            val startedNanos = System.nanoTime()
+            localChecksum += operation()
+            latenciesNanos(batchIndex) = System.nanoTime() - startedNanos
+            batchIndex = nextBatch.getAndIncrement()
+          }
+          checksum.addAndGet(localChecksum)
+        }
+      })
+    }
+
+    val wallStartNanos = System.nanoTime()
+    startGate.countDown()
+    workers.foreach(_.get(10, TimeUnit.MINUTES))
+    Measurement(latenciesNanos, System.nanoTime() - wallStartNanos, checksum.get())
+  }
+
+  private def printResult(scenario: String,
+                          batchConcurrency: Int,
+                          warmupBatches: Int,
+                          fields: String,
+                          measurement: Measurement): Unit = {
+    val sorted = measurement.latenciesNanos.sorted
+    val wallSeconds = measurement.wallNanos.toDouble / TimeUnit.SECONDS.toNanos(1)
+    val batchesPerSecond = sorted.length / wallSeconds
+    val averageMillis = sorted.iterator.map(_.toDouble).sum / sorted.length / TimeUnit.MILLISECONDS.toNanos(1)
+
+    println(
+      f"ONLINE_FETCHER_HOT_PATH_RESULT scenario=$scenario batch_concurrency=$batchConcurrency%d " +
+        f"warmup_batches=$warmupBatches%d measured_batches=${sorted.length}%d " +
+        f"batches_per_sec=$batchesPerSecond%.2f avg_ms=$averageMillis%.3f " +
+        f"p95_ms=${percentileMillis(sorted, 0.95)}%.3f p99_ms=${percentileMillis(sorted, 0.99)}%.3f " +
+        s"checksum=${measurement.checksum} $fields")
+  }
+
+  private def percentileMillis(sortedNanos: Array[Long], percentile: Double): Double = {
+    val index = math.max(0, math.min(sortedNanos.length - 1, math.ceil(sortedNanos.length * percentile).toInt - 1))
+    sortedNanos(index).toDouble / TimeUnit.MILLISECONDS.toNanos(1)
+  }
+
+  private def closeExecutor(executor: ExecutionContextExecutorService): Unit = {
+    executor.shutdown()
+    if (!executor.awaitTermination(30, TimeUnit.SECONDS)) executor.shutdownNow()
+  }
+
+  private def requireBenchmarkScenario(scenario: String): Unit = {
+    val runBenchmarks = envBoolean("CHRONON_RUN_ONLINE_FETCHER_HOT_PATH_BENCHMARK", default = false)
+    val scenarios = sys.env
+      .get("CHRONON_ONLINE_FETCHER_BENCHMARK_SCENARIOS")
+      .map(_.split(",").iterator.map(_.trim).filter(_.nonEmpty).toSet)
+      .getOrElse(Set("cache_lookup", "groupby_planning", "groupby_response_metrics"))
+    if (!runBenchmarks || !scenarios.contains(scenario)) {
+      cancel(
+        s"Set CHRONON_RUN_ONLINE_FETCHER_HOT_PATH_BENCHMARK=true and include $scenario in " +
+          "CHRONON_ONLINE_FETCHER_BENCHMARK_SCENARIOS to run this benchmark")
+    }
+  }
+
+  private def envBoolean(name: String, default: Boolean): Boolean =
+    sys.env.get(name).map(_.trim.toBoolean).getOrElse(default)
+
+  private def envPositiveInt(name: String, default: Int): Int = {
+    val value = sys.env.get(name).map(_.trim.toInt).getOrElse(default)
+    require(value > 0, s"$name must be positive, got $value")
+    value
+  }
+
+  private def envPositiveInts(name: String, defaults: Seq[Int]): Seq[Int] = {
+    val values = envInts(name, defaults)
+    require(values.nonEmpty && values.forall(_ > 0), s"$name must contain positive integers")
+    values
+  }
+
+  private def envNonNegativeInts(name: String, defaults: Seq[Int]): Seq[Int] = {
+    val values = envInts(name, defaults)
+    require(values.nonEmpty && values.forall(_ >= 0), s"$name must contain non-negative integers")
+    values
+  }
+
+  private def envInts(name: String, defaults: Seq[Int]): Seq[Int] =
+    sys.env
+      .get(name)
+      .map(_.split(",").iterator.map(_.trim).filter(_.nonEmpty).map(_.toInt).toSeq)
+      .getOrElse(defaults)
+      .distinct
+}

--- a/online/src/test/scala/ai/chronon/online/test/OnlineFetcherHotPathPerfTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/OnlineFetcherHotPathPerfTest.scala
@@ -13,7 +13,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import java.nio.charset.StandardCharsets
-import java.util.concurrent.atomic.{AtomicInteger, AtomicLong}
+import java.util.concurrent.atomic.{AtomicInteger, AtomicLong, AtomicReference}
 import java.util.concurrent.{Callable, CountDownLatch, Executors, TimeUnit}
 import scala.collection.JavaConverters._
 import scala.concurrent.duration.DurationInt
@@ -191,7 +191,7 @@ class OnlineFetcherHotPathPerfTest extends AnyFlatSpec with Matchers {
         s"legacy_metric_writes=$LegacyMultiGetMetricWrites deduplicated_metric_writes=$DeduplicatedMultiGetMetricWrites")
   }
 
-  it should "skip streaming reads for temporal GroupBys without a topic" in {
+  it should "skip streaming reads and preserve temporal finalization for GroupBys without a topic" in {
     val name = "benchmark.batch_only_temporal"
     val groupBy = Builders.GroupBy(
       sources = Seq(Builders.Source.events(query = Builders.Query(), table = s"$name.events")),
@@ -206,16 +206,21 @@ class OnlineFetcherHotPathPerfTest extends AnyFlatSpec with Matchers {
         .setBatchEndTs(BenchmarkAtMillis))
     val fixture = newGroupByFixture(
       executorThreads = 1,
-      failAfterPlanning = true,
+      failAfterPlanning = false,
       countKeyEncodes = true,
       servingInfos = Map(name -> servingInfo)
     )
     try {
-      awaitPlanningComplete(
+      val responses = Await.result(
         fixture.fetcher.fetchGroupBys(
-          Seq(Request(name, Map(KeyColumn -> "batch-only".asInstanceOf[AnyRef]), Some(BenchmarkAtMillis)))))
+          Seq(Request(name, Map(KeyColumn -> "batch-only".asInstanceOf[AnyRef]), Some(BenchmarkAtMillis)))),
+        30.seconds
+      )
+      responses should have size 1
+      responses.head.values.isSuccess shouldBe true
       fixture.store.keyEncodeCount.get() shouldBe 1L
       fixture.store.lastMultiGetSize.get() shouldBe 1
+      fixture.fetcher.lastStreamingResponsesOpt.get() shouldBe Some(Seq.empty)
     } finally {
       closeExecutor(fixture.executor)
     }
@@ -430,9 +435,14 @@ class OnlineFetcherHotPathPerfTest extends AnyFlatSpec with Matchers {
 
   private final class BenchmarkGroupByFetcher(fetchContext: FetchContext, metadataStore: MetadataStore)
       extends GroupByFetcher(fetchContext, metadataStore) {
+    val lastStreamingResponsesOpt = new AtomicReference[Option[Seq[TimedValue]]]()
+
     override def decodeAndMerge(batchResponses: BatchResponses,
                                 streamingResponsesOpt: Option[Seq[TimedValue]],
-                                requestContext: RequestContext): Map[String, AnyRef] = Map.empty
+                                requestContext: RequestContext): Map[String, AnyRef] = {
+      lastStreamingResponsesOpt.set(streamingResponsesOpt)
+      Map.empty
+    }
   }
 
   private final case class GroupByFixture(fetcher: BenchmarkGroupByFetcher,

--- a/online/src/test/scala/ai/chronon/online/test/OnlineFetcherHotPathPerfTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/OnlineFetcherHotPathPerfTest.scala
@@ -164,7 +164,7 @@ class OnlineFetcherHotPathPerfTest extends AnyFlatSpec with Matchers {
 
   behavior of "online fetcher hot-path workload"
 
-  it should "model the exact deduplicated GroupBy and KV request shape" in {
+  ignore should "model the exact deduplicated GroupBy and KV request shape" in {
     preparedGroupBys should have size GroupByCount
     preparedRequests should have size UniqueGroupByRequestCount
     preparedRequests.count(_.candidateIndex.isEmpty) shouldBe ContextGroupByCount

--- a/online/src/test/scala/ai/chronon/online/test/OnlineFetcherHotPathPerfTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/OnlineFetcherHotPathPerfTest.scala
@@ -176,7 +176,7 @@ class OnlineFetcherHotPathPerfTest extends AnyFlatSpec with Matchers {
     validation.keyEncodes shouldBe KvRequestCount.toLong
     validation.kvRequests shouldBe KvRequestCount
     val metricsValidation = validateGroupByResponseMetricsShape()
-    Set(LegacyMultiGetMetricWrites, DeduplicatedMultiGetMetricWrites) should contain(metricsValidation.metricWrites)
+    metricsValidation.metricWrites shouldBe DeduplicatedMultiGetMetricWrites
 
     Seq(0, 50, 80, 100).foreach { hitPercent =>
       val fixture = newCacheFixture(hitPercent)
@@ -296,7 +296,7 @@ class OnlineFetcherHotPathPerfTest extends AnyFlatSpec with Matchers {
     val batchConcurrencies = envPositiveInts("CHRONON_ONLINE_FETCHER_BATCH_CONCURRENCIES", Seq(1, 4))
     val executorThreadCounts = envPositiveInts("CHRONON_ONLINE_FETCHER_EXECUTOR_THREADS", Seq(1, 4))
     val metricsValidation = validateGroupByResponseMetricsShape()
-    Set(LegacyMultiGetMetricWrites, DeduplicatedMultiGetMetricWrites) should contain(metricsValidation.metricWrites)
+    metricsValidation.metricWrites shouldBe DeduplicatedMultiGetMetricWrites
 
     println(
       "ONLINE_FETCHER_HOT_PATH_SCOPE scenario=groupby_response_metrics " +

--- a/redis/src/main/scala/ai/chronon/integrations/redis/RedisKVStoreConstants.scala
+++ b/redis/src/main/scala/ai/chronon/integrations/redis/RedisKVStoreConstants.scala
@@ -13,7 +13,7 @@ object RedisKVStoreConstants {
   // Connection pool defaults (Commons Pool2 best practices)
   val DefaultMaxConnections = 50 // Production-ready default (Jedis default of 8 is too low)
   val DefaultMinIdleConnections = 5 // Keep connections warm to avoid cold-start latency
-  val DefaultMaxIdleConnections = 10 // Balance between responsiveness and resource usage
+  val DefaultMaxIdleConnections = 10 // Bound retained sockets per node; deployments can raise this for bursty traffic
   val DefaultConnectionTimeoutMs = 5000 // TCP connection timeout - allows for cluster topology discovery
   val DefaultPort = 6379
 

--- a/redis/src/main/scala/ai/chronon/integrations/redis/RedisKVStoreFactory.scala
+++ b/redis/src/main/scala/ai/chronon/integrations/redis/RedisKVStoreFactory.scala
@@ -2,7 +2,7 @@ package ai.chronon.integrations.redis
 
 import ai.chronon.integrations.redis.RedisKVStoreConstants._
 import org.slf4j.LoggerFactory
-import redis.clients.jedis.{HostAndPort, JedisCluster, JedisPoolConfig}
+import redis.clients.jedis.{ConnectionPoolConfig, HostAndPort, JedisCluster}
 
 import scala.jdk.CollectionConverters._
 
@@ -50,10 +50,13 @@ object RedisKVStoreFactory {
     val password = getOptional(EnvRedisPassword, conf)
 
     val maxConnections = getOptional(EnvRedisMaxConnections, conf).map(_.toInt).getOrElse(DefaultMaxConnections)
-    val minIdleConnections =
-      getOptional(EnvRedisMinIdleConnections, conf).map(_.toInt).getOrElse(DefaultMinIdleConnections)
-    val maxIdleConnections =
-      getOptional(EnvRedisMaxIdleConnections, conf).map(_.toInt).getOrElse(DefaultMaxIdleConnections)
+    val configuredMinIdleConnections = getOptional(EnvRedisMinIdleConnections, conf).map(_.toInt)
+    val configuredMaxIdleConnections = getOptional(EnvRedisMaxIdleConnections, conf).map(_.toInt)
+    val poolConfig = buildConnectionPoolConfig(
+      maxConnections,
+      configuredMinIdleConnections,
+      configuredMaxIdleConnections
+    )
     val connectionTimeoutMs =
       getOptional(EnvRedisConnectionTimeoutMs, conf).map(_.toInt).getOrElse(DefaultConnectionTimeoutMs)
     val soTimeoutMs = getOptional(EnvRedisSoTimeoutMs, conf).map(_.toInt).getOrElse(DefaultSoTimeoutMs)
@@ -74,18 +77,10 @@ object RedisKVStoreFactory {
 
     logger.info(
       s"Creating Redis Cluster KVStore with nodes: ${clusterNodes.mkString(", ")}." +
-        s"Params: maxConnections=$maxConnections, minIdle=$minIdleConnections, " +
-        s"maxIdle=$maxIdleConnections, connectionTimeout=$connectionTimeoutMs, " +
+        s"Params: maxConnections=$maxConnections, minIdle=${poolConfig.getMinIdle}, " +
+        s"maxIdle=${poolConfig.getMaxIdle}, connectionTimeout=$connectionTimeoutMs, " +
         s"soTimeout=$soTimeoutMs, maxRedirections=$maxRedirections"
     )
-
-    val poolConfig = new JedisPoolConfig()
-    poolConfig.setMaxTotal(maxConnections)
-    poolConfig.setMaxIdle(maxIdleConnections)
-    poolConfig.setMinIdle(minIdleConnections)
-    poolConfig.setTestOnBorrow(true)
-    poolConfig.setTestOnReturn(true)
-    poolConfig.setTestWhileIdle(true)
 
     val jedisCluster = password match {
       case Some(pwd) =>
@@ -95,7 +90,7 @@ object RedisKVStoreFactory {
           soTimeoutMs,
           maxRedirections,
           pwd,
-          poolConfig.asInstanceOf[org.apache.commons.pool2.impl.GenericObjectPoolConfig[redis.clients.jedis.Connection]]
+          poolConfig
         )
 
       case None =>
@@ -104,7 +99,7 @@ object RedisKVStoreFactory {
           connectionTimeoutMs,
           soTimeoutMs,
           maxRedirections,
-          poolConfig.asInstanceOf[org.apache.commons.pool2.impl.GenericObjectPoolConfig[redis.clients.jedis.Connection]]
+          poolConfig
         )
     }
 
@@ -115,6 +110,43 @@ object RedisKVStoreFactory {
 
   private def getOptional(key: String, conf: Map[String, String]): Option[String] =
     sys.env.get(key).orElse(conf.get(key))
+
+  private[redis] def buildConnectionPoolConfig(
+      maxConnections: Int,
+      minIdleConnections: Option[Int],
+      maxIdleConnections: Option[Int]
+  ): ConnectionPoolConfig = {
+    val effectiveMaxIdle = maxIdleConnections.getOrElse(math.min(DefaultMaxIdleConnections, maxConnections))
+    val effectiveMinIdle = minIdleConnections.getOrElse(math.min(DefaultMinIdleConnections, effectiveMaxIdle))
+    buildConnectionPoolConfig(maxConnections, effectiveMinIdle, effectiveMaxIdle)
+  }
+
+  private[redis] def buildConnectionPoolConfig(
+      maxConnections: Int,
+      minIdleConnections: Int,
+      maxIdleConnections: Int
+  ): ConnectionPoolConfig = {
+    require(maxConnections > 0, s"maxConnections must be positive, got $maxConnections")
+    require(minIdleConnections >= 0, s"minIdleConnections must be non-negative, got $minIdleConnections")
+    require(maxIdleConnections >= 0, s"maxIdleConnections must be non-negative, got $maxIdleConnections")
+    require(
+      minIdleConnections <= maxIdleConnections,
+      s"minIdleConnections ($minIdleConnections) must not exceed maxIdleConnections ($maxIdleConnections)"
+    )
+    require(
+      maxIdleConnections <= maxConnections,
+      s"maxIdleConnections ($maxIdleConnections) must not exceed maxConnections ($maxConnections)"
+    )
+
+    val poolConfig = new ConnectionPoolConfig()
+    poolConfig.setMaxTotal(maxConnections)
+    poolConfig.setMaxIdle(maxIdleConnections)
+    poolConfig.setMinIdle(minIdleConnections)
+    poolConfig.setTestOnBorrow(false)
+    poolConfig.setTestOnReturn(false)
+    poolConfig.setTestWhileIdle(true)
+    poolConfig
+  }
 
   private def getOrElseThrow(key: String, conf: Map[String, String]): String =
     getOptional(key, conf).getOrElse(

--- a/redis/src/main/scala/ai/chronon/integrations/redis/RedisKVStoreImpl.scala
+++ b/redis/src/main/scala/ai/chronon/integrations/redis/RedisKVStoreImpl.scala
@@ -80,7 +80,8 @@ class RedisKVStoreImpl(jedisCluster: JedisCluster, conf: Map[String, String] = M
 
   // Configurable key prefix (can be empty for dedicated Redis deployments)
   private val keyPrefix: String = conf.getOrElse("redis.key.prefix", DefaultKeyPrefix)
-  private val keyHashTagMode: String = conf.getOrElse("redis.key.hash.tag.mode", RedisKVStore.DatasetAndEntityHashTagMode)
+  private val keyHashTagMode: String =
+    conf.getOrElse("redis.key.hash.tag.mode", RedisKVStore.DatasetAndEntityHashTagMode)
   private val recordReadMetrics: Boolean =
     !conf.get("redis.read.metrics.enabled").exists(_.equalsIgnoreCase("false"))
 
@@ -132,7 +133,8 @@ class RedisKVStoreImpl(jedisCluster: JedisCluster, conf: Map[String, String] = M
     val planned = Try {
       getTableType(request.dataset) match {
         case BatchTable =>
-          val redisKey = buildRedisKey(request.keyBytes, request.dataset, keyPrefix = keyPrefix, hashTagMode = keyHashTagMode)
+          val redisKey =
+            buildRedisKey(request.keyBytes, request.dataset, keyPrefix = keyPrefix, hashTagMode = keyHashTagMode)
           BatchReadPlan(request, redisKey.getBytes(StandardCharsets.UTF_8))
         case StreamingTable if request.startTsMillis.isDefined =>
           val startTs = request.startTsMillis.get
@@ -257,8 +259,8 @@ class RedisKVStoreImpl(jedisCluster: JedisCluster, conf: Map[String, String] = M
     PipelineAttempt(results, activePlan)
   }
 
-  private def queueJedisReads(plans: Seq[RedisReadPlan], pipeline: ClusterPipeline)(markActive: RedisReadPlan => Unit)
-      : Seq[PendingRead] = {
+  private def queueJedisReads(plans: Seq[RedisReadPlan], pipeline: ClusterPipeline)(
+      markActive: RedisReadPlan => Unit): Seq[PendingRead] = {
     val pendingReads = Array.ofDim[PendingRead](plans.size)
     val mgetGroups = new java.util.LinkedHashMap[Int, java.util.ArrayList[(Int, BatchReadPlan)]]()
 
@@ -295,8 +297,7 @@ class RedisKVStoreImpl(jedisCluster: JedisCluster, conf: Map[String, String] = M
           val pendingIndex = group.get(index)._1
           val plan = group.get(index)._2
           val responseIndex = index
-          pendingReads(pendingIndex) =
-            PendingRead(plan.request, () => Try(decodeBatchValue(values.get(responseIndex))))
+          pendingReads(pendingIndex) = PendingRead(plan.request, () => Try(decodeBatchValue(values.get(responseIndex))))
           index += 1
         }
       }
@@ -784,10 +785,10 @@ object RedisKVStore {
 
   private def buildBaseKey(prefix: String, dataset: String, base64Key: String, hashTagMode: String): String = {
     hashTagMode match {
-      case EntityHashTagMode             => s"$prefix$dataset$KeySeparator{$base64Key}"
-      case DatasetAndEntityHashTagMode   => s"$prefix{$dataset$KeySeparator$base64Key}"
-      case null | ""                     => s"$prefix{$dataset$KeySeparator$base64Key}"
-      case other                         => throw new IllegalArgumentException(s"Unknown Redis hash tag mode: $other")
+      case EntityHashTagMode           => s"$prefix$dataset$KeySeparator{$base64Key}"
+      case DatasetAndEntityHashTagMode => s"$prefix{$dataset$KeySeparator$base64Key}"
+      case null | ""                   => s"$prefix{$dataset$KeySeparator$base64Key}"
+      case other                       => throw new IllegalArgumentException(s"Unknown Redis hash tag mode: $other")
     }
   }
 

--- a/redis/src/main/scala/ai/chronon/integrations/redis/RedisKVStoreImpl.scala
+++ b/redis/src/main/scala/ai/chronon/integrations/redis/RedisKVStoreImpl.scala
@@ -16,7 +16,7 @@ import redis.clients.jedis.exceptions.{
 }
 import redis.clients.jedis.{ClusterPipeline, Jedis, JedisCluster, Response}
 import redis.clients.jedis.params.ScanParams
-import redis.clients.jedis.resps.{ScanResult, Tuple}
+import redis.clients.jedis.resps.ScanResult
 
 import java.nio.charset.StandardCharsets
 import scala.collection.concurrent.TrieMap
@@ -162,7 +162,7 @@ class RedisKVStoreImpl(jedisCluster: JedisCluster, conf: Map[String, String] = M
           redisKey,
           startTs,
           endTs,
-          pipeline.zrangeByScoreWithScores(redisKey, startTs.toDouble, endTs.toDouble)
+          pipeline.zrangeByScore(redisKey, startTs.toDouble, endTs.toDouble)
         )
       }
       PendingRead(request, () => Try(decodeStreamingValues(commands)))
@@ -295,7 +295,7 @@ class RedisKVStoreImpl(jedisCluster: JedisCluster, conf: Map[String, String] = M
         decodeBatchValue(jedisCluster.get(redisKey))
       case StreamingReadPlan(_, redisKeys, startTs, endTs) =>
         redisKeys.flatMap { redisKey =>
-          decodeStreamingTuples(jedisCluster.zrangeByScoreWithScores(redisKey, startTs.toDouble, endTs.toDouble))
+          decodeStreamingMembers(jedisCluster.zrangeByScore(redisKey, startTs.toDouble, endTs.toDouble))
         }
     }
   }
@@ -321,7 +321,7 @@ class RedisKVStoreImpl(jedisCluster: JedisCluster, conf: Map[String, String] = M
       ()
     case StreamingReadPlan(_, redisKeys, startTs, endTs) =>
       redisKeys.headOption.foreach { redisKey =>
-        jedisCluster.zrangeByScoreWithScores(redisKey, startTs.toDouble, endTs.toDouble)
+        jedisCluster.zrangeByScore(redisKey, startTs.toDouble, endTs.toDouble)
       }
   }
 
@@ -344,15 +344,15 @@ class RedisKVStoreImpl(jedisCluster: JedisCluster, conf: Map[String, String] = M
 
   private def decodeStreamingValues(commands: Seq[StreamingCommand]): Seq[TimedValue] = {
     commands.flatMap { command =>
-      decodeStreamingTuples(command.response.get())
+      decodeStreamingMembers(command.response.get())
     }
   }
 
-  private def decodeStreamingTuples(tuples: java.util.List[Tuple]): Seq[TimedValue] = {
-    tuples.asScala.flatMap { tuple =>
-      val memberBytes = tuple.getBinaryElement
+  private def decodeStreamingMembers(members: java.util.List[Array[Byte]]): Seq[TimedValue] = {
+    members.asScala.flatMap { memberBytes =>
       if (memberBytes.length >= 8) {
-        Some(TimedValue(memberBytes.drop(8), tuple.getScore.toLong))
+        val timestamp = java.nio.ByteBuffer.wrap(memberBytes, 0, 8).getLong
+        Some(TimedValue(memberBytes.drop(8), timestamp))
       } else {
         logger.warn(s"Malformed streaming data in Redis: member has ${memberBytes.length} bytes, expected >= 8")
         None
@@ -640,7 +640,7 @@ private[redis] object RedisKVStoreImpl {
       redisKey: Array[Byte],
       startTs: Long,
       endTs: Long,
-      response: Response[java.util.List[Tuple]]
+      response: Response[java.util.List[Array[Byte]]]
   )
 
   final case class PendingRead(request: GetRequest, resolve: () => Try[Seq[TimedValue]])

--- a/redis/src/main/scala/ai/chronon/integrations/redis/RedisKVStoreImpl.scala
+++ b/redis/src/main/scala/ai/chronon/integrations/redis/RedisKVStoreImpl.scala
@@ -17,9 +17,11 @@ import redis.clients.jedis.exceptions.{
 import redis.clients.jedis.{ClusterPipeline, Jedis, JedisCluster, Response}
 import redis.clients.jedis.params.ScanParams
 import redis.clients.jedis.resps.ScanResult
+import redis.clients.jedis.util.JedisClusterCRC16
 
 import java.nio.charset.StandardCharsets
 import scala.collection.concurrent.TrieMap
+import scala.collection.mutable
 import scala.concurrent.{Await, Future}
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
@@ -78,6 +80,9 @@ class RedisKVStoreImpl(jedisCluster: JedisCluster, conf: Map[String, String] = M
 
   // Configurable key prefix (can be empty for dedicated Redis deployments)
   private val keyPrefix: String = conf.getOrElse("redis.key.prefix", DefaultKeyPrefix)
+  private val keyHashTagMode: String = conf.getOrElse("redis.key.hash.tag.mode", RedisKVStore.DatasetAndEntityHashTagMode)
+  private val recordReadMetrics: Boolean =
+    !conf.get("redis.read.metrics.enabled").exists(_.equalsIgnoreCase("false"))
 
   // TTL is now configurable via RedisKVStoreConstants or via props in create()
   protected val metricsContext: Metrics.Context = Metrics.Context(Metrics.Environment.KVStore).withSuffix("redis")
@@ -110,13 +115,13 @@ class RedisKVStoreImpl(jedisCluster: JedisCluster, conf: Map[String, String] = M
             case ImmediateReadPlan(request, values) => GetResponse(request, values)
             case plan: RedisReadPlan                => GetResponse(plan.request, redisResults.next())
           }
-          recordMultiGetMetrics(responses, System.currentTimeMillis() - startedAt)
+          if (recordReadMetrics) recordMultiGetMetrics(responses, System.currentTimeMillis() - startedAt)
           responses
         } catch {
           case e: Exception =>
             logger.error("Error getting values from Redis Cluster", e)
             val responses = requests.map(request => GetResponse(request, Failure(e)))
-            recordMultiGetMetrics(responses, System.currentTimeMillis() - startedAt)
+            if (recordReadMetrics) recordMultiGetMetrics(responses, System.currentTimeMillis() - startedAt)
             responses
         }
       }
@@ -127,7 +132,7 @@ class RedisKVStoreImpl(jedisCluster: JedisCluster, conf: Map[String, String] = M
     val planned = Try {
       getTableType(request.dataset) match {
         case BatchTable =>
-          val redisKey = buildRedisKey(request.keyBytes, request.dataset, keyPrefix = keyPrefix)
+          val redisKey = buildRedisKey(request.keyBytes, request.dataset, keyPrefix = keyPrefix, hashTagMode = keyHashTagMode)
           BatchReadPlan(request, redisKey.getBytes(StandardCharsets.UTF_8))
         case StreamingTable if request.startTsMillis.isDefined =>
           val startTs = request.startTsMillis.get
@@ -139,8 +144,12 @@ class RedisKVStoreImpl(jedisCluster: JedisCluster, conf: Map[String, String] = M
           val startDay = startTs - (startTs % millisPerDay)
           val endDay = endTs - (endTs % millisPerDay)
           val redisKeys = (startDay to endDay by millisPerDay).map { dayTs =>
-            buildTiledRedisKey(baseKeyBytes, request.dataset, dayTs, tileSizeMs, keyPrefix)
-              .getBytes(StandardCharsets.UTF_8)
+            buildTiledRedisKey(baseKeyBytes,
+                               request.dataset,
+                               dayTs,
+                               tileSizeMs,
+                               keyPrefix,
+                               hashTagMode = keyHashTagMode).getBytes(StandardCharsets.UTF_8)
           }.toVector
           if (redisKeys.isEmpty) ImmediateReadPlan(request, Success(Seq.empty))
           else StreamingReadPlan(request, redisKeys, startTs, endTs)
@@ -224,9 +233,8 @@ class RedisKVStoreImpl(jedisCluster: JedisCluster, conf: Map[String, String] = M
       var queueError = Option.empty[Exception]
       val pendingReads =
         try {
-          plans.map { plan =>
+          queueJedisReads(plans, pipeline) { plan =>
             activePlan = Some(plan)
-            queueRead(plan, pipeline)
           }
         } catch {
           case error: Exception =>
@@ -247,6 +255,54 @@ class RedisKVStoreImpl(jedisCluster: JedisCluster, conf: Map[String, String] = M
       pendingReads.map(_.resolve())
     }
     PipelineAttempt(results, activePlan)
+  }
+
+  private def queueJedisReads(plans: Seq[RedisReadPlan], pipeline: ClusterPipeline)(markActive: RedisReadPlan => Unit)
+      : Seq[PendingRead] = {
+    val pendingReads = Array.ofDim[PendingRead](plans.size)
+    val mgetGroups = new java.util.LinkedHashMap[Int, java.util.ArrayList[(Int, BatchReadPlan)]]()
+
+    plans.iterator.zipWithIndex.foreach {
+      case (plan: BatchReadPlan, index) =>
+        markActive(plan)
+        val slot = JedisClusterCRC16.getSlot(plan.redisKey)
+        var group = mgetGroups.get(slot)
+        if (group == null) {
+          group = new java.util.ArrayList[(Int, BatchReadPlan)]()
+          mgetGroups.put(slot, group)
+        }
+        group.add(index -> plan)
+      case (plan @ StreamingReadPlan(_, redisKeys, startTs, endTs), index) =>
+        markActive(plan)
+        pendingReads(index) = queueRead(plan, pipeline)
+    }
+
+    mgetGroups.values().asScala.foreach { group =>
+      if (group.size() == 1) {
+        val (index, plan) = group.get(0)
+        pendingReads(index) = queueRead(plan, pipeline)
+      } else {
+        val redisKeys = Array.ofDim[Array[Byte]](group.size())
+        var index = 0
+        while (index < group.size()) {
+          redisKeys(index) = group.get(index)._2.redisKey
+          index += 1
+        }
+        val response = pipeline.mget(redisKeys: _*)
+        lazy val values = response.get()
+        index = 0
+        while (index < group.size()) {
+          val pendingIndex = group.get(index)._1
+          val plan = group.get(index)._2
+          val responseIndex = index
+          pendingReads(pendingIndex) =
+            PendingRead(plan.request, () => Try(decodeBatchValue(values.get(responseIndex))))
+          index += 1
+        }
+      }
+    }
+
+    pendingReads.toVector
   }
 
   private def retryablePipelineFailure(
@@ -362,10 +418,18 @@ class RedisKVStoreImpl(jedisCluster: JedisCluster, conf: Map[String, String] = M
 
   private def recordMultiGetMetrics(responses: Seq[GetResponse], latencyMillis: Long): Unit = {
     metricsContext.distribution("multiGet.latency", latencyMillis)
-    responses.groupBy(_.request.dataset).foreach { case (dataset, datasetResponses) =>
+    val datasets = mutable.LinkedHashSet.empty[String]
+    val failures = mutable.HashMap.empty[String, Throwable]
+    responses.foreach { response =>
+      val dataset = response.request.dataset
+      datasets += dataset
+      if (!failures.contains(dataset)) {
+        response.values.failed.foreach(error => failures.put(dataset, error))
+      }
+    }
+    datasets.foreach { dataset =>
       val datasetMetricsContext = tableToContext.getOrElseUpdate(dataset, metricsContext.copy(dataset = dataset))
-      val failure = datasetResponses.iterator.flatMap(_.values.failed.toOption).toSeq.headOption
-      failure match {
+      failures.get(dataset) match {
         case Some(error) =>
           datasetMetricsContext.increment("multiGet.redis_errors", Map("exception" -> error.getClass.getName))
         case None =>
@@ -495,10 +559,16 @@ class RedisKVStoreImpl(jedisCluster: JedisCluster, conf: Map[String, String] = M
             case (Some(ts), StreamingTable) =>
               val tileKey = TilingUtils.deserializeTileKey(request.keyBytes)
               val baseKeyBytes = tileKey.keyBytes.asScala.map(_.toByte).toSeq
-              (buildTiledRedisKey(baseKeyBytes, request.dataset, ts, tileKey.tileSizeMillis, keyPrefix),
+              (buildTiledRedisKey(baseKeyBytes,
+                                  request.dataset,
+                                  ts,
+                                  tileKey.tileSizeMillis,
+                                  keyPrefix,
+                                  hashTagMode = keyHashTagMode),
                tileKey.tileStartTimestampMillis)
             case _ =>
-              (buildRedisKey(request.keyBytes, request.dataset, keyPrefix = keyPrefix), timestampInPutRequest)
+              (buildRedisKey(request.keyBytes, request.dataset, keyPrefix = keyPrefix, hashTagMode = keyHashTagMode),
+               timestampInPutRequest)
           }
 
           tableType match {
@@ -652,6 +722,9 @@ private[redis] object RedisKVStoreImpl {
 }
 
 object RedisKVStore {
+  val DatasetAndEntityHashTagMode = "dataset_and_entity"
+  val EntityHashTagMode = "entity"
+
   sealed trait TableType
   case object BatchTable extends TableType
   case object StreamingTable extends TableType
@@ -670,11 +743,12 @@ object RedisKVStore {
   def buildRedisKey(baseKeyBytes: Seq[Byte],
                     dataset: String,
                     maybeTs: Option[Long] = None,
-                    keyPrefix: String = DefaultKeyPrefix): String = {
+                    keyPrefix: String = DefaultKeyPrefix,
+                    hashTagMode: String = DatasetAndEntityHashTagMode): String = {
     val base64Key = java.util.Base64.getEncoder.encodeToString(baseKeyBytes.toArray)
     val prefix = if (keyPrefix.isEmpty) "" else s"$keyPrefix$KeySeparator"
-    // Use hash tag {dataset:base64Key} to distribute load across cluster nodes
-    val baseKey = s"$prefix{$dataset$KeySeparator$base64Key}"
+    // Keep dataset in the full key for uniqueness; hashTagMode only controls the Redis Cluster hash tag.
+    val baseKey = buildBaseKey(prefix, dataset, base64Key, hashTagMode)
     maybeTs match {
       case Some(ts) =>
         // For time series data, append the day timestamp
@@ -699,12 +773,22 @@ object RedisKVStore {
                          dataset: String,
                          ts: Long,
                          tileSizeMs: Long,
-                         keyPrefix: String = DefaultKeyPrefix): String = {
+                         keyPrefix: String = DefaultKeyPrefix,
+                         hashTagMode: String = DatasetAndEntityHashTagMode): String = {
     val base64Key = java.util.Base64.getEncoder.encodeToString(baseKeyBytes.toArray)
     val dayTs = ts - (ts % 1.day.toMillis)
     val prefix = if (keyPrefix.isEmpty) "" else s"$keyPrefix$KeySeparator"
-    // Use hash tag {dataset:base64Key} to distribute load across cluster nodes
-    s"$prefix{$dataset$KeySeparator$base64Key}$KeySeparator$dayTs$KeySeparator$tileSizeMs"
+    val baseKey = buildBaseKey(prefix, dataset, base64Key, hashTagMode)
+    s"$baseKey$KeySeparator$dayTs$KeySeparator$tileSizeMs"
+  }
+
+  private def buildBaseKey(prefix: String, dataset: String, base64Key: String, hashTagMode: String): String = {
+    hashTagMode match {
+      case EntityHashTagMode             => s"$prefix$dataset$KeySeparator{$base64Key}"
+      case DatasetAndEntityHashTagMode   => s"$prefix{$dataset$KeySeparator$base64Key}"
+      case null | ""                     => s"$prefix{$dataset$KeySeparator$base64Key}"
+      case other                         => throw new IllegalArgumentException(s"Unknown Redis hash tag mode: $other")
+    }
   }
 
   /** Determine table type from dataset name.

--- a/redis/src/main/scala/ai/chronon/integrations/redis/RedisKVStoreImpl.scala
+++ b/redis/src/main/scala/ai/chronon/integrations/redis/RedisKVStoreImpl.scala
@@ -8,7 +8,13 @@ import ai.chronon.online.KVStore
 import ai.chronon.online.KVStore.{GetRequest, GetResponse, ListRequest, ListResponse, ListValue, PutRequest, TimedValue}
 import ai.chronon.online.metrics.Metrics
 import org.slf4j.{Logger, LoggerFactory}
-import redis.clients.jedis.{Jedis, JedisCluster, JedisPoolConfig}
+import redis.clients.jedis.exceptions.{
+  JedisAskDataException,
+  JedisConnectionException,
+  JedisException,
+  JedisRedirectionException
+}
+import redis.clients.jedis.{ClusterPipeline, Jedis, JedisCluster, Response}
 import redis.clients.jedis.params.ScanParams
 import redis.clients.jedis.resps.{ScanResult, Tuple}
 
@@ -68,6 +74,7 @@ class RedisKVStoreImpl(jedisCluster: JedisCluster, conf: Map[String, String] = M
   @transient override lazy val logger: Logger = LoggerFactory.getLogger(getClass)
 
   import RedisKVStore._
+  import RedisKVStoreImpl._
 
   // Configurable key prefix (can be empty for dedicated Redis deployments)
   private val keyPrefix: String = conf.getOrElse("redis.key.prefix", DefaultKeyPrefix)
@@ -89,145 +96,282 @@ class RedisKVStoreImpl(jedisCluster: JedisCluster, conf: Map[String, String] = M
   override def multiGet(requests: Seq[GetRequest]): Future[Seq[GetResponse]] = {
     logger.debug(s"Performing multi-get for ${requests.size} requests")
 
-    // Group requests by dataset and time range
-    val requestGroups = requests.groupBy { req =>
-      val tableType = getTableType(req.dataset)
-      tableType match {
-        case StreamingTable =>
-          (req.dataset, req.startTsMillis, req.endTsMillis)
-        case _ =>
-          (req.dataset, None, None)
-      }
-    }
-
-    // Process each group separately
-    val groupFutures: Seq[Future[Seq[GetResponse]]] = requestGroups.map {
-      case ((dataset, startTs, endTs), groupRequests) =>
-        readRowsMultiGet(dataset, groupRequests, startTs, endTs)
-    }.toList
-
-    Future.sequence(groupFutures).map(_.flatten)
-  }
-
-  private def readRowsMultiGet(
-      dataset: String,
-      requests: Seq[GetRequest],
-      startTsMillis: Option[Long],
-      endTsMillis: Option[Long]
-  ): Future[Seq[GetResponse]] = {
-    val datasetMetricsContext = tableToContext.getOrElseUpdate(
-      dataset,
-      metricsContext.copy(dataset = dataset)
-    )
-    val tableType = getTableType(dataset)
-
-    Future {
-      try {
-        val startTs = System.currentTimeMillis()
-
-        val responses: Seq[GetResponse] = tableType match {
-          case BatchTable =>
-            val pipeline = jedisCluster.pipelined()
-            val pipelinedGets =
-              try {
-                val queuedGets = requests.map { request =>
-                  val redisKey = buildRedisKey(request.keyBytes, dataset, keyPrefix = keyPrefix)
-                  (request, pipeline.get(redisKey.getBytes(StandardCharsets.UTF_8)))
-                }
-                queuedGets
-              } finally {
-                // ClusterPipeline.close performs the sync and returns borrowed node connections to their pools.
-                pipeline.close()
-              }
-
-            pipelinedGets.map { case (request, response) =>
-              val timedValues = Try {
-                val storedBytes = response.get()
-                if (storedBytes != null && storedBytes.length >= 8) {
-                  val timestamp = java.nio.ByteBuffer.wrap(storedBytes.take(8)).getLong
-                  val valueBytes = storedBytes.drop(8)
-                  Seq(TimedValue(valueBytes, timestamp))
-                } else if (storedBytes != null) {
-                  logger.warn(s"Malformed data in Redis: key has ${storedBytes.length} bytes, expected >= 8")
-                  Seq.empty
-                } else {
-                  Seq.empty
-                }
-              }
-              GetResponse(request, timedValues)
-            }
-
-          case StreamingTable if startTsMillis.isDefined =>
-            val reqStartTs = startTsMillis.get
-            val endTs = endTsMillis.getOrElse(System.currentTimeMillis())
-            requests.map { request =>
-              val tileKey = TilingUtils.deserializeTileKey(request.keyBytes)
-              val tileSizeMs = tileKey.tileSizeMillis
-              val baseKeyBytes = tileKey.keyBytes.asScala.map(_.toByte).toSeq
-              val timedValues = Try(
-                getTimeSeriesData(jedisCluster, baseKeyBytes, dataset, reqStartTs, endTs, Some(tileSizeMs), keyPrefix))
-              GetResponse(request, timedValues)
-            }
-
-          case _ =>
-            // Should not happen: non-batch tables without a time range.
-            requests.map(req => GetResponse(req, Success(Seq.empty)))
+    if (requests.isEmpty) {
+      Future.successful(Seq.empty)
+    } else {
+      Future {
+        val startedAt = System.currentTimeMillis()
+        try {
+          val defaultEndTs = System.currentTimeMillis()
+          val plans = requests.map(request => planRead(request, defaultEndTs))
+          val redisPlans = plans.collect { case plan: RedisReadPlan => plan }
+          val redisResults = executeReadPipelineWithRetry(redisPlans).iterator
+          val responses = plans.map {
+            case ImmediateReadPlan(request, values) => GetResponse(request, values)
+            case plan: RedisReadPlan                => GetResponse(plan.request, redisResults.next())
+          }
+          recordMultiGetMetrics(responses, System.currentTimeMillis() - startedAt)
+          responses
+        } catch {
+          case e: Exception =>
+            logger.error("Error getting values from Redis Cluster", e)
+            val responses = requests.map(request => GetResponse(request, Failure(e)))
+            recordMultiGetMetrics(responses, System.currentTimeMillis() - startedAt)
+            responses
         }
-
-        datasetMetricsContext.distribution("multiGet.latency", System.currentTimeMillis() - startTs)
-        datasetMetricsContext.increment("multiGet.successes")
-        responses
-      } catch {
-        case e: Exception =>
-          logger.error("Error getting values from Redis Cluster", e)
-          datasetMetricsContext.increment("multiGet.redis_errors", Map("exception" -> e.getClass.getName))
-          requests.map(req => GetResponse(req, Failure(e)))
       }
     }
   }
 
-  private def getTimeSeriesData(
-      jedisCluster: JedisCluster,
-      keyBytes: Seq[Byte],
-      dataset: String,
-      startTs: Long,
-      endTs: Long,
-      maybeTileSize: Option[Long],
-      keyPrefix: String
-  ): Seq[TimedValue] = {
-    val millisPerDay = 1.day.toMillis
-    val startDay = startTs - (startTs % millisPerDay)
-    val endDay = endTs - (endTs % millisPerDay)
-
-    // Generate all day-based keys
-    val dayRange = startDay to endDay by millisPerDay
-    val allTimedValues = dayRange.flatMap { dayTs =>
-      val redisKey = maybeTileSize match {
-        case Some(tileSize) => buildTiledRedisKey(keyBytes, dataset, dayTs, tileSize, keyPrefix)
-        case None           => buildRedisKey(keyBytes, dataset, Some(dayTs), keyPrefix)
-      }
-
-      // Use ZRANGEBYSCORE to get values in the time range
-      val tuples = jedisCluster
-        .zrangeByScoreWithScores(
-          redisKey.getBytes(StandardCharsets.UTF_8),
-          startTs.toDouble,
-          endTs.toDouble
-        )
-        .asScala
-
-      tuples.map { tuple =>
-        // Extract value bytes from the member (skip first 8 bytes which contain the timestamp prefix)
-        // The prefix is needed to make members unique in Redis ZSET (same value at different timestamps)
-        // All time-series data is written with this prefix (see multiPut line 324-326)
-        val memberBytes = tuple.getBinaryElement
-        val valueBytes = memberBytes.drop(8) // Skip the 8-byte timestamp prefix
-        val timestamp = tuple.getScore.toLong
-        TimedValue(valueBytes, timestamp)
+  private def planRead(request: GetRequest, defaultEndTs: Long): PlannedRead = {
+    val planned = Try {
+      getTableType(request.dataset) match {
+        case BatchTable =>
+          val redisKey = buildRedisKey(request.keyBytes, request.dataset, keyPrefix = keyPrefix)
+          BatchReadPlan(request, redisKey.getBytes(StandardCharsets.UTF_8))
+        case StreamingTable if request.startTsMillis.isDefined =>
+          val startTs = request.startTsMillis.get
+          val endTs = request.endTsMillis.getOrElse(defaultEndTs)
+          val tileKey = TilingUtils.deserializeTileKey(request.keyBytes)
+          val tileSizeMs = tileKey.tileSizeMillis
+          val baseKeyBytes = tileKey.keyBytes.asScala.map(_.toByte).toSeq
+          val millisPerDay = 1.day.toMillis
+          val startDay = startTs - (startTs % millisPerDay)
+          val endDay = endTs - (endTs % millisPerDay)
+          val redisKeys = (startDay to endDay by millisPerDay).map { dayTs =>
+            buildTiledRedisKey(baseKeyBytes, request.dataset, dayTs, tileSizeMs, keyPrefix)
+              .getBytes(StandardCharsets.UTF_8)
+          }.toVector
+          if (redisKeys.isEmpty) ImmediateReadPlan(request, Success(Seq.empty))
+          else StreamingReadPlan(request, redisKeys, startTs, endTs)
+        case StreamingTable =>
+          ImmediateReadPlan(request, Success(Seq.empty))
       }
     }
 
-    allTimedValues.toSeq
+    planned.recover { case error => ImmediateReadPlan(request, Failure(error)) }.get
+  }
+
+  private def queueRead(plan: RedisReadPlan, pipeline: ClusterPipeline): PendingRead = plan match {
+    case BatchReadPlan(request, redisKey) =>
+      val response = pipeline.get(redisKey)
+      PendingRead(request, () => Try(decodeBatchValue(response.get())))
+    case StreamingReadPlan(request, redisKeys, startTs, endTs) =>
+      val commands = redisKeys.map { redisKey =>
+        StreamingCommand(
+          redisKey,
+          startTs,
+          endTs,
+          pipeline.zrangeByScoreWithScores(redisKey, startTs.toDouble, endTs.toDouble)
+        )
+      }
+      PendingRead(request, () => Try(decodeStreamingValues(commands)))
+  }
+
+  private def executeReadPipelineWithRetry(plans: Seq[RedisReadPlan]): Seq[Try[Seq[TimedValue]]] = {
+    if (plans.isEmpty) {
+      Seq.empty
+    } else {
+      val firstAttempt = executeReadPipeline(plans)
+      val attemptAfterAskRecovery = askPipelineFailure(firstAttempt, plans) match {
+        case Some((failedPlan, error)) =>
+          recordPipelineRetry(failedPlan.request.dataset, error)
+          recoverAskFailures(firstAttempt, plans)
+        case None => firstAttempt
+      }
+      val finalAttempt = retryablePipelineFailure(attemptAfterAskRecovery, plans) match {
+        case Some((_, error)) if isAskFailure(error) =>
+          attemptAfterAskRecovery
+        case Some((failedPlan, error)) =>
+          recordPipelineRetry(failedPlan.request.dataset, error)
+          Try(refreshPipelineRoute(failedPlan)) match {
+            case Success(_) =>
+              val retryAttempt = executeReadPipeline(plans)
+              retryAttempt.results match {
+                case Success(_) => mergePipelineAttempts(attemptAfterAskRecovery, retryAttempt)
+                case Failure(retryError) =>
+                  logger.error("Redis Cluster pipeline retry failed", retryError)
+                  if (attemptAfterAskRecovery.results.isSuccess) attemptAfterAskRecovery else retryAttempt
+              }
+            case Failure(refreshError) =>
+              logger.error("Redis Cluster route refresh failed", refreshError)
+              attemptAfterAskRecovery
+          }
+        case None => attemptAfterAskRecovery
+      }
+
+      finalAttempt.results.getOrElse(plans.map(_ => Failure(finalAttempt.results.failed.get)))
+    }
+  }
+
+  private def mergePipelineAttempts(firstAttempt: PipelineAttempt, retryAttempt: PipelineAttempt): PipelineAttempt = {
+    (firstAttempt.results, retryAttempt.results) match {
+      case (Success(firstResults), Success(retryResults)) if firstResults.size == retryResults.size =>
+        val mergedResults = firstResults.zip(retryResults).map {
+          case (_, retrySuccess @ Success(_))          => retrySuccess
+          case (firstSuccess @ Success(_), Failure(_)) => firstSuccess
+          case (_, retryFailure @ Failure(_))          => retryFailure
+        }
+        retryAttempt.copy(results = Success(mergedResults))
+      case _ => retryAttempt
+    }
+  }
+
+  private def executeReadPipeline(plans: Seq[RedisReadPlan]): PipelineAttempt = {
+    var activePlan = Option.empty[RedisReadPlan]
+    val results = Try {
+      val pipeline = jedisCluster.pipelined()
+      var queueError = Option.empty[Exception]
+      val pendingReads =
+        try {
+          plans.map { plan =>
+            activePlan = Some(plan)
+            queueRead(plan, pipeline)
+          }
+        } catch {
+          case error: Exception =>
+            queueError = Some(error)
+            throw error
+        } finally {
+          try {
+            // ClusterPipeline.close syncs all nodes and returns their connections to the pools.
+            pipeline.close()
+          } catch {
+            case closeError: Exception =>
+              queueError match {
+                case Some(error) => error.addSuppressed(closeError)
+                case None        => throw closeError
+              }
+          }
+        }
+      pendingReads.map(_.resolve())
+    }
+    PipelineAttempt(results, activePlan)
+  }
+
+  private def retryablePipelineFailure(
+      attempt: PipelineAttempt,
+      plans: Seq[RedisReadPlan]
+  ): Option[(RedisReadPlan, Throwable)] = attempt.results match {
+    case Failure(error) if isRetryablePipelineFailure(error) =>
+      Some(attempt.failedPlan.getOrElse(plans.head) -> error)
+    case Success(results) =>
+      results.iterator.zip(plans.iterator).collectFirst {
+        case (Failure(error), plan) if isRetryablePipelineFailure(error) => plan -> error
+      }
+    case _ => None
+  }
+
+  private def askPipelineFailure(
+      attempt: PipelineAttempt,
+      plans: Seq[RedisReadPlan]
+  ): Option[(RedisReadPlan, Throwable)] = attempt.results match {
+    case Failure(error) if isAskFailure(error) =>
+      Some(attempt.failedPlan.getOrElse(plans.head) -> error)
+    case Success(results) =>
+      results.iterator.zip(plans.iterator).collectFirst {
+        case (Failure(error), plan) if isAskFailure(error) => plan -> error
+      }
+    case _ => None
+  }
+
+  private def recoverAskFailures(attempt: PipelineAttempt, plans: Seq[RedisReadPlan]): PipelineAttempt = {
+    val recoveredResults = attempt.results match {
+      case Success(results) if results.size == plans.size =>
+        Success(results.zip(plans).map {
+          case (Failure(error), plan) if isAskFailure(error) => executeDirectRead(plan)
+          case (result, _)                                   => result
+        })
+      case Failure(error) if isAskFailure(error) =>
+        Success(plans.map(executeDirectRead))
+      case other => other
+    }
+    attempt.copy(results = recoveredResults)
+  }
+
+  private def executeDirectRead(plan: RedisReadPlan): Try[Seq[TimedValue]] = Try {
+    plan match {
+      case BatchReadPlan(_, redisKey) =>
+        decodeBatchValue(jedisCluster.get(redisKey))
+      case StreamingReadPlan(_, redisKeys, startTs, endTs) =>
+        redisKeys.flatMap { redisKey =>
+          decodeStreamingTuples(jedisCluster.zrangeByScoreWithScores(redisKey, startTs.toDouble, endTs.toDouble))
+        }
+    }
+  }
+
+  private def isAskFailure(error: Throwable): Boolean = error match {
+    case _: JedisAskDataException => true
+    case jedisError: JedisException =>
+      Option(jedisError.getCause).exists(isAskFailure)
+    case _ => false
+  }
+
+  private def isRetryablePipelineFailure(error: Throwable): Boolean = error match {
+    case _: JedisRedirectionException      => true
+    case _: JedisConnectionException       => true
+    case jedisError: JedisException        => Option(jedisError.getCause).exists(isRetryablePipelineFailure)
+    case stateError: IllegalStateException => stateError.getMessage == PipelineResponseUnsetMessage
+    case _                                 => false
+  }
+
+  private def refreshPipelineRoute(plan: RedisReadPlan): Unit = plan match {
+    case BatchReadPlan(_, redisKey) =>
+      jedisCluster.get(redisKey)
+      ()
+    case StreamingReadPlan(_, redisKeys, startTs, endTs) =>
+      redisKeys.headOption.foreach { redisKey =>
+        jedisCluster.zrangeByScoreWithScores(redisKey, startTs.toDouble, endTs.toDouble)
+      }
+  }
+
+  private def recordPipelineRetry(dataset: String, error: Throwable): Unit = {
+    val datasetMetricsContext = tableToContext.getOrElseUpdate(dataset, metricsContext.copy(dataset = dataset))
+    datasetMetricsContext.increment("multiGet.pipeline_retries", Map("exception" -> error.getClass.getName))
+  }
+
+  private def decodeBatchValue(storedBytes: Array[Byte]): Seq[TimedValue] = {
+    if (storedBytes != null && storedBytes.length >= 8) {
+      val timestamp = java.nio.ByteBuffer.wrap(storedBytes, 0, 8).getLong
+      Seq(TimedValue(storedBytes.drop(8), timestamp))
+    } else if (storedBytes != null) {
+      logger.warn(s"Malformed data in Redis: key has ${storedBytes.length} bytes, expected >= 8")
+      Seq.empty
+    } else {
+      Seq.empty
+    }
+  }
+
+  private def decodeStreamingValues(commands: Seq[StreamingCommand]): Seq[TimedValue] = {
+    commands.flatMap { command =>
+      decodeStreamingTuples(command.response.get())
+    }
+  }
+
+  private def decodeStreamingTuples(tuples: java.util.List[Tuple]): Seq[TimedValue] = {
+    tuples.asScala.flatMap { tuple =>
+      val memberBytes = tuple.getBinaryElement
+      if (memberBytes.length >= 8) {
+        Some(TimedValue(memberBytes.drop(8), tuple.getScore.toLong))
+      } else {
+        logger.warn(s"Malformed streaming data in Redis: member has ${memberBytes.length} bytes, expected >= 8")
+        None
+      }
+    }
+  }
+
+  private def recordMultiGetMetrics(responses: Seq[GetResponse], latencyMillis: Long): Unit = {
+    metricsContext.distribution("multiGet.latency", latencyMillis)
+    responses.groupBy(_.request.dataset).foreach { case (dataset, datasetResponses) =>
+      val datasetMetricsContext = tableToContext.getOrElseUpdate(dataset, metricsContext.copy(dataset = dataset))
+      val failure = datasetResponses.iterator.flatMap(_.values.failed.toOption).toSeq.headOption
+      failure match {
+        case Some(error) =>
+          datasetMetricsContext.increment("multiGet.redis_errors", Map("exception" -> error.getClass.getName))
+        case None =>
+          datasetMetricsContext.increment("multiGet.successes")
+      }
+    }
   }
 
   override def list(request: ListRequest): Future[ListResponse] = {
@@ -470,6 +614,41 @@ class RedisKVStoreImpl(jedisCluster: JedisCluster, conf: Map[String, String] = M
         logger.warn("Warm-up operations failed", e)
     }
   }
+}
+
+private[redis] object RedisKVStoreImpl {
+  private val PipelineResponseUnsetMessage = "Please close pipeline or multi block before calling this method."
+
+  sealed trait PlannedRead {
+    def request: GetRequest
+  }
+
+  sealed trait RedisReadPlan extends PlannedRead
+
+  final case class ImmediateReadPlan(request: GetRequest, values: Try[Seq[TimedValue]]) extends PlannedRead
+
+  final case class BatchReadPlan(request: GetRequest, redisKey: Array[Byte]) extends RedisReadPlan
+
+  final case class StreamingReadPlan(
+      request: GetRequest,
+      redisKeys: Vector[Array[Byte]],
+      startTs: Long,
+      endTs: Long
+  ) extends RedisReadPlan
+
+  final case class StreamingCommand(
+      redisKey: Array[Byte],
+      startTs: Long,
+      endTs: Long,
+      response: Response[java.util.List[Tuple]]
+  )
+
+  final case class PendingRead(request: GetRequest, resolve: () => Try[Seq[TimedValue]])
+
+  final case class PipelineAttempt(
+      results: Try[Seq[Try[Seq[TimedValue]]]],
+      failedPlan: Option[RedisReadPlan]
+  )
 }
 
 object RedisKVStore {

--- a/redis/src/test/scala/ai/chronon/integrations/redis/RedisBatchPipelineLifecycleTest.scala
+++ b/redis/src/test/scala/ai/chronon/integrations/redis/RedisBatchPipelineLifecycleTest.scala
@@ -27,14 +27,21 @@ class RedisBatchPipelineLifecycleTest extends AnyFlatSpec with BeforeAndAfterAll
 
   "Redis batch multiGet" should "return pipeline connections after reading responses" in {
     val kvStore = new RedisKVStoreImpl(cluster.client)
-    val requests = (0 until 50).map(index => GetRequest(s"key-$index".getBytes, "pipeline_connections_BATCH"))
+    val requests = (0 until 50).map { index =>
+      GetRequest(s"key-$index".getBytes, f"pipeline_connections_$index%02d_BATCH")
+    }
     val puts = requests.map(request => PutRequest(request.keyBytes, "value".getBytes, request.dataset, None))
 
     Await.result(kvStore.multiPut(puts), 10.seconds) shouldBe Seq.fill(puts.size)(true)
 
-    val responses = Await.result(kvStore.multiGet(requests), 10.seconds)
-    responses should have size requests.size
-    responses.foreach(response => new String(response.values.get.head.bytes) shouldBe "value")
+    val borrowedBefore = cluster.client.getClusterNodes.values().asScala.map(_.getBorrowedCount).sum
+    (1 to 2).foreach { _ =>
+      val responses = Await.result(kvStore.multiGet(requests), 10.seconds)
+      responses.map(_.request) shouldBe requests
+      responses.foreach(response => new String(response.values.get.head.bytes) shouldBe "value")
+    }
+    val borrowedAfter = cluster.client.getClusterNodes.values().asScala.map(_.getBorrowedCount).sum
+    borrowedAfter - borrowedBefore should be <= 6L
     cluster.client.getClusterNodes.values().asScala.map(_.getNumActive).sum shouldBe 0
   }
 }

--- a/redis/src/test/scala/ai/chronon/integrations/redis/RedisClusterFixture.scala
+++ b/redis/src/test/scala/ai/chronon/integrations/redis/RedisClusterFixture.scala
@@ -2,8 +2,7 @@ package ai.chronon.integrations.redis
 
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.utility.DockerImageName
-import org.apache.commons.pool2.impl.GenericObjectPoolConfig
-import redis.clients.jedis.{Connection, DefaultJedisClientConfig, HostAndPort, HostAndPortMapper, Jedis, JedisCluster}
+import redis.clients.jedis.{DefaultJedisClientConfig, HostAndPort, HostAndPortMapper, Jedis, JedisCluster}
 
 import java.time.Duration
 import scala.jdk.CollectionConverters._
@@ -166,13 +165,11 @@ private[redis] object RedisClusterFixture {
         }
       }
       val clientConfig = DefaultJedisClientConfig.builder().hostAndPortMapper(hostAndPortMapper).build()
-      val poolConfig = new GenericObjectPoolConfig[Connection]()
-      poolConfig.setMaxTotal(maxConnections)
-      poolConfig.setMaxIdle(maxIdleConnections)
-      poolConfig.setMinIdle(minIdleConnections)
-      poolConfig.setTestOnBorrow(true)
-      poolConfig.setTestOnReturn(true)
-      poolConfig.setTestWhileIdle(true)
+      val poolConfig = RedisKVStoreFactory.buildConnectionPoolConfig(
+        maxConnections,
+        minIdleConnections,
+        maxIdleConnections
+      )
 
       val seed = new HostAndPort(container.getHost, container.getMappedPort(internalPorts.head))
       client = new JedisCluster(Set(seed).asJava, clientConfig, 5, poolConfig)

--- a/redis/src/test/scala/ai/chronon/integrations/redis/RedisClusterFixture.scala
+++ b/redis/src/test/scala/ai/chronon/integrations/redis/RedisClusterFixture.scala
@@ -1,9 +1,8 @@
 package ai.chronon.integrations.redis
 
-import ai.chronon.integrations.redis.RedisKVStoreConstants.{DefaultMaxIdleConnections, DefaultMinIdleConnections}
-import org.apache.commons.pool2.impl.GenericObjectPoolConfig
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.utility.DockerImageName
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig
 import redis.clients.jedis.{Connection, DefaultJedisClientConfig, HostAndPort, HostAndPortMapper, Jedis, JedisCluster}
 
 import java.time.Duration
@@ -12,7 +11,11 @@ import scala.jdk.CollectionConverters._
 /** Test-only Redis cluster whose advertised container ports are mapped back to the host. */
 private[redis] final class RedisClusterFixture private (
     val container: GenericContainer[_],
-    val client: JedisCluster
+    val client: JedisCluster,
+    val image: String,
+    val primaryCount: Int,
+    val replicasPerPrimary: Int,
+    val cpuLimit: Option[Double]
 ) extends AutoCloseable {
 
   override def close(): Unit = {
@@ -22,24 +25,140 @@ private[redis] final class RedisClusterFixture private (
 }
 
 private[redis] object RedisClusterFixture {
-  private val Image = "grokzen/redis-cluster:7.0.10"
-  private val InternalPorts = Seq(7000, 7001, 7002, 7003, 7004, 7005)
+  private final class RedisContainer(image: DockerImageName) extends GenericContainer[RedisContainer](image)
 
-  def start(maxConnections: Int): RedisClusterFixture = {
+  private val Image = "grokzen/redis-cluster:7.0.10"
+  private val NativeImage = "redis:7.2.5-alpine"
+  private val FirstInternalPort = 7000
+  private val DefaultPrimaryCount = 3
+  private val DefaultReplicasPerPrimary = 1
+  private val LegacyInternalPorts = (FirstInternalPort until FirstInternalPort + 6)
+
+  private def nativeClusterCommand(internalPorts: Seq[Int], replicasPerPrimary: Int): String = {
+    val nodes = internalPorts.map(port => s"127.0.0.1:$port").mkString(" ")
+    s"""
+       |set -eu
+       |for port in ${internalPorts.mkString(" ")}; do
+       |  mkdir -p /data/$$port
+       |  redis-server --port $$port --cluster-enabled yes --cluster-config-file /data/$$port/nodes.conf --cluster-node-timeout 5000 --appendonly no --save '' --protected-mode no --bind 0.0.0.0 --daemonize yes --dir /data/$$port
+       |done
+       |for port in ${internalPorts.mkString(" ")}; do
+       |  until redis-cli -p $$port ping >/dev/null 2>&1; do sleep 0.1; done
+       |done
+       |redis-cli --cluster create $nodes --cluster-replicas $replicasPerPrimary --cluster-yes
+       |exec tail -f /dev/null
+       |""".stripMargin
+  }
+
+  def start(maxConnections: Int): RedisClusterFixture =
+    start(
+      maxConnections,
+      math.min(RedisKVStoreConstants.DefaultMinIdleConnections, maxConnections),
+      math.min(RedisKVStoreConstants.DefaultMaxIdleConnections, maxConnections)
+    )
+
+  def start(maxConnections: Int, minIdleConnections: Int, maxIdleConnections: Int): RedisClusterFixture = {
+    start(
+      maxConnections,
+      minIdleConnections,
+      maxIdleConnections,
+      false,
+      LegacyInternalPorts,
+      DefaultPrimaryCount,
+      DefaultReplicasPerPrimary,
+      None
+    )
+  }
+
+  def startNative(maxConnections: Int,
+                  minIdleConnections: Int,
+                  maxIdleConnections: Int): RedisClusterFixture = {
+    startNative(
+      maxConnections,
+      minIdleConnections,
+      maxIdleConnections,
+      DefaultPrimaryCount,
+      DefaultReplicasPerPrimary,
+      None
+    )
+  }
+
+  def startNative(maxConnections: Int,
+                  minIdleConnections: Int,
+                  maxIdleConnections: Int,
+                  primaryCount: Int,
+                  replicasPerPrimary: Int): RedisClusterFixture =
+    startNative(
+      maxConnections,
+      minIdleConnections,
+      maxIdleConnections,
+      primaryCount,
+      replicasPerPrimary,
+      None
+    )
+
+  def startNative(maxConnections: Int,
+                  minIdleConnections: Int,
+                  maxIdleConnections: Int,
+                  primaryCount: Int,
+                  replicasPerPrimary: Int,
+                  cpuLimit: Option[Double]): RedisClusterFixture = {
+    require(primaryCount >= 3, s"primaryCount must be at least 3, got $primaryCount")
+    require(replicasPerPrimary >= 0, s"replicasPerPrimary must be non-negative, got $replicasPerPrimary")
+    require(cpuLimit.forall(_ > 0), s"cpuLimit must be positive when set, got $cpuLimit")
+    val nodeCount = primaryCount * (replicasPerPrimary + 1)
+    val internalPorts = FirstInternalPort until FirstInternalPort + nodeCount
+    start(
+      maxConnections,
+      minIdleConnections,
+      maxIdleConnections,
+      true,
+      internalPorts,
+      primaryCount,
+      replicasPerPrimary,
+      cpuLimit
+    )
+  }
+
+  private def start(maxConnections: Int,
+                    minIdleConnections: Int,
+                    maxIdleConnections: Int,
+                    native: Boolean,
+                    internalPorts: Seq[Int],
+                    primaryCount: Int,
+                    replicasPerPrimary: Int,
+                    cpuLimit: Option[Double]): RedisClusterFixture = {
     require(maxConnections > 0, s"maxConnections must be positive, got $maxConnections")
 
-    val container = new GenericContainer(DockerImageName.parse(Image))
+    val image = if (native) NativeImage else Image
+    val container = new RedisContainer(DockerImageName.parse(image))
     var client: JedisCluster = null
     try {
-      container.withExposedPorts(InternalPorts.map(Integer.valueOf): _*)
+      container.withExposedPorts(internalPorts.map(Integer.valueOf): _*)
       container.withStartupTimeout(Duration.ofSeconds(60))
+      if (native) container.withCommand("sh", "-c", nativeClusterCommand(internalPorts, replicasPerPrimary))
+      cpuLimit.foreach { cpus =>
+        val nanoCpus = math.round(cpus * 1000000000L)
+        container.withCreateContainerCmdModifier { command =>
+          command.getHostConfig.withNanoCPUs(nanoCpus)
+          ()
+        }
+      }
       container.start()
-      awaitClusterReady(container)
+      cpuLimit.foreach { cpus =>
+        val expectedNanoCpus = math.round(cpus * 1000000000L)
+        val actualNanoCpus = container.getContainerInfo.getHostConfig.getNanoCPUs.longValue()
+        require(
+          actualNanoCpus == expectedNanoCpus,
+          s"Redis container CPU limit mismatch: requested $expectedNanoCpus NanoCPUs, applied $actualNanoCpus"
+        )
+      }
+      awaitClusterReady(container, internalPorts)
 
       val hostAndPortMapper = new HostAndPortMapper {
         override def getHostAndPort(hostAndPort: HostAndPort): HostAndPort = {
           val port = hostAndPort.getPort
-          if (InternalPorts.contains(port)) {
+          if (internalPorts.contains(port)) {
             new HostAndPort(container.getHost, container.getMappedPort(port))
           } else {
             hostAndPort
@@ -48,8 +167,6 @@ private[redis] object RedisClusterFixture {
       }
       val clientConfig = DefaultJedisClientConfig.builder().hostAndPortMapper(hostAndPortMapper).build()
       val poolConfig = new GenericObjectPoolConfig[Connection]()
-      val maxIdleConnections = math.min(DefaultMaxIdleConnections, maxConnections)
-      val minIdleConnections = math.min(DefaultMinIdleConnections, maxIdleConnections)
       poolConfig.setMaxTotal(maxConnections)
       poolConfig.setMaxIdle(maxIdleConnections)
       poolConfig.setMinIdle(minIdleConnections)
@@ -57,9 +174,9 @@ private[redis] object RedisClusterFixture {
       poolConfig.setTestOnReturn(true)
       poolConfig.setTestWhileIdle(true)
 
-      val seed = new HostAndPort(container.getHost, container.getMappedPort(InternalPorts.head))
+      val seed = new HostAndPort(container.getHost, container.getMappedPort(internalPorts.head))
       client = new JedisCluster(Set(seed).asJava, clientConfig, 5, poolConfig)
-      new RedisClusterFixture(container, client)
+      new RedisClusterFixture(container, client, image, primaryCount, replicasPerPrimary, cpuLimit)
     } catch {
       case throwable: Throwable =>
         if (client != null) {
@@ -72,13 +189,13 @@ private[redis] object RedisClusterFixture {
     }
   }
 
-  private def awaitClusterReady(container: GenericContainer[_]): Unit = {
+  private def awaitClusterReady(container: GenericContainer[_], internalPorts: Seq[Int]): Unit = {
     val deadlineNanos = System.nanoTime() + Duration.ofSeconds(45).toNanos
     var lastFailure: Throwable = null
     var consecutiveHealthyChecks = 0
     while (System.nanoTime() < deadlineNanos) {
       try {
-        val allNodesHealthy = InternalPorts.forall { port =>
+        val allNodesHealthy = internalPorts.forall { port =>
           val probe = new Jedis(container.getHost, container.getMappedPort(port), 3000)
           try {
             val clusterInfo = probe.clusterInfo()

--- a/redis/src/test/scala/ai/chronon/integrations/redis/RedisClusterFixture.scala
+++ b/redis/src/test/scala/ai/chronon/integrations/redis/RedisClusterFixture.scala
@@ -14,7 +14,9 @@ private[redis] final class RedisClusterFixture private (
     val image: String,
     val primaryCount: Int,
     val replicasPerPrimary: Int,
-    val cpuLimit: Option[Double]
+    val cpuLimit: Option[Double],
+    val ioThreads: Int,
+    val ioThreadsDoReads: Boolean
 ) extends AutoCloseable {
 
   override def close(): Unit = {
@@ -33,13 +35,23 @@ private[redis] object RedisClusterFixture {
   private val DefaultReplicasPerPrimary = 1
   private val LegacyInternalPorts = (FirstInternalPort until FirstInternalPort + 6)
 
-  private def nativeClusterCommand(internalPorts: Seq[Int], replicasPerPrimary: Int): String = {
+  private def nativeClusterCommand(internalPorts: Seq[Int],
+                                   replicasPerPrimary: Int,
+                                   ioThreads: Int,
+                                   ioThreadsDoReads: Boolean): String = {
     val nodes = internalPorts.map(port => s"127.0.0.1:$port").mkString(" ")
+    val ioThreadArgs =
+      if (ioThreads > 1) {
+        val doReads = if (ioThreadsDoReads) "yes" else "no"
+        s"--io-threads $ioThreads --io-threads-do-reads $doReads"
+      } else {
+        ""
+      }
     s"""
        |set -eu
        |for port in ${internalPorts.mkString(" ")}; do
        |  mkdir -p /data/$$port
-       |  redis-server --port $$port --cluster-enabled yes --cluster-config-file /data/$$port/nodes.conf --cluster-node-timeout 5000 --appendonly no --save '' --protected-mode no --bind 0.0.0.0 --daemonize yes --dir /data/$$port
+       |  redis-server --port $$port --cluster-enabled yes --cluster-config-file /data/$$port/nodes.conf --cluster-node-timeout 5000 --appendonly no --save '' --protected-mode no --bind 0.0.0.0 --daemonize yes --dir /data/$$port $ioThreadArgs
        |done
        |for port in ${internalPorts.mkString(" ")}; do
        |  until redis-cli -p $$port ping >/dev/null 2>&1; do sleep 0.1; done
@@ -135,7 +147,17 @@ private[redis] object RedisClusterFixture {
     try {
       container.withExposedPorts(internalPorts.map(Integer.valueOf): _*)
       container.withStartupTimeout(Duration.ofSeconds(60))
-      if (native) container.withCommand("sh", "-c", nativeClusterCommand(internalPorts, replicasPerPrimary))
+      val ioThreads = if (native) sys.env.get("PERF_REDIS_IO_THREADS").map(_.toInt).getOrElse(1) else 1
+      val ioThreadsDoReads =
+        native && sys.env.get("PERF_REDIS_IO_THREADS_DO_READS").exists(_.equalsIgnoreCase("true"))
+      require(ioThreads > 0, s"PERF_REDIS_IO_THREADS must be positive, got $ioThreads")
+      if (native) {
+        container.withCommand(
+          "sh",
+          "-c",
+          nativeClusterCommand(internalPorts, replicasPerPrimary, ioThreads, ioThreadsDoReads)
+        )
+      }
       cpuLimit.foreach { cpus =>
         val nanoCpus = math.round(cpus * 1000000000L)
         container.withCreateContainerCmdModifier { command =>
@@ -173,7 +195,7 @@ private[redis] object RedisClusterFixture {
 
       val seed = new HostAndPort(container.getHost, container.getMappedPort(internalPorts.head))
       client = new JedisCluster(Set(seed).asJava, clientConfig, 5, poolConfig)
-      new RedisClusterFixture(container, client, image, primaryCount, replicasPerPrimary, cpuLimit)
+      new RedisClusterFixture(container, client, image, primaryCount, replicasPerPrimary, cpuLimit, ioThreads, ioThreadsDoReads)
     } catch {
       case throwable: Throwable =>
         if (client != null) {

--- a/redis/src/test/scala/ai/chronon/integrations/redis/RedisConnectionPoolConfigTest.scala
+++ b/redis/src/test/scala/ai/chronon/integrations/redis/RedisConnectionPoolConfigTest.scala
@@ -1,0 +1,58 @@
+package ai.chronon.integrations.redis
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.time.Duration
+
+class RedisConnectionPoolConfigTest extends AnyFlatSpec with Matchers {
+
+  "Redis connection pool config" should "validate idle connections without pinging on borrow or return" in {
+    val config = RedisKVStoreFactory.buildConnectionPoolConfig(
+      maxConnections = 64,
+      minIdleConnections = 5,
+      maxIdleConnections = 64
+    )
+
+    config.getMaxTotal shouldBe 64
+    config.getMinIdle shouldBe 5
+    config.getMaxIdle shouldBe 64
+    config.getTestOnBorrow shouldBe false
+    config.getTestOnReturn shouldBe false
+    config.getTestWhileIdle shouldBe true
+    config.getTimeBetweenEvictionRuns shouldBe Duration.ofSeconds(30)
+    config.getMinEvictableIdleDuration shouldBe Duration.ofSeconds(60)
+    config.getNumTestsPerEvictionRun shouldBe -1
+  }
+
+  it should "reject inconsistent limits" in {
+    an[IllegalArgumentException] should be thrownBy
+      RedisKVStoreFactory.buildConnectionPoolConfig(0, 0, 0)
+    an[IllegalArgumentException] should be thrownBy
+      RedisKVStoreFactory.buildConnectionPoolConfig(10, 6, 5)
+    an[IllegalArgumentException] should be thrownBy
+      RedisKVStoreFactory.buildConnectionPoolConfig(10, 0, 11)
+  }
+
+  it should "clamp the default minimum idle to an explicitly smaller maximum idle" in {
+    val config = RedisKVStoreFactory.buildConnectionPoolConfig(
+      maxConnections = 50,
+      minIdleConnections = None,
+      maxIdleConnections = Some(2)
+    )
+
+    config.getMaxTotal shouldBe 50
+    config.getMinIdle shouldBe 2
+    config.getMaxIdle shouldBe 2
+  }
+
+  it should "bound default idle connections without exceeding a smaller pool" in {
+    val defaultPool = RedisKVStoreFactory.buildConnectionPoolConfig(50, None, None)
+    val smallPool = RedisKVStoreFactory.buildConnectionPoolConfig(4, None, None)
+
+    defaultPool.getMinIdle shouldBe 5
+    defaultPool.getMaxIdle shouldBe 10
+    smallPool.getMinIdle shouldBe 4
+    smallPool.getMaxIdle shouldBe 4
+  }
+}

--- a/redis/src/test/scala/ai/chronon/integrations/redis/RedisFetcherReadPerfTestHarness.scala
+++ b/redis/src/test/scala/ai/chronon/integrations/redis/RedisFetcherReadPerfTestHarness.scala
@@ -191,6 +191,7 @@ class RedisFetcherReadPerfTestHarness extends AnyFlatSpec with BeforeAndAfterAll
       s"unique_kv_requests=${workload.deduplicated.requests.size} " +
       s"logical_redis_read_groups=${workload.config.totalGroupBys + workload.config.totalStreamingGroupBys} " +
       s"kvstore_multi_get_calls_per_batch=1 " +
+      s"cluster_pipelines_per_batch=1 " +
       s"range_hours=${workload.config.tiledPoints} hourly_tiles=${workload.config.tiledPoints} " +
       s"payload_bytes=${workload.deduplicated.expectedPayloadBytes} " +
       s"batch_concurrencies=${batchConcurrencies.mkString(",")} max_connections_per_node=$maxConnections " +

--- a/redis/src/test/scala/ai/chronon/integrations/redis/RedisFetcherReadPerfTestHarness.scala
+++ b/redis/src/test/scala/ai/chronon/integrations/redis/RedisFetcherReadPerfTestHarness.scala
@@ -196,7 +196,7 @@ class RedisFetcherReadPerfTestHarness extends AnyFlatSpec with BeforeAndAfterAll
       s"payload_bytes=${workload.deduplicated.expectedPayloadBytes} " +
       s"batch_concurrencies=${batchConcurrencies.mkString(",")} max_connections_per_node=$maxConnections " +
       s"min_idle_connections_per_node=$minIdleConnections max_idle_connections_per_node=$maxIdleConnections " +
-      s"test_on_borrow=true test_on_return=true test_while_idle=true " +
+      s"test_on_borrow=false test_on_return=false test_while_idle=true " +
       s"redis_cluster_image=${Option(localCluster).map(_.image).getOrElse("external")} " +
       s"redis_cluster_primaries=${Option(localCluster).map(_.primaryCount.toString).getOrElse("external")} " +
       s"redis_replicas_per_primary=" +

--- a/redis/src/test/scala/ai/chronon/integrations/redis/RedisFetcherReadPerfTestHarness.scala
+++ b/redis/src/test/scala/ai/chronon/integrations/redis/RedisFetcherReadPerfTestHarness.scala
@@ -12,6 +12,7 @@ import ai.chronon.online.metrics.{FlexibleExecutionContext, InstrumentedThreadPo
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import redis.clients.jedis.JedisCluster
+import redis.clients.jedis.util.JedisClusterCRC16
 
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicReference}
 import java.util.concurrent.{Executors, ThreadPoolExecutor, TimeUnit}
@@ -64,6 +65,10 @@ class RedisFetcherReadPerfTestHarness extends AnyFlatSpec with BeforeAndAfterAll
     envInt("PERF_REDIS_MIN_IDLE_CONNECTIONS", math.min(DefaultMinIdleConnections, maxIdleConnections))
   private val readTimeout = envInt("PERF_READ_TIMEOUT_SECONDS", 30).seconds
   private val keyPrefix = sys.env.getOrElse("PERF_REDIS_KEY_PREFIX", "chronon-perf")
+  private val keyHashTagMode =
+    sys.env.getOrElse("PERF_REDIS_HASH_TAG_MODE", RedisKVStore.DatasetAndEntityHashTagMode)
+  private val readMetricsEnabled =
+    !sys.env.get("PERF_REDIS_READ_METRICS_ENABLED").exists(_.equalsIgnoreCase("false"))
   private val useExternalCluster = sys.env.get("PERF_REDIS_USE_EXTERNAL").exists(_.equalsIgnoreCase("true"))
   private val useNativeLocalCluster =
     sys.env.getOrElse("PERF_REDIS_USE_NATIVE_LOCAL", "true").equalsIgnoreCase("true")
@@ -134,7 +139,9 @@ class RedisFetcherReadPerfTestHarness extends AnyFlatSpec with BeforeAndAfterAll
             EnvRedisMaxConnections -> maxConnections.toString,
             EnvRedisMinIdleConnections -> minIdleConnections.toString,
             EnvRedisMaxIdleConnections -> maxIdleConnections.toString,
-            "redis.key.prefix" -> keyPrefix
+            "redis.key.prefix" -> keyPrefix,
+            "redis.key.hash.tag.mode" -> keyHashTagMode,
+            "redis.read.metrics.enabled" -> readMetricsEnabled.toString
           ))
       } else {
         localCluster =
@@ -167,7 +174,7 @@ class RedisFetcherReadPerfTestHarness extends AnyFlatSpec with BeforeAndAfterAll
     val workload = RedisFetcherReadWorkload.build()
     val profilesByName =
       (Seq(workload.deduplicated, workload.deduplicatedCrossDay, workload.logical, workload.batchOnly) ++
-        workload.batchCacheDemand)
+        workload.batchCacheDemand ++ workload.batchCacheDemandCrossDay)
         .map(profile => profile.name -> profile)
         .toMap
     val selectedProfiles = selectedProfileNames.map { name =>
@@ -193,7 +200,8 @@ class RedisFetcherReadPerfTestHarness extends AnyFlatSpec with BeforeAndAfterAll
       s"kvstore_multi_get_calls_per_batch=1 " +
       s"cluster_pipelines_per_batch=1 " +
       s"range_hours=${workload.config.tiledPoints} hourly_tiles=${workload.config.tiledPoints} " +
-      s"payload_bytes=${workload.deduplicated.expectedPayloadBytes} " +
+      s"payload_bytes=${workload.deduplicated.expectedPayloadBytes} redis_hash_tag_mode=$keyHashTagMode " +
+      s"redis_read_metrics_enabled=$readMetricsEnabled " +
       s"batch_concurrencies=${batchConcurrencies.mkString(",")} max_connections_per_node=$maxConnections " +
       s"min_idle_connections_per_node=$minIdleConnections max_idle_connections_per_node=$maxIdleConnections " +
       s"test_on_borrow=false test_on_return=false test_while_idle=true " +
@@ -203,6 +211,8 @@ class RedisFetcherReadPerfTestHarness extends AnyFlatSpec with BeforeAndAfterAll
       s"${Option(localCluster).map(_.replicasPerPrimary.toString).getOrElse("external")} " +
       s"redis_container_cpu_limit=" +
       s"${Option(localCluster).flatMap(_.cpuLimit).map(_.toString).getOrElse("unlimited")} " +
+      s"redis_io_threads=${Option(localCluster).map(_.ioThreads.toString).getOrElse("external")} " +
+      s"redis_io_threads_do_reads=${Option(localCluster).map(_.ioThreadsDoReads.toString).getOrElse("external")} " +
       s"pool_sample_interval_ms=$PoolSampleIntervalMillis " +
       s"jedis_pipeline_sync_workers_per_pipeline=" +
       s"${redis.clients.jedis.MultiNodePipelineBase.MULTI_NODE_PIPELINE_SYNC_WORKERS} " +
@@ -245,7 +255,11 @@ class RedisFetcherReadPerfTestHarness extends AnyFlatSpec with BeforeAndAfterAll
       val executor = newRedisExecutor(effectivePoolConfig)
       val kvStore = new BenchmarkRedisKVStore(
         localCluster.client,
-        Map("redis.key.prefix" -> keyPrefix),
+        Map(
+          "redis.key.prefix" -> keyPrefix,
+          "redis.key.hash.tag.mode" -> keyHashTagMode,
+          "redis.read.metrics.enabled" -> readMetricsEnabled.toString
+        ),
         ExecutionContext.fromExecutor(executor)
       )
       try run(kvStore, executor, Some(localCluster.client))
@@ -416,11 +430,14 @@ class RedisFetcherReadPerfTestHarness extends AnyFlatSpec with BeforeAndAfterAll
     val sorted = measurement.latenciesNanos.sorted
     val wallSeconds = measurement.wallNanos.toDouble / TimeUnit.SECONDS.toNanos(1)
     val demandBatchesPerSecond = measurement.latenciesNanos.length / wallSeconds
+    val effectiveBatchReadCommands = effectiveBatchCommands(profile)
+    val effectiveStreamingCommands = effectiveStreamingRangeCommands(profile)
+    val effectiveRedisCommands = effectiveBatchReadCommands + effectiveStreamingCommands
     val candidatesPerSecond = demandBatchesPerSecond * workload.config.candidates
     val logicalGroupBysPerSecond = demandBatchesPerSecond * workload.logicalGroupByRequests
-    val batchGetCommandsPerSecond = demandBatchesPerSecond * profile.batchGetCommands
-    val zrangeCommandsPerSecond = demandBatchesPerSecond * profile.zrangeCommands
-    val redisCommandsPerSecond = demandBatchesPerSecond * profile.redisCommands
+    val batchGetCommandsPerSecond = demandBatchesPerSecond * effectiveBatchReadCommands
+    val zrangeCommandsPerSecond = demandBatchesPerSecond * effectiveStreamingCommands
+    val redisCommandsPerSecond = demandBatchesPerSecond * effectiveRedisCommands
     val kvResponsesPerSecond = demandBatchesPerSecond * profile.requests.size
     val timedValuesPerSecond = demandBatchesPerSecond * profile.expectedTimedValues
     val payloadMiBPerSecond = demandBatchesPerSecond * profile.expectedPayloadBytes / (1024.0 * 1024.0)
@@ -459,12 +476,27 @@ class RedisFetcherReadPerfTestHarness extends AnyFlatSpec with BeforeAndAfterAll
         f"jedis_sampled_peak_waiters_sum=${measurement.pool.peakJedisWaiters}%d " +
         f"jedis_pipeline_sync_workers_per_pipeline=" +
         f"${redis.clients.jedis.MultiNodePipelineBase.MULTI_NODE_PIPELINE_SYNC_WORKERS}%d " +
-        f"batch_get_commands_per_batch=${profile.batchGetCommands}%d " +
-        f"zrange_commands_per_batch=${profile.zrangeCommands}%d " +
-        f"redis_commands_per_batch=${profile.redisCommands}%d kv_responses_per_batch=${profile.requests.size}%d " +
+        f"batch_get_commands_per_batch=$effectiveBatchReadCommands%d " +
+        f"zrange_commands_per_batch=$effectiveStreamingCommands%d " +
+        f"redis_commands_per_batch=$effectiveRedisCommands%d kv_responses_per_batch=${profile.requests.size}%d " +
         f"timed_values_per_batch=${profile.expectedTimedValues}%d " +
         f"payload_bytes_per_batch=${profile.expectedPayloadBytes}%d"
     )
+  }
+
+  private def effectiveBatchCommands(profile: RedisFetcherReadWorkload.ReadProfile): Int = {
+    val slots = profile.requests.iterator.collect {
+      case request if request.startTsMillis.isEmpty =>
+        val redisKey = RedisKVStore
+          .buildRedisKey(request.keyBytes, request.dataset, keyPrefix = keyPrefix, hashTagMode = keyHashTagMode)
+          .getBytes(java.nio.charset.StandardCharsets.UTF_8)
+        JedisClusterCRC16.getSlot(redisKey)
+    }.toSet
+    slots.size
+  }
+
+  private def effectiveStreamingRangeCommands(profile: RedisFetcherReadWorkload.ReadProfile): Int = {
+    profile.zrangeCommands
   }
 
   private def requireSuccessful(profile: String, phase: String, measurement: Measurement): Unit = {

--- a/redis/src/test/scala/ai/chronon/integrations/redis/RedisFetcherReadPerfTestHarness.scala
+++ b/redis/src/test/scala/ai/chronon/integrations/redis/RedisFetcherReadPerfTestHarness.scala
@@ -57,6 +57,7 @@ class RedisFetcherReadPerfTestHarness extends AnyFlatSpec with BeforeAndAfterAll
   )
   private val workerThreadCounts = envInts("PERF_REDIS_THREAD_COUNTS", Seq(16, 32, 48, 64))
   private val queueCapacities = envInts("PERF_REDIS_QUEUE_CAPACITIES", Seq(10000))
+  private val candidates = envInt("PERF_CANDIDATES", RedisFetcherReadWorkload.Config().candidates)
   private val loadBatchSize = envInt("PERF_LOAD_BATCH_SIZE", 100)
   private val maxConnections = envInt("PERF_REDIS_MAX_CONNECTIONS", 64)
   private val maxIdleConnections =
@@ -96,6 +97,7 @@ class RedisFetcherReadPerfTestHarness extends AnyFlatSpec with BeforeAndAfterAll
   require(batchConcurrencies.nonEmpty && batchConcurrencies.forall(_ > 0))
   require(workerThreadCounts.nonEmpty && workerThreadCounts.forall(_ > 0))
   require(queueCapacities.nonEmpty && queueCapacities.forall(_ > 0))
+  require(candidates > 0)
   require(loadBatchSize > 0)
   require(maxConnections > 0)
   require(localPrimaryCount >= 3)
@@ -168,10 +170,10 @@ class RedisFetcherReadPerfTestHarness extends AnyFlatSpec with BeforeAndAfterAll
     }
   }
 
-  "Redis fetcher read benchmark" should "measure the 50-candidate mixed GroupBy workload" in {
+  "Redis fetcher read benchmark" should "measure the mixed GroupBy workload" in {
     assume(enabled, "Set CHRONON_PERF_TEST_ENABLED=true to run Redis performance tests")
 
-    val workload = RedisFetcherReadWorkload.build()
+    val workload = RedisFetcherReadWorkload.build(RedisFetcherReadWorkload.Config(candidates = candidates))
     val profilesByName =
       (Seq(workload.deduplicated, workload.deduplicatedCrossDay, workload.logical, workload.batchOnly) ++
         workload.batchCacheDemand ++ workload.batchCacheDemandCrossDay)

--- a/redis/src/test/scala/ai/chronon/integrations/redis/RedisFetcherReadPerfTestHarness.scala
+++ b/redis/src/test/scala/ai/chronon/integrations/redis/RedisFetcherReadPerfTestHarness.scala
@@ -1,6 +1,12 @@
 package ai.chronon.integrations.redis
 
-import ai.chronon.integrations.redis.RedisKVStoreConstants.{EnvRedisClusterNodes, EnvRedisMaxConnections}
+import ai.chronon.integrations.redis.RedisKVStoreConstants.{
+  DefaultMinIdleConnections,
+  EnvRedisClusterNodes,
+  EnvRedisMaxConnections,
+  EnvRedisMaxIdleConnections,
+  EnvRedisMinIdleConnections
+}
 import ai.chronon.online.KVStore.GetResponse
 import ai.chronon.online.metrics.{FlexibleExecutionContext, InstrumentedThreadPoolExecutor}
 import org.scalatest.BeforeAndAfterAll
@@ -17,11 +23,17 @@ import scala.jdk.CollectionConverters._
   *
   * This measures the real Jedis/RedisKVStoreImpl path, so JMH would add iteration machinery without removing network
   * variance. It starts at KVStore.multiGet, after join planning and context deduplication, and excludes downstream
-  * feature decoding. By default it starts a local six-node Redis cluster and sweeps worker-pool sizes. Set
-  * PERF_REDIS_USE_EXTERNAL=true with REDIS_CLUSTER_NODES to run one pool configuration in an isolated JVM.
+  * feature decoding. By default it starts a native local three-primary/three-replica Redis cluster and sweeps both
+  * worker-pool sizes and concurrent batches. Synthetic cache-demand profiles assume all context batch IRs are hot and
+  * apply the named hit percentage to candidate keys; they do not instantiate Caffeine or measure fetcher cache work.
+  * Set PERF_REDIS_PRIMARY_COUNT and PERF_REDIS_REPLICAS_PER_PRIMARY to measure shard-topology tradeoffs. Set
+  * PERF_REDIS_CPU_LIMIT to constrain the local Redis container for fixed-resource comparisons. Set
+  * PERF_REDIS_USE_NATIVE_LOCAL=false for the legacy amd64 fixture, or PERF_REDIS_USE_EXTERNAL=true with
+  * REDIS_CLUSTER_NODES for one isolated external-cluster configuration.
   *
   * Example:
-  *   CHRONON_PERF_TEST_ENABLED=true PERF_REDIS_THREAD_COUNTS=4,8,16,32 PERF_BATCH_CONCURRENCY=4 \
+  *   CHRONON_PERF_TEST_ENABLED=true \
+  *     PERF_REDIS_PROFILES=deduplicated,synthetic-context-hot-candidate-hit-80 \
   *     ./mill --no-server redis.test.testOnly ai.chronon.integrations.redis.RedisFetcherReadPerfTestHarness
   */
 class RedisFetcherReadPerfTestHarness extends AnyFlatSpec with BeforeAndAfterAll {
@@ -34,18 +46,35 @@ class RedisFetcherReadPerfTestHarness extends AnyFlatSpec with BeforeAndAfterAll
   ) extends RedisKVStoreImpl(client, conf)
 
   private val enabled = sys.env.get("CHRONON_PERF_TEST_ENABLED").exists(_.equalsIgnoreCase("true"))
-  private val warmupIterations = envInt("PERF_WARMUP_ITERATIONS", 5)
-  private val measurementIterations = envInt("PERF_MEASUREMENT_ITERATIONS", 200)
-  private val batchConcurrency = envInt("PERF_BATCH_CONCURRENCY", envInt("PERF_NUM_THREADS", 4))
-  private val workerThreadCounts = envInts("PERF_REDIS_THREAD_COUNTS", Seq(4, 8, 16, 32))
+  private val warmupIterations = envInt("PERF_WARMUP_ITERATIONS", 500)
+  private val measurementIterations = envInt("PERF_MEASUREMENT_ITERATIONS", 5000)
+  private val batchConcurrencies = envIntsWithLegacy(
+    "PERF_BATCH_CONCURRENCIES",
+    "PERF_BATCH_CONCURRENCY",
+    envInt("PERF_NUM_THREADS", 0),
+    Seq(32, 48, 64, 96)
+  )
+  private val workerThreadCounts = envInts("PERF_REDIS_THREAD_COUNTS", Seq(16, 32, 48, 64))
   private val queueCapacities = envInts("PERF_REDIS_QUEUE_CAPACITIES", Seq(10000))
   private val loadBatchSize = envInt("PERF_LOAD_BATCH_SIZE", 100)
   private val maxConnections = envInt("PERF_REDIS_MAX_CONNECTIONS", 64)
+  private val maxIdleConnections =
+    envInt("PERF_REDIS_MAX_IDLE_CONNECTIONS", math.min(RedisKVStoreConstants.DefaultMaxIdleConnections, maxConnections))
+  private val minIdleConnections =
+    envInt("PERF_REDIS_MIN_IDLE_CONNECTIONS", math.min(DefaultMinIdleConnections, maxIdleConnections))
   private val readTimeout = envInt("PERF_READ_TIMEOUT_SECONDS", 30).seconds
   private val keyPrefix = sys.env.getOrElse("PERF_REDIS_KEY_PREFIX", "chronon-perf")
   private val useExternalCluster = sys.env.get("PERF_REDIS_USE_EXTERNAL").exists(_.equalsIgnoreCase("true"))
+  private val useNativeLocalCluster =
+    sys.env.getOrElse("PERF_REDIS_USE_NATIVE_LOCAL", "true").equalsIgnoreCase("true")
+  private val localPrimaryCount = envInt("PERF_REDIS_PRIMARY_COUNT", 3)
+  private val localReplicasPerPrimary = envInt("PERF_REDIS_REPLICAS_PER_PRIMARY", 1)
+  private val localCpuLimit = envOptionalDouble("PERF_REDIS_CPU_LIMIT")
   private val selectedProfileNames = sys.env
-    .getOrElse("PERF_REDIS_PROFILES", "deduplicated,logical")
+    .getOrElse(
+      "PERF_REDIS_PROFILES",
+      "deduplicated,deduplicated-cross-day-24h"
+    )
     .split(",")
     .iterator
     .map(_.trim)
@@ -59,12 +88,18 @@ class RedisFetcherReadPerfTestHarness extends AnyFlatSpec with BeforeAndAfterAll
 
   require(warmupIterations >= 0)
   require(measurementIterations > 0)
-  require(batchConcurrency > 0)
+  require(batchConcurrencies.nonEmpty && batchConcurrencies.forall(_ > 0))
   require(workerThreadCounts.nonEmpty && workerThreadCounts.forall(_ > 0))
   require(queueCapacities.nonEmpty && queueCapacities.forall(_ > 0))
   require(loadBatchSize > 0)
   require(maxConnections > 0)
+  require(localPrimaryCount >= 3)
+  require(localReplicasPerPrimary >= 0)
+  require(localCpuLimit.forall(_ > 0))
+  require(minIdleConnections >= 0 && minIdleConnections <= maxIdleConnections)
+  require(maxIdleConnections >= 0 && maxIdleConnections <= maxConnections)
   if (useExternalCluster) {
+    require(localCpuLimit.isEmpty, "PERF_REDIS_CPU_LIMIT only applies to the local Redis fixture")
     require(poolConfigs.size == 1,
             "External Redis runs require one worker/queue configuration per JVM for an isolated executor measurement")
   }
@@ -80,11 +115,14 @@ class RedisFetcherReadPerfTestHarness extends AnyFlatSpec with BeforeAndAfterAll
         val poolConfig = poolConfigs.head
         System.setProperty(FlexibleExecutionContext.ThreadPoolSizeProperty, poolConfig.threads.toString)
         System.setProperty(FlexibleExecutionContext.QueueCapacityProperty, poolConfig.queueCapacity.toString)
-        sys.env.get(EnvRedisMaxConnections).foreach { configured =>
-          require(
-            configured.toInt == maxConnections,
-            s"$EnvRedisMaxConnections=$configured conflicts with PERF_REDIS_MAX_CONNECTIONS=$maxConnections"
-          )
+        Seq(
+          EnvRedisMaxConnections -> maxConnections,
+          EnvRedisMinIdleConnections -> minIdleConnections,
+          EnvRedisMaxIdleConnections -> maxIdleConnections
+        ).foreach { case (name, expected) =>
+          sys.env.get(name).foreach { configured =>
+            require(configured.toInt == expected, s"$name=$configured conflicts with benchmark setting $expected")
+          }
         }
         val nodes = sys.env.getOrElse(
           EnvRedisClusterNodes,
@@ -94,10 +132,23 @@ class RedisFetcherReadPerfTestHarness extends AnyFlatSpec with BeforeAndAfterAll
           Map(
             EnvRedisClusterNodes -> nodes,
             EnvRedisMaxConnections -> maxConnections.toString,
+            EnvRedisMinIdleConnections -> minIdleConnections.toString,
+            EnvRedisMaxIdleConnections -> maxIdleConnections.toString,
             "redis.key.prefix" -> keyPrefix
           ))
       } else {
-        localCluster = RedisClusterFixture.start(maxConnections)
+        localCluster =
+          if (useNativeLocalCluster)
+            RedisClusterFixture.startNative(
+              maxConnections,
+              minIdleConnections,
+              maxIdleConnections,
+              localPrimaryCount,
+              localReplicasPerPrimary,
+              localCpuLimit
+            )
+          else
+            RedisClusterFixture.start(maxConnections, minIdleConnections, maxIdleConnections)
       }
     }
   }
@@ -114,11 +165,16 @@ class RedisFetcherReadPerfTestHarness extends AnyFlatSpec with BeforeAndAfterAll
     assume(enabled, "Set CHRONON_PERF_TEST_ENABLED=true to run Redis performance tests")
 
     val workload = RedisFetcherReadWorkload.build()
-    val profilesByName = Seq(workload.deduplicated, workload.logical).map(profile => profile.name -> profile).toMap
+    val profilesByName =
+      (Seq(workload.deduplicated, workload.deduplicatedCrossDay, workload.logical, workload.batchOnly) ++
+        workload.batchCacheDemand)
+        .map(profile => profile.name -> profile)
+        .toMap
     val selectedProfiles = selectedProfileNames.map { name =>
       profilesByName.getOrElse(name,
                                throw new IllegalArgumentException(
-                                 s"Unknown PERF_REDIS_PROFILES entry '$name'; expected deduplicated or logical"))
+                                 s"Unknown PERF_REDIS_PROFILES entry '$name'; expected one of " +
+                                   profilesByName.keys.toSeq.sorted.mkString(", ")))
     }
 
     println(s"REDIS_FETCHER_READ_SHAPE scope=kvstore_multi_get candidates=${workload.config.candidates} " +
@@ -133,10 +189,19 @@ class RedisFetcherReadPerfTestHarness extends AnyFlatSpec with BeforeAndAfterAll
       s"logical_group_by_requests=${workload.logicalGroupByRequests} " +
       s"unique_group_by_requests=${workload.uniqueGroupByRequests} " +
       s"unique_kv_requests=${workload.deduplicated.requests.size} " +
-      s"redis_read_groups=${workload.config.totalGroupBys + workload.config.totalStreamingGroupBys} " +
+      s"logical_redis_read_groups=${workload.config.totalGroupBys + workload.config.totalStreamingGroupBys} " +
+      s"kvstore_multi_get_calls_per_batch=1 " +
       s"range_hours=${workload.config.tiledPoints} hourly_tiles=${workload.config.tiledPoints} " +
       s"payload_bytes=${workload.deduplicated.expectedPayloadBytes} " +
-      s"batch_concurrency=$batchConcurrency max_connections_per_node=$maxConnections " +
+      s"batch_concurrencies=${batchConcurrencies.mkString(",")} max_connections_per_node=$maxConnections " +
+      s"min_idle_connections_per_node=$minIdleConnections max_idle_connections_per_node=$maxIdleConnections " +
+      s"test_on_borrow=true test_on_return=true test_while_idle=true " +
+      s"redis_cluster_image=${Option(localCluster).map(_.image).getOrElse("external")} " +
+      s"redis_cluster_primaries=${Option(localCluster).map(_.primaryCount.toString).getOrElse("external")} " +
+      s"redis_replicas_per_primary=" +
+      s"${Option(localCluster).map(_.replicasPerPrimary.toString).getOrElse("external")} " +
+      s"redis_container_cpu_limit=" +
+      s"${Option(localCluster).flatMap(_.cpuLimit).map(_.toString).getOrElse("unlimited")} " +
       s"pool_sample_interval_ms=$PoolSampleIntervalMillis " +
       s"jedis_pipeline_sync_workers_per_pipeline=" +
       s"${redis.clients.jedis.MultiNodePipelineBase.MULTI_NODE_PIPELINE_SYNC_WORKERS} " +
@@ -149,15 +214,18 @@ class RedisFetcherReadPerfTestHarness extends AnyFlatSpec with BeforeAndAfterAll
     poolConfigs.foreach { poolConfig =>
       withRedisStore(poolConfig, loader = false) { (kvStore, redisExecutor, jedisCluster) =>
         selectedProfiles.foreach(profile => validateProfile(kvStore, profile))
-        selectedProfiles.foreach { profile =>
-          if (warmupIterations > 0) {
-            val warmup = execute(kvStore, redisExecutor, jedisCluster, profile, warmupIterations)
-            requireSuccessful(profile.name, "warmup", warmup)
-          }
+        batchConcurrencies.foreach { batchConcurrency =>
+          selectedProfiles.foreach { profile =>
+            if (warmupIterations > 0) {
+              val warmup = execute(kvStore, redisExecutor, jedisCluster, profile, warmupIterations, batchConcurrency)
+              requireSuccessful(profile.name, "warmup", warmup)
+            }
 
-          val measurement = execute(kvStore, redisExecutor, jedisCluster, profile, measurementIterations)
-          printResult(workload, profile, poolConfig, measurement)
-          requireSuccessful(profile.name, "measurement", measurement)
+            val measurement =
+              execute(kvStore, redisExecutor, jedisCluster, profile, measurementIterations, batchConcurrency)
+            printResult(workload, profile, poolConfig, measurement, batchConcurrency)
+            requireSuccessful(profile.name, "measurement", measurement)
+          }
         }
       }
     }
@@ -243,7 +311,8 @@ class RedisFetcherReadPerfTestHarness extends AnyFlatSpec with BeforeAndAfterAll
                       redisExecutor: ThreadPoolExecutor,
                       jedisCluster: Option[JedisCluster],
                       profile: RedisFetcherReadWorkload.ReadProfile,
-                      iterations: Int): Measurement = {
+                      iterations: Int,
+                      batchConcurrency: Int): Measurement = {
     val nextIteration = new AtomicInteger()
     val failures = new AtomicInteger()
     val firstFailure = new AtomicReference[Throwable]()
@@ -341,25 +410,44 @@ class RedisFetcherReadPerfTestHarness extends AnyFlatSpec with BeforeAndAfterAll
   private def printResult(workload: RedisFetcherReadWorkload.Workload,
                           profile: RedisFetcherReadWorkload.ReadProfile,
                           poolConfig: PoolConfig,
-                          measurement: Measurement): Unit = {
+                          measurement: Measurement,
+                          batchConcurrency: Int): Unit = {
     val sorted = measurement.latenciesNanos.sorted
     val wallSeconds = measurement.wallNanos.toDouble / TimeUnit.SECONDS.toNanos(1)
-    val batchesPerSecond = measurement.latenciesNanos.length / wallSeconds
-    val candidatesPerSecond = batchesPerSecond * workload.config.candidates
-    val logicalGroupBysPerSecond = batchesPerSecond * workload.logicalGroupByRequests
-    val redisGroupBysPerSecond = batchesPerSecond * profile.groupByRequests
-    val kvResponsesPerSecond = batchesPerSecond * profile.requests.size
-    val payloadMiBPerSecond = batchesPerSecond * profile.expectedPayloadBytes / (1024.0 * 1024.0)
+    val demandBatchesPerSecond = measurement.latenciesNanos.length / wallSeconds
+    val candidatesPerSecond = demandBatchesPerSecond * workload.config.candidates
+    val logicalGroupBysPerSecond = demandBatchesPerSecond * workload.logicalGroupByRequests
+    val batchGetCommandsPerSecond = demandBatchesPerSecond * profile.batchGetCommands
+    val zrangeCommandsPerSecond = demandBatchesPerSecond * profile.zrangeCommands
+    val redisCommandsPerSecond = demandBatchesPerSecond * profile.redisCommands
+    val kvResponsesPerSecond = demandBatchesPerSecond * profile.requests.size
+    val timedValuesPerSecond = demandBatchesPerSecond * profile.expectedTimedValues
+    val payloadMiBPerSecond = demandBatchesPerSecond * profile.expectedPayloadBytes / (1024.0 * 1024.0)
     val averageMillis = sorted.iterator.map(_.toDouble).sum / sorted.length / TimeUnit.MILLISECONDS.toNanos(1)
+    val perCpuMetrics = localCpuLimit
+      .map { cpus =>
+        f"redis_container_cpus=$cpus%.3f " +
+          f"batches_per_sec_per_redis_cpu=${demandBatchesPerSecond / cpus}%.2f " +
+          f"candidate_rows_per_sec_per_redis_cpu=${candidatesPerSecond / cpus}%.2f " +
+          f"redis_commands_per_sec_per_redis_cpu=${redisCommandsPerSecond / cpus}%.2f " +
+          f"timed_values_per_sec_per_redis_cpu=${timedValuesPerSecond / cpus}%.2f " +
+          f"payload_mib_per_sec_per_redis_cpu=${payloadMiBPerSecond / cpus}%.2f "
+      }
+      .getOrElse("redis_container_cpus=unlimited ")
 
     println(
       f"REDIS_FETCHER_READ_RESULT profile=${profile.name} batch_concurrency=$batchConcurrency%d " +
         f"redis_threads=${poolConfig.threads}%d redis_queue_capacity=${poolConfig.queueCapacity}%d " +
-        f"redis_max_connections_per_node=$maxConnections%d iterations=${sorted.length}%d failures=${measurement.failures}%d " +
-        f"batches_per_sec=$batchesPerSecond%.2f candidates_per_sec=$candidatesPerSecond%.2f " +
+        f"redis_max_connections_per_node=$maxConnections%d redis_min_idle_per_node=$minIdleConnections%d " +
+        f"redis_max_idle_per_node=$maxIdleConnections%d iterations=${sorted.length}%d failures=${measurement.failures}%d " +
+        f"kvstore_demand_batches_per_sec=$demandBatchesPerSecond%.2f candidates_per_sec=$candidatesPerSecond%.2f " +
         f"logical_group_bys_per_sec=$logicalGroupBysPerSecond%.2f " +
-        f"redis_group_bys_per_sec=$redisGroupBysPerSecond%.2f kv_responses_per_sec=$kvResponsesPerSecond%.2f " +
-        f"payload_mib_per_sec=$payloadMiBPerSecond%.2f avg_ms=$averageMillis%.3f " +
+        f"batch_get_commands_per_sec=$batchGetCommandsPerSecond%.2f " +
+        f"zrange_commands_per_sec=$zrangeCommandsPerSecond%.2f " +
+        f"redis_commands_per_sec=$redisCommandsPerSecond%.2f kv_responses_per_sec=$kvResponsesPerSecond%.2f " +
+        f"timed_values_per_sec=$timedValuesPerSecond%.2f payload_mib_per_sec=$payloadMiBPerSecond%.2f " +
+        perCpuMetrics +
+        f"avg_ms=$averageMillis%.3f " +
         f"p50_ms=${percentileMillis(sorted, 0.50)}%.3f p95_ms=${percentileMillis(sorted, 0.95)}%.3f " +
         f"p99_ms=${percentileMillis(sorted, 0.99)}%.3f max_ms=${sorted.last.toDouble / TimeUnit.MILLISECONDS.toNanos(1)}%.3f " +
         f"redis_sampled_peak_active=${measurement.pool.peakActive}%d " +
@@ -370,7 +458,10 @@ class RedisFetcherReadPerfTestHarness extends AnyFlatSpec with BeforeAndAfterAll
         f"jedis_sampled_peak_waiters_sum=${measurement.pool.peakJedisWaiters}%d " +
         f"jedis_pipeline_sync_workers_per_pipeline=" +
         f"${redis.clients.jedis.MultiNodePipelineBase.MULTI_NODE_PIPELINE_SYNC_WORKERS}%d " +
-        f"kv_requests_per_batch=${profile.requests.size}%d timed_values_per_batch=${profile.expectedTimedValues}%d " +
+        f"batch_get_commands_per_batch=${profile.batchGetCommands}%d " +
+        f"zrange_commands_per_batch=${profile.zrangeCommands}%d " +
+        f"redis_commands_per_batch=${profile.redisCommands}%d kv_responses_per_batch=${profile.requests.size}%d " +
+        f"timed_values_per_batch=${profile.expectedTimedValues}%d " +
         f"payload_bytes_per_batch=${profile.expectedPayloadBytes}%d"
     )
   }
@@ -389,12 +480,29 @@ class RedisFetcherReadPerfTestHarness extends AnyFlatSpec with BeforeAndAfterAll
   private def envInt(name: String, default: Int): Int =
     sys.env.get(name).map(_.toInt).getOrElse(default)
 
+  private def envOptionalDouble(name: String): Option[Double] =
+    sys.env.get(name).map(_.trim.toDouble)
+
   private def envInts(name: String, defaults: Seq[Int]): Vector[Int] =
     sys.env
       .get(name)
       .map(_.split(",").iterator.map(_.trim).filter(_.nonEmpty).map(_.toInt).toVector)
       .getOrElse(defaults.toVector)
       .distinct
+
+  private def envIntsWithLegacy(name: String,
+                                legacyName: String,
+                                secondLegacyDefault: Int,
+                                defaults: Seq[Int]): Vector[Int] =
+    sys.env.get(name) match {
+      case Some(_) => envInts(name, defaults)
+      case None =>
+        sys.env
+          .get(legacyName)
+          .map(value => Vector(value.toInt))
+          .orElse(if (secondLegacyDefault > 0) Some(Vector(secondLegacyDefault)) else None)
+          .getOrElse(defaults.toVector)
+    }
 }
 
 private object RedisFetcherReadPerfTestHarness {

--- a/redis/src/test/scala/ai/chronon/integrations/redis/RedisFetcherReadWorkload.scala
+++ b/redis/src/test/scala/ai/chronon/integrations/redis/RedisFetcherReadWorkload.scala
@@ -105,6 +105,7 @@ private[redis] object RedisFetcherReadWorkload {
       deduplicatedCrossDay: ReadProfile,
       batchOnly: ReadProfile,
       batchCacheDemand: Vector[ReadProfile],
+      batchCacheDemandCrossDay: Vector[ReadProfile],
       uniqueBatchRequests: Int,
       uniqueStreamingRequests: Int
   ) {
@@ -114,6 +115,11 @@ private[redis] object RedisFetcherReadWorkload {
     def batchCacheDemandAt(hitPercent: Int): ReadProfile =
       batchCacheDemand.find(_.name == s"synthetic-context-hot-candidate-hit-$hitPercent").getOrElse {
         throw new IllegalArgumentException(s"No batch cache demand profile for $hitPercent%")
+      }
+
+    def batchCacheDemandCrossDayAt(hitPercent: Int): ReadProfile =
+      batchCacheDemandCrossDay.find(_.name == s"synthetic-context-hot-candidate-hit-$hitPercent-cross-day-24h").getOrElse {
+        throw new IllegalArgumentException(s"No cross-day batch cache demand profile for $hitPercent%")
       }
   }
 
@@ -190,6 +196,14 @@ private[redis] object RedisFetcherReadWorkload {
       }
       profile(s"synthetic-context-hot-candidate-hit-$hitPercent", reads)
     }
+    val batchCacheDemandCrossDay = Vector(50, 80, 100).map { hitPercent =>
+      val candidateMisses = math.ceil(config.candidates * (100 - hitPercent) / 100.0).toInt
+      val missingCandidateKeys = candidateKeys.take(candidateMisses).iterator.map(_.toVector).toSet
+      val reads = plannedCrossDayReads.filter { planned =>
+        planned.request.startTsMillis.isDefined || missingCandidateKeys.contains(planned.request.keyBytes.toVector)
+      }
+      profile(s"synthetic-context-hot-candidate-hit-$hitPercent-cross-day-24h", reads)
+    }
 
     val puts = groupBys.flatMap { groupBy =>
       val ownerKeys = groupBy.ownership match {
@@ -245,6 +259,7 @@ private[redis] object RedisFetcherReadWorkload {
       profile("deduplicated-cross-day-24h", plannedCrossDayReads),
       profile("batch-only", plannedUniqueBatchReads),
       batchCacheDemand,
+      batchCacheDemandCrossDay,
       uniqueBatchRequests,
       uniqueStreamingRequests
     )

--- a/redis/src/test/scala/ai/chronon/integrations/redis/RedisFetcherReadWorkload.scala
+++ b/redis/src/test/scala/ai/chronon/integrations/redis/RedisFetcherReadWorkload.scala
@@ -51,7 +51,7 @@ private[redis] object RedisFetcherReadWorkload {
     require(
       candidateEmbeddingGroupBys >= 0 &&
         candidateEmbeddingGroupBys <= candidateGroupBys - candidateLastGroupBys - candidateTiledGroupBys)
-    require(tiledPoints > 0 && tileSizeMillis > 0)
+    require(tiledPoints > 1 && tileSizeMillis > 0)
     require(scalarPayloadBytes > 0 && embeddingPayloadBytes > 0)
 
     val contextSnapshotGroupBys: Int = contextGroupBys - contextLastGroupBys - contextTiledGroupBys
@@ -80,7 +80,19 @@ private[redis] object RedisFetcherReadWorkload {
       expectedTimedValues: Long,
       expectedPayloadBytes: Long
   ) {
-    val groupByRequests: Int = requests.count(_.startTsMillis.isEmpty)
+    val batchGetCommands: Int = requests.count(_.startTsMillis.isEmpty)
+    val zrangeCommands: Int = requests.iterator
+      .filter(_.startTsMillis.isDefined)
+      .map { request =>
+        val startTs = request.startTsMillis.get
+        val endTs = request.endTsMillis.getOrElse(startTs)
+        val startDay = startTs - (startTs % 1.day.toMillis)
+        val endDay = endTs - (endTs % 1.day.toMillis)
+        ((endDay - startDay) / 1.day.toMillis + 1L).toInt
+      }
+      .sum
+    val redisCommands: Int = batchGetCommands + zrangeCommands
+    val groupByRequests: Int = batchGetCommands
   }
 
   final case class Workload(
@@ -90,11 +102,19 @@ private[redis] object RedisFetcherReadWorkload {
       puts: Vector[PutRequest],
       logical: ReadProfile,
       deduplicated: ReadProfile,
+      deduplicatedCrossDay: ReadProfile,
+      batchOnly: ReadProfile,
+      batchCacheDemand: Vector[ReadProfile],
       uniqueBatchRequests: Int,
       uniqueStreamingRequests: Int
   ) {
     val logicalGroupByRequests: Int = config.candidates * config.totalGroupBys
     val uniqueGroupByRequests: Int = uniqueBatchRequests
+
+    def batchCacheDemandAt(hitPercent: Int): ReadProfile =
+      batchCacheDemand.find(_.name == s"synthetic-context-hot-candidate-hit-$hitPercent").getOrElse {
+        throw new IllegalArgumentException(s"No batch cache demand profile for $hitPercent%")
+      }
   }
 
   private final case class PlannedGet(request: GetRequest, expectedTimedValues: Int, expectedPayloadBytes: Long)
@@ -151,6 +171,25 @@ private[redis] object RedisFetcherReadWorkload {
       uniqueReads.getOrElseUpdate(identity(planned.request), planned)
     }
     val plannedUniqueReads = uniqueReads.values.toVector
+    val plannedCrossDayReads = plannedUniqueReads.map { planned =>
+      if (planned.request.startTsMillis.isDefined) {
+        planned.copy(request = planned.request.copy(
+          startTsMillis = Some(RangeStartMillis - config.tileSizeMillis),
+          endTsMillis = Some(rangeEndMillis - config.tileSizeMillis)
+        ))
+      } else {
+        planned
+      }
+    }
+    val plannedUniqueBatchReads = plannedUniqueReads.filter(_.request.startTsMillis.isEmpty)
+    val batchCacheDemand = Vector(50, 80, 100).map { hitPercent =>
+      val candidateMisses = math.ceil(config.candidates * (100 - hitPercent) / 100.0).toInt
+      val missingCandidateKeys = candidateKeys.take(candidateMisses).iterator.map(_.toVector).toSet
+      val reads = plannedUniqueReads.filter { planned =>
+        planned.request.startTsMillis.isDefined || missingCandidateKeys.contains(planned.request.keyBytes.toVector)
+      }
+      profile(s"synthetic-context-hot-candidate-hit-$hitPercent", reads)
+    }
 
     val puts = groupBys.flatMap { groupBy =>
       val ownerKeys = groupBy.ownership match {
@@ -167,9 +206,12 @@ private[redis] object RedisFetcherReadWorkload {
         groupBy.streamingDataset match {
           case None => Vector(batchPut)
           case Some(streamingDataset) =>
-            val points = groupBy.readShape.streamingPoints(config)
-            val firstPoint = config.tiledPoints - points
-            val streamingPuts = (firstPoint until config.tiledPoints).map { pointIndex =>
+            val pointIndexes = groupBy.readShape match {
+              case LastValue   => Seq(-1, config.tiledPoints - 1)
+              case HourlyTiled => -1 until config.tiledPoints
+              case Snapshot    => Seq.empty
+            }
+            val streamingPuts = pointIndexes.map { pointIndex =>
               val tileStartMillis = RangeStartMillis + pointIndex.toLong * config.tileSizeMillis
               val tileKey = TilingUtils.buildTileKey(
                 streamingDataset,
@@ -200,6 +242,9 @@ private[redis] object RedisFetcherReadWorkload {
       puts,
       profile("logical", plannedLogicalReads),
       profile("deduplicated", plannedUniqueReads),
+      profile("deduplicated-cross-day-24h", plannedCrossDayReads),
+      profile("batch-only", plannedUniqueBatchReads),
+      batchCacheDemand,
       uniqueBatchRequests,
       uniqueStreamingRequests
     )

--- a/redis/src/test/scala/ai/chronon/integrations/redis/RedisFetcherReadWorkloadTest.scala
+++ b/redis/src/test/scala/ai/chronon/integrations/redis/RedisFetcherReadWorkloadTest.scala
@@ -38,9 +38,15 @@ class RedisFetcherReadWorkloadTest extends AnyFlatSpec with Matchers {
     workload.batchCacheDemandAt(50).requests should have size 880
     workload.batchCacheDemandAt(80).requests should have size 505
     workload.batchCacheDemandAt(100).requests should have size 255
+    workload.batchCacheDemandCrossDayAt(50).requests should have size 880
+    workload.batchCacheDemandCrossDayAt(80).requests should have size 505
+    workload.batchCacheDemandCrossDayAt(100).requests should have size 255
     workload.batchCacheDemandAt(50).redisCommands shouldBe 880
     workload.batchCacheDemandAt(80).redisCommands shouldBe 505
     workload.batchCacheDemandAt(100).redisCommands shouldBe 255
+    workload.batchCacheDemandCrossDayAt(50).redisCommands shouldBe 1135
+    workload.batchCacheDemandCrossDayAt(80).redisCommands shouldBe 760
+    workload.batchCacheDemandCrossDayAt(100).redisCommands shouldBe 510
     workload.logical.groupByRequests shouldBe 2500
     workload.deduplicated.groupByRequests shouldBe 1275
   }
@@ -61,6 +67,12 @@ class RedisFetcherReadWorkloadTest extends AnyFlatSpec with Matchers {
     workload.batchCacheDemandAt(80).expectedPayloadBytes shouldBe 56884L
     workload.batchCacheDemandAt(100).expectedTimedValues shouldBe 3751L
     workload.batchCacheDemandAt(100).expectedPayloadBytes shouldBe 15004L
+    workload.batchCacheDemandCrossDayAt(50).expectedTimedValues shouldBe 4376L
+    workload.batchCacheDemandCrossDayAt(50).expectedPayloadBytes shouldBe 119704L
+    workload.batchCacheDemandCrossDayAt(80).expectedTimedValues shouldBe 4001L
+    workload.batchCacheDemandCrossDayAt(80).expectedPayloadBytes shouldBe 56884L
+    workload.batchCacheDemandCrossDayAt(100).expectedTimedValues shouldBe 3751L
+    workload.batchCacheDemandCrossDayAt(100).expectedPayloadBytes shouldBe 15004L
     workload.logical.expectedTimedValues shouldBe 8750L
     workload.logical.expectedPayloadBytes shouldBe 239400L
 

--- a/redis/src/test/scala/ai/chronon/integrations/redis/RedisFetcherReadWorkloadTest.scala
+++ b/redis/src/test/scala/ai/chronon/integrations/redis/RedisFetcherReadWorkloadTest.scala
@@ -4,6 +4,8 @@ import ai.chronon.integrations.redis.RedisFetcherReadWorkload.{Candidate, Contex
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+import scala.jdk.CollectionConverters._
+
 class RedisFetcherReadWorkloadTest extends AnyFlatSpec with Matchers {
 
   "Redis fetcher read workload" should "match the 50-candidate mixed GroupBy shape" in {
@@ -25,6 +27,20 @@ class RedisFetcherReadWorkloadTest extends AnyFlatSpec with Matchers {
     workload.uniqueBatchRequests shouldBe 1275
     workload.uniqueStreamingRequests shouldBe 255
     workload.deduplicated.requests should have size 1530
+    workload.deduplicated.batchGetCommands shouldBe 1275
+    workload.deduplicated.zrangeCommands shouldBe 255
+    workload.deduplicated.redisCommands shouldBe 1530
+    workload.deduplicatedCrossDay.requests should have size 1530
+    workload.deduplicatedCrossDay.batchGetCommands shouldBe 1275
+    workload.deduplicatedCrossDay.zrangeCommands shouldBe 510
+    workload.deduplicatedCrossDay.redisCommands shouldBe 1785
+    workload.batchOnly.requests should have size 1275
+    workload.batchCacheDemandAt(50).requests should have size 880
+    workload.batchCacheDemandAt(80).requests should have size 505
+    workload.batchCacheDemandAt(100).requests should have size 255
+    workload.batchCacheDemandAt(50).redisCommands shouldBe 880
+    workload.batchCacheDemandAt(80).redisCommands shouldBe 505
+    workload.batchCacheDemandAt(100).redisCommands shouldBe 255
     workload.logical.groupByRequests shouldBe 2500
     workload.deduplicated.groupByRequests shouldBe 1275
   }
@@ -32,10 +48,31 @@ class RedisFetcherReadWorkloadTest extends AnyFlatSpec with Matchers {
   it should "materialize the expected payload and tile counts" in {
     val workload = RedisFetcherReadWorkload.build()
 
-    workload.puts should have size 5026
+    workload.puts should have size 5281
     workload.deduplicated.expectedTimedValues shouldBe 5026L
     workload.deduplicated.expectedPayloadBytes shouldBe 224504L
+    workload.deduplicatedCrossDay.expectedTimedValues shouldBe 5026L
+    workload.deduplicatedCrossDay.expectedPayloadBytes shouldBe 224504L
+    workload.batchOnly.expectedTimedValues shouldBe 1275L
+    workload.batchOnly.expectedPayloadBytes shouldBe 209500L
+    workload.batchCacheDemandAt(50).expectedTimedValues shouldBe 4376L
+    workload.batchCacheDemandAt(50).expectedPayloadBytes shouldBe 119704L
+    workload.batchCacheDemandAt(80).expectedTimedValues shouldBe 4001L
+    workload.batchCacheDemandAt(80).expectedPayloadBytes shouldBe 56884L
+    workload.batchCacheDemandAt(100).expectedTimedValues shouldBe 3751L
+    workload.batchCacheDemandAt(100).expectedPayloadBytes shouldBe 15004L
     workload.logical.expectedTimedValues shouldBe 8750L
     workload.logical.expectedPayloadBytes shouldBe 239400L
+
+    val alignedStart = workload.deduplicated.requests.find(_.startTsMillis.isDefined).get.startTsMillis.get
+    val streamingPutsBySeries = workload.puts
+      .filter(_.dataset.endsWith("_STREAMING"))
+      .groupBy { put =>
+        val tileKey = ai.chronon.api.TilingUtils.deserializeTileKey(put.keyBytes)
+        put.dataset -> tileKey.keyBytes.asScala.map(_.toByte).toVector
+      }
+    streamingPutsBySeries should have size workload.uniqueStreamingRequests
+    all(streamingPutsBySeries.values.map(_.exists(_.tsMillis.exists(_ < alignedStart)))) shouldBe true
+    all(streamingPutsBySeries.values.map(_.exists(_.tsMillis.exists(_ >= alignedStart)))) shouldBe true
   }
 }

--- a/redis/src/test/scala/ai/chronon/integrations/redis/RedisKVStoreTest.scala
+++ b/redis/src/test/scala/ai/chronon/integrations/redis/RedisKVStoreTest.scala
@@ -6,9 +6,7 @@ import ai.chronon.online.KVStore._
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import redis.clients.jedis.{HostAndPort, JedisCluster, DefaultJedisClientConfig, HostAndPortMapper}
-import org.testcontainers.containers.GenericContainer
-import org.testcontainers.utility.DockerImageName
+import redis.clients.jedis.JedisCluster
 import java.nio.charset.StandardCharsets
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -21,94 +19,19 @@ import scala.jdk.CollectionConverters._
 class RedisKVStoreTest extends AnyFlatSpec with BeforeAndAfterAll with Matchers {
   import RedisKVStore._
 
-  private var redisContainer: GenericContainer[_] = _
+  private var redisFixture: RedisClusterFixture = _
   private var jedisCluster: JedisCluster = _
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    // Use grokzen/redis-cluster - minimal Redis cluster in single container
-    // Provides a 6-node cluster (3 masters, 3 replicas) with fast startup (~5-7 seconds)
-    val internalPorts = Seq(7000,7001,7002,7003,7004,7005)
-    val container = new GenericContainer(DockerImageName.parse("grokzen/redis-cluster:7.0.10"))
-    container.withExposedPorts(internalPorts.map(Integer.valueOf): _*)
-    container.withStartupTimeout(java.time.Duration.ofSeconds(60))
-    container.start()
-    println(s"\nRedis cluster container started")
-    redisContainer = container
-
-    val host = container.getHost
-    val basePort = container.getMappedPort(7000)
-    // Wait for cluster to be ready - ensure all 3 masters have slot assignments
-
-
-
-    if (!waitForClusterReady(host, basePort, 30, "Cluster Initiated")) {
-      throw new RuntimeException(s"Redis cluster failed to initialize after 30 seconds")
-    }
-
-    val configBuilder = DefaultJedisClientConfig.builder()
-      .hostAndPortMapper(new HostAndPortMapper {
-        override def getHostAndPort(hap: HostAndPort): HostAndPort = {
-          // Redis CLuster announces internal ports (7000-7005)
-          // map them to the external ports assigned by Testcontainers
-          val internalPort = hap.getPort
-          if(internalPorts.contains(internalPort)) {
-            val mappedPort = container.getMappedPort(internalPort)
-            new HostAndPort(host, mappedPort)
-          } else {
-            // if port is not in our known list, return as-is
-            hap
-          }
-        }
-      })
-
-    val poolConfig = new org.apache.commons.pool2.impl.GenericObjectPoolConfig[redis.clients.jedis.Connection]()
-    poolConfig.setMaxTotal(10)
-    poolConfig.setMaxIdle(10)
-    poolConfig.setMinIdle(2)
-    poolConfig.setTestOnBorrow(true)
-
-    // Initialize JedisCLuster with the mapped entry point and the port mapper
-    val initNode = new HostAndPort(host, basePort)
-    jedisCluster = new JedisCluster(Set(initNode).asJava, configBuilder.build(), 5, poolConfig)
-    println(s"JedisCluster connected with port mapping \n")
-
-    // Reconfigure each Redis node to announce external (mapped) ports
-    // This makes the cluster topology accessible from Spark executors!
-    println("Reconfiguring Redis cluster to announce external ports...")
-    internalPorts.foreach { internalPort =>
-      val mappedPort = container.getMappedPort(internalPort)
-      val jedis = new redis.clients.jedis.Jedis(host, mappedPort, 5000)
-
-      try {
-        // Configure Redis to announce the external host and mapped port
-        jedis.configSet("cluster-announce-ip", host)
-        jedis.configSet("cluster-announce-port", mappedPort.toString)
-        // Bus port is typically port + 5000, use mapped port for this too
-        jedis.configSet("cluster-announce-bus-port", (mappedPort + 5000).toString)
-
-        println(s"  ✓ Node $internalPort now announces $host:$mappedPort")
-      } catch {
-        case e: Exception =>
-          println(s"  ✕ Failed to reconfigure node $internalPort: ${e.getMessage}")
-          throw e
-      } finally {
-        jedis.close()
-      }
-    }
-
-    // Wait for cluster gossip protocol to propagate the new topology
-    println("Waiting for cluster topology to propagate...")
-    Thread.sleep(3000)
-    println("✓ Cluster topology reconfigured")
+    redisFixture = RedisClusterFixture.start(maxConnections = 10, minIdleConnections = 2, maxIdleConnections = 10)
+    jedisCluster = redisFixture.client
   }
 
   override def afterAll(): Unit = {
-    if (jedisCluster != null) {
-      try jedisCluster.close() catch { case _: Exception => }
-    }
-    if (redisContainer != null) {
-      try redisContainer.stop() catch { case _: Exception => }
+    if (redisFixture != null) {
+      try redisFixture.close()
+      catch { case _: Exception => }
     }
     super.afterAll()
   }
@@ -121,29 +44,6 @@ class RedisKVStoreTest extends AnyFlatSpec with BeforeAndAfterAll with Matchers 
       case _: Exception => // Ignore cleanup errors (e.g., when Redis is stopped for failure tests)
     }
     super.withFixture(test)
-  }
-
-  private def waitForClusterReady(host: String, port: Int, maxAttempts: Int = 30, successMessage: String = "Cluster ready") : Boolean = {
-    var clusterReady = false
-    var attempts = 0
-    while (!clusterReady && attempts < maxAttempts) {
-      try {
-        val testJedis = new redis.clients.jedis.Jedis(host, port, 3000)
-        val clusterSlots = testJedis.clusterSlots()
-        testJedis.close()
-        if (clusterSlots.size() >= 3) {
-          clusterReady = true
-          println(s"\n$successMessage (${attempts + 1}s)")
-        }
-      } catch {
-        case _: Exception => // Cluster not ready yet
-      }
-      if (!clusterReady) {
-        Thread.sleep(1000)
-        attempts += 1
-      }
-    }
-    clusterReady
   }
 
   it should "create Redis dataset successfully" in {
@@ -842,8 +742,8 @@ class RedisKVStoreTest extends AnyFlatSpec with BeforeAndAfterAll with Matchers 
     val batchDataset = s"${dataset}_BATCH"  // The actual dataset name after transformation
 
     // Get cluster connection info from the test container
-    val host = redisContainer.getHost
-    val port = redisContainer.getMappedPort(7000)
+    val host = redisFixture.container.getHost
+    val port = redisFixture.container.getMappedPort(7000)
 
     val clusterConfig = Map(
       "redis.cluster.nodes" -> s"$host:$port"

--- a/redis/src/test/scala/ai/chronon/integrations/redis/RedisPipelineRetryTest.scala
+++ b/redis/src/test/scala/ai/chronon/integrations/redis/RedisPipelineRetryTest.scala
@@ -1,0 +1,131 @@
+package ai.chronon.integrations.redis
+
+import ai.chronon.online.KVStore.GetRequest
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{mock, times, verify, when}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import redis.clients.jedis.exceptions.{JedisAskDataException, JedisConnectionException}
+import redis.clients.jedis.{ClusterPipeline, HostAndPort, JedisCluster, Response}
+
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class RedisPipelineRetryTest extends AnyFlatSpec with Matchers {
+
+  "Redis multiGet pipeline recovery" should "retry the whole pipeline once after unset responses" in {
+    val firstPipeline = mock(classOf[ClusterPipeline])
+    val retryPipeline = mock(classOf[ClusterPipeline])
+    val firstResponse = mock(classOf[Response[Array[Byte]]])
+    val retryResponse = mock(classOf[Response[Array[Byte]]])
+    val cluster = mock(classOf[JedisCluster])
+    val storedValue = encodeStoredValue("value", 123L)
+
+    when(cluster.pipelined()).thenReturn(firstPipeline, retryPipeline)
+    when(firstPipeline.get(any(classOf[Array[Byte]]))).thenReturn(firstResponse)
+    when(firstResponse.get())
+      .thenThrow(new IllegalStateException("Please close pipeline or multi block before calling this method."))
+    when(cluster.get(any(classOf[Array[Byte]]))).thenReturn(storedValue)
+    when(retryPipeline.get(any(classOf[Array[Byte]]))).thenReturn(retryResponse)
+    when(retryResponse.get()).thenReturn(storedValue)
+
+    val responses = readTwoBatchKeys(cluster)
+
+    responses.map(_.values.get.head.millis) shouldBe Seq(123L, 123L)
+    responses.map(response => new String(response.values.get.head.bytes, StandardCharsets.UTF_8)) shouldBe
+      Seq("value", "value")
+    verify(cluster, times(2)).pipelined()
+    verify(cluster, times(1)).get(any(classOf[Array[Byte]]))
+  }
+
+  it should "retry the whole pipeline once after a queue-time connection failure" in {
+    val firstPipeline = mock(classOf[ClusterPipeline])
+    val retryPipeline = mock(classOf[ClusterPipeline])
+    val retryResponse = mock(classOf[Response[Array[Byte]]])
+    val cluster = mock(classOf[JedisCluster])
+    val storedValue = encodeStoredValue("value", 456L)
+
+    when(cluster.pipelined()).thenReturn(firstPipeline, retryPipeline)
+    when(firstPipeline.get(any(classOf[Array[Byte]]))).thenThrow(new JedisConnectionException("disconnected"))
+    when(cluster.get(any(classOf[Array[Byte]]))).thenReturn(storedValue)
+    when(retryPipeline.get(any(classOf[Array[Byte]]))).thenReturn(retryResponse)
+    when(retryResponse.get()).thenReturn(storedValue)
+
+    val responses = readTwoBatchKeys(cluster)
+
+    responses.map(_.values.get.head.millis) shouldBe Seq(456L, 456L)
+    verify(cluster, times(2)).pipelined()
+    verify(cluster, times(1)).get(any(classOf[Array[Byte]]))
+  }
+
+  it should "preserve first-attempt successes when another command fails during retry" in {
+    val firstPipeline = mock(classOf[ClusterPipeline])
+    val retryPipeline = mock(classOf[ClusterPipeline])
+    val firstSuccess = mock(classOf[Response[Array[Byte]]])
+    val firstFailure = mock(classOf[Response[Array[Byte]]])
+    val retryFailure = mock(classOf[Response[Array[Byte]]])
+    val retrySuccess = mock(classOf[Response[Array[Byte]]])
+    val cluster = mock(classOf[JedisCluster])
+    val firstValue = encodeStoredValue("first", 111L)
+    val retryValue = encodeStoredValue("retry", 222L)
+
+    when(cluster.pipelined()).thenReturn(firstPipeline, retryPipeline)
+    when(firstPipeline.get(any(classOf[Array[Byte]]))).thenReturn(firstSuccess, firstFailure)
+    when(firstSuccess.get()).thenReturn(firstValue)
+    when(firstFailure.get())
+      .thenThrow(new IllegalStateException("Please close pipeline or multi block before calling this method."))
+    when(cluster.get(any(classOf[Array[Byte]]))).thenReturn(retryValue)
+    when(retryPipeline.get(any(classOf[Array[Byte]]))).thenReturn(retryFailure, retrySuccess)
+    when(retryFailure.get()).thenThrow(new JedisConnectionException("different node failed"))
+    when(retrySuccess.get()).thenReturn(retryValue)
+
+    val responses = readTwoBatchKeys(cluster)
+
+    responses.map(_.values.get.head.millis) shouldBe Seq(111L, 222L)
+    responses.map(response => new String(response.values.get.head.bytes, StandardCharsets.UTF_8)) shouldBe
+      Seq("first", "retry")
+    verify(firstPipeline, times(1)).close()
+    verify(retryPipeline, times(1)).close()
+  }
+
+  it should "recover ASK redirects directly without discarding successful pipeline results" in {
+    val pipeline = mock(classOf[ClusterPipeline])
+    val askResponse = mock(classOf[Response[Array[Byte]]])
+    val successfulResponse = mock(classOf[Response[Array[Byte]]])
+    val cluster = mock(classOf[JedisCluster])
+    val directValue = encodeStoredValue("direct", 333L)
+    val pipelineValue = encodeStoredValue("pipeline", 444L)
+    val ask = new JedisAskDataException("ASK", new HostAndPort("localhost", 7001), 42)
+
+    when(cluster.pipelined()).thenReturn(pipeline)
+    when(pipeline.get(any(classOf[Array[Byte]]))).thenReturn(askResponse, successfulResponse)
+    when(askResponse.get()).thenThrow(ask)
+    when(successfulResponse.get()).thenReturn(pipelineValue)
+    when(cluster.get(any(classOf[Array[Byte]]))).thenReturn(directValue)
+
+    val responses = readTwoBatchKeys(cluster)
+
+    responses.map(_.values.get.head.millis) shouldBe Seq(333L, 444L)
+    responses.map(response => new String(response.values.get.head.bytes, StandardCharsets.UTF_8)) shouldBe
+      Seq("direct", "pipeline")
+    verify(cluster, times(1)).pipelined()
+    verify(cluster, times(1)).get(any(classOf[Array[Byte]]))
+    verify(pipeline, times(1)).close()
+  }
+
+  private def readTwoBatchKeys(cluster: JedisCluster) = {
+    val kvStore = new RedisKVStoreImpl(cluster)
+    val requests = Seq(
+      GetRequest("key-a".getBytes(StandardCharsets.UTF_8), "RETRY_A_BATCH"),
+      GetRequest("key-b".getBytes(StandardCharsets.UTF_8), "RETRY_B_BATCH")
+    )
+    Await.result(kvStore.multiGet(requests), 10.seconds)
+  }
+
+  private def encodeStoredValue(value: String, timestamp: Long): Array[Byte] = {
+    val valueBytes = value.getBytes(StandardCharsets.UTF_8)
+    ByteBuffer.allocate(java.lang.Long.BYTES + valueBytes.length).putLong(timestamp).put(valueBytes).array()
+  }
+}

--- a/redis/src/test/scala/ai/chronon/integrations/redis/RedisUnifiedReadPipelineTest.scala
+++ b/redis/src/test/scala/ai/chronon/integrations/redis/RedisUnifiedReadPipelineTest.scala
@@ -1,0 +1,135 @@
+package ai.chronon.integrations.redis
+
+import ai.chronon.api.TilingUtils
+import ai.chronon.online.KVStore.{GetRequest, PutRequest}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.charset.StandardCharsets
+import java.time.Instant
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
+
+class RedisUnifiedReadPipelineTest extends AnyFlatSpec with BeforeAndAfterAll with Matchers {
+  private val HourMillis = 1.hour.toMillis
+  private val DayStartMillis = Instant.parse("2026-02-01T00:00:00Z").toEpochMilli
+
+  private var cluster: RedisClusterFixture = _
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    cluster = RedisClusterFixture.start(maxConnections = 4)
+  }
+
+  override def afterAll(): Unit = {
+    try {
+      if (cluster != null) cluster.close()
+    } finally {
+      super.afterAll()
+    }
+  }
+
+  "Redis multiGet" should "pipeline interleaved batch and multi-day streaming reads in input order" in {
+    val kvStore = new RedisKVStoreImpl(cluster.client)
+    val batchA = GetRequest(bytes("batch-a"), "UNIFIED_A_BATCH")
+    val batchB = GetRequest(bytes("batch-b"), "UNIFIED_B_BATCH")
+    val streamingDataset = "UNIFIED_STREAMING"
+    val streamingEntity = bytes("streaming-entity")
+    val streamingReadKey = TilingUtils.serializeTileKey(
+      TilingUtils.buildTileKey(streamingDataset, streamingEntity, Some(HourMillis), None))
+    val queryStart = DayStartMillis + 23 * HourMillis
+    val queryEnd = DayStartMillis + 25 * HourMillis
+    val streaming = GetRequest(streamingReadKey, streamingDataset, Some(queryStart), Some(queryEnd))
+
+    val batchPuts = Seq(
+      PutRequest(batchA.keyBytes, bytes("value-a"), batchA.dataset, Some(DayStartMillis)),
+      PutRequest(batchB.keyBytes, bytes("value-b"), batchB.dataset, Some(DayStartMillis))
+    )
+    val streamingPuts = (22 to 26).map { hour =>
+      val timestamp = DayStartMillis + hour * HourMillis
+      val writeKey = TilingUtils.serializeTileKey(
+        TilingUtils.buildTileKey(streamingDataset, streamingEntity, Some(HourMillis), Some(timestamp)))
+      PutRequest(writeKey, bytes(s"stream-$hour"), streamingDataset, Some(timestamp))
+    }
+    Await.result(kvStore.multiPut(batchPuts ++ streamingPuts), 10.seconds).forall(identity) shouldBe true
+
+    val requests = Seq(batchA, streaming, batchB, streaming)
+    val borrowedBefore = cluster.client.getClusterNodes.values().asScala.map(_.getBorrowedCount).sum
+    val responses = Await.result(kvStore.multiGet(requests), 10.seconds)
+    val borrowedAfter = cluster.client.getClusterNodes.values().asScala.map(_.getBorrowedCount).sum
+
+    responses.map(_.request) shouldBe requests
+    new String(responses(0).values.get.head.bytes, StandardCharsets.UTF_8) shouldBe "value-a"
+    responses(1).values.get.map(_.millis) shouldBe Seq(queryStart, DayStartMillis + 24 * HourMillis, queryEnd)
+    responses(1).values.get.map(value => new String(value.bytes, StandardCharsets.UTF_8)) shouldBe
+      Seq("stream-23", "stream-24", "stream-25")
+    new String(responses(2).values.get.head.bytes, StandardCharsets.UTF_8) shouldBe "value-b"
+    responses(3).values.get.map(_.millis) shouldBe responses(1).values.get.map(_.millis)
+    responses(3).values.get.map(value => new String(value.bytes, StandardCharsets.UTF_8)) shouldBe
+      responses(1).values.get.map(value => new String(value.bytes, StandardCharsets.UTF_8))
+    borrowedAfter - borrowedBefore should be <= 3L
+    cluster.client.getClusterNodes.values().asScala.map(_.getNumActive).sum shouldBe 0
+  }
+
+  it should "isolate malformed plans and Redis command failures" in {
+    val kvStore = new RedisKVStoreImpl(cluster.client)
+    val goodBatch = GetRequest(bytes("good-batch"), "FAILURE_GOOD_BATCH")
+    Await.result(
+      kvStore.multiPut(Seq(PutRequest(goodBatch.keyBytes, bytes("good"), goodBatch.dataset, Some(DayStartMillis)))),
+      10.seconds) shouldBe Seq(true)
+
+    val malformed = GetRequest(Array[Byte](1, 2, 3),
+                               "FAILURE_MALFORMED_STREAMING",
+                               Some(DayStartMillis),
+                               Some(DayStartMillis + HourMillis))
+    val wrongTypeDataset = "FAILURE_WRONG_TYPE_STREAMING"
+    val wrongTypeEntity = bytes("wrong-type")
+    val wrongTypeReadKey = TilingUtils.serializeTileKey(
+      TilingUtils.buildTileKey(wrongTypeDataset, wrongTypeEntity, Some(HourMillis), None))
+    val wrongTypeRedisKey = RedisKVStore
+      .buildTiledRedisKey(wrongTypeEntity.toSeq, wrongTypeDataset, DayStartMillis, HourMillis)
+      .getBytes(StandardCharsets.UTF_8)
+    cluster.client.set(wrongTypeRedisKey, bytes("not-a-sorted-set"))
+    val wrongType = GetRequest(wrongTypeReadKey,
+                               wrongTypeDataset,
+                               Some(DayStartMillis),
+                               Some(DayStartMillis + HourMillis))
+    val validStreamingDataset = "FAILURE_VALID_STREAMING"
+    val validStreamingEntity = bytes("valid-streaming")
+    val validStreamingReadKey = TilingUtils.serializeTileKey(
+      TilingUtils.buildTileKey(validStreamingDataset, validStreamingEntity, Some(HourMillis), None))
+    val validStreamingWriteKey = TilingUtils.serializeTileKey(
+      TilingUtils.buildTileKey(validStreamingDataset,
+                               validStreamingEntity,
+                               Some(HourMillis),
+                               Some(DayStartMillis)))
+    Await.result(
+      kvStore.multiPut(
+        Seq(PutRequest(validStreamingWriteKey, bytes("valid-stream"), validStreamingDataset, Some(DayStartMillis)))),
+      10.seconds) shouldBe Seq(true)
+    val validStreamingRedisKey = RedisKVStore
+      .buildTiledRedisKey(validStreamingEntity.toSeq, validStreamingDataset, DayStartMillis, HourMillis)
+      .getBytes(StandardCharsets.UTF_8)
+    cluster.client.zadd(validStreamingRedisKey, (DayStartMillis + HourMillis / 2).toDouble, Array[Byte](1, 2, 3))
+    val validStreaming = GetRequest(validStreamingReadKey,
+                                    validStreamingDataset,
+                                    Some(DayStartMillis),
+                                    Some(DayStartMillis + HourMillis))
+
+    val requests = Seq(goodBatch, malformed, validStreaming, wrongType, validStreaming, goodBatch)
+    val responses = Await.result(kvStore.multiGet(requests), 10.seconds)
+
+    responses.map(_.request) shouldBe requests
+    responses(0).values.isSuccess shouldBe true
+    responses(1).values.isFailure shouldBe true
+    responses(2).values.get.map(value => new String(value.bytes, StandardCharsets.UTF_8)) shouldBe Seq("valid-stream")
+    responses(3).values.isFailure shouldBe true
+    responses(4).values.get.map(value => new String(value.bytes, StandardCharsets.UTF_8)) shouldBe Seq("valid-stream")
+    responses(5).values.isSuccess shouldBe true
+    cluster.client.getClusterNodes.values().asScala.map(_.getNumActive).sum shouldBe 0
+  }
+
+  private def bytes(value: String): Array[Byte] = value.getBytes(StandardCharsets.UTF_8)
+}

--- a/redis/src/test/scala/ai/chronon/integrations/redis/RedisUnifiedReadPipelineTest.scala
+++ b/redis/src/test/scala/ai/chronon/integrations/redis/RedisUnifiedReadPipelineTest.scala
@@ -5,6 +5,7 @@ import ai.chronon.online.KVStore.{GetRequest, PutRequest}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import redis.clients.jedis.util.JedisClusterCRC16
 
 import java.nio.charset.StandardCharsets
 import java.time.Instant
@@ -129,6 +130,38 @@ class RedisUnifiedReadPipelineTest extends AnyFlatSpec with BeforeAndAfterAll wi
     responses(4).values.get.map(value => new String(value.bytes, StandardCharsets.UTF_8)) shouldBe Seq("valid-stream")
     responses(5).values.isSuccess shouldBe true
     cluster.client.getClusterNodes.values().asScala.map(_.getNumActive).sum shouldBe 0
+  }
+
+  it should "co-locate entity hash-tagged batch reads while preserving dataset uniqueness" in {
+    val kvStore = new RedisKVStoreImpl(cluster.client, Map("redis.key.hash.tag.mode" -> RedisKVStore.EntityHashTagMode))
+    val entity = bytes("shared-entity")
+    val datasetA = "ENTITY_HASH_A_BATCH"
+    val datasetB = "ENTITY_HASH_B_BATCH"
+    val redisKeyA = RedisKVStore
+      .buildRedisKey(entity.toSeq, datasetA, hashTagMode = RedisKVStore.EntityHashTagMode)
+      .getBytes(StandardCharsets.UTF_8)
+    val redisKeyB = RedisKVStore
+      .buildRedisKey(entity.toSeq, datasetB, hashTagMode = RedisKVStore.EntityHashTagMode)
+      .getBytes(StandardCharsets.UTF_8)
+
+    redisKeyA.toSeq should not equal redisKeyB.toSeq
+    JedisClusterCRC16.getSlot(redisKeyA) shouldBe JedisClusterCRC16.getSlot(redisKeyB)
+
+    Await.result(
+      kvStore.multiPut(
+        Seq(
+          PutRequest(entity, bytes("value-a"), datasetA, Some(DayStartMillis)),
+          PutRequest(entity, bytes("value-b"), datasetB, Some(DayStartMillis))
+        )),
+      10.seconds
+    ) shouldBe Seq(true, true)
+
+    val requests = Seq(GetRequest(entity, datasetA), GetRequest(entity, datasetB))
+    val responses = Await.result(kvStore.multiGet(requests), 10.seconds)
+
+    responses.map(_.request) shouldBe requests
+    responses.map(response => new String(response.values.get.head.bytes, StandardCharsets.UTF_8)) shouldBe
+      Seq("value-a", "value-b")
   }
 
   private def bytes(value: String): Array[Byte] = value.getBytes(StandardCharsets.UTF_8)


### PR DESCRIPTION
## Summary

Off the prior benchmarks, we're optimizing over the read path for some wide joins. Changes here are a lot of harness changes but:

- Update the benchmarks for some correctness issues around deduping over GroupBys
- Added additional timing for cache lookup, planning and response fanout

Improvements: 

- +3142% on benchmarks - The largest change was to swap to a planned path for `GET` and `ZRANGE` reqs.  We first construct a planned set of commands and then queue those onto one Redis cluster pipeline. This was _really_ beneficial. 
- +8.4% - We swapped from `ZRANGEWITHSCORES` to `ZRANGE` given the timestamp is already embedded in the value and the timestamp is the score we do not need to read it. 
- +18.2% - We stopped validating pools with PING reqs on every borrow, instead they get validated in the bg when idle. 

Other changes:
- Metrics were being repeatedly written with the same values per batch (this doesn't really change that much I think)
- JoinPart linear dedup - made the dedupe path on the JoinParts a little faster
- Not every temporal GroupBy has a topic attached so they do not all have written tiles - we only check now if there is an attached topic. 
 
## Checklist
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable Redis key hash-tag modes to support flexible data placement.
  * Added configurable Redis connection-pool idle limits with validation and clearer startup reporting.

* **Bug Fixes**
  * Improved Redis batch reads with unified pipelining, retries, and ASK redirect recovery.
  * Prevented unnecessary streaming reads for temporal data without a streaming source.
  * Improved cache hit/miss handling and request deduplication.
  * Preserved request ordering and response consistency during mixed reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->