### PR TITLE
add in the batch end ts to the status endpoint

### DIFF
--- a/cloud_aws/src/main/scala/ai/chronon/integrations/aws/DynamoDBKVStoreImpl.scala
+++ b/cloud_aws/src/main/scala/ai/chronon/integrations/aws/DynamoDBKVStoreImpl.scala
@@ -57,18 +57,26 @@ class DynamoDBKVStoreImpl(rawDynamoDbClient: DynamoDbAsyncClient, conf: Map[Stri
 
   protected val metricsContext: Metrics.Context = Metrics.Context(Metrics.Environment.KVStore).withSuffix("dynamodb")
 
+  private def loadBatchTableName(dataset: String, stronglyConsistent: Boolean): String = {
+    val keyMap = Map(
+      partitionKeyColumn -> AttributeValue.builder.b(SdkBytes.fromByteArray(dataset.getBytes(Constants.UTF8))).build)
+    val request = GetItemRequest.builder
+      .tableName(batchTableRegistry)
+      .key(keyMap.toJava)
+      .build
+    val response =
+      if (stronglyConsistent) prefixedDynamoDbClient.getItemStronglyConsistent(request)
+      else prefixedDynamoDbClient.getItem(request)
+    val item = response.join().item().toScala
+    item
+      .get("valueBytes")
+      .map(value => new String(value.b().asByteArray(), Constants.UTF8))
+      .getOrElse(dataset)
+  }
+
   // TTLCache: resolves logical batch dataset names to physical date-suffixed table names
   private val batchTableCache: TTLCache[String, String] = new TTLCache[String, String](
-    f = { dataset =>
-      val keyMap = Map(partitionKeyColumn -> AttributeValue.builder.b(SdkBytes.fromByteArray(dataset.getBytes)).build)
-      val request = GetItemRequest.builder
-        .tableName(batchTableRegistry)
-        .key(keyMap.toJava)
-        .build
-
-      val item = prefixedDynamoDbClient.getItem(request).join().item().toScala
-      item.get("valueBytes").map(v => new String(v.b().asByteArray())).getOrElse(dataset)
-    },
+    f = { dataset => loadBatchTableName(dataset, stronglyConsistent = false) },
     contextBuilder = { _ => metricsContext.withSuffix("batch_table_cache") }
   )
 
@@ -168,29 +176,59 @@ class DynamoDBKVStoreImpl(rawDynamoDbClient: DynamoDbAsyncClient, conf: Map[Stri
     Future.sequence(getItemResults ++ aggregatedQueryResults)
   }
 
+  override def getFresh(request: KVStore.GetRequest): Future[KVStore.GetResponse] = {
+    if (request.startTsMillis.isDefined || request.endTsMillis.isDefined) {
+      Future.successful(
+        GetResponse(request,
+                    Failure(new UnsupportedOperationException("DynamoDB fresh reads only support exact-key lookups"))))
+    } else {
+      Try {
+        if (request.dataset.endsWith(batchSuffix)) loadBatchTableName(request.dataset, stronglyConsistent = true)
+        else request.dataset
+      } match {
+        case Success(tableName) =>
+          getLookup(request,
+                    tableName,
+                    stronglyConsistent = true,
+                    metricsSuffix = "get_fresh",
+                    defaultTimestamp = Instant.now().toEpochMilli)
+        case Failure(exception) => Future.successful(GetResponse(request, Failure(exception)))
+      }
+    }
+  }
+
+  private def getLookup(request: KVStore.GetRequest,
+                        tableName: String,
+                        stronglyConsistent: Boolean,
+                        metricsSuffix: String,
+                        defaultTimestamp: Long): Future[GetResponse] = {
+    val keyAttributeMap = primaryKeyMap(request.keyBytes)
+    val getItemRequest = GetItemRequest.builder.key(keyAttributeMap.toJava).tableName(tableName).build
+    val startTs = System.currentTimeMillis()
+    val response =
+      if (stronglyConsistent) prefixedDynamoDbClient.getItemStronglyConsistent(getItemRequest)
+      else prefixedDynamoDbClient.getItem(getItemRequest)
+
+    handleDynamoDbOperation(metricsContext.withSuffix(metricsSuffix), request.dataset, startTs)(response)
+      .transform {
+        case Success(getItemResponse) =>
+          val resultValue = extractTimedValues(List(getItemResponse.item()).toJava, defaultTimestamp)
+          Success(GetResponse(request, resultValue))
+        case Failure(exception) =>
+          Success(GetResponse(request, Failure(exception)))
+      }
+  }
+
   protected def doGetLookups(getLookups: Seq[KVStore.GetRequest]): Seq[Future[GetResponse]] = {
-    val getItemCompletables = getLookups.map { req =>
-      val keyAttributeMap = primaryKeyMap(req.keyBytes)
-      val tableName = resolveTableName(req.dataset)
-      val getItemReq = GetItemRequest.builder.key(keyAttributeMap.toJava).tableName(tableName).build
-      val startTs = System.currentTimeMillis()
-      (req, prefixedDynamoDbClient.getItem(getItemReq), startTs)
-    }
-
-    // timestamp to use for all get responses when the underlying tables don't have a ts field
+    // Keep the existing behavior of assigning one fallback timestamp to all exact reads in this multiGet.
     val defaultTimestamp = Instant.now().toEpochMilli
-
-    val getItemResults = getItemCompletables.map { case (req, completableFuture, startTs) =>
-      handleDynamoDbOperation(metricsContext.withSuffix("multiget"), req.dataset, startTs)(completableFuture)
-        .transform {
-          case Success(response) =>
-            val resultValue = extractTimedValues(List(response.item()).toJava, defaultTimestamp)
-            Success(GetResponse(req, resultValue))
-          case Failure(e) =>
-            Success(GetResponse(req, Failure(e)))
-        }
+    getLookups.map { request =>
+      getLookup(request,
+                resolveTableName(request.dataset),
+                stronglyConsistent = false,
+                metricsSuffix = "multiget",
+                defaultTimestamp = defaultTimestamp)
     }
-    getItemResults
   }
 
   protected def queryPartition(dataset: String,

--- a/cloud_aws/src/main/scala/ai/chronon/integrations/aws/PrefixedDynamoDbAsyncClient.scala
+++ b/cloud_aws/src/main/scala/ai/chronon/integrations/aws/PrefixedDynamoDbAsyncClient.scala
@@ -34,6 +34,16 @@ class PrefixedDynamoDbAsyncClient(delegate: DynamoDbAsyncClient, tablePrefix: St
     delegate.getItem(prefixedRequest)
   }
 
+  /** Strongly consistent GetItem sent to the underlying DynamoDB client. */
+  private[aws] def getItemStronglyConsistent(request: GetItemRequest): CompletableFuture[GetItemResponse] = {
+    val originalTableName = request.tableName()
+    val prefixedTableName = prefixTableName(originalTableName)
+    logger.debug(
+      s"getItemStronglyConsistent: original table name='$originalTableName' -> prefixed table name='$prefixedTableName'")
+    val prefixedRequest = request.toBuilder.tableName(prefixedTableName).consistentRead(true).build()
+    delegate.getItem(prefixedRequest)
+  }
+
   def query(request: QueryRequest): CompletableFuture[QueryResponse] = {
     val originalTableName = request.tableName()
     val prefixedTableName = prefixTableName(originalTableName)

--- a/cloud_aws/src/test/scala/ai/chronon/integrations/aws/DynamoDBBatchTableRegistryTest.scala
+++ b/cloud_aws/src/test/scala/ai/chronon/integrations/aws/DynamoDBBatchTableRegistryTest.scala
@@ -98,6 +98,44 @@ class DynamoDBBatchTableRegistryTest extends AnyFlatSpec with BeforeAndAfterAll 
     resolved2 shouldBe physicalName
   }
 
+  it should "bypass the cached batch generation for fresh metadata reads" in {
+    val kvStore = new DynamoDBKVStoreImpl(client)
+
+    kvStore.create(batchTableRegistry)
+
+    val logicalName = "FRESH_METADATA_GROUPBY_BATCH"
+    val oldPhysicalName = "FRESH_METADATA_GROUPBY_BATCH_2026_02_17"
+    val newPhysicalName = "FRESH_METADATA_GROUPBY_BATCH_2026_02_18"
+    val metadataKey = "group_by_serving_info"
+    val metadataKeyBytes = metadataKey.getBytes(StandardCharsets.UTF_8)
+
+    Seq(oldPhysicalName, newPhysicalName).foreach(kvStore.create(_, Map.empty))
+    Await.result(
+      kvStore.multiPut(
+        Seq(
+          PutRequest(metadataKeyBytes, "old".getBytes(StandardCharsets.UTF_8), oldPhysicalName),
+          PutRequest(metadataKeyBytes, "new".getBytes(StandardCharsets.UTF_8), newPhysicalName),
+          PutRequest(logicalName.getBytes(StandardCharsets.UTF_8),
+                     oldPhysicalName.getBytes(StandardCharsets.UTF_8),
+                     batchTableRegistry)
+        )),
+      1.minute
+    )
+
+    kvStore.getString(metadataKey, logicalName, 5.seconds.toMillis).get shouldBe "old"
+
+    Await.result(
+      kvStore.multiPut(
+        Seq(PutRequest(logicalName.getBytes(StandardCharsets.UTF_8),
+                       newPhysicalName.getBytes(StandardCharsets.UTF_8),
+                       batchTableRegistry))),
+      1.minute
+    )
+
+    kvStore.getString(metadataKey, logicalName, 5.seconds.toMillis).get shouldBe "old"
+    kvStore.getStringFresh(metadataKey, logicalName, 5.seconds.toMillis).get shouldBe "new"
+  }
+
   it should "resolve batch table names in multiGet for get lookups" in {
     val kvStore = new DynamoDBKVStoreImpl(client)
 

--- a/cloud_aws/src/test/scala/ai/chronon/integrations/aws/PrefixedDynamoDbAsyncClientTest.scala
+++ b/cloud_aws/src/test/scala/ai/chronon/integrations/aws/PrefixedDynamoDbAsyncClientTest.scala
@@ -41,6 +41,23 @@ class PrefixedDynamoDbAsyncClientTest extends AnyFlatSpec with Matchers with Moc
     captor.getValue.tableName() shouldBe s"$testPrefix$originalTableName"
   }
 
+  it should "prefix and strongly consistency-mark fresh getItem requests" in {
+    val client = new PrefixedDynamoDbAsyncClient(mockDelegate, testPrefix)
+    val originalTableName = "metadata_table"
+    val request = GetItemRequest.builder().tableName(originalTableName).consistentRead(false).build()
+
+    when(mockDelegate.getItem(any[GetItemRequest]())).thenReturn(
+      CompletableFuture.completedFuture(GetItemResponse.builder().build())
+    )
+
+    client.getItemStronglyConsistent(request)
+
+    val captor = ArgumentCaptor.forClass(classOf[GetItemRequest])
+    verify(mockDelegate).getItem(captor.capture())
+    captor.getValue.tableName() shouldBe s"$testPrefix$originalTableName"
+    captor.getValue.consistentRead() shouldBe true
+  }
+
   it should "prefix table name in putItem request" in {
     val client = new PrefixedDynamoDbAsyncClient(mockDelegate, testPrefix)
     val originalTableName = "my_table"

--- a/docker/fetcher/README.md
+++ b/docker/fetcher/README.md
@@ -70,7 +70,7 @@ The service exposes the following HTTP endpoints:
 |GET |`/v1/joins` | List of Chronon joins marked online            |
 |GET|`/v1/join/:name/schema` | Returns a join schema payload |
 |GET|`/v1/groupby/:name/schema` | Returns an online GroupBy schema payload |
-|GET|`/v1/groupby/:name/status` | Returns online GroupBy upload status |
+|GET|`/v1/groupby/:name/status` | Returns the latest uploaded batch watermark for an online GroupBy |
 |POST|`/v1/fetch/groupby/:name`| Retrieve features for a specific GroupBy
 |POST|`/v1/fetch/join/:name`| Retrieve features for a specific Join
 |POST|`/v2/fetch/join/:name`| Retrieve features for a specific Join with the features response as an Avro binary string (base64 encoded)

--- a/docs/source/setup/Fetcher_API.md
+++ b/docs/source/setup/Fetcher_API.md
@@ -18,7 +18,7 @@ Names in path parameters are Chronon metadata names. URL-encode names that conta
 | `GET` | `/v1/joins` | Lists Chronon joins marked `online=True`. |
 | `GET` | `/v1/join/:name/schema` | Returns the online fetch schema for a join. |
 | `GET` | `/v1/groupby/:name/schema` | Returns the online fetch schema for a GroupBy. |
-| `GET` | `/v1/groupby/:name/status` | Returns online GroupBy upload status. |
+| `GET` | `/v1/groupby/:name/status` | Returns the latest uploaded batch watermark for an online GroupBy. |
 | `GET` | `/v1/stats/:tableName` | Returns enhanced statistics for a table when stats are available. |
 | `POST` | `/v1/fetch/groupby/:name` | Fetches features for one GroupBy. |
 | `POST` | `/v1/fetch/join/:name` | Fetches features for one join. |
@@ -91,7 +91,7 @@ GroupBy schema fetching is available only for online GroupBys. If a GroupBy is n
 
 ## GroupBy Status
 
-`GET /v1/groupby/:name/status` returns the latest uploaded batch watermark for an online GroupBy.
+`GET /v1/groupby/:name/status` returns the latest uploaded batch serving watermark for an online GroupBy.
 
 ```bash
 curl "http://localhost:9000/v1/groupby/quickstart.user_activity_v1/status" | jq
@@ -102,7 +102,8 @@ Response fields:
 | Field | Description |
 |-------|-------------|
 | `groupByName` | GroupBy metadata name. |
-| `batchEndDate` | Date through which batch upload data is available in the online KV store. |
+| `batchEndDate` | Formatted partition boundary through which batch upload data is available in the online KV store. |
+| `batchEndTs` | Epoch millis watermark through which batch upload data is available in the online KV store. Prefer this field for subdaily grids. |
 
 ## CLI
 

--- a/docs/source/setup/Fetcher_API.md
+++ b/docs/source/setup/Fetcher_API.md
@@ -103,7 +103,7 @@ Response fields:
 |-------|-------------|
 | `groupByName` | GroupBy metadata name. |
 | `batchEndDate` | Formatted partition boundary through which batch upload data is available in the online KV store. |
-| `batchEndTs` | Epoch millis watermark through which batch upload data is available in the online KV store. Prefer this field for subdaily grids. |
+| `batchEndTs` | Explicit epoch millis watermark uploaded with the serving info, or `null` when absent. Prefer this field for subdaily grids. |
 
 ## CLI
 

--- a/online/src/main/java/ai/chronon/online/JavaGroupByStatusResponse.java
+++ b/online/src/main/java/ai/chronon/online/JavaGroupByStatusResponse.java
@@ -5,18 +5,25 @@ import ai.chronon.online.fetcher.Fetcher;
 public class JavaGroupByStatusResponse {
     public String groupByName;
     public String batchEndDate;
+    public long batchEndTs;
 
     public JavaGroupByStatusResponse(String groupByName, String batchEndDate) {
+        this(groupByName, batchEndDate, 0L);
+    }
+
+    public JavaGroupByStatusResponse(String groupByName, String batchEndDate, long batchEndTs) {
         this.groupByName = groupByName;
         this.batchEndDate = batchEndDate;
+        this.batchEndTs = batchEndTs;
     }
 
     public JavaGroupByStatusResponse(Fetcher.GroupByStatusResponse scalaResponse) {
         this.groupByName = scalaResponse.groupByName();
         this.batchEndDate = scalaResponse.batchEndDate();
+        this.batchEndTs = scalaResponse.batchEndTs();
     }
 
     public Fetcher.GroupByStatusResponse toScala() {
-        return new Fetcher.GroupByStatusResponse(groupByName, batchEndDate);
+        return new Fetcher.GroupByStatusResponse(groupByName, batchEndDate, batchEndTs);
     }
 }

--- a/online/src/main/java/ai/chronon/online/JavaGroupByStatusResponse.java
+++ b/online/src/main/java/ai/chronon/online/JavaGroupByStatusResponse.java
@@ -5,13 +5,13 @@ import ai.chronon.online.fetcher.Fetcher;
 public class JavaGroupByStatusResponse {
     public String groupByName;
     public String batchEndDate;
-    public long batchEndTs;
+    public Long batchEndTs;
 
     public JavaGroupByStatusResponse(String groupByName, String batchEndDate) {
-        this(groupByName, batchEndDate, 0L);
+        this(groupByName, batchEndDate, null);
     }
 
-    public JavaGroupByStatusResponse(String groupByName, String batchEndDate, long batchEndTs) {
+    public JavaGroupByStatusResponse(String groupByName, String batchEndDate, Long batchEndTs) {
         this.groupByName = groupByName;
         this.batchEndDate = batchEndDate;
         this.batchEndTs = batchEndTs;

--- a/online/src/main/scala/ai/chronon/online/Api.scala
+++ b/online/src/main/scala/ai/chronon/online/Api.scala
@@ -84,23 +84,31 @@ trait KVStore {
 
   // helper method to blocking read a string - used for fetching metadata & not in hotpath.
   def getString(key: String, dataset: String, timeoutMillis: Long): Try[String] = {
-    val bytesTry = getResponse(key, dataset, timeoutMillis)
+    val bytesTry = getResponse(key, dataset, timeoutMillis, get)
+    bytesTry.map(bytes => new String(bytes, Constants.UTF8))
+  }
+
+  /** Blocking metadata read that bypasses implementation-specific read caches when supported. */
+  def getStringFresh(key: String, dataset: String, timeoutMillis: Long): Try[String] = {
+    val bytesTry = getResponse(key, dataset, timeoutMillis, getFresh)
     bytesTry.map(bytes => new String(bytes, Constants.UTF8))
   }
 
   def getStringArray(key: String, dataset: String, timeoutMillis: Long): Try[Seq[String]] = {
-    val bytesTry = getResponse(key, dataset, timeoutMillis)
+    val bytesTry = getResponse(key, dataset, timeoutMillis, get)
     bytesTry.map(bytes => StringArrayConverter.bytesToStrings(bytes))
   }
 
-  private def getResponse(key: String, dataset: String, timeoutMillis: Long): Try[Array[Byte]] = {
+  private def getResponse(key: String,
+                          dataset: String,
+                          timeoutMillis: Long,
+                          read: GetRequest => Future[GetResponse]): Try[Array[Byte]] = {
     val fetchRequest = KVStore.GetRequest(key.getBytes(Constants.UTF8), dataset)
-    val responseFutureOpt = get(fetchRequest)
 
     def buildException(e: Throwable) =
       new RuntimeException(s"Request for key ${key} in dataset ${dataset} failed", e)
 
-    Try(Await.result(responseFutureOpt, Duration(timeoutMillis, MILLISECONDS))) match {
+    Try(Await.result(read(fetchRequest), Duration(timeoutMillis, MILLISECONDS))) match {
       case Failure(e) =>
         Failure(buildException(e))
       case Success(resp) =>
@@ -121,6 +129,9 @@ trait KVStore {
         throw e
       }
   }
+
+  /** Exact read path for callers that require implementation-specific caches to be bypassed. */
+  def getFresh(request: GetRequest): Future[GetResponse] = get(request)
 
   // Method for taking the set of keys and constructing the byte array sent to the KVStore
   def createKeyBytes(keys: Map[String, AnyRef],

--- a/online/src/main/scala/ai/chronon/online/fetcher/Fetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/Fetcher.scala
@@ -163,18 +163,39 @@ object Fetcher {
     * @param batchEndTs - Epoch millis watermark through which batch upload data is available in the KV store
     */
   case class GroupByStatusResponse(groupByName: String, batchEndDate: String) {
-    private var batchEndTsValue: Long = 0L
+    private var batchEndTsValue: java.lang.Long = null
 
-    def this(groupByName: String, batchEndDate: String, batchEndTs: Long) = {
+    def this(groupByName: String, batchEndDate: String, batchEndTs: java.lang.Long) = {
       this(groupByName, batchEndDate)
       batchEndTsValue = batchEndTs
     }
 
-    def batchEndTs: Long = batchEndTsValue
+    def batchEndTs: java.lang.Long = batchEndTsValue
+
+    def copy(groupByName: String, batchEndDate: String): GroupByStatusResponse =
+      GroupByStatusResponse(groupByName, batchEndDate, batchEndTs)
+
+    def copy(groupByName: String = this.groupByName,
+             batchEndDate: String = this.batchEndDate,
+             batchEndTs: java.lang.Long = this.batchEndTs): GroupByStatusResponse =
+      GroupByStatusResponse(groupByName, batchEndDate, batchEndTs)
+
+    override def equals(other: Any): Boolean = other match {
+      case that: GroupByStatusResponse =>
+        that.canEqual(this) &&
+        groupByName == that.groupByName &&
+        batchEndDate == that.batchEndDate &&
+        batchEndTs == that.batchEndTs
+      case _ => false
+    }
+
+    override def hashCode(): Int = (groupByName, batchEndDate, batchEndTs).hashCode()
+
+    override def toString: String = s"GroupByStatusResponse($groupByName,$batchEndDate,$batchEndTs)"
   }
 
   object GroupByStatusResponse {
-    def apply(groupByName: String, batchEndDate: String, batchEndTs: Long): GroupByStatusResponse =
+    def apply(groupByName: String, batchEndDate: String, batchEndTs: java.lang.Long): GroupByStatusResponse =
       new GroupByStatusResponse(groupByName, batchEndDate, batchEndTs)
   }
 
@@ -900,7 +921,11 @@ class Fetcher(val kvStore: KVStore,
         }
       }
       .map { servingInfo =>
-        val response = GroupByStatusResponse(groupByName, servingInfo.batchEndDate, servingInfo.batchEndTsMillis)
+        val batchEndTs =
+          if (servingInfo.groupByServingInfo.isSetBatchEndTs)
+            java.lang.Long.valueOf(servingInfo.groupByServingInfo.getBatchEndTs)
+          else null
+        val response = GroupByStatusResponse(groupByName, servingInfo.batchEndDate, batchEndTs)
         ctx.distribution(Metrics.Name.LatencyMillis, System.currentTimeMillis() - startTime)
         response
       }

--- a/online/src/main/scala/ai/chronon/online/fetcher/Fetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/Fetcher.scala
@@ -159,9 +159,24 @@ object Fetcher {
 
   /** Response for a groupBy status request.
     * @param groupByName - Name of the groupBy
-    * @param batchEndDate - Date through which batch upload data is available in the KV store
+    * @param batchEndDate - Formatted partition boundary through which batch upload data is available in the KV store
+    * @param batchEndTs - Epoch millis watermark through which batch upload data is available in the KV store
     */
-  case class GroupByStatusResponse(groupByName: String, batchEndDate: String)
+  case class GroupByStatusResponse(groupByName: String, batchEndDate: String) {
+    private var batchEndTsValue: Long = 0L
+
+    def this(groupByName: String, batchEndDate: String, batchEndTs: Long) = {
+      this(groupByName, batchEndDate)
+      batchEndTsValue = batchEndTs
+    }
+
+    def batchEndTs: Long = batchEndTsValue
+  }
+
+  object GroupByStatusResponse {
+    def apply(groupByName: String, batchEndDate: String, batchEndTs: Long): GroupByStatusResponse =
+      new GroupByStatusResponse(groupByName, batchEndDate, batchEndTs)
+  }
 
   private[fetcher] def codecForCurrentThread(codec: AvroCodec): AvroCodec =
     AvroCodec.ofThreaded(codec.schemaStr, codec.writerSchemaStr).get()
@@ -880,11 +895,12 @@ class Fetcher(val kvStore: KVStore,
               s"GroupBy $groupByName is not online. Fetcher status is only available for online GroupBys. " +
                 "Enable online=True and upload the GroupBy."))
         } else {
-          metadataStore.getGroupByServingInfo(groupByName)
+          // Serving info is the authoritative upload watermark; status bypasses its long-lived read caches.
+          metadataStore.getGroupByServingInfoFresh(groupByName)
         }
       }
       .map { servingInfo =>
-        val response = GroupByStatusResponse(groupByName, servingInfo.batchEndDate)
+        val response = GroupByStatusResponse(groupByName, servingInfo.batchEndDate, servingInfo.batchEndTsMillis)
         ctx.distribution(Metrics.Name.LatencyMillis, System.currentTimeMillis() - startTime)
         response
       }

--- a/online/src/main/scala/ai/chronon/online/fetcher/MetadataStore.scala
+++ b/online/src/main/scala/ai/chronon/online/fetcher/MetadataStore.scala
@@ -392,58 +392,62 @@ class MetadataStore(fetchContext: FetchContext) extends ThrottledLogging {
       { _ => Metrics.Context(environment = "stats.serving_info.fetch") }
     )
 
-  // pull and cache groupByServingInfo from the groupBy uploads
+  private def loadGroupByServingInfo(name: String, fresh: Boolean = false): Try[GroupByServingInfoParsed] = {
+    val startTimeMs = System.currentTimeMillis()
+    val batchDataset = s"${name.sanitize.toUpperCase()}_BATCH"
+    val metaData =
+      // Metadata string reads can throw when the batch dataset is reachable but the serving-info key is absent.
+      // Capture that miss so it flows as a Failure instead of escaping the cache loader and collapsing the fetch.
+      Try {
+        if (fresh) {
+          fetchContext.kvStore
+            .getStringFresh(Constants.GroupByServingInfoKey, batchDataset, fetchContext.timeoutMillis)
+        } else {
+          fetchContext.kvStore
+            .getString(Constants.GroupByServingInfoKey, batchDataset, fetchContext.timeoutMillis)
+        }
+      }.flatten
+        .recover {
+          case e: java.util.NoSuchElementException =>
+            logThrottled(
+              ERROR,
+              s"missing_group_by_serving_info_$batchDataset",
+              s"Failed to fetch metadata for $batchDataset, is it possible Group By Upload for $name has not succeeded?"
+            )
+            throw e
+          case e: Throwable =>
+            logThrottled(ERROR,
+                         s"group_by_serving_info_failure_$batchDataset",
+                         s"Failed to fetch metadata for $batchDataset",
+                         e)
+            throw e
+        }
+    logger.info(s"Fetched ${Constants.GroupByServingInfoKey} from: $batchDataset (fresh=$fresh)")
+    if (metaData.isFailure) {
+      Metrics
+        .Context(Metrics.Environment.MetaDataFetching, groupBy = name)
+        .withSuffix("group_by")
+        .incrementException(metaData.failed.get)
+      Failure(
+        new RuntimeException(s"Couldn't fetch group by serving info for $batchDataset, " +
+                               "please make sure a batch upload was successful",
+                             metaData.failed.get))
+    } else {
+      import ai.chronon.online.metrics
+      val groupByServingInfo = ThriftJsonCodec
+        .fromJsonStr[GroupByServingInfo](metaData.get, check = false, classOf[GroupByServingInfo])
+      metrics.Metrics
+        .Context(metrics.Metrics.Environment.MetaDataFetching, groupByServingInfo.groupBy)
+        .withSuffix("group_by")
+        .distribution(metrics.Metrics.Name.LatencyMillis, System.currentTimeMillis() - startTimeMs)
+      Success(new GroupByServingInfoParsed(groupByServingInfo))
+    }
+  }
+
+  // Pull and cache GroupByServingInfo for feature-serving hot paths.
   lazy val getGroupByServingInfo: TTLCache[String, Try[GroupByServingInfoParsed]] =
     new TTLCache[String, Try[GroupByServingInfoParsed]](
-      { name =>
-        val startTimeMs = System.currentTimeMillis()
-        val batchDataset = s"${name.sanitize.toUpperCase()}_BATCH"
-        val metaData =
-          // getString throws (rather than returning a Failure) when the batch dataset is reachable but the
-          // serving-info key is absent - e.g. a client still calling a version whose upload has been retired.
-          // Production stores surface that miss as Success(empty), which getString turns into a raw
-          // NoSuchElementException. Capture it here so it flows as a Failure instead of escaping the TTLCache
-          // loader unhandled and collapsing the whole (join) fetch into an opaque 500.
-          Try {
-            fetchContext.kvStore
-              .getString(Constants.GroupByServingInfoKey, batchDataset, fetchContext.timeoutMillis)
-          }.flatten
-            .recover {
-              case e: java.util.NoSuchElementException =>
-                logThrottled(
-                  ERROR,
-                  s"missing_group_by_serving_info_$batchDataset",
-                  s"Failed to fetch metadata for $batchDataset, is it possible Group By Upload for $name has not succeeded?"
-                )
-                throw e
-              case e: Throwable =>
-                logThrottled(ERROR,
-                             s"group_by_serving_info_failure_$batchDataset",
-                             s"Failed to fetch metadata for $batchDataset",
-                             e)
-                throw e
-            }
-        logger.info(s"Fetched ${Constants.GroupByServingInfoKey} from : $batchDataset")
-        if (metaData.isFailure) {
-          Metrics
-            .Context(Metrics.Environment.MetaDataFetching, groupBy = name)
-            .withSuffix("group_by")
-            .incrementException(metaData.failed.get)
-          Failure(
-            new RuntimeException(s"Couldn't fetch group by serving info for $batchDataset, " +
-                                   "please make sure a batch upload was successful",
-                                 metaData.failed.get))
-        } else {
-          import ai.chronon.online.metrics
-          val groupByServingInfo = ThriftJsonCodec
-            .fromJsonStr[GroupByServingInfo](metaData.get, check = false, classOf[GroupByServingInfo])
-          metrics.Metrics
-            .Context(metrics.Metrics.Environment.MetaDataFetching, groupByServingInfo.groupBy)
-            .withSuffix("group_by")
-            .distribution(metrics.Metrics.Name.LatencyMillis, System.currentTimeMillis() - startTimeMs)
-          Success(new GroupByServingInfoParsed(groupByServingInfo))
-        }
-      },
+      loadGroupByServingInfo(_),
       { gb =>
         import ai.chronon.online.metrics
         metrics.Metrics.Context(environment = "group_by.serving_info.fetch", groupBy = gb)
@@ -453,6 +457,10 @@ class MetadataStore(fetchContext: FetchContext) extends ThrottledLogging {
       // subsequent request for the join would fail until a refresh finally succeeded.
       isValid = (servingInfo: Try[GroupByServingInfoParsed]) => servingInfo.isSuccess
     )
+
+  /** Bypass serving-info and KV implementation caches for low-volume callers that require current metadata. */
+  def getGroupByServingInfoFresh(name: String): Try[GroupByServingInfoParsed] =
+    loadGroupByServingInfo(name, fresh = true)
 
   def put(
       kVPairs: Map[String, Seq[String]],

--- a/online/src/test/scala/ai/chronon/online/test/FetcherSchemaTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/FetcherSchemaTest.scala
@@ -2,10 +2,10 @@ package ai.chronon.online.test
 
 import ai.chronon.api.Extensions.GroupByOps
 import ai.chronon.api.{Constants, ThriftJsonCodec}
+import ai.chronon.online.{GroupByServingInfoParsed, InMemoryKvStore, JavaGroupByStatusResponse}
 import ai.chronon.online.KVStore.PutRequest
 import ai.chronon.online.fetcher.Fetcher
 import ai.chronon.online.serde.AvroCodec
-import ai.chronon.online.InMemoryKvStore
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -14,8 +14,14 @@ import scala.concurrent.duration.DurationInt
 
 class FetcherSchemaTest extends AnyFlatSpec with Matchers {
 
-  private def putString(kvStore: InMemoryKvStore, key: String, value: String, dataset: String): Unit = {
-    Await.result(kvStore.put(PutRequest(key.getBytes(Constants.UTF8), value.getBytes(Constants.UTF8), dataset)), 1.second)
+  private def putString(kvStore: InMemoryKvStore,
+                        key: String,
+                        value: String,
+                        dataset: String,
+                        tsMillis: Option[Long] = None): Unit = {
+    Await.result(
+      kvStore.put(PutRequest(key.getBytes(Constants.UTF8), value.getBytes(Constants.UTF8), dataset, tsMillis)),
+      1.second)
   }
 
   it should "fetch schema for online groupBys" in {
@@ -43,24 +49,47 @@ class FetcherSchemaTest extends AnyFlatSpec with Matchers {
     valueCodec.fieldNames.toSet shouldBe Set("int_val", "id_last2_1d", "id2_last2_1d")
   }
 
-  it should "fetch status for online groupBys" in {
+  it should "fetch current status directly from batch serving info" in {
     val kvStore = InMemoryKvStore.build(s"FetcherSchemaTest_status_${System.nanoTime()}")
     kvStore.create(Constants.MetadataDataset)
 
     val servingInfo = GroupByDerivationsTest.makeTestGroupByServingInfoParsed().groupByServingInfo
     servingInfo.groupBy.metaData.setOnline(true)
+    servingInfo.setBatchEndDate("2026-06-03-04-00")
+    servingInfo.setDateFormat("yyyy-MM-dd-HH-mm")
+    servingInfo.setBatchEndTs(1780459200000L)
     val groupByName = servingInfo.groupBy.metaData.name
     val batchDataset = new GroupByOps(servingInfo.groupBy).batchDataset
     kvStore.create(batchDataset)
 
-    putString(kvStore, servingInfo.groupBy.keyNameForKvStore, ThriftJsonCodec.toJsonStr(servingInfo.groupBy), Constants.MetadataDataset)
-    putString(kvStore, Constants.GroupByServingInfoKey, ThriftJsonCodec.toJsonStr(servingInfo), batchDataset)
+    putString(kvStore,
+              servingInfo.groupBy.keyNameForKvStore,
+              ThriftJsonCodec.toJsonStr(servingInfo.groupBy),
+              Constants.MetadataDataset)
+    putString(kvStore,
+              Constants.GroupByServingInfoKey,
+              ThriftJsonCodec.toJsonStr(servingInfo),
+              batchDataset,
+              Some(1L))
 
     val fetcher = new Fetcher(kvStore, Constants.MetadataDataset)
-    val response = fetcher.fetchGroupByStatus(groupByName).get
+    val firstResponse = fetcher.fetchGroupByStatus(groupByName).get
 
-    response.groupByName shouldBe groupByName
-    response.batchEndDate shouldBe servingInfo.batchEndDate
+    firstResponse.groupByName shouldBe groupByName
+    firstResponse.batchEndDate shouldBe servingInfo.batchEndDate
+    firstResponse.batchEndTs shouldBe new GroupByServingInfoParsed(servingInfo).batchEndTsMillis
+
+    servingInfo.setBatchEndDate("2026-07-23")
+    servingInfo.setBatchEndTs(1784764800000L)
+    putString(kvStore,
+              Constants.GroupByServingInfoKey,
+              ThriftJsonCodec.toJsonStr(servingInfo),
+              batchDataset,
+              Some(2L))
+
+    val refreshedResponse = fetcher.fetchGroupByStatus(groupByName).get
+    refreshedResponse.batchEndDate shouldBe "2026-07-23"
+    refreshedResponse.batchEndTs shouldBe 1784764800000L
   }
 
   it should "return a user-facing status error for offline groupBys" in {
@@ -70,17 +99,27 @@ class FetcherSchemaTest extends AnyFlatSpec with Matchers {
     val servingInfo = GroupByDerivationsTest.makeTestGroupByServingInfoParsed().groupByServingInfo
     servingInfo.groupBy.metaData.setOnline(false)
     val groupByName = servingInfo.groupBy.metaData.name
-    val batchDataset = new GroupByOps(servingInfo.groupBy).batchDataset
-    kvStore.create(batchDataset)
 
-    putString(kvStore, servingInfo.groupBy.keyNameForKvStore, ThriftJsonCodec.toJsonStr(servingInfo.groupBy), Constants.MetadataDataset)
-    putString(kvStore, Constants.GroupByServingInfoKey, ThriftJsonCodec.toJsonStr(servingInfo), batchDataset)
+    putString(kvStore,
+              servingInfo.groupBy.keyNameForKvStore,
+              ThriftJsonCodec.toJsonStr(servingInfo.groupBy),
+              Constants.MetadataDataset)
 
     val fetcher = new Fetcher(kvStore, Constants.MetadataDataset)
     val failure = fetcher.fetchGroupByStatus(groupByName).failed.get
 
     failure shouldBe a[IllegalArgumentException]
     failure.getMessage should include("online=True")
+    failure.getMessage should include("upload the GroupBy")
+  }
+
+  it should "retain the two-field status response API" in {
+    val scalaResponse = Fetcher.GroupByStatusResponse("legacy_group_by", "2026-05-20")
+    val javaResponse = new JavaGroupByStatusResponse("legacy_group_by", "2026-05-20")
+
+    scalaResponse.productArity shouldBe 2
+    scalaResponse.batchEndTs shouldBe 0L
+    javaResponse.batchEndTs shouldBe 0L
   }
 
   // A GroupBy that is only a join dependency is uploaded to <NAME>_BATCH (so the join can fetch it) but

--- a/online/src/test/scala/ai/chronon/online/test/FetcherSchemaTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/FetcherSchemaTest.scala
@@ -118,8 +118,28 @@ class FetcherSchemaTest extends AnyFlatSpec with Matchers {
     val javaResponse = new JavaGroupByStatusResponse("legacy_group_by", "2026-05-20")
 
     scalaResponse.productArity shouldBe 2
-    scalaResponse.batchEndTs shouldBe 0L
-    javaResponse.batchEndTs shouldBe 0L
+    scalaResponse.batchEndTs shouldBe null
+    javaResponse.batchEndTs shouldBe null
+  }
+
+  it should "include batchEndTs in status response value semantics" in {
+    val batchEndTs = java.lang.Long.valueOf(1779235200000L)
+    val response = Fetcher.GroupByStatusResponse("test_group_by", "2026-05-20", batchEndTs)
+    val equalResponse = Fetcher.GroupByStatusResponse("test_group_by", "2026-05-20", batchEndTs)
+    val differentWatermark = Fetcher.GroupByStatusResponse("test_group_by", "2026-05-20", batchEndTs + 1L)
+
+    response shouldBe equalResponse
+    response.hashCode() shouldBe equalResponse.hashCode()
+    response.hashCode() shouldBe (response.groupByName, response.batchEndDate, response.batchEndTs).hashCode()
+    response should not be differentWatermark
+    response.toString shouldBe "GroupByStatusResponse(test_group_by,2026-05-20,1779235200000)"
+
+    val copied = response.copy(batchEndDate = "2026-05-21")
+    copied.groupByName shouldBe response.groupByName
+    copied.batchEndDate shouldBe "2026-05-21"
+    copied.batchEndTs shouldBe batchEndTs
+
+    response.copy(batchEndTs = batchEndTs + 1L) shouldBe differentWatermark
   }
 
   // A GroupBy that is only a join dependency is uploaded to <NAME>_BATCH (so the join can fetch it) but

--- a/service/src/test/java/ai/chronon/service/handlers/GroupByStatusHandlerTest.java
+++ b/service/src/test/java/ai/chronon/service/handlers/GroupByStatusHandlerTest.java
@@ -3,6 +3,7 @@ package ai.chronon.service.handlers;
 import ai.chronon.online.JTry;
 import ai.chronon.online.JavaFetcher;
 import ai.chronon.online.JavaGroupByStatusResponse;
+import ai.chronon.online.fetcher.Fetcher;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonObject;
@@ -69,7 +70,8 @@ public class GroupByStatusHandlerTest {
         Async async = context.async();
 
         JavaGroupByStatusResponse groupByStatusResponse =
-                new JavaGroupByStatusResponse("test_group_by", "2026-05-20");
+                new JavaGroupByStatusResponse(
+                        new Fetcher.GroupByStatusResponse("test_group_by", "2026-05-20", 1779235200000L));
         JTry<JavaGroupByStatusResponse> groupByStatusResponseTry = JTry.success(groupByStatusResponse);
 
         when(mockFetcher.fetchGroupByStatus(anyString())).thenReturn(groupByStatusResponseTry);
@@ -79,6 +81,7 @@ public class GroupByStatusHandlerTest {
 
             context.assertEquals(actualResponse.getString("groupByName"), "test_group_by");
             context.assertEquals(actualResponse.getString("batchEndDate"), "2026-05-20");
+            context.assertEquals(actualResponse.getLong("batchEndTs"), 1779235200000L);
         });
 
         handler.handle(routingContext);


### PR DESCRIPTION
## Summary

This change is not as large as it might seem. This adds the `batchEndTs` change onto the status endpoint (and lets the status endpoint return fresh status info) for GroupBys. This is useful to know for outside orchestration. 

## Checklist
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fresh metadata reads that bypass cached values to return the latest data when required.
  * GroupBy status responses now include an epoch-milliseconds serving watermark (`batchEndTs`).
* **Bug Fixes**
  * Improved DynamoDB-backed lookups to use strongly consistent reads for exact-key metadata, improving freshness and correctness.
* **Documentation**
  * Updated Fetcher API docs to clarify GroupBy status now reports the latest uploaded/serving batch watermark and how to use `batchEndTs`.
* **Tests**
  * Added/updated tests covering fresh reads, strongly consistent behavior, and the expanded GroupBy status response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->